### PR TITLE
Appveyor notifications

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -38,3 +38,9 @@ notifications:
   on_build_success: false
   on_build_failure: true
   on_build_status_changed: true
+notifications:
+  - provider: Webhook
+    url: https://webhooks.gitter.im/e/c36ee3620811669b4c32
+    on_build_success: true
+    on_build_failure: true
+    on_build_status_changed: true  


### PR DESCRIPTION
I have updated the AppVeyor notifications section to include a custom webhook for posting information to the newly created Gitter Chat Room for the choco repository:

https://gitter.im/chocolatey/choco

This will make information about new builds starting/stopping/failing etc, appear in the activity stream, similar to what happens in the ChocolateyGUI chat room:

![image](https://cloud.githubusercontent.com/assets/1271146/5794043/9c913c3e-9f54-11e4-8042-5f1af1c1ec3e.png)
