### PR TITLE
(build) Adding Gitter Notification

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -38,3 +38,8 @@ notifications:
   on_build_success: false
   on_build_failure: true
   on_build_status_changed: true
+- provider: Webhook
+  url: https://webhooks.gitter.im/e/c36ee3620811669b4c32
+  on_build_success: true
+  on_build_failure: true
+  on_build_status_changed: true  


### PR DESCRIPTION
I have updated the AppVeyor notifications section to include a custom webhook for posting information to the newly created Gitter Chat Room for the choco repository:

https://gitter.im/chocolatey/choco

This will make information about new builds starting/stopping/failing etc, appear in the activity stream, similar to what happens in the ChocolateyGUI chat room:

![image](https://cloud.githubusercontent.com/assets/1271146/5794099/02d325aa-9f57-11e4-8a5d-09db3699168d.png)
