### PR TITLE
(GH-10) Packages.config

### DIFF
--- a/src/chocolatey/ObjectExtensions.cs
+++ b/src/chocolatey/ObjectExtensions.cs
@@ -15,6 +15,9 @@
 
 namespace chocolatey
 {
+    using System.IO;
+    using System.Runtime.Serialization.Formatters.Binary;
+
     /// <summary>
     ///   Extensions for Object
     /// </summary>
@@ -31,5 +34,17 @@ namespace chocolatey
 
             return input.ToString();
         }
+
+        public static T deep_copy<T>(this T other)
+        {
+            using (var ms = new MemoryStream())
+            {
+                var formatter = new BinaryFormatter();
+                formatter.Serialize(ms, other);
+                ms.Position = 0;
+                return (T)formatter.Deserialize(ms);
+            }
+        }
+
     }
 }

--- a/src/chocolatey/chocolatey.csproj
+++ b/src/chocolatey/chocolatey.csproj
@@ -91,6 +91,8 @@
     <Compile Include="infrastructure.app\commands\ChocolateyUpgradeCommand.cs" />
     <Compile Include="infrastructure.app\commands\ChocolateyVersionCommand.cs" />
     <Compile Include="infrastructure.app\configuration\ConfigFileFeatureSetting.cs" />
+    <Compile Include="infrastructure.app\configuration\PackagesConfigFilePackageSetting.cs" />
+    <Compile Include="infrastructure.app\configuration\PackagesConfigFileSettings.cs" />
     <Compile Include="infrastructure.app\domain\FeatureCommandType.cs" />
     <Compile Include="infrastructure.app\domain\PinCommandType.cs" />
     <Compile Include="infrastructure.app\domain\SourceCommandType.cs" />

--- a/src/chocolatey/infrastructure.app/configuration/ChocolateyConfiguration.cs
+++ b/src/chocolatey/infrastructure.app/configuration/ChocolateyConfiguration.cs
@@ -25,6 +25,7 @@ namespace chocolatey.infrastructure.app.configuration
     /// <summary>
     ///   The chocolatey configuration.
     /// </summary>
+    [Serializable]
     public class ChocolateyConfiguration
     {
         public ChocolateyConfiguration()
@@ -202,6 +203,7 @@ namespace chocolatey.infrastructure.app.configuration
         public PinCommandConfiguration PinCommand { get; private set; }
     }
 
+    [Serializable]
     public sealed class InformationCommandConfiguration
     {
         // application set variables
@@ -214,6 +216,7 @@ namespace chocolatey.infrastructure.app.configuration
         public bool IsInteractive { get; set; }
     }
 
+    [Serializable]
     public sealed class FeaturesConfiguration
     {
         public bool AutoUninstaller { get; set; }
@@ -222,6 +225,7 @@ namespace chocolatey.infrastructure.app.configuration
 
     //todo: retrofit other command configs this way
 
+    [Serializable]
     public sealed class ListCommandConfiguration
     {
         // list
@@ -229,6 +233,7 @@ namespace chocolatey.infrastructure.app.configuration
         public bool IncludeRegistryPrograms { get; set; }
     }
 
+    [Serializable]
     public sealed class NewCommandConfiguration
     {
         public NewCommandConfiguration()
@@ -241,6 +246,7 @@ namespace chocolatey.infrastructure.app.configuration
         public IDictionary<string, string> TemplateProperties { get; private set; }
     }
 
+    [Serializable]
     public sealed class SourcesCommandConfiguration
     {
         public string Name { get; set; }
@@ -255,17 +261,20 @@ namespace chocolatey.infrastructure.app.configuration
         public FeatureCommandType Command { get; set; }
     }
 
+    [Serializable]
     public sealed class PinCommandConfiguration
     {
         public string Name { get; set; }
         public PinCommandType Command { get; set; }
     }
 
+    [Serializable]
     public sealed class ApiKeyCommandConfiguration
     {
         public string Key { get; set; }
     }
 
+    [Serializable]
     public sealed class PushCommandConfiguration
     {
         public string Key { get; set; }

--- a/src/chocolatey/infrastructure.app/configuration/ChocolateyConfiguration.cs
+++ b/src/chocolatey/infrastructure.app/configuration/ChocolateyConfiguration.cs
@@ -253,8 +253,9 @@ namespace chocolatey.infrastructure.app.configuration
         public SourceCommandType Command { get; set; }
         public string Username { get; set; }
         public string Password { get; set; }
-    } 
-    
+    }
+
+    [Serializable]
     public sealed class FeatureCommandConfiguration
     {
         public string Name { get; set; }

--- a/src/chocolatey/infrastructure.app/configuration/PackagesConfigFilePackageSetting.cs
+++ b/src/chocolatey/infrastructure.app/configuration/PackagesConfigFilePackageSetting.cs
@@ -1,0 +1,55 @@
+﻿// Copyright © 2011 - Present RealDimensions Software, LLC
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// 
+// You may obtain a copy of the License at
+// 
+// 	http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace chocolatey.infrastructure.app.configuration
+{
+    using System;
+    using System.Xml.Serialization;
+
+    /// <summary>
+    ///   XML packages.config file package element
+    /// </summary>
+    [Serializable]
+    [XmlType("package")]
+    public sealed class PackagesConfigFilePackageSetting
+    {
+        [XmlAttribute(AttributeName = "id")]
+        public string Id { get; set; }
+
+        [XmlAttribute(AttributeName = "source")]
+        public string Source { get; set; }
+
+        [XmlAttribute(AttributeName = "version")]
+        public string Version { get; set; }
+
+        [XmlAttribute(AttributeName = "installArguments")]
+        public string InstallArguments { get; set; }
+
+        [XmlAttribute(AttributeName = "packageParameters")]
+        public string PackageParameters { get; set; }
+
+        [XmlAttribute(AttributeName = "forceX86")]
+        public bool ForceX86 { get; set; }
+
+        [XmlAttribute(AttributeName = "allowMultipleVersions")]
+        public bool AllowMultipleVersions { get; set; }
+
+        [XmlAttribute(AttributeName = "ignoreDependencies")]
+        public bool IgnoreDependencies { get; set; }
+
+        [XmlAttribute(AttributeName = "disabled")]
+        public bool Disabled { get; set; }
+    }
+}

--- a/src/chocolatey/infrastructure.app/configuration/PackagesConfigFilePackageSetting.cs
+++ b/src/chocolatey/infrastructure.app/configuration/PackagesConfigFilePackageSetting.cs
@@ -22,7 +22,7 @@ namespace chocolatey.infrastructure.app.configuration
     ///   XML packages.config file package element
     /// </summary>
     [Serializable]
-    [XmlType("package")]
+    //[XmlType("package")]
     public sealed class PackagesConfigFilePackageSetting
     {
         [XmlAttribute(AttributeName = "id")]

--- a/src/chocolatey/infrastructure.app/configuration/PackagesConfigFileSettings.cs
+++ b/src/chocolatey/infrastructure.app/configuration/PackagesConfigFileSettings.cs
@@ -1,0 +1,32 @@
+﻿// Copyright © 2011 - Present RealDimensions Software, LLC
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// 
+// You may obtain a copy of the License at
+// 
+// 	http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace chocolatey.infrastructure.app.configuration
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Xml.Serialization;
+
+    /// <summary>
+    ///   XML packages.config configuration file
+    /// </summary>
+    [Serializable]
+    [XmlRoot("chocolatey")]
+    public class PackagesConfigFileSettings
+    {
+        [XmlArray("packages")]
+        public HashSet<PackagesConfigFilePackageSetting> Packages { get; set; }
+    }
+}

--- a/src/chocolatey/infrastructure.app/configuration/PackagesConfigFileSettings.cs
+++ b/src/chocolatey/infrastructure.app/configuration/PackagesConfigFileSettings.cs
@@ -23,10 +23,10 @@ namespace chocolatey.infrastructure.app.configuration
     ///   XML packages.config configuration file
     /// </summary>
     [Serializable]
-    [XmlRoot("chocolatey")]
+    [XmlRoot("packages")]
     public class PackagesConfigFileSettings
     {
-        [XmlArray("packages")]
+        [XmlElement("package")]
         public HashSet<PackagesConfigFilePackageSetting> Packages { get; set; }
     }
 }

--- a/src/chocolatey/infrastructure.app/services/NugetService.cs
+++ b/src/chocolatey/infrastructure.app/services/NugetService.cs
@@ -253,50 +253,50 @@ spam/junk folder.");
 
             foreach (string packageName in packageNames.or_empty_list_if_null())
             {
-                    //todo: get smarter about realizing multiple versions have been installed before and allowing that
-                    
-                    remove_existing_rollback_directory(packageName);
+                //todo: get smarter about realizing multiple versions have been installed before and allowing that
 
-                    IPackage installedPackage = packageManager.LocalRepository.FindPackage(packageName);
-                    
-                    if (installedPackage != null && (version == null || version == installedPackage.Version) && !config.Force)
-                    {
-                        string logMessage = "{0} v{1} already installed.{2} Use --force to reinstall, specify a version to install, or try upgrade.".format_with(installedPackage.Id, installedPackage.Version, Environment.NewLine);
-                        var results = packageInstalls.GetOrAdd(packageName, new PackageResult(installedPackage, ApplicationParameters.PackagesLocation));
-                        results.Messages.Add(new ResultMessage(ResultType.Inconclusive, logMessage));
-                        this.Log().Warn(ChocolateyLoggers.Important, logMessage);
-                        continue;
-                    }
+                remove_existing_rollback_directory(packageName);
 
-                    if (installedPackage != null && (version == null || version == installedPackage.Version) && config.Force)
-                    {
-                        this.Log().Debug(() => "{0} v{1} already installed. Forcing reinstall.".format_with(installedPackage.Id, installedPackage.Version));
-                        version = installedPackage.Version;
-                    }
+                IPackage installedPackage = packageManager.LocalRepository.FindPackage(packageName);
 
-                    IPackage availablePackage = packageManager.SourceRepository.FindPackage(packageName, version, config.Prerelease, allowUnlisted: false);
-                    if (availablePackage == null)
-                    {
-                        var logMessage = "{0} not installed. The package was not found with the source(s) listed.{1} If you specified a particular version and are receiving this message, it is possible that the package name exists but the version does not.{1} Version: \"{2}\"{1} Source(s): \"{3}\"".format_with(packageName, Environment.NewLine, config.Version, config.Sources);
-                        this.Log().Error(ChocolateyLoggers.Important, logMessage);
-                        var results = packageInstalls.GetOrAdd(packageName, new PackageResult(packageName, version.to_string(), null));
-                        results.Messages.Add(new ResultMessage(ResultType.Error, logMessage));
-                        continue;
-                    }
+                if (installedPackage != null && (version == null || version == installedPackage.Version) && !config.Force)
+                {
+                    string logMessage = "{0} v{1} already installed.{2} Use --force to reinstall, specify a version to install, or try upgrade.".format_with(installedPackage.Id, installedPackage.Version, Environment.NewLine);
+                    var results = packageInstalls.GetOrAdd(packageName, new PackageResult(installedPackage, ApplicationParameters.PackagesLocation));
+                    results.Messages.Add(new ResultMessage(ResultType.Inconclusive, logMessage));
+                    this.Log().Warn(ChocolateyLoggers.Important, logMessage);
+                    continue;
+                }
 
-                    if (installedPackage != null && (installedPackage.Version == availablePackage.Version))
-                    {
-                        packageManager.UninstallPackage(installedPackage, forceRemove: config.Force, removeDependencies: config.ForceDependencies);
-                    }
+                if (installedPackage != null && (version == null || version == installedPackage.Version) && config.Force)
+                {
+                    this.Log().Debug(() => "{0} v{1} already installed. Forcing reinstall.".format_with(installedPackage.Id, installedPackage.Version));
+                    version = installedPackage.Version;
+                }
 
-                    using (packageManager.SourceRepository.StartOperation(
-                        RepositoryOperationNames.Install,
-                        packageName,
-                        version == null ? null : version.ToString()))
-                    {
-                        packageManager.InstallPackage(availablePackage, config.IgnoreDependencies, config.Prerelease);
-                        //packageManager.InstallPackage(packageName, version, configuration.IgnoreDependencies, configuration.Prerelease);
-                    }
+                IPackage availablePackage = packageManager.SourceRepository.FindPackage(packageName, version, config.Prerelease, allowUnlisted: false);
+                if (availablePackage == null)
+                {
+                    var logMessage = "{0} not installed. The package was not found with the source(s) listed.{1} If you specified a particular version and are receiving this message, it is possible that the package name exists but the version does not.{1} Version: \"{2}\"{1} Source(s): \"{3}\"".format_with(packageName, Environment.NewLine, config.Version, config.Sources);
+                    this.Log().Error(ChocolateyLoggers.Important, logMessage);
+                    var results = packageInstalls.GetOrAdd(packageName, new PackageResult(packageName, version.to_string(), null));
+                    results.Messages.Add(new ResultMessage(ResultType.Error, logMessage));
+                    continue;
+                }
+
+                if (installedPackage != null && (installedPackage.Version == availablePackage.Version))
+                {
+                    packageManager.UninstallPackage(installedPackage, forceRemove: config.Force, removeDependencies: config.ForceDependencies);
+                }
+
+                using (packageManager.SourceRepository.StartOperation(
+                    RepositoryOperationNames.Install,
+                    packageName,
+                    version == null ? null : version.ToString()))
+                {
+                    packageManager.InstallPackage(availablePackage, config.IgnoreDependencies, config.Prerelease);
+                    //packageManager.InstallPackage(packageName, version, configuration.IgnoreDependencies, configuration.Prerelease);
+                }
             }
 
             return packageInstalls;
@@ -333,7 +333,7 @@ spam/junk folder.");
 
             SemanticVersion version = config.Version != null ? new SemanticVersion(config.Version) : null;
             var packageManager = NugetCommon.GetPackageManager(
-                config, 
+                config,
                 _nugetLogger,
                 installSuccessAction: (e) =>
                     {
@@ -364,7 +364,7 @@ spam/junk folder.");
                     if (config.RegularOuptut) this.Log().Error(ChocolateyLoggers.Important, logMessage);
                     continue;
                 }
-                
+
                 var pkgInfo = _packageInfoService.get_package_information(installedPackage);
                 if (pkgInfo != null && pkgInfo.IsPinned)
                 {
@@ -460,7 +460,7 @@ spam/junk folder.");
                 this.Log().Debug("Backing up existing {0} prior to upgrade.".format_with(installedPackage.Id));
 
                 var backupLocation = pkgInstallPath + ApplicationParameters.RollbackPackageSuffix;
-                _fileSystem.copy_directory(pkgInstallPath,backupLocation,overwriteExisting:true);
+                _fileSystem.copy_directory(pkgInstallPath, backupLocation, overwriteExisting: true);
             }
         }
 

--- a/src/chocolatey/infrastructure.app/services/NugetService.cs
+++ b/src/chocolatey/infrastructure.app/services/NugetService.cs
@@ -253,13 +253,6 @@ spam/junk folder.");
 
             foreach (string packageName in packageNames.or_empty_list_if_null())
             {
-                if (packageName.to_lower().EndsWith(".config"))
-                {
-                    //todo: determine if .config file for packages .config
-                    //todo: determine if config file exists
-                }
-                else
-                {
                     //todo: get smarter about realizing multiple versions have been installed before and allowing that
                     
                     remove_existing_rollback_directory(packageName);
@@ -304,7 +297,6 @@ spam/junk folder.");
                         packageManager.InstallPackage(availablePackage, config.IgnoreDependencies, config.Prerelease);
                         //packageManager.InstallPackage(packageName, version, configuration.IgnoreDependencies, configuration.Prerelease);
                     }
-                }
             }
 
             return packageInstalls;


### PR DESCRIPTION
If a config file is specified, use that to determine settings for each
package to install. Clone the config and make adjustments based on what
is in the packages.config file for that particular package.

 - [x] packages.config deserializing
 - [x] install from packages.config
 - [x] Use original packages.config format - relates to #54 

Closes #10