### PR TITLE
Fix GetChocolatey so one can get chocolatey

### DIFF
--- a/src/chocolatey.console/Program.cs
+++ b/src/chocolatey.console/Program.cs
@@ -52,7 +52,7 @@ namespace chocolatey.console
                 Bootstrap.initialize();
                 Bootstrap.startup();
 
-                var container = SimpleInjectorContainer.initialize();
+                var container = SimpleInjectorContainer.Container;
                 var config = container.GetInstance<ChocolateyConfiguration>();
                 var fileSystem = container.GetInstance<IFileSystem>();
 

--- a/src/chocolatey.tests.integration/NUnitSetup.cs
+++ b/src/chocolatey.tests.integration/NUnitSetup.cs
@@ -36,7 +36,7 @@ namespace chocolatey.tests.integration
 
         public override void BeforeEverything()
         {
-            Container = SimpleInjectorContainer.initialize();
+            Container = SimpleInjectorContainer.Container;
             fix_application_parameter_variables(Container);
             var config = Container.GetInstance<ChocolateyConfiguration>();
             var force = config.Force;

--- a/src/chocolatey.tests/GetChocolateySpecs.cs
+++ b/src/chocolatey.tests/GetChocolateySpecs.cs
@@ -1,0 +1,82 @@
+﻿// Copyright © 2011 - Present RealDimensions Software, LLC
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// 
+// You may obtain a copy of the License at
+// 
+// 	http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace chocolatey.tests
+{
+    using log4net;
+    using Should;
+
+    public class GetChocolateySpecs
+    {
+        public abstract class GetChocolateySpecsBase : TinySpec
+        {
+            public override void Context()
+            {
+            }
+        }
+
+        public class when_getting_chocolatey : GetChocolateySpecsBase
+        {
+            private GetChocolatey _chocolatey;
+
+            public override void Because()
+            {
+                _chocolatey = Lets.GetChocolatey();
+            }
+
+            [Fact]
+            public void should_get_chocolotey()
+            {
+                _chocolatey.ShouldNotBeNull();
+            }
+
+            [Fact]
+            public void should_conigure_log4net()
+            {
+                LogManager.GetRepository().Configured.ShouldBeTrue();
+            }
+        }
+
+        public class when_getting_chocolatey_more_than_once : GetChocolateySpecsBase
+        {
+            private GetChocolatey _chocolatey1;
+            private GetChocolatey _chocolatey2;
+
+            public override void Because()
+            {
+                _chocolatey1 = Lets.GetChocolatey();
+                _chocolatey2 = Lets.GetChocolatey();
+            }
+
+            [Fact]
+            public void should_get_instantiated_chocolotey1()
+            {
+                _chocolatey1.ShouldNotBeNull();
+            }
+
+            [Fact]
+            public void should_get_instantiated_chocolotey2()
+            {
+                _chocolatey2.ShouldNotBeNull();
+            }
+
+            [Fact]
+            public void should_have_distinct_configurations()
+            {
+                _chocolatey1.GetConfiguration().ShouldNotEqual(_chocolatey2.GetConfiguration());
+            }
+        }
+    }
+}

--- a/src/chocolatey.tests/chocolatey.tests.csproj
+++ b/src/chocolatey.tests/chocolatey.tests.csproj
@@ -32,6 +32,10 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="log4net, Version=1.2.13.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\log4net.2.0.3\lib\net40-full\log4net.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.Web.XmlTransform, Version=2.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Web.Xdt.2.1.1\lib\net40\Microsoft.Web.XmlTransform.dll</HintPath>
     </Reference>
@@ -57,6 +61,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="GetChocolateySpecs.cs" />
     <Compile Include="infrastructure.app\attributes\CommandForAttributeSpecs.cs" />
     <Compile Include="infrastructure.app\commands\ChocolateyApiKeyCommandSpecs.cs" />
     <Compile Include="infrastructure.app\commands\ChocolateyFeatureCommandSpecs.cs" />

--- a/src/chocolatey.tests/infrastructure.app/configuration/ConfigurationOptionsSpec.cs
+++ b/src/chocolatey.tests/infrastructure.app/configuration/ConfigurationOptionsSpec.cs
@@ -44,6 +44,7 @@ namespace chocolatey.tests.infrastructure.app.configuration
             public override void Context()
             {
                 ConfigurationOptions.initialize_with(new Lazy<IConsole>(() => console.Object));
+                ConfigurationOptions.reset_options();
                 console.Setup((c) => c.Error).Returns(writer);
             }
 

--- a/src/chocolatey.tests/packages.config
+++ b/src/chocolatey.tests/packages.config
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 
 <packages>
+  <package id="log4net" version="2.0.3" targetFramework="net40" />
   <package id="Microsoft.Web.Xdt" version="2.1.1" targetFramework="net40" />
   <package id="Moq" version="4.2.1402.2112" targetFramework="net40" />
   <package id="NuGet.Core" version="2.8.2" targetFramework="net40" />

--- a/src/chocolatey/GetChocolatey.cs
+++ b/src/chocolatey/GetChocolatey.cs
@@ -58,8 +58,10 @@ namespace chocolatey
         /// </summary>
         public GetChocolatey()
         {
+            Log4NetAppenderConfiguration.configure();
+            Bootstrap.initialize();
             _configuration = new ChocolateyConfiguration();
-            _container = SimpleInjectorContainer.initialize();
+            _container = SimpleInjectorContainer.Container;
             _fileSystem = _container.GetInstance<IFileSystem>();
 
             set_defaults();
@@ -67,7 +69,7 @@ namespace chocolatey
 
         private void set_defaults()
         {
-            ConfigurationBuilder.set_up_configuration(null, _configuration, _fileSystem, _container.GetInstance<IXmlService>(), null);
+            ConfigurationBuilder.set_up_configuration(new List<string>(), _configuration, _fileSystem, _container.GetInstance<IXmlService>(), null);
             Config.initialize_with(_configuration);
 
             _configuration.PromptForConfirmation = false;

--- a/src/chocolatey/infrastructure.app/builders/ConfigurationBuilder.cs
+++ b/src/chocolatey/infrastructure.app/builders/ConfigurationBuilder.cs
@@ -61,6 +61,7 @@ namespace chocolatey.infrastructure.app.builders
         public static void set_up_configuration(IList<string> args, ChocolateyConfiguration config, IFileSystem fileSystem, IXmlService xmlService, Action<string> notifyWarnLoggingAction)
         {
             set_file_configuration(config, fileSystem, xmlService, notifyWarnLoggingAction);
+            ConfigurationOptions.reset_options();
             set_global_options(args, config);
             set_environment_options(config);
         }

--- a/src/chocolatey/infrastructure.app/configuration/ConfigurationOptions.cs
+++ b/src/chocolatey/infrastructure.app/configuration/ConfigurationOptions.cs
@@ -34,6 +34,11 @@ namespace chocolatey.infrastructure.app.configuration
             _console = console;
         }
 
+        public static void reset_options()
+        {
+            _optionSet.Clear();
+        }
+
         private static IConsole Console
         {
             get { return _console.Value; }

--- a/src/chocolatey/infrastructure/logging/Log4NetAppenderConfiguration.cs
+++ b/src/chocolatey/infrastructure/logging/Log4NetAppenderConfiguration.cs
@@ -34,10 +34,11 @@ namespace chocolatey.infrastructure.logging
         private static bool _alreadyConfiguredFileAppender;
 
         /// <summary>
-        ///   Pulls xmlconfiguration from embedded location and applies it. Then it configures a file appender to the specified output directory.
+        ///   Pulls xmlconfiguration from embedded location and applies it. 
+        ///   Then it configures a file appender to the specified output directory if one is provided.
         /// </summary>
         /// <param name="outputDirectory">The output directory.</param>
-        public static void configure(string outputDirectory)
+        public static void configure(string outputDirectory = null)
         {
             var assembly = Assembly.GetExecutingAssembly();
             var resource = ApplicationParameters.Log4NetConfigurationResource;
@@ -49,7 +50,11 @@ namespace chocolatey.infrastructure.logging
             Stream xmlConfigStream = assembly.get_manifest_stream(resource);
 
             XmlConfigurator.Configure(xmlConfigStream);
-            set_file_appender(outputDirectory);
+
+            if (outputDirectory != null)
+            {
+                set_file_appender(outputDirectory);
+            }
 
             _logger.DebugFormat("Configured {0} from assembly {1}", resource, assembly.FullName);
         }

--- a/src/chocolatey/infrastructure/registration/SimpleInjectorContainer.cs
+++ b/src/chocolatey/infrastructure/registration/SimpleInjectorContainer.cs
@@ -24,7 +24,7 @@ namespace chocolatey.infrastructure.registration
     /// </summary>
     public static class SimpleInjectorContainer
     {
-        private static readonly Lazy<Container> _container = new Lazy<Container>(() => new Container());
+        private static readonly Lazy<Container> _container = new Lazy<Container>(initialize);
 
         /// <summary>
         ///   Gets the container.
@@ -37,25 +37,21 @@ namespace chocolatey.infrastructure.registration
         /// <summary>
         ///   Initializes the container
         /// </summary>
-        public static Container initialize()
+        private static Container initialize()
         {
-            Container.Options.AllowOverridingRegistrations = true;
-            var originalConstructorResolutionBehavior = Container.Options.ConstructorResolutionBehavior;
-            Container.Options.ConstructorResolutionBehavior = new SimpleInjectorContainerResolutionBehavior(originalConstructorResolutionBehavior);
+            var container = new Container();
+            container.Options.AllowOverridingRegistrations = true;
+            var originalConstructorResolutionBehavior = container.Options.ConstructorResolutionBehavior;
+            container.Options.ConstructorResolutionBehavior = new SimpleInjectorContainerResolutionBehavior(originalConstructorResolutionBehavior);
 
-            initialize_container(Container);
-
-#if DEBUG
-            Container.Verify();
-#endif
-
-            return Container;
-        }
-
-        private static void initialize_container(Container container)
-        {
             var binding = new ContainerBinding();
             binding.RegisterComponents(container);
+
+#if DEBUG
+            container.Verify();
+#endif
+
+            return container;
         }
     }
 }


### PR DESCRIPTION
I encountered a few problems with `GetChocolatey`. Here are the issues this fixes:

1. NullRefException when calling `Lets.GetChocolatey` when the agrs are parsed.
2. Calling `Lets.GetChocolatey` more than once in a single process raised an exception when setting the `ConstructorResolutionBehavior` on SimpleInjector since it can only be called once. I made some changes to `SimpleInjectorContainer` that ensures the initializer is only called once in the `lazy` initializer of `_container` and made that initializer private. So callers would instead call `SimpleInjectorContainer.Container` and the very first call initializes a new container. 
3. After fixing 2, adding items to the configuration option set was raising duplicate key errors. I changed the `ConfigurationOptions` to reset each time they are parsed.
4. There was no logging sent to stdout upon calling `run`. `GetChocolatey` now configures log4net but with no log file. Callers should be able to use `SetCustomLogger` if they do want file logging.

I added some integration tests for `GetChocolatey` and I ran all integration tests. 2 tests are failing but those same tests are failing in master as well so they appear to be unrelated.