### PR TITLE
(GH-133) defer container lookups until Run()

### DIFF
--- a/src/chocolatey.tests/GetChocolateySpecs.cs
+++ b/src/chocolatey.tests/GetChocolateySpecs.cs
@@ -71,12 +71,6 @@ namespace chocolatey.tests
             {
                 _chocolatey2.ShouldNotBeNull();
             }
-
-            [Fact]
-            public void should_have_distinct_configurations()
-            {
-                _chocolatey1.GetConfiguration().ShouldNotEqual(_chocolatey2.GetConfiguration());
-            }
         }
     }
 }


### PR DESCRIPTION
This fixes calls to `RegisterContainerComponents` complaining that components cannot be registered after calls to `GetInstance`, etc.

The container is not touched in the constructor and configuration setup is is performed just prior to `Run`.

Closes #133 