### PR TITLE
(maint) Change the "not an official build" warning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ SolutionVersion.vb
 
 .DS_Store
 *.db
+src/_dotCover.chocolatey/
+src/_dotTrace.chocolatey/
+src/chocolatey.sln.GhostDoc.xml

--- a/src/chocolatey/infrastructure.app/runners/GenericRunner.cs
+++ b/src/chocolatey/infrastructure.app/runners/GenericRunner.cs
@@ -79,7 +79,7 @@ Custom unofficial builds are not allowed by default.
                     else
                     {
                         this.Log().Warn(ChocolateyLoggers.Important, @"
-choco.exe is not an official build (bypassed with --allow-unofficial).
+Chocolatey is not an official build (bypassed with --allow-unofficial).
  If you are seeing this message and it is not expected, your system may 
  now be in a bad state. Only official builds are to be trusted.
 "
@@ -105,4 +105,5 @@ choco.exe is not an official build (bypassed with --allow-unofficial).
             }
         }
     }
+
 }


### PR DESCRIPTION
The warning happens on API calls when choco.exe is not on the system,
so it should reference the product name "chocolatey" not the app name.