### PR TITLE
(GH-143) Make NuGet calls yield return, so we stream output as it comes

### DIFF
--- a/src/chocolatey.tests/infrastructure.app/commands/ChocolateyPinCommandSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/commands/ChocolateyPinCommandSpecs.cs
@@ -337,10 +337,12 @@ namespace chocolatey.tests.infrastructure.app.commands
                 configuration.Sources = ApplicationParameters.PackagesLocation;
                 configuration.ListCommand.LocalOnly = true;
                 configuration.AllVersions = true;
-                var packageResults = new ConcurrentDictionary<string, PackageResult>(); 
-                packageResults.GetOrAdd("regular", new PackageResult(package.Object, null));
-                packageResults.GetOrAdd("pinned", new PackageResult(pinnedPackage.Object, null));
-                nugetService.Setup(n => n.list_run(It.IsAny<ChocolateyConfiguration>(), false)).Returns(packageResults);
+                var packageResults = new []
+                {
+                    new PackageResult(package.Object, null),
+                    new PackageResult(pinnedPackage.Object, null)
+                };
+                nugetService.Setup(n => n.list_run(It.IsAny<ChocolateyConfiguration>(), true)).Returns(packageResults);
                 configuration.PinCommand.Command = PinCommandType.list;
             }
 
@@ -412,7 +414,7 @@ namespace chocolatey.tests.infrastructure.app.commands
                 configuration.PinCommand.Command = PinCommandType.list;
                 command.run(configuration);
 
-                nugetService.Verify(n => n.list_run(It.IsAny<ChocolateyConfiguration>(), false), Times.Once);
+                nugetService.Verify(n => n.list_run(It.IsAny<ChocolateyConfiguration>(), true), Times.Once);
             }
             
             [Pending("NuGet is killing me with extension methods. Need to find proper item to mock out to return the package object.")]

--- a/src/chocolatey/infrastructure.app/commands/ChocolateyPinCommand.cs
+++ b/src/chocolatey/infrastructure.app/commands/ChocolateyPinCommand.cs
@@ -139,10 +139,9 @@ Pin a package to suppress upgrades.
 
         public void list_pins(IPackageManager packageManager, ChocolateyConfiguration config)
         {
-            var localPackages = _nugetService.list_run(config, logResults: false);
-            foreach (var pkg in localPackages.or_empty_list_if_null())
+            foreach (var pkg in _nugetService.list_run(config, logResults: true))
             {
-                var pkgInfo = _packageInfoService.get_package_information(pkg.Value.Package);
+                var pkgInfo = _packageInfoService.get_package_information(pkg.Package);
                 if (pkgInfo != null && pkgInfo.IsPinned)
                 {
                     this.Log().Info(() => "{0}|{1}".format_with(pkgInfo.Package.Id,pkgInfo.Package.Version));

--- a/src/chocolatey/infrastructure.app/services/ChocolateyPackageService.cs
+++ b/src/chocolatey/infrastructure.app/services/ChocolateyPackageService.cs
@@ -80,7 +80,7 @@ namespace chocolatey.infrastructure.app.services
                 var list = _nugetService.list_run(config, logResults: true);
                 if (config.RegularOuptut)
                 {
-                    this.Log().Warn(() => @"{0} packages {1}.".format_with(list.Count, config.ListCommand.LocalOnly ? "installed" : "found"));
+                    this.Log().Warn(() => @"{0} packages {1}.".format_with(list.Count(), config.ListCommand.LocalOnly ? "installed" : "found"));
 
                     if (config.ListCommand.LocalOnly && config.ListCommand.IncludeRegistryPrograms)
                     {
@@ -90,14 +90,14 @@ namespace chocolatey.infrastructure.app.services
             }
         }
 
-        private void report_registry_programs(ChocolateyConfiguration config, ConcurrentDictionary<string, PackageResult> list)
+        private void report_registry_programs(ChocolateyConfiguration config, IEnumerable<PackageResult> list)
         {
             var itemsToRemoveFromMachine = new List<string>();
             foreach (var packageResult in list)
             {
-                if (packageResult.Value != null && packageResult.Value.Package != null)
+                if (packageResult != null && packageResult.Package != null)
                 {
-                    var pkginfo = _packageInfoService.get_package_information(packageResult.Value.Package);
+                    var pkginfo = _packageInfoService.get_package_information(packageResult.Package);
                     if (pkginfo.RegistrySnapshot == null)
                     {
                         continue;

--- a/src/chocolatey/infrastructure.app/services/INugetService.cs
+++ b/src/chocolatey/infrastructure.app/services/INugetService.cs
@@ -17,6 +17,7 @@ namespace chocolatey.infrastructure.app.services
 {
     using System;
     using System.Collections.Concurrent;
+    using System.Collections.Generic;
     using configuration;
     using results;
 
@@ -34,7 +35,7 @@ namespace chocolatey.infrastructure.app.services
         /// <param name="config">The configuration.</param>
         /// <param name="logResults">Should results be logged?</param>
         /// <returns></returns>
-        ConcurrentDictionary<string, PackageResult> list_run(ChocolateyConfiguration config, bool logResults);
+        IEnumerable<PackageResult> list_run(ChocolateyConfiguration config, bool logResults);
 
         /// <summary>
         ///   Run pack in noop mode.

--- a/src/chocolatey/infrastructure.app/services/NugetService.cs
+++ b/src/chocolatey/infrastructure.app/services/NugetService.cs
@@ -71,36 +71,31 @@ namespace chocolatey.infrastructure.app.services
                                 ));
         }
 
-        public ConcurrentDictionary<string, PackageResult> list_run(ChocolateyConfiguration config, bool logResults = true)
+        public IEnumerable<PackageResult> list_run(ChocolateyConfiguration config, bool logResults)
         {
-            var packageResults = new ConcurrentDictionary<string, PackageResult>();
-
-            var packages = NugetList.GetPackages(config, _nugetLogger).ToList();
-
-            foreach (var package in packages.or_empty_list_if_null())
+            foreach (var package in NugetList.GetPackages(config, _nugetLogger))
             {
+                var pkg = package; // for lamda access
                 if (logResults)
                 {
                     if (config.RegularOuptut)
                     {
-                        this.Log().Info(config.Verbose ? ChocolateyLoggers.Important : ChocolateyLoggers.Normal, () => "{0} {1}".format_with(package.Id, package.Version.to_string()));
-                        if (config.Verbose) this.Log().Info(() => " {0}{1} Description: {2}{1} Tags: {3}{1} Number of Downloads: {4}{1}".format_with(package.Title.escape_curly_braces(), Environment.NewLine, package.Description.escape_curly_braces(), package.Tags.escape_curly_braces(), package.DownloadCount <= 0 ? "n/a" : package.DownloadCount.to_string()));
-                        // Maintainer(s):{3}{1} | package.Owners.join(", ") - null at the moment
+                        this.Log().Info(config.Verbose ? ChocolateyLoggers.Important : ChocolateyLoggers.Normal, () => "{0} {1}".format_with(pkg.Id, pkg.Version.to_string()));
+                        if (config.Verbose) this.Log().Info(() => " {0}{1} Description: {2}{1} Tags: {3}{1} Number of Downloads: {4}{1}".format_with(pkg.Title.escape_curly_braces(), Environment.NewLine, pkg.Description.escape_curly_braces(), pkg.Tags.escape_curly_braces(), pkg.DownloadCount <= 0 ? "n/a" : pkg.DownloadCount.to_string()));
+                        // Maintainer(s):{3}{1} | pkg.Owners.join(", ") - null at the moment
                     }
                     else
                     {
-                        this.Log().Info(config.Verbose ? ChocolateyLoggers.Important : ChocolateyLoggers.Normal, () => "{0}|{1}".format_with(package.Id, package.Version.to_string()));
+                        this.Log().Info(config.Verbose ? ChocolateyLoggers.Important : ChocolateyLoggers.Normal, () => "{0}|{1}".format_with(pkg.Id, pkg.Version.to_string()));
                     }
                 }
                 else
                 {
-                    this.Log().Debug(() => "{0} {1}".format_with(package.Id, package.Version.to_string()));
+                    this.Log().Debug(() => "{0} {1}".format_with(pkg.Id, pkg.Version.to_string()));
                 }
 
-                packageResults.GetOrAdd(package.Id, new PackageResult(package, null));
+                yield return new PackageResult(pkg, null);
             }
-
-            return packageResults;
         }
 
         public void pack_noop(ChocolateyConfiguration config)
@@ -871,13 +866,11 @@ packages as of version 1.0.0. That is what the install command is for.
                 var input = config.Input;
                 config.Input = string.Empty;
 
-                var localPackages = list_run(config, logResults: false);
-
+                config.PackageNames = list_run(config, false).Select(p => p.Name).@join(ApplicationParameters.PackageNamesSeparator);
                 config.Input = input;
                 config.Noop = noop;
                 config.Prerelease = pre;
                 config.Sources = sources;
-                config.PackageNames = string.Join(ApplicationParameters.PackageNamesSeparator, localPackages.Select((p) => p.Key).or_empty_list_if_null());
 
                 if (customAction != null) customAction.Invoke();
             }


### PR DESCRIPTION
Also stop sorting things into the order they're already in anyway, because sorting blocks output.