### PR TITLE
Added Remove-BinFile Helper

### DIFF
--- a/src/chocolatey.resources/chocolatey.resources.csproj
+++ b/src/chocolatey.resources/chocolatey.resources.csproj
@@ -117,9 +117,10 @@
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="helpers\functions\Generate-BinFile.ps1" />
+    <EmbeddedResource Include="helpers\functions\Remove-BinFile.ps1" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">
   </Target>

--- a/src/chocolatey.resources/helpers/functions/Remove-BinFile.ps1
+++ b/src/chocolatey.resources/helpers/functions/Remove-BinFile.ps1
@@ -1,0 +1,54 @@
+﻿# Copyright 2011 - Present RealDimensions Software, LLC & original authors/contributors from https://github.com/chocolatey/chocolatey
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+function Remove-BinFile {
+param(
+  [string] $name, 
+  [string] $path
+)
+  Write-Debug "Running 'Remove-BinFile' for $name with path:`'$path`'";
+
+  $packageBatchFileName = Join-Path $nugetExePath "$name.bat"
+  $packageBashFileName = Join-Path $nugetExePath "$name"
+  $packageShimFileName = Join-Path $nugetExePath "$name.exe"
+  $path = $path.ToLower().Replace($nugetPath.ToLower(), "%DIR%..\").Replace("\\","\")
+  $pathBash = $path.Replace("%DIR%..\","`$DIR/../").Replace("\","/")
+
+  Write-Debug "Attempting to remove the batch and bash shortcuts: $packageBatchFileName and $packageBashFileName"
+
+  if (Test-Path $packageBatchFileName) {
+    Write-Host "Removing batch file $packageBatchFileName which pointed to `'$path`'." -ForegroundColor $Note
+    Remove-Item $packageBatchFileName
+  }
+  else {
+    Write-Debug "Tried to remove batch file $packageBatchFileName but it was already removed."
+  }
+
+  if (Test-Path $packageBashFileName) {
+    Write-Host "Removing bash file $packageBashFileName which pointed to `'$path`'." -ForegroundColor $Note
+    Remove-Item $packageBashFileName
+  }
+  else {
+    Write-Debug "Tried to remove bash file $packageBashFileName but it was already removed."
+  }
+
+  Write-Debug "Attempting to remove the shim: $packageShimFileName"
+  if (Test-Path $packageShimFileName) {
+    Write-Host "Removing shim $packageShimFileName which pointed to `'$path`'." -ForegroundColor $Note
+    Remove-Item $packageShimFileName
+  }
+  else {
+    Write-Debug "Tried to remove shim $packageShimFileName but it was already removed."
+  }
+}


### PR DESCRIPTION
Previously, Chocolatey had an internal helper function
called Remove-BinFile.  While this was never part of the
public API, many packages take a dependency on it.

Without this change, a number of packages will fail to
install.

Closes #195 