### PR TITLE
#185 Remove default choice from `InteractivePrompt.prompt_for_confirmation` and all associated tests

### DIFF
--- a/src/chocolatey.console/Program.cs
+++ b/src/chocolatey.console/Program.cs
@@ -194,7 +194,7 @@ Chocolatey detected you are not running from an elevated command shell
  elevated shell. When you open the command shell, you should ensure 
  that you do so with ""Run as Administrator"" selected.
 
- Do you want to continue?", new[] {"yes", "no"}, "no", requireAnswer: true);
+ Do you want to continue?", new[] { "yes", "no" }, defaultChoice: null, requireAnswer: true);
 
                 if (selection.is_equal_to("no"))
                 {

--- a/src/chocolatey/infrastructure.app/services/ChocolateyPackageService.cs
+++ b/src/chocolatey/infrastructure.app/services/ChocolateyPackageService.cs
@@ -618,7 +618,7 @@ ATTENTION: You must take manual action to remove {1} from
             var rollback = true;
             if (config.PromptForConfirmation)
             {
-                var selection = InteractivePrompt.prompt_for_confirmation(" Unsuccessful operation for {0}.{1}  Do you want to rollback to previous version (package files only)?".format_with(packageResult.Name, Environment.NewLine), new[] { "yes", "no" }, "yes", requireAnswer: true);
+                var selection = InteractivePrompt.prompt_for_confirmation(" Unsuccessful operation for {0}.{1}  Do you want to rollback to previous version (package files only)?".format_with(packageResult.Name, Environment.NewLine), new[] { "yes", "no" }, defaultChoice: null, requireAnswer: true);
                 if (selection.is_equal_to("no")) rollback = false;
             }
 

--- a/src/chocolatey/infrastructure.app/services/NugetService.cs
+++ b/src/chocolatey/infrastructure.app/services/NugetService.cs
@@ -816,7 +816,7 @@ packages as of version 1.0.0. That is what the install command is for.
                             choices.Add(allVersionsChoice);
                         }
 
-                        var selection = InteractivePrompt.prompt_for_confirmation("Which version of {0} would you like to uninstall?".format_with(packageName), choices, abortChoice, true);
+                        var selection = InteractivePrompt.prompt_for_confirmation("Which version of {0} would you like to uninstall?".format_with(packageName), choices, defaultChoice: null, requireAnswer: true);
 
                         if (string.IsNullOrWhiteSpace(selection)) continue;
                         if (selection.is_equal_to(abortChoice)) continue;

--- a/src/chocolatey/infrastructure.app/services/PowershellService.cs
+++ b/src/chocolatey/infrastructure.app/services/PowershellService.cs
@@ -210,7 +210,7 @@ Do you want to run the script?
  fail.
  Skip is an advanced option and most likely will never be wanted.
 "
-                                                 , new[] {"yes", "no", "skip"}, "no", requireAnswer: true);
+                                                 , new[] { "yes", "no", "skip" }, defaultChoice: null, requireAnswer: true);
                     if (selection.is_equal_to("yes")) shouldRun = true;
                     if (selection.is_equal_to("no"))
                     {


### PR DESCRIPTION
Resolves #185 (Do not offer a default option when prompting for a user choice).

Note that it simply removes the code in `interactivePrompt` for `defaultValue` (first commit) and `requireValue` (second commit) since nowhere in the code other than in tests was the value actually optional. Most of the changes other than that are tests that don't make sense anymore (e.g. all tests for optional/default prompts).

This is my first pull request for this project, so feel free to suggest changes to how I make these (e.g. leave all tests and ask), since I plan on doing a few more. All tests are green!