### PR TITLE
(GH-181) Short confirm prompt / (GH-184) Show a prompt character

### DIFF
--- a/src/chocolatey.tests/infrastructure/commandline/InteractivePromptSpecs.cs
+++ b/src/chocolatey.tests/infrastructure/commandline/InteractivePromptSpecs.cs
@@ -437,5 +437,208 @@ namespace chocolatey.tests.infrastructure.commandline
                 console.Verify(c => c.ReadLine(), Times.AtLeast(8));
             }
         }
+
+        public class when_prompting_short_with_interactivePrompt_guard_errors : InteractivePromptSpecsBase
+        {
+            private Func<string> prompt;
+
+            public override void Because()
+            {
+                console.Setup(c => c.ReadLine()).Returns(""); //Enter pressed
+                prompt = () => InteractivePrompt.prompt_for_confirmation_short(prompt_value, choices);
+            }
+
+            [Fact]
+            public void should_error_when_the_choicelist_is_null()
+            {
+                choices = null;
+                bool errored = false;
+                console.Setup(c => c.ReadLine()).Returns(""); //Enter pressed
+                try
+                {
+                    prompt();
+                }
+                catch (Exception)
+                {
+                    errored = true;
+                }
+
+                errored.ShouldBeTrue();
+                console.Verify(c => c.ReadLine(), Times.Never);
+            }
+
+            [Fact]
+            public void should_error_when_the_choicelist_is_empty()
+            {
+                choices = new List<string>();
+                bool errored = false;
+                string errorMessage = string.Empty;
+                console.Setup(c => c.ReadLine()).Returns(""); //Enter pressed
+                try
+                {
+                    prompt();
+                }
+                catch (Exception ex)
+                {
+                    errored = true;
+                    errorMessage = ex.Message;
+                }
+
+                errored.ShouldBeTrue();
+                errorMessage.ShouldContain("No choices passed in.");
+                console.Verify(c => c.ReadLine(), Times.Never);
+            }
+
+            [Fact]
+            public void should_error_when_the_prompt_input_is_null()
+            {
+                choices = new List<string> { "bob" };
+                prompt_value = null;
+                bool errored = false;
+                string errorMessage = string.Empty;
+                console.Setup(c => c.ReadLine()).Returns(""); //Enter pressed
+                try
+                {
+                    prompt();
+                }
+                catch (Exception ex)
+                {
+                    errored = true;
+                    errorMessage = ex.Message;
+                }
+
+                errored.ShouldBeTrue();
+                errorMessage.ShouldContain("Value for prompt cannot be null.");
+                console.Verify(c => c.ReadLine(), Times.Never);
+            }
+
+            [Fact]
+            public void should_error_when_the_choicelist_contains_empty_values()
+            {
+                choices = new List<string> { "bob", "" };
+                bool errored = false;
+                string errorMessage = string.Empty;
+                console.Setup(c => c.ReadLine()).Returns(""); //Enter pressed
+                try
+                {
+                    prompt();
+                }
+                catch (Exception ex)
+                {
+                    errored = true;
+                    errorMessage = ex.Message;
+                }
+
+                errored.ShouldBeTrue();
+                errorMessage.ShouldContain("Some choices are empty.");
+                console.Verify(c => c.ReadLine(), Times.Never);
+            }
+
+            [Fact]
+            public void should_error_when_the_choicelist_has_multiple_items_with_same_first_letter()
+            {
+                choices = new List<string> {"sally", "suzy"};
+                bool errored = false;
+                string errorMessage = string.Empty;
+                console.Setup(c => c.ReadLine()).Returns(""); //Enter pressed
+                try
+                {
+                    prompt();
+                }
+                catch (Exception ex)
+                {
+                    errored = true;
+                    errorMessage = ex.Message;
+                }
+
+                errored.ShouldBeTrue();
+                errorMessage.ShouldContain("Multiple choices have the same first letter.");
+                console.Verify(c => c.ReadLine(), Times.Never);
+            }
+        }
+
+        public class when_prompting_short_with_interactivePrompt : InteractivePromptSpecsBase
+        {
+            private Func<string> prompt;
+
+            public override void Because()
+            {
+                prompt = () => InteractivePrompt.prompt_for_confirmation_short(prompt_value, choices);
+            }
+
+            public override void AfterObservations()
+            {
+                base.AfterObservations();
+                should_have_called_Console_ReadLine();
+            }
+
+            [Fact]
+            public void should_error_when_no_answer_given()
+            {
+                bool errored = false;
+
+                console.Setup(c => c.ReadLine()).Returns(""); //Enter pressed
+                try
+                {
+                    prompt();
+                }
+                catch (Exception)
+                {
+                    errored = true;
+                }
+                errored.ShouldBeTrue();
+                console.Verify(c => c.ReadLine(), Times.AtLeast(8));
+            }
+
+            [Fact]
+            public void should_return_yes_when_yes_is_given()
+            {
+                console.Setup(c => c.ReadLine()).Returns("yes");
+                var result = prompt();
+                result.ShouldEqual("yes");
+            }
+
+            [Fact]
+            public void should_return_yes_when_y_is_given()
+            {
+                console.Setup(c => c.ReadLine()).Returns("y");
+                var result = prompt();
+                result.ShouldEqual("yes");
+            }
+
+            [Fact]
+            public void should_return_no_choice_when_no_is_given()
+            {
+                console.Setup(c => c.ReadLine()).Returns("no");
+                var result = prompt();
+                result.ShouldEqual("no");
+            }
+
+            [Fact]
+            public void should_return_no_choice_when_n_is_given()
+            {
+                console.Setup(c => c.ReadLine()).Returns("n");
+                var result = prompt();
+                result.ShouldEqual("no");
+            }
+
+            [Fact]
+            public void should_error_when_any_choice_not_available_is_given()
+            {
+                bool errored = false;
+
+                console.Setup(c => c.ReadLine()).Returns("yup"); //Enter pressed
+                try
+                {
+                    prompt();
+                }
+                catch (Exception)
+                {
+                    errored = true;
+                }
+                errored.ShouldBeTrue();
+                console.Verify(c => c.ReadLine(), Times.AtLeast(8));
+            }
+        }
     }
 }

--- a/src/chocolatey/infrastructure.app/runners/GenericRunner.cs
+++ b/src/chocolatey/infrastructure.app/runners/GenericRunner.cs
@@ -183,13 +183,13 @@ Chocolatey is not an official build (bypassed with --allow-unofficial).
 
             if (shouldWarn)
             {
-                var selection = InteractivePrompt.prompt_for_confirmation(@"
+                var selection = InteractivePrompt.prompt_for_confirmation_short(@"
  You may experience errors - many functions/packages
  require admin rights. Only advanced users should run choco w/out an
  elevated shell. When you open the command shell, you should ensure 
  that you do so with ""Run as Administrator"" selected.
 
- Do you want to continue?", new[] { "yes", "no" }, defaultChoice: null, requireAnswer: true);
+ Do you want to continue?", new[] { "yes", "no" });
 
                 if (selection.is_equal_to("no"))
                 {

--- a/src/chocolatey/infrastructure.app/services/AutomaticUninstallerService.cs
+++ b/src/chocolatey/infrastructure.app/services/AutomaticUninstallerService.cs
@@ -142,7 +142,7 @@ namespace chocolatey.infrastructure.app.services
                     var skipUninstaller = true;
                     if (config.PromptForConfirmation)
                     {
-                        var selection = InteractivePrompt.prompt_for_confirmation("Uninstall may not be silent (could not detect). Proceed?", new[] {"yes", "no"}, defaultChoice: null, requireAnswer: true);
+                        var selection = InteractivePrompt.prompt_for_confirmation_short("Uninstall may not be silent (could not detect). Proceed?", new[] {"yes", "no"});
                         if (selection.is_equal_to("yes")) skipUninstaller = false;
                     }
 

--- a/src/chocolatey/infrastructure.app/services/ChocolateyPackageService.cs
+++ b/src/chocolatey/infrastructure.app/services/ChocolateyPackageService.cs
@@ -832,7 +832,7 @@ ATTENTION: You must take manual action to remove {1} from
             var rollback = true;
             if (config.PromptForConfirmation)
             {
-                var selection = InteractivePrompt.prompt_for_confirmation(" Unsuccessful operation for {0}.{1}  Do you want to rollback to previous version (package files only)?".format_with(packageResult.Name, Environment.NewLine), new[] { "yes", "no" }, defaultChoice: null, requireAnswer: true);
+                var selection = InteractivePrompt.prompt_for_confirmation_short(" Unsuccessful operation for {0}.{1}  Do you want to rollback to previous version (package files only)?".format_with(packageResult.Name, Environment.NewLine), new[] { "yes", "no" });
                 if (selection.is_equal_to("no")) rollback = false;
             }
 

--- a/src/chocolatey/infrastructure.app/services/PowershellService.cs
+++ b/src/chocolatey/infrastructure.app/services/PowershellService.cs
@@ -234,15 +234,16 @@ namespace chocolatey.infrastructure.app.services
                     this.Log().Info(ChocolateyLoggers.Important, () => @"Note: To confirm automatically next time, use '-y' or consider setting 
  'allowGlobalConfirmation'. Run 'choco feature -h' for more details.");
                     
-                    var selection = InteractivePrompt.prompt_for_confirmation(@"Do you want to run the script?", new[] {"yes", "no", "print"}, defaultChoice: null, requireAnswer: true);
+                    var selection = InteractivePrompt.prompt_for_confirmation_short(@"Do you want to run the script?", new[] {"yes", "no", "print"});
 
                     if (selection.is_equal_to("print"))
                     {
                         this.Log().Info(ChocolateyLoggers.Important, "------ BEGIN SCRIPT ------");
                         this.Log().Info(() => "{0}{1}{0}".format_with(Environment.NewLine, chocoPowerShellScriptContents.escape_curly_braces()));
                         this.Log().Info(ChocolateyLoggers.Important, "------- END SCRIPT -------");
-                        selection = InteractivePrompt.prompt_for_confirmation(@"Do you want to run this script?", new[] { "yes", "no" }, defaultChoice: null, requireAnswer: true);
+                        selection = InteractivePrompt.prompt_for_confirmation_short(@"Do you want to run this script?", new[] { "yes", "no" });
                     }
+
 
                     if (selection.is_equal_to("yes")) shouldRun = true;
                     if (selection.is_equal_to("no"))

--- a/src/chocolatey/infrastructure/commandline/InteractivePrompt.cs
+++ b/src/chocolatey/infrastructure/commandline/InteractivePrompt.cs
@@ -39,6 +39,48 @@ namespace chocolatey.infrastructure.commandline
             get { return _console.Value; }
         }
 
+        public static string prompt_for_confirmation_short(string prompt, IEnumerable<string> choices, int repeat = 10)
+        {
+            if (repeat < 0) throw new ApplicationException("Too many bad attempts. Stopping before application crash.");
+            Ensure.that(() => prompt).is_not_null();
+            Ensure.that(() => choices).is_not_null();
+            Ensure
+                .that(() => choices)
+                .meets(
+                    c => c.Any(),
+                    (name, value) => { throw new ApplicationException("No choices passed in. Please ensure you pass choices."); });
+            Ensure
+                .that(() => choices)
+                .meets(
+                    c => !c.Any(String.IsNullOrWhiteSpace),
+                    (name, value) => { throw new ApplicationException("Some choices are empty. Please ensure you provide no empty choices."); });
+            Ensure
+                .that(() => choices)
+                .meets(
+                    c => c.Select(entry => entry.FirstOrDefault()).Distinct().Count() == c.Count(),
+                    (name, value) => { throw new ApplicationException("Multiple choices have the same first letter. Please ensure you pass choices with different first letters."); });
+
+            var promptWithChoices = "{0} ({1}): ".format_with(prompt, String.Join("/", choices));
+            
+            Console.Write(promptWithChoices);
+            var selection = Console.ReadLine();
+
+            "chocolatey".Log().Info(ChocolateyLoggers.LogFileOnly, "{0}{1}".format_with(promptWithChoices, selection));
+
+            // check to see if value was passed
+            foreach (var choice in choices)
+            {
+                if (choice.is_equal_to(selection) || choice.Substring(0, 1).is_equal_to(selection))
+                {
+                    selection = choice;
+                    return selection;
+                }
+            }
+
+            "chocolatey".Log().Error(ChocolateyLoggers.Important, "Your choice of '{0}' is not a valid selection.".format_with(selection));
+            return prompt_for_confirmation_short(prompt, choices, repeat - 1);
+        }
+
         public static string prompt_for_confirmation(string prompt, IEnumerable<string> choices, string defaultChoice, bool requireAnswer, int repeat = 10)
         {
             if (repeat < 0) throw new ApplicationException("Too many bad attempts. Stopping before application crash.");
@@ -69,6 +111,7 @@ namespace chocolatey.infrastructure.commandline
                 counter++;
             }
 
+            Console.Write("> ");
             var selection = Console.ReadLine();
 
             if (string.IsNullOrWhiteSpace(selection) && defaultChoice != null)

--- a/src/chocolatey/infrastructure/logging/ChocolateyLoggers.cs
+++ b/src/chocolatey/infrastructure/logging/ChocolateyLoggers.cs
@@ -20,5 +20,7 @@ namespace chocolatey.infrastructure.logging
         Normal,
         Verbose,
         Important,
+        // Used to output prompt results in log file, but not in the console
+        LogFileOnly,
     }
 }

--- a/src/chocolatey/infrastructure/logging/log4net.config.xml
+++ b/src/chocolatey/infrastructure/logging/log4net.config.xml
@@ -122,6 +122,10 @@
     <appender-ref ref="VerboseLoggingColoredConsoleAppender" />
   </logger>
 
+  <logger name="LogFileOnly">
+    <level value="INFO" />
+  </logger>
+  
   <logger name="chocolatey">
     <level value="DEBUG"/>
     <appender-ref ref="NormalLoggingColoredConsoleAppender" />


### PR DESCRIPTION
Solves #181 `When prompting for a user yes/no answer, use a short [y/n] representation`.

The output looks like this:

```
prompt-string (yes/no): y
```

I had to do a "hack", where I use the Console directly to output the prompt, and then use a LogFileOnly logger to write the prompt and the answer in the log file. I don't think it's that bad, since InteractivePrompt already depended on an IConsole.ReadLine implementation, so I did the same for IConsole.Write.

Note that it will conflict with #185 (PR #199), so once one of them is merged, I can take care of rebasing the other.