### PR TITLE
Update UnInstall-ChocolateyZipPackage.ps1

### DIFF
--- a/src/chocolatey.resources/helpers/functions/UnInstall-ChocolateyZipPackage.ps1
+++ b/src/chocolatey.resources/helpers/functions/UnInstall-ChocolateyZipPackage.ps1
@@ -50,7 +50,7 @@ param(
     $zipContentFile
     $zipContents=get-content $zipContentFile
     foreach ($fileInZip in $zipContents) {
-      remove-item "$fileInZip" -ErrorAction SilentlyContinue
+      remove-item -Path "$fileInZip" -ErrorAction SilentlyContinue -Recurse -Force
     }
   }
 }


### PR DESCRIPTION
Updating removal of items for Chocolatey ZIP packages. In this case, we want the specify to remove-item that it's a path we're removing. Right now, when a directory specification is contained in the .zip.txt file, the remove-item call hangs the uninstallation procedure.