### PR TITLE
(maint) Fix boolean typo in powershell installer.

### DIFF
--- a/src/chocolatey.resources/helpers/chocolateyInstaller.psm1
+++ b/src/chocolatey.resources/helpers/chocolateyInstaller.psm1
@@ -21,10 +21,10 @@ if ($env:ChocolateyEnvironmentVerbose -eq 'true') { $VerbosePreference = "Contin
 
 $installArguments = $env:chocolateyInstallArguments
 
-$overrideArgs = false
+$overrideArgs = $false
 if ($env:chocolateyInstallOverride -eq 'true') { $overrideArgs = true }
 
-$forceX86 = false
+$forceX86 = $false
 if ($env:chocolateyForceX86 -eq 'true') { $forceX86 = true }
 
 $packageParameters = $env:chocolateyPackageParameters


### PR DESCRIPTION
This fixes the error "the term false is not recognized".

Supersedes #213