### PR TITLE
(GH-247) Add scriptcs install provider support

### DIFF
--- a/src/chocolatey/chocolatey.csproj
+++ b/src/chocolatey/chocolatey.csproj
@@ -101,6 +101,7 @@
     <Compile Include="infrastructure.app\runners\GenericRunner.cs" />
     <Compile Include="infrastructure.app\services\AutomaticUninstallerService.cs" />
     <Compile Include="infrastructure.app\services\ChocolateyConfigSettingsService.cs" />
+    <Compile Include="infrastructure.app\services\ScriptCsService.cs" />
     <Compile Include="infrastructure\adapters\CustomString.cs" />
     <Compile Include="infrastructure.app\services\IChocolateyConfigSettingsService.cs" />
     <Compile Include="infrastructure.app\configuration\ConfigFileApiKeySetting.cs" />
@@ -132,7 +133,7 @@
     <Compile Include="infrastructure.app\services\IChocolateyPackageInformationService.cs" />
     <Compile Include="infrastructure.app\services\IChocolateyPackageService.cs" />
     <Compile Include="infrastructure.app\services\INugetService.cs" />
-    <Compile Include="infrastructure.app\services\IPowershellService.cs" />
+    <Compile Include="infrastructure.app\services\IInstallProviderService.cs" />
     <Compile Include="infrastructure.app\services\IRegistryService.cs" />
     <Compile Include="infrastructure.app\services\IShimGenerationService.cs" />
     <Compile Include="infrastructure.app\services\IAutomaticUninstallerService.cs" />

--- a/src/chocolatey/infrastructure.app/registration/ContainerBinding.cs
+++ b/src/chocolatey/infrastructure.app/registration/ContainerBinding.cs
@@ -49,7 +49,18 @@ namespace chocolatey.infrastructure.app.registration
             //nuget
             container.Register<ILogger, ChocolateyNugetLogger>(Lifestyle.Singleton);
             container.Register<INugetService, NugetService>(Lifestyle.Singleton);
-            container.Register<IPowershellService, PowershellService>(Lifestyle.Singleton);
+            container.Register<IEnumerable<IInstallProviderService>>(() =>
+            {
+                var list = new List<IInstallProviderService>
+                        {
+                            new PowershellService(container.GetInstance<IFileSystem>()),
+                            new ScriptCsService(container.GetInstance<IFileSystem>())
+                        };
+                return list.AsReadOnly();
+            }, Lifestyle.Singleton);
+            container.Register<IInstallProviderService, PowershellService>(Lifestyle.Singleton);
+
+            //container.Register<IScriptCsService, ScriptCsService>(Lifestyle.Singleton);
             container.Register<IChocolateyPackageInformationService, ChocolateyPackageInformationService>(Lifestyle.Singleton);
             container.Register<IShimGenerationService, ShimGenerationService>(Lifestyle.Singleton);
             container.Register<IRegistryService, RegistryService>(Lifestyle.Singleton);

--- a/src/chocolatey/infrastructure.app/services/IInstallProviderService.cs
+++ b/src/chocolatey/infrastructure.app/services/IInstallProviderService.cs
@@ -18,7 +18,7 @@ namespace chocolatey.infrastructure.app.services
     using configuration;
     using results;
 
-    public interface IPowershellService
+    public interface IInstallProviderService
     {
         /// <summary>
         ///   Noops the specified package install.
@@ -47,5 +47,7 @@ namespace chocolatey.infrastructure.app.services
         /// <param name="packageResult">The package result.</param>
         /// <returns>true if the chocolateyUninstall.ps1 was found, even if it has failures</returns>
         bool uninstall(ChocolateyConfiguration configuration, PackageResult packageResult);
+
+        bool can_be_used(ChocolateyConfiguration configuration);
     }
 }


### PR DESCRIPTION
This adds support for running install scripts with scriptcs in addition
to powershell. This is the first provider to add this support.

This closes #247