### PR TITLE
(GH-252) PATH exceeding 2048 breaks choco. Use %systemroot% in place of %windir%.

### DIFF
--- a/src/chocolatey/infrastructure/commands/PowershellExecutor.cs
+++ b/src/chocolatey/infrastructure/commands/PowershellExecutor.cs
@@ -29,6 +29,8 @@ namespace chocolatey.infrastructure.commands
             {
                 Environment.ExpandEnvironmentVariables("%windir%\\SysNative\\WindowsPowerShell\\v1.0\\powershell.exe"),
                 Environment.ExpandEnvironmentVariables("%windir%\\System32\\WindowsPowerShell\\v1.0\\powershell.exe"),
+                Environment.ExpandEnvironmentVariables("%systemroot%\\SysNative\\WindowsPowerShell\\v1.0\\powershell.exe"),
+                Environment.ExpandEnvironmentVariables("%systemroot%\\System32\\WindowsPowerShell\\v1.0\\powershell.exe"),
                 "powershell.exe"
             };
 


### PR DESCRIPTION
Issue: https://github.com/chocolatey/choco/issues/252
%windir% is broken when %path% exceeds 2048 chars, but %systemroot% continues to work.

I found this issue due to cygwin rewriting my PATH to larger than 2048 I believe...
when I echo %windir%, it just prints %windir%.
when I echo %systemroot%, it prints C:\Windows.

I found this from the superuser ticket.
http://superuser.com/questions/719459/strange-path-issue-in-windows-7-goes-null-after-being-set
http://allgeekallthetime.blogspot.com/2012/01/path-over-2048-chars-kills-windir.html

The user experiences something like this:
XXX not upgraded. An error occurred during installation: Unable to find suitable location for PowerShell. Searched the following locations: '%windir%\SysNative\WindowsPowerShell\v1.0\powershell.exe; %windir%\System32\WindowsPowerShell\v1.0\powershell.exe; powershell.exe'                                                         

Which is a little confusing, because running powershell.exe works fine.  I leave it to the merger to decide if %systemroot% should replace the %windir%, the fix supplied simply adds %systemroot% in addition to %windir%...this works fine too.

Thanks for choco.
--dave