### PR TITLE
(GH-274) Allow unattended installs as non-admin user

### DIFF
--- a/nuget/chocolatey/tools/chocolateysetup.psm1
+++ b/nuget/chocolatey/tools/chocolateysetup.psm1
@@ -4,7 +4,7 @@ $sysDrive = $env:SystemDrive
 $tempDir = $env:TEMP
 $defaultChocolateyPathOld = "$sysDrive\Chocolatey"
 #$ErrorActionPreference = 'Stop'
-$debugMode = $false
+$debugModeParams = ""
 
 function Initialize-Chocolatey {
 <#
@@ -34,17 +34,13 @@ param(
   Write-Debug "Initialize-Chocolatey"
 
   if ($env:ChocolateyEnvironmentDebug -eq 'true') {
-    $debugMode = $true
+    $debugModeParams = "dv"
   }
 
   Install-DotNet4IfMissing
 
   $chocoNew = Join-Path $thisScriptFolder 'chocolateyInstall\choco.exe'
-  if ($debugMode) {
-    & $chocoNew unpackself -fdvy
-  } else {
-    & $chocoNew unpackself -fy
-  }
+  & $chocoNew unpackself -fy$debugModeParams
 
   $installModule = Join-Path $thisScriptFolder 'chocolateyInstall\helpers\chocolateyInstaller.psm1'
   Import-Module $installModule -Force
@@ -313,11 +309,7 @@ param(
   $chocoExeDest = Join-Path $chocolateyPath 'choco.exe'
   Copy-Item $chocoExe $chocoExeDest -force
 
-  if ($debugMode) {
-    & $chocoExeDest unpackself -fdvy
-  } else {
-    & $chocoExeDest unpackself -fy
-  }
+  & $chocoExeDest unpackself -fy$debugModeParams
 }
 
 function Ensure-ChocolateyLibFiles {

--- a/nuget/chocolatey/tools/chocolateysetup.psm1
+++ b/nuget/chocolatey/tools/chocolateysetup.psm1
@@ -41,9 +41,9 @@ param(
 
   $chocoNew = Join-Path $thisScriptFolder 'chocolateyInstall\choco.exe'
   if ($debugMode) {
-    & $chocoNew unpackself -fdv
+    & $chocoNew unpackself -fdvy
   } else {
-    & $chocoNew unpackself -f
+    & $chocoNew unpackself -fy
   }
 
   $installModule = Join-Path $thisScriptFolder 'chocolateyInstall\helpers\chocolateyInstaller.psm1'
@@ -314,9 +314,9 @@ param(
   Copy-Item $chocoExe $chocoExeDest -force
 
   if ($debugMode) {
-    & $chocoExeDest unpackself -fdv
+    & $chocoExeDest unpackself -fdvy
   } else {
-    & $chocoExeDest unpackself -f
+    & $chocoExeDest unpackself -fy
   }
 }
 


### PR DESCRIPTION
Previously, if a non-admin user attempted to install chocolatey,
a message indicating that non-admin installs were for advanced
users only would appear and block the installation.

This runs contrary to chocolatey policy, so just pass -y during
the unpackself command. The installation should never block.

This closes #274 