### PR TITLE
Support for custom headers downloading files

### DIFF
--- a/src/chocolatey.resources/helpers/functions/Get-ChocolateyWebFile.ps1
+++ b/src/chocolatey.resources/helpers/functions/Get-ChocolateyWebFile.ps1
@@ -46,6 +46,24 @@ OPTIONAL (Right now) - 'md5' or 'sha1' - defaults to 'md5'
 .PARAMETER ChecksumType64
 OPTIONAL (Right now) - 'md5' or 'sha1' - defaults to ChecksumType
 
+.PARAMETER options
+OPTIONAL - Specify custom headers
+
+Example:
+-------- 
+	$options = 
+	@{
+		Headers = @{
+			Accept = 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8'; 
+			'Accept-Charset' = 'ISO-8859-1,utf-8;q=0.7,*;q=0.3';
+			'Accept-Language' = 'en-GB,en-US;q=0.8,en;q=0.6';
+			Cookie = 'products.download.email=ewilde@gmail.com';
+			Referer = 'http://submain.com/download/ghostdoc/';
+		}
+	}
+	
+	Get-ChocolateyWebFile 'ghostdoc' 'http://submain.com/download/GhostDoc_v4.0.zip' -options $options
+
 .EXAMPLE
 Get-ChocolateyWebFile '__NAME__' 'C:\somepath\somename.exe' 'URL' '64BIT_URL_DELETE_IF_NO_64BIT'
 
@@ -64,7 +82,8 @@ param(
   [string] $checksum = '',
   [string] $checksumType = '',
   [string] $checksum64 = '',
-  [string] $checksumType64 = $checksumType
+  [string] $checksumType64 = $checksumType,
+  [hashtable] $options = @{Headers=@{}}
 )
   Write-Debug "Running 'Get-ChocolateyWebFile' for $packageName with url:`'$url`', fileFullPath:`'$fileFullPath`', url64bit:`'$url64bit`', checksum: `'$checksum`', checksumType: `'$checksumType`', checksum64: `'$checksum64`', checksumType64: `'$checksumType64`'";
 
@@ -138,7 +157,7 @@ param(
     if ($needsDownload) {
       Write-Host "Downloading $packageName $bitPackage bit
   from `'$url`'"
-      Get-WebFile $url $fileFullPath
+      Get-WebFile $url $fileFullPath -options $options
     }
   } elseif ($url.StartsWith('ftp')) {
     Write-Host "Ftp-ing $packageName

--- a/src/chocolatey.resources/helpers/functions/Get-WebFile.ps1
+++ b/src/chocolatey.resources/helpers/functions/Get-WebFile.ps1
@@ -20,7 +20,8 @@ param(
   $fileName = $null,
   $userAgent = 'chocolatey command line',
   [switch]$Passthru,
-  [switch]$quiet
+  [switch]$quiet,
+  [hashtable] $options = @{Headers=@{}}
 )
   Write-Debug "Running 'Get-WebFile' for $fileName with url:`'$url`', userAgent: `'$userAgent`' ";
   #if ($url -eq '' return)
@@ -61,6 +62,21 @@ param(
   if ($userAgent -ne $null) {
     Write-Debug "Setting the UserAgent to `'$userAgent`'"
     $req.UserAgent = $userAgent
+  }
+
+  if ($options.Headers.Count -gt 0) {
+    Write-Debug "Setting custom headers"
+    foreach ($item in $options.Headers.GetEnumerator()) {
+      $uri = (new-object system.uri $url)
+      Write-Debug($item.Key + ':' + $item.Value)
+      switch ($item.Key) {
+        'Accept' {$req.Accept = $item.Value}
+        'Cookie' {$req.CookieContainer.SetCookies($uri, $item.Value)}
+        'Referer' {$req.Referer = $item.Value}
+        'User-Agent' {$req.UserAgent = $item.Value}
+        Default {$req.Headers.Add($item.Key, $item.Value)}
+      }
+    }
   }
 
   $res = $req.GetResponse();

--- a/src/chocolatey.resources/helpers/functions/Install-ChocolateyPackage.ps1
+++ b/src/chocolatey.resources/helpers/functions/Install-ChocolateyPackage.ps1
@@ -53,6 +53,23 @@ OPTIONAL (Right now) - 'md5' or 'sha1' - defaults to 'md5'
 .PARAMETER ChecksumType64
 OPTIONAL (Right now) - 'md5' or 'sha1' - defaults to ChecksumType
 
+.PARAMETER options
+OPTIONAL - Specify custom headers
+
+Example:
+-------- 
+  $options =
+  @{
+    Headers = @{
+      Accept = 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8';
+      'Accept-Charset' = 'ISO-8859-1,utf-8;q=0.7,*;q=0.3';
+      'Accept-Language' = 'en-GB,en-US;q=0.8,en;q=0.6';
+      Cookie = 'products.download.email=ewilde@gmail.com';
+      Referer = 'http://submain.com/download/ghostdoc/';
+    }
+  }
+
+  Get-ChocolateyWebFile 'ghostdoc' 'http://submain.com/download/GhostDoc_v4.0.zip' -options $options
 
 .EXAMPLE
 Install-ChocolateyPackage '__NAME__' 'EXE_OR_MSI' 'SILENT_ARGS' 'URL' '64BIT_URL_DELETE_IF_NO_64BIT'
@@ -78,7 +95,8 @@ param(
   [string] $checksum = '',
   [string] $checksumType = '',
   [string] $checksum64 = '',
-  [string] $checksumType64 = ''
+  [string] $checksumType64 = '',
+  [hashtable] $options = @{Headers=@{}}
 )
 
   Write-Debug "Running 'Install-ChocolateyPackage' for $packageName with url:`'$url`', args: `'$silentArgs`', fileType: `'$fileType`', url64bit: `'$url64bit`', checksum: `'$checksum`', checksumType: `'$checksumType`', checksum64: `'$checksum64`', checksumType64: `'$checksumType64`', validExitCodes: `'$validExitCodes`' ";
@@ -89,6 +107,6 @@ param(
   if (![System.IO.Directory]::Exists($tempDir)) { [System.IO.Directory]::CreateDirectory($tempDir) | Out-Null }
   $file = Join-Path $tempDir "$($packageName)Install.$fileType"
 
-  Get-ChocolateyWebFile $packageName $file $url $url64bit -checksum $checksum -checksumType $checksumType -checksum64 $checksum64 -checksumType64 $checksumType64
+  Get-ChocolateyWebFile $packageName $file $url $url64bit -checksum $checksum -checksumType $checksumType -checksum64 $checksum64 -checksumType64 $checksumType64 -options $options
   Install-ChocolateyInstallPackage $packageName $fileType $silentArgs $file -validExitCodes $validExitCodes
 }

--- a/src/chocolatey.resources/helpers/functions/Install-ChocolateyZipPackage.ps1
+++ b/src/chocolatey.resources/helpers/functions/Install-ChocolateyZipPackage.ps1
@@ -45,6 +45,24 @@ OPTIONAL (Right now) - 'md5' or 'sha1' - defaults to 'md5'
 .PARAMETER ChecksumType64
 OPTIONAL (Right now) - 'md5' or 'sha1' - defaults to ChecksumType
 
+.PARAMETER options
+OPTIONAL - Specify custom headers
+
+Example:
+-------- 
+  $options =
+  @{
+    Headers = @{
+      Accept = 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8';
+      'Accept-Charset' = 'ISO-8859-1,utf-8;q=0.7,*;q=0.3';
+      'Accept-Language' = 'en-GB,en-US;q=0.8,en;q=0.6';
+      Cookie = 'products.download.email=ewilde@gmail.com';
+      Referer = 'http://submain.com/download/ghostdoc/';
+    }
+  }
+
+  Get-ChocolateyWebFile 'ghostdoc' 'http://submain.com/download/GhostDoc_v4.0.zip' -options $options
+
 .EXAMPLE
 Install-ChocolateyZipPackage '__NAME__' 'URL' "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
 
@@ -68,7 +86,8 @@ param(
   [string] $checksum = '',
   [string] $checksumType = '',
   [string] $checksum64 = '',
-  [string] $checksumType64 = ''
+  [string] $checksumType64 = '',
+  [hashtable] $options = @{Headers=@{}}
 )
   Write-Debug "Running 'Install-ChocolateyZipPackage' for $packageName with url:`'$url`', unzipLocation: `'$unzipLocation`', url64bit: `'$url64bit`', specificFolder: `'$specificFolder`', checksum: `'$checksum`', checksumType: `'$checksumType`', checksum64: `'$checksum64`', checksumType64: `'$checksumType64`' ";
 
@@ -79,6 +98,6 @@ param(
   if (![System.IO.Directory]::Exists($tempDir)) {[System.IO.Directory]::CreateDirectory($tempDir) | Out-Null}
   $file = Join-Path $tempDir "$($packageName)Install.$fileType"
   
-  Get-ChocolateyWebFile $packageName $file $url $url64bit -checkSum $checkSum -checksumType $checksumType -checkSum64 $checkSum64 -checksumType64 $checksumType64
+  Get-ChocolateyWebFile $packageName $file $url $url64bit -checkSum $checkSum -checksumType $checksumType -checkSum64 $checkSum64 -checksumType64 $checksumType64 -options $options
   Get-ChocolateyUnzip "$file" $unzipLocation $specificFolder $packageName
 }


### PR DESCRIPTION
Resubmitting pull request from: https://github.com/chocolatey/chocolatey/pull/171
Implements issue: #246

Some web sites require specific headers to allow you to download the
setup program/zip

functions:
Get-WebFile.ps1
Get-ChocolateyWebFile.ps1
Install-ChocolateyPackage.ps1
Install-ChocolateyZipPackage.ps1

now support an options hashtable which allows use to specify individual
headers.

The options hash table structure allows for future settings to be flowed through the application without updating multiple method signatures.

The structure at the moment is:
<pre> 
$options = @ {
   Headers = @{
      Header1 = 'somevalue'; Header2 = 'somevalue'
 }
}
</pre>
In the future you could use the options to pass down cookies by domain for example
<pre> 
$options = @ {
   Headers = @{
      Header1 = 'somevalue'; Header2 = 'somevalue'
   };
   Cookies = @{
      'http://domain.com' = 'value1';
      'http://secure.domain.com = 'value2';
   }   
}

</pre> 