### PR TITLE
(GH-293) choco upgrade all -except="package1,package2"

### DIFF
--- a/src/chocolatey/infrastructure.app/commands/ChocolateyUpgradeCommand.cs
+++ b/src/chocolatey/infrastructure.app/commands/ChocolateyUpgradeCommand.cs
@@ -94,6 +94,9 @@ namespace chocolatey.infrastructure.app.commands
                       {
                         if (option != null) configuration.Features.CheckSumFiles = false;
                       })
+                 .Add("except=",
+                     "Except - a comma-separated list of package names that should not be upgraded when upgrading 'all'. Defaults to empty.",
+                     option => configuration.UpgradeCommand.PackageNamesToSkip = option.remove_surrounding_quotes())
                 ;
         }
 
@@ -137,6 +140,8 @@ NOTE: `all` is a special package keyword that will allow you to upgrade
     choco upgrade nodejs.install --version 0.10.35
     choco upgrade git -s ""https://somewhere/out/there""
     choco upgrade git -s ""https://somewhere/protected"" -u user -p pass
+    choco upgrade all
+    choco upgrade all --except=""skype,conemu""
 ");
 
             "chocolatey".Log().Info(ChocolateyLoggers.Important, "Options and Switches");

--- a/src/chocolatey/infrastructure.app/configuration/ChocolateyConfiguration.cs
+++ b/src/chocolatey/infrastructure.app/configuration/ChocolateyConfiguration.cs
@@ -363,6 +363,7 @@ NOTE: Hiding sensitive configuration data! Please double and triple
         public bool FailOnUnfound { get; set; }
         public bool FailOnNotInstalled { get; set; }
         public bool NotifyOnlyAvailableUpgrades { get; set; }
+        public string PackageNamesToSkip { get; set; }
     }
 
     [Serializable]

--- a/src/chocolatey/infrastructure.app/services/NugetService.cs
+++ b/src/chocolatey/infrastructure.app/services/NugetService.cs
@@ -1154,13 +1154,45 @@ spam/junk folder.");
                 var quiet = config.QuietOutput;
                 config.QuietOutput = true;
 
-                config.PackageNames = list_run(config).Select(p => p.Name).@join(ApplicationParameters.PackageNamesSeparator);
+                var packagesToUpdate = list_run(config).Select(p => p.Name).ToList();
+
+                if (!String.IsNullOrWhiteSpace(config.UpgradeCommand.PackageNamesToSkip))
+                {
+                    var packagesToSkip = config.UpgradeCommand.PackageNamesToSkip
+                        .Split(',')
+                        .Where(x => !String.IsNullOrWhiteSpace(x))
+                        .Select(x => x.trim_safe())
+                        .ToList();
+
+                    var unknownPackagesToSkip = packagesToSkip
+                        .Where(x => !packagesToUpdate.Contains(x, StringComparer.OrdinalIgnoreCase))
+                        .ToList();
+
+                    if (unknownPackagesToSkip.Any())
+                    {
+                        this.Log().Warn(() => "Some packages specified in the 'except' list were not found in the local packages: '{0}'".format_with(String.Join(",", unknownPackagesToSkip)));
+
+                        packagesToSkip = packagesToSkip
+                            .Where(x => !unknownPackagesToSkip.Contains(x))
+                            .ToList();
+                    }
+
+                    if (packagesToSkip.Any())
+                    {
+                        packagesToUpdate = packagesToUpdate
+                            .Where(x => !packagesToSkip.Contains(x, StringComparer.OrdinalIgnoreCase))
+                            .ToList();
+
+                        this.Log().Info("These packages will not be upgraded because they were specified in the 'except' list: {0}".format_with(String.Join(",", packagesToSkip)));
+                    }
+                }
 
                 config.QuietOutput = quiet;
                 config.Input = input;
                 config.Noop = noop;
                 config.Prerelease = pre;
                 config.Sources = sources;
+                config.PackageNames = packagesToUpdate.@join(ApplicationParameters.PackageNamesSeparator);
 
                 if (customAction != null) customAction.Invoke();
             }


### PR DESCRIPTION
This pull request implements #293 by providing a list of packages to ignore.

* It will print `These packages will not be upgraded because they were specified in '-except': package1` when specifying packages to skip
* If some packages specified in `-except` do not exist in the installed list of packages, it will display a warning: `Some packages specified in '-except' were not found in the local packages: 'package1'`
* If the `-except` argument is not provided, there is no difference
* There was no tests for `choco upgrade all` that I could find, so I added a very basic one, based on the fact that upgrades are already tested in `UpgradeScenarios`
* I would have preferred `-skip` but it seems `-s*` will be catched by `-source`, so I stucked with `-except`

Hopefully, all will be good with that pull request :)

Fixes #293.