### PR TITLE
(GH-353) Externalize Nuget IPackage interfaces.

### DIFF
--- a/.build.custom/ilmerge.internalize.ignore.txt
+++ b/.build.custom/ilmerge.internalize.ignore.txt
@@ -1,2 +1,3 @@
 chocolatey.*
 NuGet.Manifest
+NuGet.IPackage


### PR DESCRIPTION
Update ILMerge's interlize ignore document to externalize the
NuGet.IPackage interfaces. This allows for library use of NuGet package
information.