### PR TITLE
Fix Travis-CI builds by specifying mono version. Fails NUnit tests.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: csharp
+mono:
+  - 3.12.0
 install:
   - sudo apt-get install mono-devel mono-gmcs
   - nuget restore src/chocolatey.sln


### PR DESCRIPTION
Related Travis Doc [here](http://docs.travis-ci.com/user/languages/csharp/#Choosing-Mono-version-to-test-against)

I chose 3.12.0 which actually gets the latest in the 3.12.X line, as
mentioned in [Travis-CI Issue #4130](https://github.com/travis-ci/travis-ci/issues/4130)

Travis Builds still fail, that that is a code problem, not an infrastructure one. ;)