### PR TITLE
GH-303 Install-ChocolateyPath Expands Variables in PATH, Overwriting

### DIFF
--- a/src/chocolatey.resources/helpers/functions/Get-EnvironmentVariable.ps1
+++ b/src/chocolatey.resources/helpers/functions/Get-EnvironmentVariable.ps1
@@ -12,8 +12,24 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-function Get-EnvironmentVariable([string] $Name, [System.EnvironmentVariableTarget] $Scope) {
-    [Environment]::GetEnvironmentVariable($Name, $Scope)
+function Get-EnvironmentVariable([string] $Name, [System.EnvironmentVariableTarget] $Scope, [bool] $PreserveVariables = $False) {
+    if ($pathType -eq [System.EnvironmentVariableTarget]::Machine) {
+        $reg = [Microsoft.Win32.Registry]::Machine.OpenSubKey("Environment", $true)
+    } else {
+        $reg = [Microsoft.Win32.Registry]::CurrentUser.OpenSubKey("Environment", $true)
+    }
+
+    if ($PreserveVariables -eq $True) {
+        $option = [Microsoft.Win32.RegistryValueOptions]::DoNotExpandEnvironmentNames
+    } else {
+        $option = [Microsoft.Win32.RegistryValueOptions]::None
+    }
+
+    $value = $reg.GetValue('Path', $null, $option)
+
+    $reg.Close()
+
+    return $value
 }
 
 # Some enhancements to think about here.

--- a/src/chocolatey.resources/helpers/functions/Install-ChocolateyPath.ps1
+++ b/src/chocolatey.resources/helpers/functions/Install-ChocolateyPath.ps1
@@ -26,7 +26,7 @@ param(
   if (!$envPath.ToLower().Contains($pathToInstall.ToLower()))
   {
     Write-Host "PATH environment variable does not have $pathToInstall in it. Adding..."
-    $actualPath = Get-EnvironmentVariable -Name 'Path' -Scope $pathType
+    $actualPath = Get-EnvironmentVariable -Name 'Path' -Scope $pathType -PreserveVariables $True
 
     $statementTerminator = ";"
     #does the path end in ';'?


### PR DESCRIPTION
Preexisting Variables

When adding a new element to PATH, Install-ChocolateyPath reads PATH
(wh ich contains expanded variables), appends the new element, and then
writes the value back to PATH. This results in PATH having its
variables overwritten with its values. Instead of reading $env:PATH to
find the current path, read it from the registry, which will retain the
PATH's original variables.