### PR TITLE
(GH-390) Fix log4net dependency version in nuspec

### DIFF
--- a/nuget/chocolatey.lib/chocolatey.lib.nuspec
+++ b/nuget/chocolatey.lib/chocolatey.lib.nuspec
@@ -22,7 +22,7 @@ This is the core package which allows Chocolatey to be embedded in your applicat
     <tags>apt-get yum machine repository chocolatey</tags>
     <iconUrl>https://github.com/chocolatey/chocolatey/raw/master/docs/logo/chocolateyicon.gif</iconUrl>
     <dependencies>
-      <dependency id="log4net" version="[1.2.10]" />
+      <dependency id="log4net" version="[2.0.3]" />
     </dependencies>
   </metadata>
 </package>


### PR DESCRIPTION
This corrects the version of log4net declared in the chocolatey.lib
nuspec. changing it to 2.0.3 which maps to assembly version 1.2.13.

Closes #390