### PR TITLE
(GH-392) pass 4.0 reference assemblies to ilmerge

### DIFF
--- a/.build.custom/ilmerge.replace.build
+++ b/.build.custom/ilmerge.replace.build
@@ -25,8 +25,8 @@
   <property name="file.merge.name" value="__REPLACE__" overwrite="false" />
   <!-- exe winexe dll -->
   <property name="merge.target.type" value="__REPLACE__" overwrite="false" />
-  <property name="args.ilmerge" value="/internalize /targetplatform:v4 /target:${merge.target.type} /out:${dirs.merge.to}${path.separator}${file.merge.name} /keyfile:${path.key.name.private} /log:${dirs.merge.log}${path.separator}${log.merge} /xmldocs /ndebug /allowDup ${file.merge.name} " />
-  <property name="args.ilmerge" value="/internalize:${path.file.internalize.ignore} /targetplatform:v4 /target:${merge.target.type} /out:${dirs.merge.to}${path.separator}${file.merge.name} /keyfile:${path.key.name.private} /log:${dirs.merge.log}${path.separator}${log.merge} /xmldocs /ndebug /allowDup ${file.merge.name} " if="${file::exists(path.file.internalize.ignore)}"/>
+  <property name="args.ilmerge" value="/internalize /targetplatform:v4,&quot;${environment::get-variable('ProgramFiles(x86)')}\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.0&quot; /target:${merge.target.type} /out:${dirs.merge.to}${path.separator}${file.merge.name} /keyfile:${path.key.name.private} /log:${dirs.merge.log}${path.separator}${log.merge} /xmldocs /ndebug /allowDup ${file.merge.name} " />
+  <property name="args.ilmerge" value="/internalize:${path.file.internalize.ignore} /targetplatform:v4,&quot;${environment::get-variable('ProgramFiles(x86)')}\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.0&quot; /target:${merge.target.type} /out:${dirs.merge.to}${path.separator}${file.merge.name} /keyfile:${path.key.name.private} /log:${dirs.merge.log}${path.separator}${log.merge} /xmldocs /ndebug /allowDup ${file.merge.name} " if="${file::exists(path.file.internalize.ignore)}"/>
 
   <target name="go" depends="run_normal_tasks" />
 
@@ -39,8 +39,8 @@
     <property name="dirs.merge.to" value="${environment::get-variable('uc.dirs.merge.to')}" if="${environment::variable-exists('uc.dirs.merge.to')}" />
     <property name="file.merge.name" value="${environment::get-variable('uc.file.merge.name')}" if="${environment::variable-exists('uc.file.merge.name')}" />
     <property name="merge.target.type" value="${environment::get-variable('uc.merge.target.type')}" if="${environment::variable-exists('uc.merge.target.type')}" />
-    <property name="args.ilmerge" value="/internalize /targetplatform:v4 /target:${merge.target.type} /out:${dirs.merge.to}${path.separator}${file.merge.name} /keyfile:${path.key.name.private} /log:${dirs.merge.log}${path.separator}${log.merge} /ndebug /allowDup ${file.merge.name} " />
-    <property name="args.ilmerge" value="/internalize:${path.file.internalize.ignore} /targetplatform:v4 /target:${merge.target.type} /out:${dirs.merge.to}${path.separator}${file.merge.name} /keyfile:${path.key.name.private} /log:${dirs.merge.log}${path.separator}${log.merge} /ndebug /allowDup ${file.merge.name} " if="${file::exists(path.file.internalize.ignore)}"/>
+    <property name="args.ilmerge" value="/internalize /targetplatform:v4,&quot;${environment::get-variable('ProgramFiles(x86)')}\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.0&quot; /target:${merge.target.type} /out:${dirs.merge.to}${path.separator}${file.merge.name} /keyfile:${path.key.name.private} /log:${dirs.merge.log}${path.separator}${log.merge} /ndebug /allowDup ${file.merge.name} " />
+    <property name="args.ilmerge" value="/internalize:${path.file.internalize.ignore} /targetplatform:v4,&quot;${environment::get-variable('ProgramFiles(x86)')}\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.0&quot; /target:${merge.target.type} /out:${dirs.merge.to}${path.separator}${file.merge.name} /keyfile:${path.key.name.private} /log:${dirs.merge.log}${path.separator}${log.merge} /ndebug /allowDup ${file.merge.name} " if="${file::exists(path.file.internalize.ignore)}"/>
   </target>
 
   <target name="error_check">

--- a/.build.custom/ilmergeDLL.build
+++ b/.build.custom/ilmergeDLL.build
@@ -26,8 +26,8 @@
   <!-- exe winexe dll -->
   <!-- overwrite this property -->
   <property name="merge.target.type" value="dll" />
-  <property name="args.ilmerge" value="/internalize /targetplatform:v4 /target:${merge.target.type} /out:${dirs.merge.to}${path.separator}${file.merge.name} /keyfile:${path.key.name.private} /log:${dirs.merge.log}${path.separator}${log.merge} /xmldocs /ndebug /allowDup ${file.merge.name} " />
-  <property name="args.ilmerge" value="/internalize:${path.file.internalize.ignore} /targetplatform:v4 /target:${merge.target.type} /out:${dirs.merge.to}${path.separator}${file.merge.name} /keyfile:${path.key.name.private} /log:${dirs.merge.log}${path.separator}${log.merge} /xmldocs /ndebug /allowDup ${file.merge.name} " if="${file::exists(path.file.internalize.ignore)}"/>
+  <property name="args.ilmerge" value="/internalize /targetplatform:v4,&quot;${environment::get-variable('ProgramFiles(x86)')}\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.0&quot; /target:${merge.target.type} /out:${dirs.merge.to}${path.separator}${file.merge.name} /keyfile:${path.key.name.private} /log:${dirs.merge.log}${path.separator}${log.merge} /xmldocs /ndebug /allowDup ${file.merge.name} " />
+  <property name="args.ilmerge" value="/internalize:${path.file.internalize.ignore} /targetplatform:v4,&quot;${environment::get-variable('ProgramFiles(x86)')}\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.0&quot; /target:${merge.target.type} /out:${dirs.merge.to}${path.separator}${file.merge.name} /keyfile:${path.key.name.private} /log:${dirs.merge.log}${path.separator}${log.merge} /xmldocs /ndebug /allowDup ${file.merge.name} " if="${file::exists(path.file.internalize.ignore)}"/>
 
   <target name="go"
           depends="prepare, get_regular_dlls, run_ilmerge, copy_configs, remove_unneeded_assemblies, copy_from_merge, delete_merge_folder"

--- a/.build/ilmerge.build
+++ b/.build/ilmerge.build
@@ -23,8 +23,8 @@
   <property name="file.merge.name" value="__REPLACE__" overwrite="false" />
   <!-- exe winexe dll -->
   <property name="merge.target.type" value="__REPLACE__" overwrite="false" />
-  <property name="args.ilmerge" value="/internalize /targetplatform:v4 /target:${merge.target.type} /out:${dirs.merge.to}${path.separator}${file.merge.name} /log:${dirs.merge.log}${path.separator}${log.merge} /xmldocs /ndebug /allowDup ${file.merge.name} " />
-  <property name="args.ilmerge" value="/internalize:${path.file.internalize.ignore} /targetplatform:v4 /target:${merge.target.type} /out:${dirs.merge.to}${path.separator}${file.merge.name} /log:${dirs.merge.log}${path.separator}${log.merge} /xmldocs /ndebug /allowDup ${file.merge.name} " if="${file::exists(path.file.internalize.ignore)}"/>
+  <property name="args.ilmerge" value="/internalize /targetplatform:v4,&quot;${environment::get-variable('ProgramFiles(x86)')}\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.0&quot; /target:${merge.target.type} /out:${dirs.merge.to}${path.separator}${file.merge.name} /log:${dirs.merge.log}${path.separator}${log.merge} /xmldocs /ndebug /allowDup ${file.merge.name} " />
+  <property name="args.ilmerge" value="/internalize:${path.file.internalize.ignore} /targetplatform:v4,&quot;${environment::get-variable('ProgramFiles(x86)')}\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.0&quot; /target:${merge.target.type} /out:${dirs.merge.to}${path.separator}${file.merge.name} /log:${dirs.merge.log}${path.separator}${log.merge} /xmldocs /ndebug /allowDup ${file.merge.name} " if="${file::exists(path.file.internalize.ignore)}"/>
 
   <target name="go" depends="load_uppercut_assemblies, run_tasks" if="${run.ilmerge}" />
 
@@ -38,8 +38,8 @@
     <property name="dirs.merge.to" value="${environment::get-variable('uc.dirs.merge.to')}" if="${environment::variable-exists('uc.dirs.merge.to')}" />
     <property name="file.merge.name" value="${environment::get-variable('uc.file.merge.name')}" if="${environment::variable-exists('uc.file.merge.name')}" />
     <property name="merge.target.type" value="${environment::get-variable('uc.merge.target.type')}" if="${environment::variable-exists('uc.merge.target.type')}" />
-    <property name="args.ilmerge" value="/internalize /targetplatform:v4 /target:${merge.target.type} /out:${dirs.merge.to}${path.separator}${file.merge.name} /log:${dirs.merge.log}${path.separator}${log.merge} /ndebug /allowDup ${file.merge.name} " />
-    <property name="args.ilmerge" value="/internalize:${path.file.internalize.ignore} /targetplatform:v4 /target:${merge.target.type} /out:${dirs.merge.to}${path.separator}${file.merge.name} /log:${dirs.merge.log}${path.separator}${log.merge} /ndebug /allowDup ${file.merge.name} " if="${file::exists(path.file.internalize.ignore)}"/>
+    <property name="args.ilmerge" value="/internalize /targetplatform:v4,&quot;${environment::get-variable('ProgramFiles(x86)')}\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.0&quot; /target:${merge.target.type} /out:${dirs.merge.to}${path.separator}${file.merge.name} /log:${dirs.merge.log}${path.separator}${log.merge} /ndebug /allowDup ${file.merge.name} " />
+    <property name="args.ilmerge" value="/internalize:${path.file.internalize.ignore} /targetplatform:v4,&quot;${environment::get-variable('ProgramFiles(x86)')}\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.0&quot; /target:${merge.target.type} /out:${dirs.merge.to}${path.separator}${file.merge.name} /log:${dirs.merge.log}${path.separator}${log.merge} /ndebug /allowDup ${file.merge.name} " if="${file::exists(path.file.internalize.ignore)}"/>
   </target>
 
   <target name="error_check">

--- a/lib/NuGet-Chocolatey/strongname.cmd
+++ b/lib/NuGet-Chocolatey/strongname.cmd
@@ -7,4 +7,4 @@ SET DIR=%~d0%~p0%
 echo Make sure you have webtransform here for the merge. Continue?
 pause
 
-%DIR%..\ILMerge\ILMerge.exe NuGet.Core.dll /keyfile:%DIR%..\..\chocolatey.snk /out:%DIR%NuGet.Core.dll /targetplatform:v4 /log:%DIR%ILMerge.DELETE.log /ndebug /allowDup
+%DIR%..\ILMerge\ILMerge.exe NuGet.Core.dll /keyfile:%DIR%..\..\chocolatey.snk /out:%DIR%NuGet.Core.dll /targetplatform:v4,"%ProgramFiles(x86)%\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.0" /log:%DIR%ILMerge.DELETE.log /ndebug /allowDup


### PR DESCRIPTION
Makes chocolatey builds more portable and allows it to be built on .net
4.5+ machines while maintaining compatibility with .net 4.0 clients.

Closes #392