### PR TITLE
[DO NOT MERGE](maint) Do not assume $env:TEMP is set in powershell helper functions

### DIFF
--- a/src/chocolatey.resources/helpers/functions/Install-ChocolateyPackage.ps1
+++ b/src/chocolatey.resources/helpers/functions/Install-ChocolateyPackage.ps1
@@ -101,6 +101,9 @@ param(
 
   Write-Debug "Running 'Install-ChocolateyPackage' for $packageName with url:`'$url`', args: `'$silentArgs`', fileType: `'$fileType`', url64bit: `'$url64bit`', checksum: `'$checksum`', checksumType: `'$checksumType`', checksum64: `'$checksum64`', checksumType64: `'$checksumType64`', validExitCodes: `'$validExitCodes`' ";
 
+  if ($env:TEMP -eq $null) {
+    $env:TEMP = Join-Path $env:SystemDrive 'temp'
+  }
   $chocTempDir = Join-Path $env:TEMP "chocolatey"
   $tempDir = Join-Path $chocTempDir "$packageName"
   if ($env:packageVersion -ne $null) {$tempDir = Join-Path $tempDir "$env:packageVersion"; }

--- a/src/chocolatey.resources/helpers/functions/Install-ChocolateyVsixPackage.ps1
+++ b/src/chocolatey.resources/helpers/functions/Install-ChocolateyVsixPackage.ps1
@@ -102,6 +102,9 @@ param(
         $installer = Join-Path $dir "VsixInstaller.exe"
     }
     if($installer) {
+        if ($env:TEMP -eq $null) {
+          $env:TEMP = Join-Path $env:SystemDrive 'temp'
+        }
         $download="$env:TEMP\$($packageName.Replace(' ','')).vsix"
         try{
             Get-ChocolateyWebFile $packageName $download $vsixUrl -checksum $checksum -checksumType $checksumType

--- a/src/chocolatey.resources/helpers/functions/Install-ChocolateyZipPackage.ps1
+++ b/src/chocolatey.resources/helpers/functions/Install-ChocolateyZipPackage.ps1
@@ -93,6 +93,9 @@ param(
 
   $fileType = 'zip'
 
+  if ($env:TEMP -eq $null) {
+    $env:TEMP = Join-Path $env:SystemDrive 'temp'
+  }
   $chocTempDir = Join-Path $env:TEMP "chocolatey"
   $tempDir = Join-Path $chocTempDir "$packageName"
   if ($env:packageVersion -ne $null) {$tempDir = Join-Path $tempDir "$env:packageVersion"; }

--- a/src/chocolatey.resources/helpers/functions/Start-ChocolateyProcessAsAdmin.ps1
+++ b/src/chocolatey.resources/helpers/functions/Start-ChocolateyProcessAsAdmin.ps1
@@ -75,6 +75,9 @@ Elevating Permissions and running $exeToRun $wrappedStatements. This may take a 
 
   $s = [System.Diagnostics.Process]::Start($psi)
 
+  if ($env:TEMP -eq $null) {
+    $env:TEMP = Join-Path $env:SystemDrive 'temp'
+  }
   $chocTempDir = Join-Path $env:TEMP "chocolatey"
   if (![System.IO.Directory]::Exists($chocTempDir)) { [System.IO.Directory]::CreateDirectory($chocTempDir) | Out-Null }
   $errorFile = Join-Path $chocTempDir "$($s.Id)-error.stream"


### PR DESCRIPTION
This is an identical fix to a missing TEMP environment variable in chocolatey/chocolatey.org#139