### PR TITLE
(GH-427) Add paging to ListCommand

### DIFF
--- a/src/chocolatey/infrastructure.app/commands/ChocolateyListCommand.cs
+++ b/src/chocolatey/infrastructure.app/commands/ChocolateyListCommand.cs
@@ -15,6 +15,7 @@
 
 namespace chocolatey.infrastructure.app.commands
 {
+    using System;
     using System.Collections.Generic;
     using System.Linq;
     using attributes;
@@ -61,6 +62,22 @@ namespace chocolatey.infrastructure.app.commands
                 .Add("p=|password=",
                      "Password - the user's password to the source. Defaults to empty.",
                      option => configuration.SourceCommand.Password = option.remove_surrounding_quotes())
+                .Add("page=",
+                     "Page - the 'page' of results to return. Defaults to return all results.", option =>
+                         {
+                             int page;
+                             if (int.TryParse(option, out page))
+                             {
+                                 configuration.ListCommand.Page = page;
+                             }
+                             else
+                             {
+                                 configuration.ListCommand.Page = null;
+                             }
+                         })
+                .Add("page-size=",
+                     "Page Size - the amount of package results to return per page. Defaults to 25.",
+                     option => configuration.ListCommand.PageSize = int.Parse(option))
                 ;
             //todo exact name
         }
@@ -94,6 +111,7 @@ Chocolatey will perform a search for a package local or remote. Some
     choco list --local-only
     choco list -li
     choco list -lai
+    choco list --page=0 --page-size=25
     choco search git
     choco search git -s ""https://somewhere/out/there""
     choco search bob -s ""https://somewhere/protected"" -u user -p pass

--- a/src/chocolatey/infrastructure.app/configuration/ChocolateyConfiguration.cs
+++ b/src/chocolatey/infrastructure.app/configuration/ChocolateyConfiguration.cs
@@ -342,9 +342,16 @@ NOTE: Hiding sensitive configuration data! Please double and triple
     [Serializable]
     public sealed class ListCommandConfiguration
     {
+        public ListCommandConfiguration()
+        {
+            PageSize = 25;
+        }
+
         // list
         public bool LocalOnly { get; set; }
         public bool IncludeRegistryPrograms { get; set; }
+        public int? Page { get; set; }
+        public int PageSize { get; set; }
     }
 
     [Serializable]

--- a/src/chocolatey/infrastructure.app/nuget/NugetList.cs
+++ b/src/chocolatey/infrastructure.app/nuget/NugetList.cs
@@ -43,6 +43,11 @@ namespace chocolatey.infrastructure.app.nuget
                 results = results.Where(p => p.IsLatestVersion);
             }
 
+            if (configuration.ListCommand.Page.HasValue)
+            {
+                results = results.Skip(configuration.ListCommand.PageSize * configuration.ListCommand.Page.Value).Take(configuration.ListCommand.PageSize);
+            }
+
             return results.OrderBy(p => p.Id)
                         .AsEnumerable()
                         .Where(PackageExtensions.IsListed)


### PR DESCRIPTION
See #427.

Adds `--page=#` and `--page-size=#` to `ListCommand`. Page size defaults to 25.