### PR TITLE
(GH-433) Externalize more Package Information

### DIFF
--- a/.build.custom/ilmerge.internalize.ignore.txt
+++ b/.build.custom/ilmerge.internalize.ignore.txt
@@ -1,3 +1,6 @@
 chocolatey.*
 NuGet.Manifest
 NuGet.IPackage
+NuGet.PackageDependency
+NuGet.IServerPackageMetadata
+NuGet.SemanticVersion


### PR DESCRIPTION
Externalizes more package information necessary to process package data returned from Chocolatey's PackageResult list.

Closes #433