### PR TITLE
(GH-431) Add Count to List Command API

### DIFF
--- a/src/chocolatey/GetChocolatey.cs
+++ b/src/chocolatey/GetChocolatey.cs
@@ -222,6 +222,15 @@ namespace chocolatey
             var runner = new GenericRunner();
             return runner.list<T>(configuration, _container, isConsole: false, parseArgs: null);
         }
+
+        public int Count()
+        {
+            extract_resources();
+            var configuration = create_configuration(new List<string>());
+            configuration.RegularOutput = true;
+            var runner = new GenericRunner();
+            return runner.count(configuration, _container, isConsole: false, parseArgs: null);
+        }
     }
 
     // ReSharper restore InconsistentNaming

--- a/src/chocolatey/GetChocolatey.cs
+++ b/src/chocolatey/GetChocolatey.cs
@@ -185,6 +185,36 @@ namespace chocolatey
             runner.run(args, configuration, _container);
         }
 
+        /// <summary>
+        ///    Run chocolatey after setting the options, and list the results.
+        /// </summary>
+        /// <typeparam name="T">The typer of results you're expecting back.</typeparam>
+        public IEnumerable<T> List<T>()
+        {
+            extract_resources();
+            var configuration = create_configuration(new List<string>());
+            configuration.RegularOutput = true;
+            var runner = new GenericRunner();
+            return runner.list<T>(configuration, _container, isConsole: false, parseArgs: null);
+        }
+
+        /// <summary>
+        ///    Run chocolatey after setting the options,
+        ///    and get the count of items that would be returned if you listed the results.
+        /// </summary>
+        /// <remarks>
+        ///    Is intended to be more efficient then simply calling <see cref="List{T}">List</see> and then Count() on the returned list.
+        ///    It also returns the full count as is ignores paging.
+        /// </remarks>
+        public int ListCount()
+        {
+            extract_resources();
+            var configuration = create_configuration(new List<string>());
+            configuration.RegularOutput = true;
+            var runner = new GenericRunner();
+            return runner.count(configuration, _container, isConsole: false, parseArgs: null);
+        }
+
         private ChocolateyConfiguration create_configuration(IList<string> args)
         {
             var configuration = new ChocolateyConfiguration();
@@ -212,24 +242,6 @@ namespace chocolatey
             };
 
             AssemblyFileExtractor.extract_all_resources_to_relative_directory(_container.GetInstance<IFileSystem>(), Assembly.GetAssembly(typeof(ChocolateyResourcesAssembly)), ApplicationParameters.InstallLocation, folders, ApplicationParameters.ChocolateyFileResources);
-        }
-
-        public IEnumerable<T> List<T>()
-        {
-            extract_resources();
-            var configuration = create_configuration(new List<string>());
-            configuration.RegularOutput = true;
-            var runner = new GenericRunner();
-            return runner.list<T>(configuration, _container, isConsole: false, parseArgs: null);
-        }
-
-        public int Count()
-        {
-            extract_resources();
-            var configuration = create_configuration(new List<string>());
-            configuration.RegularOutput = true;
-            var runner = new GenericRunner();
-            return runner.count(configuration, _container, isConsole: false, parseArgs: null);
         }
     }
 

--- a/src/chocolatey/infrastructure.app/commands/ChocolateyListCommand.cs
+++ b/src/chocolatey/infrastructure.app/commands/ChocolateyListCommand.cs
@@ -140,6 +140,12 @@ Chocolatey will perform a search for a package local or remote. Some
             return _packageService.list_run(configuration);
         }
 
+        public int count(ChocolateyConfiguration config)
+        {
+            config.QuietOutput = true;
+            return _packageService.count_run(config);
+        }
+
         public bool may_require_admin_access()
         {
             return false;

--- a/src/chocolatey/infrastructure.app/commands/ChocolateySourceCommand.cs
+++ b/src/chocolatey/infrastructure.app/commands/ChocolateySourceCommand.cs
@@ -148,6 +148,11 @@ Chocolatey will allow you to interact with sources.
             return _configSettingsService.source_list(configuration);
         }
 
+        public int count(ChocolateyConfiguration config)
+        {
+            return list(config).Count();
+        }
+
         public bool may_require_admin_access()
         {
             return true;

--- a/src/chocolatey/infrastructure.app/nuget/NugetList.cs
+++ b/src/chocolatey/infrastructure.app/nuget/NugetList.cs
@@ -30,6 +30,11 @@ namespace chocolatey.infrastructure.app.nuget
             return execute_package_search(configuration, nugetLogger);
         }
 
+        public static int GetCount(ChocolateyConfiguration configuration, ILogger nugetLogger)
+        {
+            return execute_package_search(configuration, nugetLogger).Count();
+        }
+
         private static IQueryable<IPackage> execute_package_search(ChocolateyConfiguration configuration, ILogger nugetLogger)
         {
             var packageRepository = NugetCommon.GetRemoteRepository(configuration, nugetLogger);

--- a/src/chocolatey/infrastructure.app/runners/GenericRunner.cs
+++ b/src/chocolatey/infrastructure.app/runners/GenericRunner.cs
@@ -150,6 +150,24 @@ Chocolatey is not an official build (bypassed with --allow-unofficial).
             }
         }
 
+        public int count(ChocolateyConfiguration config, Container container, bool isConsole, Action<ICommand> parseArgs)
+        {
+            var command = find_command(config, container, isConsole, parseArgs) as IListCommand;
+            if (command == null)
+            {
+                if (!string.IsNullOrWhiteSpace(config.CommandName))
+                {
+                    throw new Exception("The implementation of '{0}' does not support listing.".format_with(config.CommandName));
+                }
+                return 0;
+            }
+            else
+            {
+                this.Log().Debug("_ {0}:{1} - Normal Count Mode _".format_with(ApplicationParameters.Name, command.GetType().Name));
+                return command.count(config);
+            }
+        }
+
         public void warn_when_admin_needs_elevation(ChocolateyConfiguration config)
         {
             var shouldWarn = (!config.Information.IsProcessElevated && config.Information.IsUserAdministrator);

--- a/src/chocolatey/infrastructure.app/services/ChocolateyPackageService.cs
+++ b/src/chocolatey/infrastructure.app/services/ChocolateyPackageService.cs
@@ -70,6 +70,11 @@ namespace chocolatey.infrastructure.app.services
             perform_source_runner_action(config, r => r.ensure_source_app_installed(config, (packageResult) => handle_package_result(packageResult, config, CommandNameType.install)));
         }
 
+        public int count_run(ChocolateyConfiguration config)
+        {
+            return perform_source_runner_function(config, r => r.count_run(config));
+        }
+
         private void perform_source_runner_action(ChocolateyConfiguration config, Action<ISourceRunner> action)
         {
             var runner = _sourceRunners.FirstOrDefault(r => r.SourceType == config.SourceType);

--- a/src/chocolatey/infrastructure.app/services/CygwinService.cs
+++ b/src/chocolatey/infrastructure.app/services/CygwinService.cs
@@ -156,6 +156,11 @@ namespace chocolatey.infrastructure.app.services
             set_root_dir_if_not_set();
         }
 
+        public int count_run(ChocolateyConfiguration config)
+        {
+            throw new NotImplementedException("Count is not supported for this source runner.");
+        }
+
         public void set_root_dir_if_not_set()
         {
             if (!string.IsNullOrWhiteSpace(_rootDirectory)) return;

--- a/src/chocolatey/infrastructure.app/services/IChocolateyPackageService.cs
+++ b/src/chocolatey/infrastructure.app/services/IChocolateyPackageService.cs
@@ -33,6 +33,13 @@ namespace chocolatey.infrastructure.app.services
         void ensure_source_app_installed(ChocolateyConfiguration config);
 
         /// <summary>
+        ///   Retrieves the count of items that meet the search criteria.
+        /// </summary>
+        /// <param name="config"></param>
+        /// <returns></returns>
+        int count_run(ChocolateyConfiguration config);
+
+        /// <summary>
         ///   Run list in noop mode
         /// </summary>
         /// <param name="config">The configuration.</param>

--- a/src/chocolatey/infrastructure.app/services/ISourceRunner.cs
+++ b/src/chocolatey/infrastructure.app/services/ISourceRunner.cs
@@ -40,6 +40,13 @@ namespace chocolatey.infrastructure.app.services
         void ensure_source_app_installed(ChocolateyConfiguration config, Action<PackageResult> ensureAction);
 
         /// <summary>
+        ///     Retrieve the listed packages from the source feed cout
+        /// </summary>
+        /// <param name="config">The configuration.</param>
+        /// <returns>Packages count</returns>
+        int count_run(ChocolateyConfiguration config);
+
+        /// <summary>
         ///   Run list in noop mode
         /// </summary>
         /// <param name="config">The configuration.</param>

--- a/src/chocolatey/infrastructure.app/services/NugetService.cs
+++ b/src/chocolatey/infrastructure.app/services/NugetService.cs
@@ -75,6 +75,27 @@ namespace chocolatey.infrastructure.app.services
             // nothing to do. Nuget.Core is already part of Chocolatey
         }
 
+        public int count_run(ChocolateyConfiguration config)
+        {
+            int count = 0;
+
+            if (config.ListCommand.LocalOnly)
+            {
+                config.Sources = ApplicationParameters.PackagesLocation;
+                config.Prerelease = true;
+            }
+
+            int? pageValue = config.ListCommand.Page;
+            try
+            {
+                return NugetList.GetCount(config, _nugetLogger);
+            }
+            finally
+            {
+                config.ListCommand.Page = pageValue;
+            }
+        }
+
         public void list_noop(ChocolateyConfiguration config)
         {
             this.Log().Info("{0} would have searched for '{1}' against the following source(s) :\"{2}\"".format_with(

--- a/src/chocolatey/infrastructure.app/services/PythonService.cs
+++ b/src/chocolatey/infrastructure.app/services/PythonService.cs
@@ -193,6 +193,11 @@
             }
         }
 
+        public int count_run(ChocolateyConfiguration config)
+        {
+            throw new NotImplementedException("Count is not supported for this source runner.");
+        }
+
         public void set_executable_path_if_not_set()
         {
             if (!string.IsNullOrWhiteSpace(_exePath)) return;

--- a/src/chocolatey/infrastructure.app/services/RubyGemsService.cs
+++ b/src/chocolatey/infrastructure.app/services/RubyGemsService.cs
@@ -126,6 +126,11 @@
             }
         }
 
+        public int count_run(ChocolateyConfiguration config)
+        {
+            throw new NotImplementedException("Count is not supported for this source runner.");
+        }
+
         public void list_noop(ChocolateyConfiguration config)
         {
             var args = ExternalCommandArgsBuilder.build_arguments(config, _listArguments);

--- a/src/chocolatey/infrastructure.app/services/WebPiService.cs
+++ b/src/chocolatey/infrastructure.app/services/WebPiService.cs
@@ -122,6 +122,11 @@ namespace chocolatey.infrastructure.app.services
             }
         }
 
+        public int count_run(ChocolateyConfiguration config)
+        {
+            throw new NotImplementedException("Count is not supported for this source runner.");
+        }
+
         public void list_noop(ChocolateyConfiguration config)
         {
             var args = ExternalCommandArgsBuilder.build_arguments(config, _listArguments);

--- a/src/chocolatey/infrastructure.app/services/WindowsFeatureService.cs
+++ b/src/chocolatey/infrastructure.app/services/WindowsFeatureService.cs
@@ -157,6 +157,11 @@ namespace chocolatey.infrastructure.app.services
             set_executable_path_if_not_set();
         }
 
+        public int count_run(ChocolateyConfiguration config)
+        {
+            throw new NotImplementedException("Count is not supported for this source runner.");
+        }
+
         public void set_executable_path_if_not_set()
         {
             if (!string.IsNullOrWhiteSpace(_exePath)) return;

--- a/src/chocolatey/infrastructure/commands/IListCommand.cs
+++ b/src/chocolatey/infrastructure/commands/IListCommand.cs
@@ -18,7 +18,12 @@ namespace chocolatey.infrastructure.commands
     using System.Collections.Generic;
     using app.configuration;
 
-    public interface IListCommand<out T> : ICommand
+    public interface IListCommand : ICommand
+    {
+        int count(ChocolateyConfiguration config);
+    }
+
+    public interface IListCommand<out T> : IListCommand
     {
         IEnumerable<T> list(ChocolateyConfiguration config);
     }


### PR DESCRIPTION
Adds the ability to efficiently retrieve a "count" for a given list command. Usefully for when you want to total number of given packages for a command that meets certain search criteria, but you're also using paging and need a reliable "total". Mostly only relevant to NuGet at this point.

Closes #431