### PR TITLE
(GH-460) (maint) Amended Template

### DIFF
--- a/src/chocolatey/infrastructure.app/templates/ChocolateyUninstallTemplate.cs
+++ b/src/chocolatey/infrastructure.app/templates/ChocolateyUninstallTemplate.cs
@@ -58,7 +58,7 @@ $local_key     = 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Uninstall\*'
 $machine_key   = 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\*'
 $machine_key6432 = 'HKLM:\SOFTWARE\Wow6432Node\Microsoft\Windows\CurrentVersion\Uninstall\*'
 
-$key = Get-ItemProperty -Path @($machine_key6432,$machine_key, $local_key) `
+[array]$key = Get-ItemProperty -Path @($machine_key6432,$machine_key, $local_key) `
                         -ErrorAction SilentlyContinue `
          | ? { $_.DisplayName -like ""$softwareName"" }
 


### PR DESCRIPTION
Using 'choco new' to produce ChocolateyUninstall.ps1 for your package would result in the uninstall code never being executed as the $key variable type was wrong. Updated the script template to force the $key variable to always be an array and therefore have a Count method that can be evaluated.

Closes #460