### PR TITLE
(GH-460) Fix Uninstall Template $key array

### DIFF
--- a/.uppercut
+++ b/.uppercut
@@ -19,7 +19,7 @@
   <property name="version.minor" value="9" overwrite="false" />
   <property name="version.patch" value="10" overwrite="false" />
   <property name="version.fix" value="0" overwrite="false" />
-  <property name="version.nuget.prerelease" value="alpha" overwrite="false" />
+  <property name="version.nuget.prerelease" value="beta" overwrite="false" />
   <property name="version.use.build_date" value="true" overwrite="false" />
   <property name="assembly.description" value="${project.name} is a product of ${company.name} - All Rights Reserved." overwrite="false" />
   <property name="assembly.copyright" value="Copyright © 2011 - Present, ${company.name} - All Rights Reserved." overwrite="false" />

--- a/src/chocolatey/infrastructure.app/templates/ChocolateyUninstallTemplate.cs
+++ b/src/chocolatey/infrastructure.app/templates/ChocolateyUninstallTemplate.cs
@@ -58,7 +58,7 @@ $local_key     = 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Uninstall\*'
 $machine_key   = 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\*'
 $machine_key6432 = 'HKLM:\SOFTWARE\Wow6432Node\Microsoft\Windows\CurrentVersion\Uninstall\*'
 
-$key = Get-ItemProperty -Path @($machine_key6432,$machine_key, $local_key) `
+[array]$key = Get-ItemProperty -Path @($machine_key6432,$machine_key, $local_key) `
                         -ErrorAction SilentlyContinue `
          | ? { $_.DisplayName -like ""$softwareName"" }
 


### PR DESCRIPTION
Using 'choco new' to produce ChocolateyUninstall.ps1 for your package would result in the uninstall block never being executed as the $key variable type was wrong. Updated the script template to force the $key variable to always be an array and therefore have a Count method that can be evaluated and the uninstall block executed.

Closes #460
Supersedes #461 