### PR TITLE
Removing unused variable.

### DIFF
--- a/src/chocolatey/infrastructure.app/services/NugetService.cs
+++ b/src/chocolatey/infrastructure.app/services/NugetService.cs
@@ -77,8 +77,6 @@ namespace chocolatey.infrastructure.app.services
 
         public int count_run(ChocolateyConfiguration config)
         {
-            int count = 0;
-
             if (config.ListCommand.LocalOnly)
             {
                 config.Sources = ApplicationParameters.PackagesLocation;


### PR DESCRIPTION
Removing unused local variable "count" in NugetService.cs