### PR TITLE
(GH-534) packagename needed for zip uninstalls

### DIFF
--- a/src/chocolatey/infrastructure.app/templates/ChocolateyUninstallTemplate.cs
+++ b/src/chocolatey/infrastructure.app/templates/ChocolateyUninstallTemplate.cs
@@ -96,7 +96,7 @@ if ($key.Count -eq 1) {
 
 ## OTHER HELPERS
 ## https://github.com/chocolatey/choco/wiki/HelpersReference
-#Uninstall-ChocolateyZipPackage
+#Uninstall-ChocolateyZipPackage $packageName
 #Uninstall-BinFile # Only needed if you added one in the installer script, choco will remove the ones it added automatically.
 #remove any shortcuts you added
 


### PR DESCRIPTION
resubmitting to `stable` instead of `master`

Supersedes #536 
Closes #534