### PR TITLE
(GH-551) adding unset to config commands

### DIFF
--- a/src/chocolatey.tests/infrastructure.app/commands/ChocolateyConfigCommandSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/commands/ChocolateyConfigCommandSpecs.cs
@@ -131,6 +131,14 @@ namespace chocolatey.tests.infrastructure.app.commands
                 because();
                 configSettingsService.Verify(c => c.config_set(configuration), Times.Once);
             }
+
+            [Fact]
+            public void should_call_service_source_unset_when_command_is_unset()
+            {
+                configuration.ConfigCommand.Command = ConfigCommandType.unset;
+                because();
+                configSettingsService.Verify(c => c.config_unset(configuration), Times.Once);
+            }
         }
     }
 }

--- a/src/chocolatey/infrastructure.app/commands/ChocolateyConfigCommand.cs
+++ b/src/chocolatey/infrastructure.app/commands/ChocolateyConfigCommand.cs
@@ -96,7 +96,7 @@ Chocolatey will allow you to interact with the configuration file settings.
 
             "chocolatey".Log().Info(ChocolateyLoggers.Important, "Usage");
             "chocolatey".Log().Info(@"
-    choco config [list]|get|set [<options/switches>]
+    choco config [list]|get|set|unset [<options/switches>]
 ");
 
             "chocolatey".Log().Info(ChocolateyLoggers.Important, "Examples");
@@ -107,6 +107,8 @@ Chocolatey will allow you to interact with the configuration file settings.
     choco config get --name cacheLocation
     choco config set cacheLocation c:\temp\choco
     choco config set --name cacheLocation --value c:\temp\choco
+    choco config unset proxy
+    choco config unset --name proxy
 ");
 
             "chocolatey".Log().Info(ChocolateyLoggers.Important, "Options and Switches");
@@ -129,6 +131,9 @@ Chocolatey will allow you to interact with the configuration file settings.
                     break;
                 case ConfigCommandType.set:
                     _configSettingsService.config_set(configuration);
+                    break;
+                case ConfigCommandType.unset:
+                    _configSettingsService.config_unset(configuration);
                     break;
             }
         }

--- a/src/chocolatey/infrastructure.app/domain/ConfigCommandType.cs
+++ b/src/chocolatey/infrastructure.app/domain/ConfigCommandType.cs
@@ -21,5 +21,6 @@ namespace chocolatey.infrastructure.app.domain
         list,
         get,
         set,
+        unset,
     }
 }

--- a/src/chocolatey/infrastructure.app/services/ChocolateyConfigSettingsService.cs
+++ b/src/chocolatey/infrastructure.app/services/ChocolateyConfigSettingsService.cs
@@ -356,5 +356,21 @@ namespace chocolatey.infrastructure.app.services
                 }
             }
         }
+
+        public void config_unset(ChocolateyConfiguration configuration)
+        {
+            var config = config_get(configuration.ConfigCommand.Name);
+            if (config == null || string.IsNullOrEmpty(config.Value))
+            {
+                this.Log().Warn(NO_CHANGE_MESSAGE);
+            }
+            else
+            {
+                config.Value = "";
+                _xmlService.serialize(configFileSettings, ApplicationParameters.GlobalConfigFileLocation);
+
+                this.Log().Warn(() => "Unset {0}".format_with(config.Key));
+            }
+        }
     }
 }

--- a/src/chocolatey/infrastructure.app/services/IChocolateyConfigSettingsService.cs
+++ b/src/chocolatey/infrastructure.app/services/IChocolateyConfigSettingsService.cs
@@ -35,5 +35,6 @@ namespace chocolatey.infrastructure.app.services
         void config_list(ChocolateyConfiguration configuration);
         void config_get(ChocolateyConfiguration configuration);
         void config_set(ChocolateyConfiguration configuration);
+        void config_unset(ChocolateyConfiguration configuration);
     }
 }


### PR DESCRIPTION
Add ```unset``` to config commands so proxy can be switched on/off in scripts.

For example:
```
choco config set proxy http://localhost:8118
choco install package_requires_proxy_to_install
choco config unset proxy
choco install package_do_not_need_proxy_can_speed_up
```

Closes #551 