### PR TITLE
(GH-490) Exception if no source is enabled

### DIFF
--- a/Scenarios.md
+++ b/Scenarios.md
@@ -1,6 +1,6 @@
 ## Chocolatey Usage Scenarios
 
-### ChocolateyInstallCommand [ 34 Scenario(s), 287 Observation(s) ]
+### ChocolateyInstallCommand [ 35 Scenario(s), 288 Observation(s) ]
 
 #### when force installing a package that depends on an unavailable newer version of an installed dependency forcing dependencies
 
@@ -325,6 +325,10 @@
  * [PENDING] should not install the conflicting package in the lib directory
  * [PENDING] should not upgrade the exact version dependency
 
+#### when installing a package with no sources enabled
+
+ * should have no sources enabled result
+
 #### when installing a side by side package
 
  * config should match package result name
@@ -391,7 +395,7 @@
  * should not have inconclusive package result
  * should not have warning package result
 
-### ChocolateyListCommand [ 6 Scenario(s), 30 Observation(s) ]
+### ChocolateyListCommand [ 7 Scenario(s), 31 Observation(s) ]
 
 #### when listing local packages
 
@@ -407,6 +411,10 @@
  * should not contain debugging messages
  * should not contain packages and versions with a space between them
  * should only have messages related to package information
+
+#### when listing packages with no sources enabled
+
+ * should have no sources enabled result
 
 #### when searching all available packages
 
@@ -613,7 +621,7 @@
 
  * should throw an error that it is not allowed
 
-### ChocolateyUpgradeCommand [ 26 Scenario(s), 214 Observation(s) ]
+### ChocolateyUpgradeCommand [ 27 Scenario(s), 215 Observation(s) ]
 
 #### when force upgrading a package
 
@@ -852,6 +860,10 @@
  * should upgrade the exact version dependency
  * should upgrade the minimum version dependency
  * should upgrade the package
+
+#### when upgrading a package with no sources enabled
+
+ * should have no sources enabled result
 
 #### when upgrading a package with readonly files
 

--- a/src/chocolatey.tests.integration/scenarios/InstallScenarios.cs
+++ b/src/chocolatey.tests.integration/scenarios/InstallScenarios.cs
@@ -3333,5 +3333,29 @@ namespace chocolatey.tests.integration.scenarios
                 _xPathNavigator.SelectSingleNode("//configuration/appSettings/add[@key='insert']/@value").TypedValue.to_string().ShouldEqual("1.0.0");
             }
         }
+
+        [Concern(typeof(ChocolateyInstallCommand))]
+        public class when_installing_a_package_with_no_sources_enabled : ScenariosBase
+        {
+
+            public override void Context()
+            {
+                base.Context();
+                Configuration.Sources = null;
+            }
+
+            public override void Because()
+            {
+                MockLogger.reset();
+                Results = Service.install_run(Configuration);
+            }
+
+            [Fact]
+            public void should_have_no_sources_enabled_result()
+            {
+                MockLogger.contains_message("Installation was NOT successful. There are no sources enabled for packages.", LogLevel.Error).ShouldBeTrue();
+                Results.Count().ShouldEqual(0);
+            }
+        }
     }
 }

--- a/src/chocolatey.tests.integration/scenarios/ListScenarios.cs
+++ b/src/chocolatey.tests.integration/scenarios/ListScenarios.cs
@@ -340,5 +340,29 @@ namespace chocolatey.tests.integration.scenarios
                 MockLogger.contains_message("End of List", LogLevel.Debug).ShouldBeFalse();
             }
         }
+
+        [Concern(typeof(ChocolateyListCommand))]
+        public class when_listing_packages_with_no_sources_enabled : ScenariosBase
+        {
+
+            public override void Context()
+            {
+                base.Context();
+                Configuration.Sources = null;
+            }
+
+            public override void Because()
+            {
+                MockLogger.reset();
+                Results = Service.list_run(Configuration).ToList();
+            }
+
+            [Fact]
+            public void should_have_no_sources_enabled_result()
+            {
+                MockLogger.contains_message("Unable to search for packages when there are no sources enabled for packages.", LogLevel.Error).ShouldBeTrue();
+                Results.Count().ShouldEqual(0);
+            }
+        }
     }
 }

--- a/src/chocolatey.tests.integration/scenarios/UpgradeScenarios.cs
+++ b/src/chocolatey.tests.integration/scenarios/UpgradeScenarios.cs
@@ -2382,5 +2382,29 @@ namespace chocolatey.tests.integration.scenarios
             }
         }
 
+        [Concern(typeof(ChocolateyUpgradeCommand))]
+        public class when_upgrading_a_package_with_no_sources_enabled : ScenariosBase
+        {
+
+            public override void Context()
+            {
+                base.Context();
+                Configuration.Sources = null;
+                //Configuration.PackageNames = Configuration.Input = "installpackage";
+            }
+
+            public override void Because()
+            {
+                MockLogger.reset();
+                Results = Service.upgrade_run(Configuration);
+            }
+
+            [Fact]
+            public void should_have_no_sources_enabled_result()
+            {
+                MockLogger.contains_message("Upgrading was NOT successful. There are no sources enabled for packages.", LogLevel.Error).ShouldBeTrue();
+                Results.Count().ShouldEqual(0);
+            }
+        }
     }
 }

--- a/src/chocolatey/infrastructure.app/services/ChocolateyPackageService.cs
+++ b/src/chocolatey/infrastructure.app/services/ChocolateyPackageService.cs
@@ -304,9 +304,17 @@ namespace chocolatey.infrastructure.app.services
         {
             this.Log().Info(@"Installing the following packages:");
             this.Log().Info(ChocolateyLoggers.Important, @"{0}".format_with(config.PackageNames));
-            this.Log().Info(@"By installing you accept licenses for the packages.");
 
             var packageInstalls = new ConcurrentDictionary<string, PackageResult>();
+
+            if (config.Sources == null)
+            {
+                this.Log().Error(ChocolateyLoggers.Important, @"Installation was NOT successful. There are no sources enabled for packages.");
+                Environment.ExitCode = 1;
+                return packageInstalls;
+            }
+
+            this.Log().Info(@"By installing you accept licenses for the packages.");
 
             foreach (var packageConfig in set_config_from_package_names_and_packages_config(config, packageInstalls).or_empty_list_if_null())
             {

--- a/src/chocolatey/infrastructure.app/services/ChocolateyPackageService.cs
+++ b/src/chocolatey/infrastructure.app/services/ChocolateyPackageService.cs
@@ -107,6 +107,13 @@ namespace chocolatey.infrastructure.app.services
 
         public IEnumerable<PackageResult> list_run(ChocolateyConfiguration config)
         {
+            if (config.Sources == null)
+            {
+                this.Log().Error(ChocolateyLoggers.Important, @"Unable to search for packages when there are no sources enabled for packages.");
+                Environment.ExitCode = 1;
+                yield break;
+            }
+
             if (config.RegularOutput) this.Log().Debug(() => "Searching for package information");
 
             var packages = new List<IPackage>();
@@ -505,6 +512,14 @@ Would have determined packages that are out of date based on what is
         {
             this.Log().Info(@"Upgrading the following packages:");
             this.Log().Info(ChocolateyLoggers.Important, @"{0}".format_with(config.PackageNames));
+
+            if (config.Sources == null)
+            {
+                this.Log().Error(ChocolateyLoggers.Important, @"Upgrading was NOT successful. There are no sources enabled for packages.");
+                Environment.ExitCode = 1;
+                return new ConcurrentDictionary<string, PackageResult>();
+            }
+
             this.Log().Info(@"By upgrading you accept licenses for the packages.");
 
             foreach (var packageConfigFile in config.PackageNames.Split(new[] { ApplicationParameters.PackageNamesSeparator }, StringSplitOptions.RemoveEmptyEntries).or_empty_list_if_null().Where(p => p.EndsWith(".config")).ToList())


### PR DESCRIPTION
Previously if no sources were available during installation of a
package, installation would fail with an Exception. This fix will make
the choco client check the source list to make sure it is not null
before attempting to install a package.

As per [my discussion ](https://github.com/chocolatey/choco/issues/490#issuecomment-169809268) with @ferventcoder this fixes #490.

The exception itself occurs at ```\src\chocolatey\infrastructure.app\services\NugetService.cs:313``` when checking the source list contains an extension without confirming there is something in the source list first. I've added in a check before showing the licenses to confirm that there is sources defined.

This PR supersedes #546.