### PR TITLE
(GH-468) Send Chocolatey Command Help to standard out not Err

### DIFF
--- a/src/chocolatey.tests/infrastructure.app/configuration/ConfigurationOptionsSpec.cs
+++ b/src/chocolatey.tests/infrastructure.app/configuration/ConfigurationOptionsSpec.cs
@@ -39,13 +39,15 @@ namespace chocolatey.tests.infrastructure.app.configuration
 
             protected Mock<IConsole> console = new Mock<IConsole>();
             protected static StringBuilder helpMessageContents = new StringBuilder();
-            protected TextWriter writer = new StringWriter(helpMessageContents);
+            protected TextWriter errorWriter = new StringWriter(helpMessageContents);
+            protected TextWriter outputWriter = new StringWriter(helpMessageContents);
 
             public override void Context()
             {
                 ConfigurationOptions.initialize_with(new Lazy<IConsole>(() => console.Object));
                 ConfigurationOptions.reset_options();
-                console.Setup((c) => c.Error).Returns(writer);
+                console.Setup((c) => c.Error).Returns(errorWriter);
+                console.Setup((c) => c.Out).Returns(outputWriter);
             }
 
             protected Action because;

--- a/src/chocolatey/infrastructure.app/configuration/ConfigurationOptions.cs
+++ b/src/chocolatey/infrastructure.app/configuration/ConfigurationOptions.cs
@@ -134,7 +134,7 @@ namespace chocolatey.infrastructure.app.configuration
                 helpMessage.Invoke();
             }
 
-            optionSet.WriteOptionDescriptions(Console.Error);
+            optionSet.WriteOptionDescriptions(Console.Out);
         }
     }
 }

--- a/src/chocolatey/infrastructure/adapters/Console.cs
+++ b/src/chocolatey/infrastructure/adapters/Console.cs
@@ -42,6 +42,8 @@ namespace chocolatey.infrastructure.adapters
 
         public TextWriter Error { get { return System.Console.Error; } }
 
+        public TextWriter Out { get { return System.Console.Out; } }
+
         public void Write(object value)
         {
             System.Console.Write(value.to_string());

--- a/src/chocolatey/infrastructure/adapters/IConsole.cs
+++ b/src/chocolatey/infrastructure/adapters/IConsole.cs
@@ -55,6 +55,15 @@ namespace chocolatey.infrastructure.adapters
         TextWriter Error { get; }
 
         /// <summary>
+        ///   Gets the standard output stream.
+        /// </summary>
+        /// <returns>
+        ///   A <see cref="T:System.IO.TextWriter" /> that represents the standard output stream.
+        /// </returns>
+        /// <filterpriority>1</filterpriority>
+        TextWriter Out { get; }
+
+        /// <summary>
         ///   Writes the specified string value to the standard output stream.
         /// </summary>
         /// <param name="value">The value to write.</param>


### PR DESCRIPTION
Commands such as:
    choco list -help | more
    choco list -help | out-host -paging
...did not page as expected.
Similarly:
    choco -help | out-file HelpDetails.txt
did not deliver all of the help output to the file.

(The workaround of using 2>&1 (or *>&1) is burdensome for the very
people who need help in the first place.)

So, in line with normal use of NDesk OptionSet, the option descriptions
are now written to Console.Out not Console.Error.

Closes #468