### PR TITLE
(GH-453) Add exact filter option to choco list

### DIFF
--- a/src/chocolatey.tests.integration/Scenario.cs
+++ b/src/chocolatey.tests.integration/Scenario.cs
@@ -128,6 +128,7 @@ namespace chocolatey.tests.integration
             config.Verbose = false;
             config.Input = config.PackageNames = string.Empty;
             config.ListCommand.LocalOnly = false;
+            config.ListCommand.Exact = false;
             //config.Features.UsePowerShellHost = true;
             //config.Features.AutoUninstaller = true;
             //config.Features.CheckSumFiles = true;

--- a/src/chocolatey.tests.integration/chocolatey.tests.integration.csproj
+++ b/src/chocolatey.tests.integration/chocolatey.tests.integration.csproj
@@ -213,6 +213,12 @@
     <None Include="context\dependencies\hasdependency\2.1.0\tools\chocolateyuninstall.ps1">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
+    <None Include="context\exactpackage\exactpackage.dontfind\1.0.0\exactpackage.dontfind.nuspec">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Include="context\exactpackage\exactpackage\1.0.0\exactpackage.nuspec">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
     <None Include="context\installpackage\1.0.0\installpackage.nuspec">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
@@ -400,6 +406,12 @@
     <None Include="context\upgradepackage\1.1.0\tools\graphical.exe">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
+    <Content Include="context\exactpackage\exactpackage.dontfind\1.0.0\tools\purpose.txt">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="context\exactpackage\exactpackage\1.0.0\tools\purpose.txt">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
     <Content Include="infrastructure\filesystem\CopyMe.txt">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>

--- a/src/chocolatey.tests.integration/context/exactpackage/exactpackage.dontfind/1.0.0/exactpackage.dontfind.nuspec
+++ b/src/chocolatey.tests.integration/context/exactpackage/exactpackage.dontfind/1.0.0/exactpackage.dontfind.nuspec
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+  <metadata>
+    <id>exactpackage.dontfind</id>
+    <version>1.0.0</version>
+    <title>exactpackage.dontfind</title>
+    <authors>__REPLACE_AUTHORS_OF_SOFTWARE__</authors>
+    <owners>__REPLACE_YOUR_NAME__</owners>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <description>__REPLACE__</description>
+    <summary>__REPLACE__</summary>
+    <releaseNotes />
+    <tags>exactpackage.dontfind admin</tags>
+  </metadata>
+  <files>
+    <file src="tools\**" target="tools" />
+  </files>
+</package>

--- a/src/chocolatey.tests.integration/context/exactpackage/exactpackage.dontfind/1.0.0/tools/purpose.txt
+++ b/src/chocolatey.tests.integration/context/exactpackage/exactpackage.dontfind/1.0.0/tools/purpose.txt
@@ -1,0 +1,1 @@
+when running choco list exactpackage -e, this package should not be returned.

--- a/src/chocolatey.tests.integration/context/exactpackage/exactpackage/1.0.0/exactpackage.nuspec
+++ b/src/chocolatey.tests.integration/context/exactpackage/exactpackage/1.0.0/exactpackage.nuspec
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+  <metadata>
+    <id>exactpackage</id>
+    <version>1.0.0</version>
+    <title>exactpackage</title>
+    <authors>__REPLACE_AUTHORS_OF_SOFTWARE__</authors>
+    <owners>__REPLACE_YOUR_NAME__</owners>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <description>__REPLACE__</description>
+    <summary>__REPLACE__</summary>
+    <releaseNotes />
+    <tags>exactpackage admin</tags>
+  </metadata>
+  <files>
+    <file src="tools\**" target="tools" />
+  </files>
+</package>

--- a/src/chocolatey.tests.integration/context/exactpackage/exactpackage/1.0.0/tools/purpose.txt
+++ b/src/chocolatey.tests.integration/context/exactpackage/exactpackage/1.0.0/tools/purpose.txt
@@ -1,0 +1,1 @@
+when running choco list exactpackage -e, this is the only package that should be returned.

--- a/src/chocolatey.tests.integration/scenarios/ListScenarios.cs
+++ b/src/chocolatey.tests.integration/scenarios/ListScenarios.cs
@@ -370,5 +370,53 @@ namespace chocolatey.tests.integration.scenarios
             }  
 
         }
+
+        [Concern(typeof(ChocolateyListCommand))]
+        public class when_searching_for_an_exact_package : ScenariosBase
+        {
+            public override void Context()
+            {
+                Configuration = Scenario.list();
+                Scenario.reset(Configuration);
+                Scenario.add_packages_to_source_location(Configuration, "exactpackage*" + Constants.PackageExtension);
+                Service = NUnitSetup.Container.GetInstance<IChocolateyPackageService>();
+
+                Configuration.ListCommand.Exact = true;
+                Configuration.Input = Configuration.PackageNames = "exactpackage";
+            }
+
+            public override void Because()
+            {
+                MockLogger.reset();
+                Results = Service.list_run(Configuration).ToList();
+            }
+
+            [Fact]
+            public void should_contain_packages_and_versions_with_a_space_between_them()
+            {
+                MockLogger.contains_message("exactpackage 1.0.0").ShouldBeTrue();
+            }
+
+            [Fact]
+            public void should_not_contain_packages_that_do_not_match()
+            {
+                MockLogger.contains_message("exactpackage.dontfind").ShouldBeFalse();
+            }
+
+            [Fact]
+            public void should_contain_a_summary()
+            {
+                MockLogger.contains_message("packages found").ShouldBeTrue();
+            }
+
+            [Fact]
+            public void should_contain_debugging_messages()
+            {
+                MockLogger.contains_message("Searching for package information", LogLevel.Debug).ShouldBeTrue();
+                MockLogger.contains_message("Running list with the following filter", LogLevel.Debug).ShouldBeTrue();
+                MockLogger.contains_message("Start of List", LogLevel.Debug).ShouldBeTrue();
+                MockLogger.contains_message("End of List", LogLevel.Debug).ShouldBeTrue();
+            }
+        }
     }
 }

--- a/src/chocolatey/infrastructure.app/commands/ChocolateyListCommand.cs
+++ b/src/chocolatey/infrastructure.app/commands/ChocolateyListCommand.cs
@@ -78,8 +78,10 @@ namespace chocolatey.infrastructure.app.commands
                 .Add("page-size=",
                      "Page Size - the amount of package results to return per page. Defaults to 25.",
                      option => configuration.ListCommand.PageSize = int.Parse(option))
+                .Add("e|exact",
+                     "Exact - Only return packages with this exact name.",
+                     option => configuration.ListCommand.Exact = option != null)
                 ;
-            //todo exact name
         }
 
         public virtual void handle_additional_argument_parsing(IList<string> unparsedArguments, ChocolateyConfiguration configuration)

--- a/src/chocolatey/infrastructure.app/configuration/ChocolateyConfiguration.cs
+++ b/src/chocolatey/infrastructure.app/configuration/ChocolateyConfiguration.cs
@@ -355,6 +355,7 @@ NOTE: Hiding sensitive configuration data! Please double and triple
         public bool IncludeRegistryPrograms { get; set; }
         public int? Page { get; set; }
         public int PageSize { get; set; }
+        public bool Exact { get; set; }
     }
 
     [Serializable]

--- a/src/chocolatey/infrastructure.app/nuget/NugetList.cs
+++ b/src/chocolatey/infrastructure.app/nuget/NugetList.cs
@@ -93,6 +93,11 @@ namespace chocolatey.infrastructure.app.nuget
                 results = results.Skip(configuration.ListCommand.PageSize * configuration.ListCommand.Page.Value).Take(configuration.ListCommand.PageSize);
             }
 
+            if (configuration.ListCommand.Exact)
+            {
+                results = results.Where(p => p.Id == configuration.Input);
+            }
+
             return results.OrderBy(p => p.Id);
         } 
 


### PR DESCRIPTION
Previously there was no way to see only packages that
match exactly what you searched for.

...

This adds the `-e, --exact` option to `choco list`.  

I added the `Exact` bool to `ListCommandConfiguration` and a simple where filter in `NugetList.execute_package_search`.  Also, added two test packages and some tests to `ListScenarios`.

[Reference post on google groups](https://groups.google.com/forum/?utm_medium=email&utm_source=footer#!msg/chocolatey/bljQlaVns8A/JEwH2u8bDQAJ).