### PR TITLE
(GH-769) API - Resolve Merged Assemblies

### DIFF
--- a/src/chocolatey/AssemblyExtensions.cs
+++ b/src/chocolatey/AssemblyExtensions.cs
@@ -17,6 +17,7 @@ namespace chocolatey
 {
     using System.IO;
     using System.Linq;
+    using System.Reflection;
     using infrastructure.adapters;
 
     /// <summary>
@@ -71,7 +72,14 @@ namespace chocolatey
         {
             if (assembly == null) return string.Empty;
 
-            byte[] publicKeyToken = assembly.GetName().GetPublicKeyToken();
+            return assembly.GetName().get_public_key_token();
+        }
+
+        public static string get_public_key_token(this AssemblyName assemblyName)
+        {
+            if (assemblyName == null) return string.Empty;
+
+            byte[] publicKeyToken = assemblyName.GetPublicKeyToken();
 
             if (publicKeyToken == null || publicKeyToken.Length == 0) return string.Empty;
 

--- a/src/chocolatey/infrastructure.app/runners/GenericRunner.cs
+++ b/src/chocolatey/infrastructure.app/runners/GenericRunner.cs
@@ -82,7 +82,7 @@ namespace chocolatey.infrastructure.app.runners
                 }
 
                 var token = Assembly.GetExecutingAssembly().get_public_key_token();
-                if (string.IsNullOrWhiteSpace(token) || token != ApplicationParameters.OfficialChocolateyPublicKey)
+                if (string.IsNullOrWhiteSpace(token) || !token.is_equal_to(ApplicationParameters.OfficialChocolateyPublicKey))
                 {
                     if (!config.AllowUnofficialBuild)
                     {


### PR DESCRIPTION
When using the API, it should resolve merged assemblies but it may
not if there is an assembly handler registered. Before loading up
code that resolves external assemblies, register an AssemblyResolve
handler with the purpose of determining if the assembly has
Chocolatey's Public Key token or not. If it does, use Chocolatey's
merged assembly instead of the conflicting assembly.

Closes #769