### PR TITLE
(GH-557) Placement of the "You have {x} v{y} installed. Version {z} is available based on your source(s)' is wrong.

### DIFF
--- a/src/chocolatey/infrastructure.app/services/NugetService.cs
+++ b/src/chocolatey/infrastructure.app/services/NugetService.cs
@@ -647,7 +647,7 @@ spam/junk folder.");
 
                 if (installedPackage.Version == availablePackage.Version)
                 {
-                    string logMessage = "{0} v{1} is the latest version available based on your source(s).".format_with(installedPackage.Id, installedPackage.Version);
+                    string logMessage = "{0}{1} v{2} is the latest version available based on your source(s).".format_with(Environment.NewLine, installedPackage.Id, installedPackage.Version);
 
                     if (!config.Force)
                     {


### PR DESCRIPTION
Closes 557

Added newline preceding the newer version available message.  Did not attempt to remove newline after message as it is part of the package name and version message when starting the install.

This implementation add the newline whether part of upgrading multiple items or single item but I could add that as I think that context is available..