### PR TITLE
(GH-828) Return OS bit width, not process

### DIFF
--- a/src/chocolatey.resources/helpers/functions/Get-OSArchitectureWidth.ps1
+++ b/src/chocolatey.resources/helpers/functions/Get-OSArchitectureWidth.ps1
@@ -45,7 +45,9 @@ param(
   Write-Debug "Running 'Get-OSArchitectureWidth'"
 
   $bits = 64
-  if ([System.IntPtr]::Size -eq 4) {
+  if (([System.IntPtr]::Size -eq 4) -and (Test-Path env:\PROCESSOR_ARCHITEW6432)) {
+    $bits = 64
+  } elseif ([System.IntPtr]::Size -eq 4) {
     $bits = 32
   }
 


### PR DESCRIPTION
(GH-828) Return OS bit width, not process

Get-OSArchitectureWidth returns the current process bit-width regardless of
OS arch. So in 32-bit powershell running on 64-bit windows, it returns 32
because [System.IntPtr]::Size returns 4 in 32-bit process regardless of
OS architecture (32 or 64). This fix returns actual OS bit width.

Closes #828 