### PR TITLE
(GH-845)  Keep the ".log" extension for serialized logs

### DIFF
--- a/src/chocolatey/infrastructure/logging/Log4NetAppenderConfiguration.cs
+++ b/src/chocolatey/infrastructure/logging/Log4NetAppenderConfiguration.cs
@@ -88,6 +88,7 @@ namespace chocolatey.infrastructure.logging
                         MaxFileSize = 1024 * 1024,
                         MaxSizeRollBackups = 10,
                         LockingModel = new FileAppender.MinimalLock(),
+                        PreserveLogFileNameExtension = true,
                     };
                 app.ActivateOptions();
 
@@ -101,7 +102,7 @@ namespace chocolatey.infrastructure.logging
                     MaxFileSize = 1024 * 1024,
                     MaxSizeRollBackups = 10,
                     LockingModel = new FileAppender.MinimalLock(),
-
+                    PreserveLogFileNameExtension = true,
                 };
                 infoOnlyAppender.AddFilter(new LevelRangeFilter { LevelMin = Level.Info, LevelMax = Level.Fatal });
                 infoOnlyAppender.ActivateOptions();


### PR DESCRIPTION
Setting the RollingFileAppender.PreserveLogFileNameExtension property to true to keep the ".log" extension for serialized logs.

Closes #845