### PR TITLE
(GH-861) Fix uninstall to use version parameter

### DIFF
--- a/src/chocolatey/infrastructure.app/services/NugetService.cs
+++ b/src/chocolatey/infrastructure.app/services/NugetService.cs
@@ -1082,8 +1082,8 @@ spam/junk folder.");
                 }
                 else
                 {
-                    IPackage installedPackage = packageManager.LocalRepository.FindPackage(packageName);
-                    if (installedPackage != null) installedPackageVersions.Add(installedPackage);
+                    SemanticVersion semanticVersion = new SemanticVersion(config.Version);
+                    installedPackageVersions = packageManager.LocalRepository.FindPackagesById(packageName).Where((p) => p.Version.Equals(semanticVersion)).ToList();
                 }
 
                 if (installedPackageVersions.Count == 0)


### PR DESCRIPTION
Previously when executing an uninstall of a specific version of a
package which was side-by-side installed, Chocolatey would always
uninstall the latest package.

This fix will change the NugetService.uninstall_run to actually
use the version when selecting the package to remove.

Closes #861 