### PR TITLE
(GH-872) Progress output never reaches completion

### DIFF
--- a/src/chocolatey.resources/helpers/functions/Get-FtpFile.ps1
+++ b/src/chocolatey.resources/helpers/functions/Get-FtpFile.ps1
@@ -160,7 +160,7 @@ param(
             Write-Progress "Downloading $url to $fileName" "Saving $total bytes..." -id 0 -Completed
           }
           if ($total -eq $goal) {
-            Write-Progress "Completed download of $url." "Completed a total of $total bytes of $fileName" -id 0 -Completed
+            Write-Progress "Completed download of $url." "Completed a total of $total bytes of $fileName" -id 0 -Completed -PercentComplete 100
           }
         }
       } while ($count -ne 0)

--- a/src/chocolatey.resources/helpers/functions/Get-FtpFile.ps1
+++ b/src/chocolatey.resources/helpers/functions/Get-FtpFile.ps1
@@ -155,11 +155,12 @@ param(
           $total += $count
           $totalFormatted = Format-FileSize $total
           if($goal -gt 0) {
-            Write-Progress "Downloading $url to $fileName" "Saving $totalFormatted of $goalFormatted ($total/$goal)" -id 0 -percentComplete (($total/$goal)*100)
+            $percentComplete = [Math]::Truncate(($total/$goal)*100)
+            Write-Progress "Downloading $url to $fileName" "Saving $totalFormatted of $goalFormatted ($total/$goal)" -id 0 -percentComplete $percentComplete
           } else {
             Write-Progress "Downloading $url to $fileName" "Saving $total bytes..." -id 0 -Completed
           }
-          if ($total -eq $goal) {
+          if ($total -eq $goal -and $count -eq 0) {
             Write-Progress "Completed download of $url." "Completed a total of $total bytes of $fileName" -id 0 -Completed -PercentComplete 100
           }
         }

--- a/src/chocolatey.resources/helpers/functions/Get-WebFile.ps1
+++ b/src/chocolatey.resources/helpers/functions/Get-WebFile.ps1
@@ -282,7 +282,7 @@ param(
             }
 
             if ($total -eq $goal) {
-              Write-Progress "Completed download of $url." "Completed download of $fileName ($goalFormatted)." -id 0 -Completed
+              Write-Progress "Completed download of $url." "Completed download of $fileName ($goalFormatted)." -id 0 -Completed -PercentComplete 100
             }
           }
         } while ($count -gt 0)

--- a/src/chocolatey.resources/helpers/functions/Get-WebFile.ps1
+++ b/src/chocolatey.resources/helpers/functions/Get-WebFile.ps1
@@ -278,10 +278,11 @@ param(
             $total += $count
             $totalFormatted = Format-FileSize $total
             if($goal -gt 0 -and ++$iterLoop%10 -eq 0) {
-              Write-Progress "Downloading $url to $fileName" "Saving $totalFormatted of $goalFormatted ($total/$goal)" -id 0 -percentComplete (($total/$goal)*100)
+              $percentComplete = [Math]::Truncate(($total/$goal)*100)
+              Write-Progress "Downloading $url to $fileName" "Saving $totalFormatted of $goalFormatted ($total/$goal)" -id 0 -percentComplete $percentComplete
             }
 
-            if ($total -eq $goal) {
+            if ($total -eq $goal -and $count -eq 0) {
               Write-Progress "Completed download of $url." "Completed download of $fileName ($goalFormatted)." -id 0 -Completed -PercentComplete 100
             }
           }

--- a/src/chocolatey/infrastructure/powershell/PoshHostUserInterface.cs
+++ b/src/chocolatey/infrastructure/powershell/PoshHostUserInterface.cs
@@ -129,7 +129,7 @@ namespace chocolatey.infrastructure.powershell
             }
 
             // http://stackoverflow.com/a/888569/18475
-            Console.Write("\rProgress: {0}% - {1}".format_with(record.PercentComplete.to_string(), record.StatusDescription.PadRight(50, ' ')));
+            Console.Write("\rProgress: {0}% - {1}".format_with(record.PercentComplete.to_string(), record.StatusDescription).PadRight(Console.WindowWidth));
         }
 
         public override void WriteVerboseLine(string message)

--- a/src/chocolatey/infrastructure/powershell/PoshHostUserInterface.cs
+++ b/src/chocolatey/infrastructure/powershell/PoshHostUserInterface.cs
@@ -118,11 +118,10 @@ namespace chocolatey.infrastructure.powershell
         }
 
         private bool hasLoggedStartProgress = false;
-        private bool hasLoggedFinalProgress = false;
         public override void WriteProgress(long sourceId, ProgressRecord record)
         {  
             if (record.PercentComplete == -1) return;
-            if (hasLoggedFinalProgress) return;
+
             if (!hasLoggedStartProgress)
             {
                 hasLoggedStartProgress = true;
@@ -131,13 +130,6 @@ namespace chocolatey.infrastructure.powershell
 
             // http://stackoverflow.com/a/888569/18475
             Console.Write("\rProgress: {0}% - {1}".format_with(record.PercentComplete.to_string(), record.StatusDescription.PadRight(50, ' ')));
-
-            if (record.PercentComplete == 100 && !hasLoggedFinalProgress)
-            {
-                hasLoggedFinalProgress = true;
-                //this.Log().Info("");
-                //this.Log().Info(record.StatusDescription.Replace("Saving","Finished downloading. Saved"));
-            }
         }
 
         public override void WriteVerboseLine(string message)


### PR DESCRIPTION
Always pass -PercentComplete to Write-Progress, otherwise the output will
not be logged due to the -1 check.

Because we can reach 100% when there are a few bytes left to retrieve,
allow further logging of progress even if we reached 100%.

Closes #872 
Closes #875