### PR TITLE
(GH-878) Fixing install with packages.config - should print out the packages to install

### DIFF
--- a/Scenarios.md
+++ b/Scenarios.md
@@ -1,6 +1,6 @@
 ## Chocolatey Usage Scenarios
 
-### ChocolateyInstallCommand [ 35 Scenario(s), 291 Observation(s) ]
+### ChocolateyInstallCommand [ 35 Scenario(s), 293 Observation(s) ]
 
 #### when force installing a package that depends on an unavailable newer version of an installed dependency forcing dependencies
 
@@ -362,6 +362,8 @@
  * should not have a successful package result for missing package
  * should not have inconclusive package result
  * should not have warning package result
+ * should print out package from config file in message
+ * should specify config file is being used in message
 
 #### when noop installing a package
 

--- a/src/chocolatey.tests.integration/scenarios/InstallScenarios.cs
+++ b/src/chocolatey.tests.integration/scenarios/InstallScenarios.cs
@@ -435,6 +435,30 @@ namespace chocolatey.tests.integration.scenarios
                     packageResult.Value.Warning.ShouldBeFalse();
                 }
             }
+
+            [Fact]
+            public void should_specify_config_file_is_being_used_in_message()
+            {
+                bool expectedMessage = false;
+                foreach (var message in MockLogger.MessagesFor(LogLevel.Info).or_empty_list_if_null())
+                {
+                    if (message.Contains("Installing from config file:")) expectedMessage = true;
+                }
+
+                expectedMessage.ShouldBeTrue();
+            }
+
+            [Fact]
+            public void should_print_out_package_from_config_file_in_message()
+            {
+                bool expectedMessage = false;
+                foreach (var message in MockLogger.MessagesFor(LogLevel.Info).or_empty_list_if_null())
+                {
+                    if (message.Contains("installpackage")) expectedMessage = true;
+                }
+
+                expectedMessage.ShouldBeTrue();
+            }
         }
 
         [Concern(typeof(ChocolateyInstallCommand))]


### PR DESCRIPTION
Trying a fix for #878.

Added a check for ``*.config`` files and added logging of the packages involved.
Also logs that we actually install from a ``*.config`` file. 

Closes #878 