### PR TITLE
(GH-598) Add output directory for choco pack

### DIFF
--- a/Scenarios.md
+++ b/Scenarios.md
@@ -462,6 +462,16 @@
  * should contain tags
  * should not contain packages and versions with a pipe between them
 
+### ChocolateyPackCommand [ 2 Scenario(s), 2 Observation(s) ]
+
+#### when packing with an output directory
+
+ * generated package should be in specified output directory
+
+#### when packing without specifying an output directory
+
+ * generated package should be in current directory
+
 ### ChocolateyPinCommand [ 9 Scenario(s), 12 Observation(s) ]
 
 #### when listing pins with an existing pin

--- a/src/chocolatey.tests.integration/Scenario.cs
+++ b/src/chocolatey.tests.integration/Scenario.cs
@@ -24,6 +24,7 @@ namespace chocolatey.tests.integration
     using chocolatey.infrastructure.commands;
     using chocolatey.infrastructure.filesystem;
     using chocolatey.infrastructure.platforms;
+    using System.Collections.Generic;
 
     public class Scenario
     {
@@ -96,6 +97,22 @@ namespace chocolatey.tests.integration
             NUnitSetup.MockLogger.Messages.Clear();
         }
 
+        public static void add_files(IEnumerable<Tuple<string, string>> files)
+        {
+            foreach (var file in files)
+            {
+                if (_fileSystem.file_exists(file.Item1))
+                {
+                    _fileSystem.delete_file(file.Item1);
+                }
+                _fileSystem.write_file(file.Item1, file.Item2);
+            }
+        }
+        
+        public static void create_directory(string directoryPath)
+        {
+            _fileSystem.create_directory(directoryPath);
+        }
         private static ChocolateyConfiguration baseline_configuration()
         {
             // note that this does not mean an empty configuration. It does get influenced by
@@ -144,6 +161,7 @@ namespace chocolatey.tests.integration
             config.Features.UsePowerShellHost = true;
             config.Features.AutoUninstaller = true;
             config.Features.CheckSumFiles = true;
+            config.OutputDirectory = null;
 
             return config;
         }
@@ -184,6 +202,14 @@ namespace chocolatey.tests.integration
         {
             var config = baseline_configuration();
             config.CommandName = "pin";
+
+            return config;
+        }
+
+        public static ChocolateyConfiguration pack()
+        {
+            var config = baseline_configuration();
+            config.CommandName = "pack";
 
             return config;
         }

--- a/src/chocolatey.tests.integration/chocolatey.tests.integration.csproj
+++ b/src/chocolatey.tests.integration/chocolatey.tests.integration.csproj
@@ -90,6 +90,7 @@
     <Compile Include="Scenario.cs" />
     <Compile Include="scenarios\InstallScenarios.cs" />
     <Compile Include="scenarios\ListScenarios.cs" />
+    <Compile Include="scenarios\PackScenarios.cs" />
     <Compile Include="scenarios\PinScenarios.cs" />
     <Compile Include="scenarios\UninstallScenarios.cs" />
     <Compile Include="scenarios\UpgradeScenarios.cs" />

--- a/src/chocolatey.tests.integration/scenarios/PackScenarios.cs
+++ b/src/chocolatey.tests.integration/scenarios/PackScenarios.cs
@@ -1,0 +1,123 @@
+﻿// Copyright © 2011 - Present RealDimensions Software, LLC
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// 
+// You may obtain a copy of the License at
+// 
+// 	http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace chocolatey.tests.integration.scenarios
+{
+    using Should;
+    using System;
+    using System.IO;
+    using bdddoc.core;
+    using chocolatey.infrastructure.app.commands;
+    using chocolatey.infrastructure.app.configuration;
+    using chocolatey.infrastructure.app.services;
+
+    public class PackScenarios
+    {
+        public abstract class ScenariosBase : TinySpec
+        {
+            protected ChocolateyConfiguration Configuration;
+            protected INugetService Service;
+
+            public override void Context()
+            {
+                Configuration = Scenario.pack();
+                Scenario.reset(Configuration);
+                Scenario.add_files(new[] { new Tuple<string, string>("myPackage.nuspec", NuspecContent) });
+
+                Service = NUnitSetup.Container.GetInstance<INugetService>();
+            }
+        }
+
+        [Concern(typeof(ChocolateyPackCommand))]
+        public class when_packing_without_specifying_an_output_directory : ScenariosBase
+        {
+            private readonly string package_path = Path.Combine(Scenario.get_top_level(), "test-package.0.1.0.nupkg");
+
+            public override void Context()
+            {
+                base.Context();
+                if (File.Exists(package_path))
+                {
+                    File.Delete(package_path);
+                }
+            }
+
+            public override void Because()
+            {
+                MockLogger.reset();
+                Service.pack_run(Configuration);
+            }
+
+            [Fact]
+            public void generated_package_should_be_in_current_directory()
+            {
+                var infos = MockLogger.MessagesFor(LogLevel.Info);
+                infos.Count.ShouldEqual(2);
+                infos[0].ShouldEqual("Attempting to build package from 'myPackage.nuspec'.");
+                infos[1].ShouldEqual(string.Concat("Successfully created package '", package_path, "'"));
+
+                File.Exists(package_path).ShouldBeTrue();
+            }
+        }
+
+        [Concern(typeof(ChocolateyPackCommand))]
+        public class when_packing_with_an_output_directory : ScenariosBase
+        {
+            private readonly string package_path = Path.Combine("PackageOutput", "test-package.0.1.0.nupkg");
+
+            public override void Context()
+            {
+                base.Context();
+                Configuration.OutputDirectory = "PackageOutput";
+                Scenario.create_directory(Configuration.OutputDirectory);
+            }
+
+            public override void Because()
+            {
+                MockLogger.reset();
+                Service.pack_run(Configuration);
+            }
+
+            [Fact]
+            public void generated_package_should_be_in_specified_output_directory()
+            {
+                var infos = MockLogger.MessagesFor(LogLevel.Info);
+                infos.Count.ShouldEqual(2);
+                infos[0].ShouldEqual("Attempting to build package from 'myPackage.nuspec'.");
+                infos[1].ShouldEqual(string.Concat("Successfully created package '", package_path, "'"));
+
+                File.Exists(package_path).ShouldBeTrue();
+            }
+        }
+
+        private const string NuspecContent = @"<?xml version=""1.0"" encoding=""utf-8""?>
+<package xmlns=""http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd"">
+  <metadata>
+    <id>test-package</id>
+    <title>Test Package</title>
+    <version>0.1.0</version>
+    <authors>package author</authors>
+    <owners>package owner</owners>
+    <summary>A brief summary</summary>
+    <description>A big description</description>
+    <tags>test admin</tags>
+    <copyright></copyright>
+    <licenseUrl>http://apache.org/2</licenseUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <releaseNotes></releaseNotes>
+  </metadata>
+</package>";
+    }
+}

--- a/src/chocolatey.tests/infrastructure.app/commands/ChocolateyPackCommandSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/commands/ChocolateyPackCommandSpecs.cs
@@ -76,6 +76,12 @@ namespace chocolatey.tests.infrastructure.app.commands
             {
                 optionSet.Contains("version").ShouldBeTrue();
             }
+
+            [Fact]
+            public void should_add_outputdirectory_to_the_option_set()
+            {
+                optionSet.Contains("outputdirectory").ShouldBeTrue();
+            }
         }
 
         public class when_handling_additional_argument_parsing : ChocolateyPackCommandSpecsBase
@@ -126,6 +132,35 @@ namespace chocolatey.tests.infrastructure.app.commands
             public void should_call_service_pack_run()
             {
                 packageService.Verify(c => c.pack_run(configuration), Times.Once);
+            }
+        }
+
+        public class when_handling_arguments_parsing : ChocolateyPackCommandSpecsBase
+        {
+            private OptionSet optionSet;
+
+            public override void Context()
+            {
+                base.Context();
+                optionSet = new OptionSet();
+                command.configure_argument_parser(optionSet, configuration);
+            }
+
+            public override void Because()
+            {
+                optionSet.Parse(new[] { "--version", "0.42.0", "--outputdirectory", "c:\\packages" });
+            }
+
+            [Fact]
+            public void should_version_equal_to_42()
+            {
+                configuration.Version.ShouldEqual("0.42.0");
+            }
+
+            [Fact]
+            public void should_outputdirectory_equal_packages()
+            {
+                configuration.OutputDirectory.ShouldEqual("c:\\packages");
             }
         }
     }

--- a/src/chocolatey/infrastructure.app/commands/ChocolateyPackCommand.cs
+++ b/src/chocolatey/infrastructure.app/commands/ChocolateyPackCommand.cs
@@ -39,6 +39,9 @@ namespace chocolatey.infrastructure.app.commands
                 .Add("version=",
                      "Version - The version you would like to insert into the package.",
                      option => configuration.Version = option.remove_surrounding_quotes())
+                .Add("outputdirectory=",
+                     "OutputDirectory - Specifies the directory for the created Chocolatey package file. If not specified, uses the current directory.",
+                     option => configuration.OutputDirectory = option)
                 ;
         }
 
@@ -79,6 +82,7 @@ NOTE: `cpack` has been deprecated as it has a name collision with CMake. Please
     choco pack
     choco pack --version 1.2.3
     choco pack path/to/nuspec
+    choco pack --outputdirectory build
 
 ");
 

--- a/src/chocolatey/infrastructure.app/services/NugetService.cs
+++ b/src/chocolatey/infrastructure.app/services/NugetService.cs
@@ -196,7 +196,7 @@ namespace chocolatey.infrastructure.app.services
         {
             this.Log().Info("{0} would have searched for a nuspec file in \"{1}\" and attempted to compile it.".format_with(
                 ApplicationParameters.Name,
-                _fileSystem.get_current_directory()
+                config.OutputDirectory ?? _fileSystem.get_current_directory()
                                 ));
         }
 
@@ -249,7 +249,7 @@ namespace chocolatey.infrastructure.app.services
             }
 
             string outputFile = builder.Id + "." + builder.Version + Constants.PackageExtension;
-            string outputPath = _fileSystem.combine_paths(_fileSystem.get_current_directory(), outputFile);
+            string outputPath = _fileSystem.combine_paths(config.OutputDirectory ?? _fileSystem.get_current_directory(), outputFile);
 
             this.Log().Info(() => "Attempting to build package from '{0}'.".format_with(_fileSystem.get_file_name(nuspecFilePath)));
 
@@ -265,7 +265,7 @@ namespace chocolatey.infrastructure.app.services
             //    AnalyzePackage(package);
             //}
 
-            this.Log().Info(ChocolateyLoggers.Important, () => "Successfully created package '{0}'".format_with(outputFile));
+            this.Log().Info(ChocolateyLoggers.Important, () => "Successfully created package '{0}'".format_with(outputPath));
         }
 
         public void push_noop(ChocolateyConfiguration config)


### PR DESCRIPTION
Add a new option outputdirectory for PackCommand and the corresponding
OutputDirectory property in ChocolateyConfiguration.

Clean version of #609.

Closes #598