### PR TITLE
(GH-897) dism ... /all was never running for source windowsfeatures

### DIFF
--- a/src/chocolatey/infrastructure.app/services/WindowsFeatureService.cs
+++ b/src/chocolatey/infrastructure.app/services/WindowsFeatureService.cs
@@ -227,7 +227,7 @@ namespace chocolatey.infrastructure.app.services
             var args = ExternalCommandArgsBuilder.build_arguments(config, argsDictionary);
 
             // at least Windows 8/2012
-            if (config.Information.PlatformVersion.Major >= 6 && config.Information.PlatformVersion.Minor >= 2)
+            if (config.Information.PlatformVersion.Major > 6 || (config.Information.PlatformVersion.Major == 6 && config.Information.PlatformVersion.Minor >= 2))
             {
                 args = args.Replace(ALL_TOKEN, "/All");
             }


### PR DESCRIPTION
(maint)

Issue here is the minor version is always required to be > 2, so now that we're at windows 10.0.x /all is not being added, even though this logic really only wanted to make sure the version was >= 6.2

This commit adds a check to see if the version is greater than 6 entirely, if not, only then does it check if its version 6 and at least minor ver. 6.2.

How this issue affects the functionality: Not calling /all as part of dism meant that dependencies for windows features are never installed as part of the installation.

Closes #897 