### PR TITLE
(GH-839) Switch to apply package parameters to dependent packages

### DIFF
--- a/src/chocolatey.tests/infrastructure.app/commands/ChocolateyInstallCommandSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/commands/ChocolateyInstallCommandSpecs.cs
@@ -152,6 +152,18 @@ namespace chocolatey.tests.infrastructure.app.commands
             }
 
             [Fact]
+            public void should_add_applyPackageParametersToDependencies_to_the_option_set()
+            {
+                optionSet.Contains("apply-package-parameters-to-dependencies").ShouldBeTrue();
+            }
+
+            [Fact]
+            public void should_add_applyInstallArgumentsToDependencies_to_the_option_set()
+            {
+                optionSet.Contains("apply-install-arguments-to-dependencies").ShouldBeTrue();
+            }
+
+            [Fact]
             public void should_add_allowmultipleversions_to_the_option_set()
             {
                 optionSet.Contains("allowmultipleversions").ShouldBeTrue();

--- a/src/chocolatey.tests/infrastructure.app/commands/ChocolateyUninstallCommandSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/commands/ChocolateyUninstallCommandSpecs.cs
@@ -134,6 +134,18 @@ namespace chocolatey.tests.infrastructure.app.commands
             }
 
             [Fact]
+            public void should_add_applyPackageParametersToDependencies_to_the_option_set()
+            {
+                optionSet.Contains("apply-package-parameters-to-dependencies").ShouldBeTrue();
+            }
+
+            [Fact]
+            public void should_add_applyInstallArgumentsToDependencies_to_the_option_set()
+            {
+                optionSet.Contains("apply-install-arguments-to-dependencies").ShouldBeTrue();
+            }
+
+            [Fact]
             public void should_add_forcedependencies_to_the_option_set()
             {
                 optionSet.Contains("forcedependencies").ShouldBeTrue();

--- a/src/chocolatey.tests/infrastructure.app/commands/ChocolateyUpgradeCommandSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/commands/ChocolateyUpgradeCommandSpecs.cs
@@ -146,6 +146,18 @@ namespace chocolatey.tests.infrastructure.app.commands
             }
 
             [Fact]
+            public void should_add_applyPackageParametersToDependencies_to_the_option_set()
+            {
+                optionSet.Contains("apply-package-parameters-to-dependencies").ShouldBeTrue();
+            }
+
+            [Fact]
+            public void should_add_applyInstallArgumentsToDependencies_to_the_option_set()
+            {
+                optionSet.Contains("apply-install-arguments-to-dependencies").ShouldBeTrue();
+            }
+
+            [Fact]
             public void should_add_allowmultipleversions_to_the_option_set()
             {
                 optionSet.Contains("allowmultipleversions").ShouldBeTrue();

--- a/src/chocolatey/infrastructure.app/commands/ChocolateyInstallCommand.cs
+++ b/src/chocolatey/infrastructure.app/commands/ChocolateyInstallCommand.cs
@@ -62,6 +62,12 @@ namespace chocolatey.infrastructure.app.commands
                 .Add("params=|parameters=|pkgparameters=|packageparameters=|package-parameters=",
                      "PackageParameters - Parameters to pass to the package. Defaults to unspecified.",
                      option => configuration.PackageParameters = option.remove_surrounding_quotes())
+                .Add("apply-install-arguments-to-dependencies",
+                     "Apply Install Arguments To Dependencies  - Should install arguments be applied to dependent packages? Defaults to false.",
+                     option => configuration.ApplyInstallArgumentsToDependencies = option != null)
+                .Add("apply-package-parameters-to-dependencies",
+                     "Apply Package Parameters To Dependencies  - Should package parameters be applied to dependent packages? Defaults to false.",
+                     option => configuration.ApplyPackageParametersToDependencies = option != null)
                 .Add("allowdowngrade|allow-downgrade",
                      "AllowDowngrade - Should an attempt at downgrading be allowed? Defaults to false.",
                      option => configuration.AllowDowngrade = option != null)

--- a/src/chocolatey/infrastructure.app/commands/ChocolateyUninstallCommand.cs
+++ b/src/chocolatey/infrastructure.app/commands/ChocolateyUninstallCommand.cs
@@ -58,6 +58,12 @@ namespace chocolatey.infrastructure.app.commands
                 .Add("params=|parameters=|pkgparameters=|packageparameters=|package-parameters=",
                      "PackageParameters - Parameters to pass to the package. Defaults to unspecified.",
                      option => configuration.PackageParameters = option.remove_surrounding_quotes())
+                .Add("apply-install-arguments-to-dependencies",
+                     "Apply Install Arguments To Dependencies  - Should install arguments be applied to dependent packages? Defaults to false.",
+                     option => configuration.ApplyInstallArgumentsToDependencies = option != null)
+                .Add("apply-package-parameters-to-dependencies",
+                     "Apply Package Parameters To Dependencies  - Should package parameters be applied to dependent packages? Defaults to false.",
+                     option => configuration.ApplyPackageParametersToDependencies = option != null)
                 .Add("m|sxs|sidebyside|side-by-side|allowmultiple|allow-multiple|allowmultipleversions|allow-multiple-versions",
                      "AllowMultipleVersions - Should multiple versions of a package be installed? Defaults to false.",
                      option => configuration.AllowMultipleVersions = option != null)

--- a/src/chocolatey/infrastructure.app/commands/ChocolateyUpgradeCommand.cs
+++ b/src/chocolatey/infrastructure.app/commands/ChocolateyUpgradeCommand.cs
@@ -63,6 +63,12 @@ namespace chocolatey.infrastructure.app.commands
                 .Add("params=|parameters=|pkgparameters=|packageparameters=|package-parameters=",
                      "PackageParameters - Parameters to pass to the package. Defaults to unspecified.",
                      option => configuration.PackageParameters = option.remove_surrounding_quotes())
+                .Add("apply-install-arguments-to-dependencies",
+                     "Apply Install Arguments To Dependencies  - Should install arguments be applied to dependent packages? Defaults to false.",
+                     option => configuration.ApplyInstallArgumentsToDependencies = option != null)
+                .Add("apply-package-parameters-to-dependencies",
+                     "Apply Package Parameters To Dependencies  - Should package parameters be applied to dependent packages? Defaults to false.",
+                     option => configuration.ApplyPackageParametersToDependencies = option != null)
                 .Add("allowdowngrade|allow-downgrade",
                      "AllowDowngrade - Should an attempt at downgrading be allowed? Defaults to false.",
                      option => configuration.AllowDowngrade = option != null)

--- a/src/chocolatey/infrastructure.app/configuration/ChocolateyConfiguration.cs
+++ b/src/chocolatey/infrastructure.app/configuration/ChocolateyConfiguration.cs
@@ -203,6 +203,8 @@ NOTE: Hiding sensitive configuration data! Please double and triple
         public bool OverrideArguments { get; set; }
         public bool NotSilent { get; set; }
         public string PackageParameters { get; set; }
+        public bool ApplyPackageParametersToDependencies { get; set; }
+        public bool ApplyInstallArgumentsToDependencies { get; set; }
         public bool IgnoreDependencies { get; set; }
         public bool AllowMultipleVersions { get; set; }
         public bool AllowDowngrade { get; set; }

--- a/src/chocolatey/infrastructure.app/configuration/PackagesConfigFilePackageSetting.cs
+++ b/src/chocolatey/infrastructure.app/configuration/PackagesConfigFilePackageSetting.cs
@@ -40,6 +40,12 @@ namespace chocolatey.infrastructure.app.configuration
         [XmlAttribute(AttributeName = "packageParameters")]
         public string PackageParameters { get; set; }
 
+        [XmlAttribute(AttributeName = "applyPackageParametersToDependencies")]
+        public bool ApplyPackageParametersToDependencies { get; set; }
+
+        [XmlAttribute(AttributeName = "applyInstallArgumentsToDependencies")]
+        public bool ApplyInstallArgumentsToDependencies { get; set; }
+
         [XmlAttribute(AttributeName = "forceX86")]
         public bool ForceX86 { get; set; }
 

--- a/src/chocolatey/infrastructure.app/services/ChocolateyPackageService.cs
+++ b/src/chocolatey/infrastructure.app/services/ChocolateyPackageService.cs
@@ -398,6 +398,8 @@ Did you know Pro / Business automatically syncs with Programs and
             if (!string.IsNullOrWhiteSpace(config.InstallArguments)) arguments.Append(" --install-arguments=\"'{0}'\"".format_with(config.InstallArguments));
             if (config.OverrideArguments) arguments.Append(" --override-arguments");
             if (!string.IsNullOrWhiteSpace(config.PackageParameters)) arguments.Append(" --package-parameters=\"'{0}'\"".format_with(config.PackageParameters));
+            if (config.ApplyPackageParametersToDependencies) arguments.Append(" --apply-package-parameters-to-dependencies");
+            if (config.ApplyInstallArgumentsToDependencies) arguments.Append(" --apply-install-arguments-to-dependencies");
             if (config.AllowDowngrade) arguments.Append(" --allow-downgrade");
             if (config.AllowMultipleVersions) arguments.Append(" --allow-multiple-versions");
             if (config.IgnoreDependencies) arguments.Append(" --ignore-dependencies");
@@ -572,6 +574,8 @@ Would have determined packages that are out of date based on what is
                     if (pkgSettings.ForceX86) packageConfig.ForceX86 = true;
                     if (pkgSettings.AllowMultipleVersions) packageConfig.AllowMultipleVersions = true;
                     if (pkgSettings.IgnoreDependencies) packageConfig.IgnoreDependencies = true;
+                    if (pkgSettings.ApplyInstallArgumentsToDependencies) packageConfig.ApplyInstallArgumentsToDependencies = true;
+                    if (pkgSettings.ApplyPackageParametersToDependencies) packageConfig.ApplyPackageParametersToDependencies = true;
 
                     this.Log().Info(ChocolateyLoggers.Important, @"{0}".format_with(packageConfig.PackageNames));
                     packageConfigs.Add(packageConfig);

--- a/src/chocolatey/infrastructure.app/services/PowershellService.cs
+++ b/src/chocolatey/infrastructure.app/services/PowershellService.cs
@@ -403,20 +403,27 @@ namespace chocolatey.infrastructure.app.services
 
             // we only want to pass the following args to packages that would apply. 
             // like choco install git -params '' should pass those params to git.install, 
-            // but not another package
-            if (!package_is_a_dependency_not_a_virtual(configuration, package.Id))
+            // but not another package unless the switch apply-install-arguments-to-dependencies is used
+            if (!package_is_a_dependency_not_a_virtual(configuration, package.Id) || configuration.ApplyInstallArgumentsToDependencies)
             {
-                this.Log().Debug(ChocolateyLoggers.Verbose, "Setting installer args and package parameters for {0}".format_with(package.Id));
+                this.Log().Debug(ChocolateyLoggers.Verbose, "Setting installer args for {0}".format_with(package.Id));
                 Environment.SetEnvironmentVariable("installArguments", configuration.InstallArguments);
                 Environment.SetEnvironmentVariable("installerArguments", configuration.InstallArguments);
                 Environment.SetEnvironmentVariable("chocolateyInstallArguments", configuration.InstallArguments);
-                Environment.SetEnvironmentVariable("packageParameters", configuration.PackageParameters);
-                Environment.SetEnvironmentVariable("chocolateyPackageParameters", configuration.PackageParameters);
 
                 if (configuration.OverrideArguments)
                 {
                     Environment.SetEnvironmentVariable("chocolateyInstallOverride", "true");
                 }
+            }
+
+            // we only want to pass package parameters to packages that would apply. 
+            // but not another package unless the switch apply-package-parameters-to-dependencies is used
+            if (!package_is_a_dependency_not_a_virtual(configuration, package.Id) || configuration.ApplyPackageParametersToDependencies)
+            {
+                this.Log().Debug(ChocolateyLoggers.Verbose, "Setting package parameters for {0}".format_with(package.Id));
+                Environment.SetEnvironmentVariable("packageParameters", configuration.PackageParameters);
+                Environment.SetEnvironmentVariable("chocolateyPackageParameters", configuration.PackageParameters);
             }
 
             if (!string.IsNullOrWhiteSpace(configuration.DownloadChecksum))


### PR DESCRIPTION
<!--
BEFORE YOU CREATE A PULL REQUEST:

Ensure you have read over CONTRIBUTING - https://github.com/chocolatey/choco/blob/master/CONTRIBUTING.md. We provide VERY defined guidance (as such, we strongly adhere to it).

A summary of our expectations:
 - You are not submitting a pull request from your MASTER branch.
 - You are able to sign the Contributor License Agreement (CLA).
 - YOUR GIT COMMIT MESSAGE FORMAT IS EXTREMELY IMPORTANT. We have a very defined expectation for this format and are sticklers about it. Really, READ the entire Contributing document. It will save you and us pain.
 - Do not reformat code, it makes it hard to see what has changed. Leave the formatting to us.

THANKS! We appreciate you reading the entire Contributing document and not just scanning through it.

DELETE EVERYTHING IN THIS COMMENT BLOCK
-->

In version 0.9.9.8 and earlier, package-parameters would also be applied to dependent packages, but in choco 0.9.10 this was changed so that package-parameters would only be applied to the specified package.
Sometimes it will be useful to pass the package parameters further to dependent packages. This can be controlled by using a cmdline switch.