### PR TITLE
(GH-920) Fix missing $ in Get-FtpFile

### DIFF
--- a/src/chocolatey.resources/helpers/functions/Get-FtpFile.ps1
+++ b/src/chocolatey.resources/helpers/functions/Get-FtpFile.ps1
@@ -190,7 +190,7 @@ param(
     }
 
     Set-PowerShellExitCode 404
-    if (env:DownloadCacheAvailable -eq 'true') {
+    if ($env:DownloadCacheAvailable -eq 'true') {
        throw "The remote file either doesn't exist, is unauthorized, or is forbidden for url '$url'. $($_.Exception.Message) `nThis package is likely not broken for licensed users - see https://chocolatey.org/docs/features-private-cdn."
     } else {
        throw "The remote file either doesn't exist, is unauthorized, or is forbidden for url '$url'. $($_.Exception.Message)"


### PR DESCRIPTION
In case an error occurs (e.g. server responds with 404) and
Get-ChocolateyWebFile's catch clause is reached, the syntax
error is reached.

Closes #920 