### PR TITLE
(GH-925) Make package title available to $env

### DIFF
--- a/src/chocolatey/infrastructure.app/services/PowershellService.cs
+++ b/src/chocolatey/infrastructure.app/services/PowershellService.cs
@@ -384,6 +384,8 @@ namespace chocolatey.infrastructure.app.services
 
             Environment.SetEnvironmentVariable("chocolateyPackageName", package.Id);
             Environment.SetEnvironmentVariable("packageName", package.Id);
+            Environment.SetEnvironmentVariable("chocolateyPackageTitle", package.Title);
+            Environment.SetEnvironmentVariable("packageTitle", package.Title);
             Environment.SetEnvironmentVariable("chocolateyPackageVersion", package.Version.to_string());
             Environment.SetEnvironmentVariable("packageVersion", package.Version.to_string());
             Environment.SetEnvironmentVariable("chocolateyPackageFolder", packageDirectory);


### PR DESCRIPTION
Some times the title of the package must be presented to the user in a
"pretty" matter. The Package Id helps, but is not "GUI-friendly".
To avoid the need to parse the Id ourselves, this adds the access to the
package title as an environment variable.

Closes #925