### PR TITLE
(GH-573)(doc) Explain how to force a failing uninstall

### DIFF
--- a/src/chocolatey/infrastructure.app/commands/ChocolateyUninstallCommand.cs
+++ b/src/chocolatey/infrastructure.app/commands/ChocolateyUninstallCommand.cs
@@ -162,6 +162,10 @@ With auto uninstaller turned off, a chocolateyUninstall.ps1 is required
  Chocolatey but does not remove the software from your system (unless
  in the package directory).
 
+NOTE: A package with a failing uninstall can be removed with the
+`-n --skipautouninstaller` flags. This will remove the package from
+chocolatey without attempting to uninstall the program.
+
 NOTE: Starting in 0.9.10+, the Automatic Uninstaller (AutoUninstaller)
  is turned on by default. To turn it off, run the following command:
 


### PR DESCRIPTION
The procedure for forcing an uninstall in the case of a failed uninstall is not well documented. In reference to issue #573 (and personal frustration with the issue, lol!) I've updated the documentation with instructions on how to bypass both the auto-uninstaller and the package's chocolatelyUninstall.ps1 via:

>  choco uninstall -n --skipautouninstaller [packagename]

It's my understanding that this will remove the package from chocolatey, along with any cached package content. I am not clear on whether the `--skipautouninstaller` flag is necessary in the presence of `-n`. 