### PR TITLE
(#1021) Authcred

### DIFF
--- a/src/chocolatey.resources/helpers/functions/Get-WebFile.ps1
+++ b/src/chocolatey.resources/helpers/functions/Get-WebFile.ps1
@@ -57,6 +57,11 @@ package folder next to the install script, the path will be like
 The user agent to use as part of the request. Defaults to 'chocolatey
 command line'.
 
+.PARAMETER Credential
+OPTIONAL - A System.Net.ICredentials object that contains credentials to
+use to authenticate to the URL server. This is just ultimately passed
+onto System.Net.HttpWebRequest Crentials property. Available in 0.10.4+
+
 .PARAMETER PassThru
 DO NOT USE - holdover from original function.
 
@@ -85,6 +90,7 @@ param(
   [parameter(Mandatory=$false, Position=0)][string] $url = '', #(Read-Host "The URL to download"),
   [parameter(Mandatory=$false, Position=1)][string] $fileName = $null,
   [parameter(Mandatory=$false, Position=2)][string] $userAgent = 'chocolatey command line',
+  [parameter(Mandatory=$false)][Object] $credential = $null,
   [parameter(Mandatory=$false)][switch] $Passthru,
   [parameter(Mandatory=$false)][switch] $quiet,
   [parameter(Mandatory=$false)][hashtable] $options = @{Headers=@{}},
@@ -109,7 +115,9 @@ param(
 
   $req = [System.Net.HttpWebRequest]::Create($url);
   $defaultCreds = [System.Net.CredentialCache]::DefaultCredentials
-  if ($defaultCreds -ne $null) {
+  if ($credential -ne $null) {
+    $req.Credentials = $credential
+  } elseif ($defaultCreds -ne $null) {
     $req.Credentials = $defaultCreds
   }
 

--- a/src/chocolatey.resources/helpers/functions/Get-WebFileName.ps1
+++ b/src/chocolatey.resources/helpers/functions/Get-WebFileName.ps1
@@ -54,6 +54,11 @@ from the url response.
 The user agent to use as part of the request. Defaults to 'chocolatey
 command line'.
 
+.PARAMETER Credential
+OPTIONAL - A System.Net.ICredentials object that contains credentials to
+use to authenticate to the URL server. This is just ultimately passed
+onto System.Net.HttpWebRequest Crentials property. Available in 0.10.4+
+
 .PARAMETER IgnoredArguments
 Allows splatting with arguments that do not apply. Do not use directly.
 
@@ -70,6 +75,7 @@ param(
   [parameter(Mandatory=$false, Position=0)][string] $url = '',
   [parameter(Mandatory=$true, Position=1)][string] $defaultName,
   [parameter(Mandatory=$false)][string] $userAgent = 'chocolatey command line',
+  [parameter(Mandatory=$false)][Object] $credential = $null,
   [parameter(ValueFromRemainingArguments = $true)][Object[]] $ignoredArguments
 )
 
@@ -107,7 +113,9 @@ param(
   }
 
   $defaultCreds = [System.Net.CredentialCache]::DefaultCredentials
-  if ($defaultCreds -ne $null) {
+  if ($credential -ne $null) {
+    $req.Credentials = $credential
+  } elseif ($defaultCreds -ne $null) {
     $request.Credentials = $defaultCreds
   }
 

--- a/src/chocolatey.resources/helpers/functions/Get-WebHeaders.ps1
+++ b/src/chocolatey.resources/helpers/functions/Get-WebHeaders.ps1
@@ -40,6 +40,11 @@ This is the url to get a request/response from.
 The user agent to use as part of the request. Defaults to 'chocolatey
 command line'.
 
+.PARAMETER Credential
+OPTIONAL - A System.Net.ICredentials object that contains credentials to
+use to authenticate to the URL server. This is just ultimately passed
+onto System.Net.HttpWebRequest Crentials property. Available in 0.10.4+
+
 .PARAMETER IgnoredArguments
 Allows splatting with arguments that do not apply. Do not use directly.
 
@@ -55,6 +60,7 @@ Get-WebFile
 param(
   [parameter(Mandatory=$false, Position=0)][string] $url = '',
   [parameter(Mandatory=$false, Position=1)][string] $userAgent = 'chocolatey command line',
+  [parameter(Mandatory=$false)][Object] $credential = $null,
   [parameter(ValueFromRemainingArguments = $true)][Object[]] $ignoredArguments
 )
 
@@ -64,7 +70,9 @@ param(
 
   $request = [System.Net.HttpWebRequest]::Create($url);
   $defaultCreds = [System.Net.CredentialCache]::DefaultCredentials
-  if ($defaultCreds -ne $null) {
+  if ($credential -ne $null) {
+    $request.Credentials = $credential
+  } elseif ($defaultCreds -ne $null) {
     $request.Credentials = $defaultCreds
   }
 

--- a/src/chocolatey.resources/helpers/functions/Install-ChocolateyPackage.ps1
+++ b/src/chocolatey.resources/helpers/functions/Install-ChocolateyPackage.ps1
@@ -166,6 +166,11 @@ https://support.microsoft.com/en-us/kb/811833 for more details.
 
 The recommendation is to use at least SHA256.
 
+.PARAMETER Credential
+OPTIONAL - A System.Net.ICredentials object that contains credentials to
+use to authenticate to the URL server. This is just ultimately passed
+onto System.Net.HttpWebRequest Crentials property. Available in 0.9.11+
+
 .PARAMETER Options
 OPTIONAL - Specify custom headers. Available in 0.9.10+.
 
@@ -269,6 +274,7 @@ param(
   [parameter(Mandatory=$false)][string] $checksumType = '',
   [parameter(Mandatory=$false)][string] $checksum64 = '',
   [parameter(Mandatory=$false)][string] $checksumType64 = '',
+  [parameter(Mandatory=$false)][object] $credential = $null,
   [parameter(Mandatory=$false)][hashtable] $options = @{Headers=@{}},
   [parameter(Mandatory=$false)]
   [alias("useOnlyPackageSilentArgs")][switch] $useOnlyPackageSilentArguments = $false,
@@ -309,6 +315,7 @@ param(
                                       -ChecksumType $checksumType `
                                       -Checksum64 $checksum64 `
                                       -ChecksumType64 $checksumType64 `
+                                      -Credential $credential `
                                       -Options $options `
                                       -GetOriginalFileName
   }

--- a/src/chocolatey.resources/helpers/functions/Install-ChocolateyPowershellCommand.ps1
+++ b/src/chocolatey.resources/helpers/functions/Install-ChocolateyPowershellCommand.ps1
@@ -131,6 +131,11 @@ https://support.microsoft.com/en-us/kb/811833 for more details.
 
 The recommendation is to use at least SHA256.
 
+.PARAMETER Credential
+OPTIONAL - A System.Net.ICredentials object that contains credentials to
+use to authenticate to the URL server. This is just ultimately passed
+onto System.Net.HttpWebRequest Crentials property. Available in 0.9.11+
+
 .PARAMETER Options
 OPTIONAL - Specify custom headers. Available in 0.9.10+.
 
@@ -184,13 +189,14 @@ param(
   [parameter(Mandatory=$false)][string] $checksumType = '',
   [parameter(Mandatory=$false)][string] $checksum64 = '',
   [parameter(Mandatory=$false)][string] $checksumType64 = '',
+  [parameter(Mandatory=$false)][object] $credential = $null,
   [parameter(Mandatory=$false)][hashtable] $options = @{Headers=@{}},
   [parameter(ValueFromRemainingArguments = $true)][Object[]] $ignoredArguments
 )
   Write-Debug "Running 'Install-ChocolateyPowershellCommand' for $packageName with psFileFullPath:`'$psFileFullPath`', url: `'$url`', url64bit:`'$url64bit`', checkSum: `'$checksum`', checksumType: `'$checksumType`', checkSum64: `'$checksum64`', checksumType64: `'$checksumType64`' ";
 
   if ($url -ne '') {
-    Get-ChocolateyWebFile $packageName $psFileFullPath $url $url64bit -checksum $checksum -checksumType $checksumType -checksum64 $checksum64 -checksumType64 $checksumType64 -Options $options
+    Get-ChocolateyWebFile $packageName $psFileFullPath $url $url64bit -checksum $checksum -checksumType $checksumType -checksum64 $checksum64 -checksumType64 $checksumType64 -Credential $credential -Options $options
   }
 
   if ($env:chocolateyPackageName -ne $null -and $env:chocolateyPackageName -eq $env:ChocolateyInstallDirectoryPackage) {

--- a/src/chocolatey.resources/helpers/functions/Install-ChocolateyVsixPackage.ps1
+++ b/src/chocolatey.resources/helpers/functions/Install-ChocolateyVsixPackage.ps1
@@ -98,6 +98,11 @@ https://support.microsoft.com/en-us/kb/811833 for more details.
 
 The recommendation is to use at least SHA256.
 
+.PARAMETER Credential
+OPTIONAL - A System.Net.ICredentials object that contains credentials to
+use to authenticate to the URL server. This is just ultimately passed
+onto System.Net.HttpWebRequest Crentials property. Available in 0.9.11+
+
 .PARAMETER Options
 OPTIONAL - Specify custom headers. Available in 0.9.10+.
 
@@ -136,6 +141,7 @@ param(
   [alias("visualStudioVersion")][parameter(Mandatory=$false, Position=2)][int] $vsVersion = 0,
   [parameter(Mandatory=$false)][string] $checksum = '',
   [parameter(Mandatory=$false)][string] $checksumType = '',
+  [parameter(Mandatory=$false)][object] $credential = $null,
   [parameter(Mandatory=$false)][hashtable] $options = @{Headers=@{}},
   [parameter(ValueFromRemainingArguments = $true)][Object[]] $ignoredArguments
 )
@@ -180,7 +186,7 @@ param(
     if ($installer) {
         $download="$env:TEMP\$($packageName.Replace(' ','')).vsix"
         try{
-            Get-ChocolateyWebFile $packageName $download $vsixUrl -checksum $checksum -checksumType $checksumType -Options $options
+            Get-ChocolateyWebFile $packageName $download $vsixUrl -checksum $checksum -checksumType $checksumType -Credential $credential -Options $options
         }
         catch {
             throw "There were errors attempting to retrieve the vsix from $vsixUrl. The error message was '$_'."

--- a/src/chocolatey.resources/helpers/functions/Install-ChocolateyZipPackage.ps1
+++ b/src/chocolatey.resources/helpers/functions/Install-ChocolateyZipPackage.ps1
@@ -132,6 +132,11 @@ https://support.microsoft.com/en-us/kb/811833 for more details.
 
 The recommendation is to use at least SHA256.
 
+.PARAMETER Credential
+OPTIONAL - A System.Net.ICredentials object that contains credentials to
+use to authenticate to the URL server. This is just ultimately passed
+onto System.Net.HttpWebRequest Crentials property. Available in 0.9.11+
+
 .PARAMETER Options
 OPTIONAL - Specify custom headers. Available in 0.9.10+.
 
@@ -172,6 +177,7 @@ param(
   [parameter(Mandatory=$false)][string] $checksumType = '',
   [parameter(Mandatory=$false)][string] $checksum64 = '',
   [parameter(Mandatory=$false)][string] $checksumType64 = '',
+  [parameter(Mandatory=$false)][object] $credential = $null,
   [parameter(Mandatory=$false)][hashtable] $options = @{Headers=@{}},
   [parameter(ValueFromRemainingArguments = $true)][Object[]] $ignoredArguments
 )
@@ -188,6 +194,6 @@ param(
   if (![System.IO.Directory]::Exists($tempDir)) {[System.IO.Directory]::CreateDirectory($tempDir) | Out-Null}
   $file = Join-Path $tempDir "$($packageName)Install.$fileType"
 
-  $filePath = Get-ChocolateyWebFile $packageName $file $url $url64bit -checkSum $checkSum -checksumType $checksumType -checkSum64 $checkSum64 -checksumType64 $checksumType64 -options $options -getOriginalFileName
+  $filePath = Get-ChocolateyWebFile $packageName $file $url $url64bit -checkSum $checkSum -checksumType $checksumType -checkSum64 $checkSum64 -checksumType64 $checksumType64 -Credential $credential -options $options -getOriginalFileName
   Get-ChocolateyUnzip "$filePath" $unzipLocation $specificFolder $packageName
 }


### PR DESCRIPTION
This is a pretty simple change - the MS web APIs take a credential object. This change adds that cred object to the appropriate chocolatey helper functions and then passes it down to the MS web APIs.

Closes #1021 