### PR TITLE
(GH-1069) Allow failOnInvalidOrMissingLicense to be disabled when one does not have a license

### DIFF
--- a/src/chocolatey/infrastructure.app/runners/GenericRunner.cs
+++ b/src/chocolatey/infrastructure.app/runners/GenericRunner.cs
@@ -121,7 +121,9 @@ Chocolatey is not an official build (bypassed with --allow-unofficial).
 
         public void fail_when_license_is_missing_or_invalid_if_requested(ChocolateyConfiguration config)
         {
-            if (!config.Features.FailOnInvalidOrMissingLicense) return;
+            if (!config.Features.FailOnInvalidOrMissingLicense || 
+                config.CommandName.Trim().Equals("feature")) 
+                return;
 
             if (!config.Information.IsLicensedVersion) throw new ApplicationException("License is missing or invalid.");
         }


### PR DESCRIPTION
This PR disables the check for a chocolatey license when the failOnInvalidOrMissingLicense is enabled and the 'features' command is being used. This allows features to be turned on and off when the failOnInvalidOrMissingLicense is enabled and the chocolatey install has no license.

This fixes an issue whereby if failOnInvalidOrMissingLicense feature is enabled and no license exists, there is no way to disable this feature to use chocolatey without a license.

Fixes #1069 