### PR TITLE
(GH-1047) Harden Xml serialization and deserialization

### DIFF
--- a/src/chocolatey/infrastructure/adapters/HashAlgorithm.cs
+++ b/src/chocolatey/infrastructure/adapters/HashAlgorithm.cs
@@ -1,5 +1,6 @@
 namespace chocolatey.infrastructure.adapters
 {
+    using System.IO;
     using cryptography;
 
     public sealed class HashAlgorithm : IHashAlgorithm
@@ -14,6 +15,11 @@ namespace chocolatey.infrastructure.adapters
         public byte[] ComputeHash(byte[] buffer)
         {
             return _algorithm.ComputeHash(buffer);
+        }
+
+        public byte[] ComputeHash(Stream stream)
+        {
+            return _algorithm.ComputeHash(stream);
         }
     }
 }

--- a/src/chocolatey/infrastructure/adapters/IHashAlgorithm.cs
+++ b/src/chocolatey/infrastructure/adapters/IHashAlgorithm.cs
@@ -1,10 +1,13 @@
 namespace chocolatey.infrastructure.adapters
 {
+    using System.IO;
     // ReSharper disable InconsistentNaming
     
     public interface IHashAlgorithm
     {
         byte[] ComputeHash(byte[] buffer);
+        
+        byte[] ComputeHash(Stream stream);
     }
 
     // ReSharper restore InconsistentNaming

--- a/src/chocolatey/infrastructure/cryptography/CryptoHashProvider.cs
+++ b/src/chocolatey/infrastructure/cryptography/CryptoHashProvider.cs
@@ -1,4 +1,4 @@
-// Copyright � 2011 - Present RealDimensions Software, LLC
+// Copyright © 2011 - Present RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/chocolatey/infrastructure/cryptography/CryptoHashProvider.cs
+++ b/src/chocolatey/infrastructure/cryptography/CryptoHashProvider.cs
@@ -1,4 +1,4 @@
-// Copyright © 2011 - Present RealDimensions Software, LLC
+// Copyright ï¿½ 2011 - Present RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -105,6 +105,20 @@ namespace chocolatey.infrastructure.cryptography
                 //IO.IO_FileTooLong2GB (over Int32.MaxValue)
                 return ApplicationParameters.HashProviderFileTooBig;
             }
+        }
+
+        public string hash_byte_array(byte[] buffer)
+        {                
+            var hash = _hashAlgorithm.ComputeHash(buffer);
+
+            return BitConverter.ToString(hash).Replace("-", string.Empty);
+        }
+
+        public string hash_stream(Stream inputStream)
+        {                
+            var hash = _hashAlgorithm.ComputeHash(inputStream);
+
+            return BitConverter.ToString(hash).Replace("-", string.Empty);
         }
 
         private static bool file_is_locked(Exception exception)

--- a/src/chocolatey/infrastructure/cryptography/IHashProvider.cs
+++ b/src/chocolatey/infrastructure/cryptography/IHashProvider.cs
@@ -1,4 +1,4 @@
-// Copyright � 2011 - Present RealDimensions Software, LLC
+// Copyright © 2011 - Present RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/chocolatey/infrastructure/cryptography/IHashProvider.cs
+++ b/src/chocolatey/infrastructure/cryptography/IHashProvider.cs
@@ -1,4 +1,4 @@
-// Copyright © 2011 - Present RealDimensions Software, LLC
+// Copyright ï¿½ 2011 - Present RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,6 +12,8 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
+using System.IO;
 
 namespace chocolatey.infrastructure.cryptography
 {
@@ -32,5 +34,19 @@ namespace chocolatey.infrastructure.cryptography
         /// <param name="filePath">The file path.</param>
         /// <returns>A computed hash of the file, based on the contents.</returns>
         string hash_file(string filePath);
+
+        /// <summary>
+        /// Returns a hash of the specified stream.
+        /// </summary>
+        /// <param name="inputStream">The stream.</param>
+        /// <returns>A computed hash of the stream, based on the contents.</returns>
+        string hash_stream(Stream inputStream);
+
+        /// <summary>
+        /// Returns a hash of the specified byte array.
+        /// </summary>
+        /// <param name="buffer">The byte array.</param>
+        /// <returns>A computed hash of the array, based on the contents.</returns>
+        string hash_byte_array(byte[] buffer);
     }
 }

--- a/src/chocolatey/infrastructure/filesystem/DotNetFileSystem.cs
+++ b/src/chocolatey/infrastructure/filesystem/DotNetFileSystem.cs
@@ -390,6 +390,25 @@ namespace chocolatey.infrastructure.filesystem
             return success != 0;
         }
 
+        
+        public void replace_file(string sourceFilePath, string destinationFilePath, string backupFilePath)
+        {
+            this.Log().Debug(ChocolateyLoggers.Verbose, () => "Attempting to replace \"{0}\"{1} with \"{2}\". Backup placed at \"{3}\".".format_with(destinationFilePath, Environment.NewLine, sourceFilePath, backupFilePath));
+
+            allow_retries(
+                () =>
+                {
+                    try
+                    {
+                        File.Replace(sourceFilePath, destinationFilePath, backupFilePath);
+                    }
+                    catch (IOException)
+                    {
+                        Alphaleonis.Win32.Filesystem.File.Replace(sourceFilePath, destinationFilePath, backupFilePath);
+                    }
+                });
+        }
+
         // ReSharper disable InconsistentNaming
 
         // http://msdn.microsoft.com/en-us/library/windows/desktop/aa363851.aspx

--- a/src/chocolatey/infrastructure/filesystem/IFileSystem.cs
+++ b/src/chocolatey/infrastructure/filesystem/IFileSystem.cs
@@ -205,6 +205,14 @@ namespace chocolatey.infrastructure.filesystem
         bool copy_file_unsafe(string sourceFilePath, string destinationFilePath, bool overwriteExisting);
 
         /// <summary>
+        ///   Replace an existing file.
+        /// </summary>
+        /// <param name="sourceFilePath">Where is the file now?</param>
+        /// <param name="destinationFilePath">Where would you like it to go?</param>
+        /// <param name="backupFilePath">Where should the existing file be placed? Null if nowhere.</param>
+        void replace_file(string sourceFilePath, string destinationFilePath, string backupFilePath);
+
+        /// <summary>
         ///   Deletes the specified file.
         /// </summary>
         /// <param name="filePath">The name of the file to be deleted. Wildcard characters are not supported.</param>


### PR DESCRIPTION
Rewrites the XML serialization service in a few specific ways:
- Should update hash checks now builds the update file in memory rather than committing it the disk, and checks the hash in memory.
- The ".update" file now using the slightly hardier File Replace to replace the undated file, and also generates a ".backup".
- When deserializing, we now check for a ".backup" if serialization fails and attempt that too.
- Generally use streams and dispose where possible.

Closes #1047
