### PR TITLE
(GH1083) Display brief usage message when run with no arguments

### DIFF
--- a/src/chocolatey.console/Program.cs
+++ b/src/chocolatey.console/Program.cs
@@ -89,6 +89,10 @@ namespace chocolatey.console
                         "chocolatey".Log().Info(ChocolateyLoggers.Important, () => "{0} v{1}{2}".format_with(ApplicationParameters.Name, config.Information.ChocolateyProductVersion, license.is_licensed_version() ? " {0}".format_with(license.LicenseType) : string.Empty));
                     }
 #endif
+                    if (args.Length == 0)
+                    {
+                        "chocolatley".Log().Info(ChocolateyLoggers.Important, () => "Please run 'choco -?' or 'choco <command> -?' for help menu.");
+                    }
                 }
 
                 if (warnings.Count != 0 && config.RegularOutput)


### PR DESCRIPTION
When run with no arguments display a short usage message to the console in both Debug and Release builds. Please let me know if you need anything else, thanks!

Closes #1083