### PR TITLE
(GH-1098) Change counter and length variables to long

### DIFF
--- a/src/chocolatey.resources/helpers/functions/Get-FtpFile.ps1
+++ b/src/chocolatey.resources/helpers/functions/Get-FtpFile.ps1
@@ -168,17 +168,11 @@ param(
       } while ($count -ne 0)
       Write-Host ""
       Write-Host "Download of $([System.IO.Path]::GetFileName($fileName)) ($goalFormatted) completed."
-    } catch {
-      throw $_.Exception
     } finally {
         $ErrorActionPreference = $originalEAP
     }
 
-    $reader.Close()
-    if ($fileName) {
-      $writer.Flush()
-      $writer.Close()
-    }
+    $writer.Flush() # closed in finally block
 
   } catch {
     if ($ftprequest -ne $null) {
@@ -197,8 +191,17 @@ param(
        throw "The remote file either doesn't exist, is unauthorized, or is forbidden for url '$url'. $($_.Exception.Message)"
     }
   } finally {
+
+    if ($reader -ne $null) {
+      try { $reader.Close(); } catch {}
+    }
+
+    if ($writer -ne $null) {
+      try { $writer.Close(); } catch {}
+    }
+
     if ($ftpresponse -ne $null) {
-      $ftpresponse.Close()
+      try { $ftpresponse.Close(); } catch {}
     }
 
     Start-Sleep 1

--- a/src/chocolatey.resources/helpers/functions/Get-FtpFile.ps1
+++ b/src/chocolatey.resources/helpers/functions/Get-FtpFile.ps1
@@ -133,7 +133,7 @@ param(
   try {
     # send the ftp request to the server
     $ftpresponse = $ftprequest.GetResponse()
-    [int]$goal = $ftpresponse.ContentLength
+    [long]$goal = $ftpresponse.ContentLength
     $goalFormatted = Format-FileSize $goal
 
     # get a download stream from the server response
@@ -141,8 +141,9 @@ param(
 
     # create the target file on the local system and the download buffer
     $writer = New-Object IO.FileStream ($fileName,[IO.FileMode]::Create)
+
     [byte[]]$buffer = New-Object byte[] 1024
-    [int]$total = [int]$count = 0
+    [long]$total = [long]$count = 0
 
     $originalEAP = $ErrorActionPreference
     $ErrorActionPreference = 'Stop'


### PR DESCRIPTION
This change avoids an integer overflow error, and brings the implementation
into line with the `Get-WebFile` function.

There is further discussion on #1098 around modifying the way the streams are handled to ensure that the output stream is closed on failure. The initial commit deals only with the core of the issue; any further changes can be added subsequently.