### PR TITLE
(GH-1099) Change buffer for FTP downloads to 1MiB

### DIFF
--- a/src/chocolatey.resources/helpers/functions/Get-FtpFile.ps1
+++ b/src/chocolatey.resources/helpers/functions/Get-FtpFile.ps1
@@ -141,7 +141,7 @@ param(
 
     # create the target file on the local system and the download buffer
     $writer = New-Object IO.FileStream ($fileName,[IO.FileMode]::Create)
-    [byte[]]$buffer = New-Object byte[] 1024
+    [byte[]]$buffer = New-Object byte[] 1048576
     [int]$total = [int]$count = 0
 
     $originalEAP = $ErrorActionPreference


### PR DESCRIPTION
Buffer size changes from 1KiB to 1MiB. This will make FTP downloads more performant, and shifts the `Get-FtpFile` implementation to match `Get-WebFile` in this detail.