### PR TITLE
(GH-1106) Hide sensitive data in choco apikey call output

### DIFF
--- a/src/chocolatey/infrastructure.app/commands/ChocolateyApiKeyCommand.cs
+++ b/src/chocolatey/infrastructure.app/commands/ChocolateyApiKeyCommand.cs
@@ -112,13 +112,15 @@ In order to save your API key for {0},
             {
                 _configSettingsService.get_api_key(configuration, (key) =>
                     {
+                        string authenticatedString = string.IsNullOrWhiteSpace(key.Key) ? string.Empty : "(Authenticated)";
+
                         if (configuration.RegularOutput)
                         {
-                            this.Log().Info(() => "{0} - {1}".format_with(key.Source, key.Key));
+                            this.Log().Info(() => "{0} - {1}".format_with(key.Source, authenticatedString));
                         }
                         else
                         {
-                            this.Log().Info(() => "{0}|{1}".format_with(key.Source, key.Key));
+                            this.Log().Info(() => "{0}|{1}".format_with(key.Source, authenticatedString));
                         }
                     });
             }


### PR DESCRIPTION
Closes #1106

Replaced plain text api key output with "(Authenticated)" where the api key is not null or whitespace.