### PR TITLE
(GH-906) Fix source path used when installing from nuspec file.

### DIFF
--- a/src/chocolatey.tests.integration/scenarios/PackScenarios.cs
+++ b/src/chocolatey.tests.integration/scenarios/PackScenarios.cs
@@ -70,6 +70,12 @@ namespace chocolatey.tests.integration.scenarios
 
                 File.Exists(package_path).ShouldBeTrue();
             }
+
+            [Fact]
+            public void sources_should_be_set_to_current_directory()
+            {
+                Configuration.Sources.ShouldEqual(Scenario.get_top_level());                
+            }
         }
 
         [Concern(typeof(ChocolateyPackCommand))]
@@ -99,6 +105,12 @@ namespace chocolatey.tests.integration.scenarios
                 infos[1].ShouldEqual(string.Concat("Successfully created package '", package_path, "'"));
 
                 File.Exists(package_path).ShouldBeTrue();
+            }
+
+            [Fact]
+            public void sources_should_be_set_to_specified_output_directory()
+            {
+                Configuration.Sources.ShouldEqual("PackageOutput");
             }
         }
 

--- a/src/chocolatey/infrastructure.app/services/NugetService.cs
+++ b/src/chocolatey/infrastructure.app/services/NugetService.cs
@@ -254,7 +254,10 @@ namespace chocolatey.infrastructure.app.services
             }
 
             string outputFile = builder.Id + "." + builder.Version + Constants.PackageExtension;
-            string outputPath = _fileSystem.combine_paths(config.OutputDirectory ?? _fileSystem.get_current_directory(), outputFile);
+            string outputFolder = config.OutputDirectory ?? _fileSystem.get_current_directory();
+            string outputPath = _fileSystem.combine_paths(outputFolder, outputFile);
+
+            config.Sources = outputFolder;
 
             this.Log().Info(() => "Attempting to build package from '{0}'.".format_with(_fileSystem.get_file_name(nuspecFilePath)));
 


### PR DESCRIPTION
Previously when the install target was a nuspec file and the output
folder was not set to the folder that contained the nuspec file then
the installation failed because the nupkg file could not be found.
Update sets the sources parameter to the output folder during the
packaging of the nuspec file.

Closes #906 