### PR TITLE
(GH-523) Be explicit about the version when installing a nupkg.

### DIFF
--- a/src/chocolatey/infrastructure.app/services/NugetService.cs
+++ b/src/chocolatey/infrastructure.app/services/NugetService.cs
@@ -359,6 +359,7 @@ folder.");
                     else
                     {
                         var packageFile = new OptimizedZipPackage(_fileSystem.get_full_path(packageName));
+                        version = packageFile.Version;
                         packageNames.Add(packageFile.Id);
                     }
                 }


### PR DESCRIPTION
Previously if there were two versions of a nupkg in the same
directory and you tried to install the older one, it would install
the newer one. Now the nupkg version is explicitly specified as
part of the install arguments.

Closes #523 