### PR TITLE
(GH-473) Correct exit code when help is requested

### DIFF
--- a/src/chocolatey.console/Program.cs
+++ b/src/chocolatey.console/Program.cs
@@ -99,10 +99,10 @@ namespace chocolatey.console
                     }
                 }
 
-                if (config.HelpRequested)
+                if (config.HelpRequested || config.UnsuccessfulParsing)
                 {
                     pause_execution_if_debug();
-                    Environment.Exit(-1);
+                    Environment.Exit(config.UnsuccessfulParsing?1:0);
                 }
 
                 Log4NetAppenderConfiguration.set_logging_level_debug_when_debug(config.Debug, excludeLoggerName: "{0}LoggingColoredConsoleAppender".format_with(ChocolateyLoggers.Verbose.to_string()));

--- a/src/chocolatey.tests.integration/Scenario.cs
+++ b/src/chocolatey.tests.integration/Scenario.cs
@@ -142,6 +142,7 @@ namespace chocolatey.tests.integration
             config.ForceDependencies = false;
             config.ForceX86 = false;
             config.HelpRequested = false;
+            config.UnsuccessfulParsing = false;
             config.IgnoreDependencies = false;
             config.InstallArguments = string.Empty;
             config.Noop = false;

--- a/src/chocolatey.tests/infrastructure.app/configuration/ConfigurationOptionsSpec.cs
+++ b/src/chocolatey.tests/infrastructure.app/configuration/ConfigurationOptionsSpec.cs
@@ -312,6 +312,26 @@ namespace chocolatey.tests.infrastructure.app.configuration
                 config.Debug.ShouldBeFalse();
                 helpMessageContents.ToString().ShouldNotBeEmpty();
             }
+
+            [Fact]
+            public void should_successfully_parse_help_option()
+            {
+                args.Add("-h");
+
+                because();
+
+                config.UnsuccessfulParsing.ShouldBeFalse();
+            }
+
+            [Fact]
+            public void should_not_parse_unknown_option()
+            {
+                args.Add("-unknown");
+
+                because();
+
+                config.UnsuccessfulParsing.ShouldBeTrue();
+            }
         }
     }
 }

--- a/src/chocolatey/infrastructure.app/builders/ConfigurationBuilder.cs
+++ b/src/chocolatey/infrastructure.app/builders/ConfigurationBuilder.cs
@@ -368,6 +368,7 @@ namespace chocolatey.infrastructure.app.builders
                         {
                             // save help for next menu
                             config.HelpRequested = false;
+                            config.UnsuccessfulParsing = false;
                         }
                     },
                 () => { },

--- a/src/chocolatey/infrastructure.app/configuration/ChocolateyConfiguration.cs
+++ b/src/chocolatey/infrastructure.app/configuration/ChocolateyConfiguration.cs
@@ -156,6 +156,10 @@ NOTE: Hiding sensitive configuration data! Please double and triple
         public bool Force { get; set; }
         public bool Noop { get; set; }
         public bool HelpRequested { get; set; }
+        /// <summary>
+        ///   Gets or sets a value indicating whether parsing was successful (everything parsed) or not.
+        /// </summary>
+        public bool UnsuccessfulParsing { get; set; }
 
         // TODO: Should look into using mutually exclusive output levels - Debug, Info (Regular), Error (Quiet)
         // Verbose and Important are not part of the levels at all

--- a/src/chocolatey/infrastructure.app/configuration/ConfigurationOptions.cs
+++ b/src/chocolatey/infrastructure.app/configuration/ConfigurationOptions.cs
@@ -85,6 +85,7 @@ namespace chocolatey.infrastructure.app.configuration
             catch (OptionException)
             {
                 show_help(_optionSet, helpMessage);
+                configuration.UnsuccessfulParsing = true;
             }
 
             // the command argument
@@ -102,6 +103,7 @@ namespace chocolatey.infrastructure.app.configuration
                 else
                 {
                     configuration.HelpRequested = true;
+                    configuration.UnsuccessfulParsing = true;
                 }
             }
 

--- a/src/chocolatey/infrastructure.app/runners/ConsoleApplication.cs
+++ b/src/chocolatey/infrastructure.app/runners/ConsoleApplication.cs
@@ -64,7 +64,7 @@ namespace chocolatey.infrastructure.app.runners
 
                 commandArgs.Add(arg);
             }
-
+            
             var runner = new GenericRunner();
             runner.run(config, container, isConsole: true, parseArgs: command =>
                 {
@@ -89,6 +89,7 @@ namespace chocolatey.infrastructure.app.runners
                                     if (unparsedArg.StartsWith("-") || unparsedArg.StartsWith("/"))
                                     {
                                         config.HelpRequested = true;
+                                        config.UnsuccessfulParsing = true;
                                     }
                                 }
                             }

--- a/src/chocolatey/infrastructure.app/runners/GenericRunner.cs
+++ b/src/chocolatey/infrastructure.app/runners/GenericRunner.cs
@@ -75,13 +75,13 @@ namespace chocolatey.infrastructure.app.runners
                 this.Log().Debug(() => "Configuration: {0}".format_with(config.ToString()));
 
 
-                if (isConsole && config.HelpRequested)
+                if (isConsole && (config.HelpRequested || config.UnsuccessfulParsing))
                 {
 #if DEBUG
                     Console.WriteLine("Press enter to continue...");
                     Console.ReadKey();
 #endif
-                    Environment.Exit(1);
+                    Environment.Exit(config.UnsuccessfulParsing?1:0);
                 }
 
                 var token = Assembly.GetExecutingAssembly().get_public_key_token();


### PR DESCRIPTION
I've introduced new property UnsuccessfulParsing in ChocolateyConfiguration to differ if parsing failed or not (respectively to show help menu or not to show). Thanks to that choco returns proper exit code. Moreover I've added 2 test cases. I hope everything is OK.

Closes #473