### PR TITLE
(GH-1141) Fix constant proxy NREs for some environments

### DIFF
--- a/src/chocolatey.resources/helpers/functions/Get-WebFile.ps1
+++ b/src/chocolatey.resources/helpers/functions/Get-WebFile.ps1
@@ -133,7 +133,7 @@ param(
 	Write-Host "Using explicit proxy server '$explicitProxy'."
     $req.Proxy = $proxy
 
-  } elseif (!$webclient.Proxy.IsBypassed($url))
+  } elseif ($client.Proxy -and !$webclient.Proxy.IsBypassed($url))
   {
 	# system proxy (pass through)
     $creds = [net.CredentialCache]::DefaultCredentials

--- a/src/chocolatey.resources/helpers/functions/Get-WebFile.ps1
+++ b/src/chocolatey.resources/helpers/functions/Get-WebFile.ps1
@@ -133,7 +133,7 @@ param(
 	Write-Host "Using explicit proxy server '$explicitProxy'."
     $req.Proxy = $proxy
 
-  } elseif ($client.Proxy -and !$webclient.Proxy.IsBypassed($url))
+  } elseif ($webclient.Proxy -and !$webclient.Proxy.IsBypassed($url))
   {
 	# system proxy (pass through)
     $creds = [net.CredentialCache]::DefaultCredentials

--- a/src/chocolatey.resources/helpers/functions/Get-WebFileName.ps1
+++ b/src/chocolatey.resources/helpers/functions/Get-WebFileName.ps1
@@ -130,7 +130,7 @@ param(
     Write-Debug "Using explicit proxy server '$explicitProxy'."
     $request.Proxy = $proxy
 
-  } elseif (!$client.Proxy.IsBypassed($url))
+  } elseif ($client.Proxy -and !$client.Proxy.IsBypassed($url))
   {
     # system proxy (pass through)
     $creds = [Net.CredentialCache]::DefaultCredentials

--- a/src/chocolatey.resources/helpers/functions/Get-WebHeaders.ps1
+++ b/src/chocolatey.resources/helpers/functions/Get-WebHeaders.ps1
@@ -87,7 +87,7 @@ param(
     Write-Host "Using explicit proxy server '$explicitProxy'."
     $request.Proxy = $proxy
 
-  } elseif (!$client.Proxy.IsBypassed($url))
+  } elseif ($client.Proxy -and !$client.Proxy.IsBypassed($url))
   {
     # system proxy (pass through)
     $creds = [Net.CredentialCache]::DefaultCredentials


### PR DESCRIPTION
In some environments, (new-object System.Net.WebClient).Proxy -eq $null
is true, as is [System.Net.WebRequest]::DefaultWebProxy -eq $null. This
means the IsBypassed() method was being called on a null object. This
checks the object's existence before using that method.

Fixes #1141