### PR TITLE
(GH-1059) Fix for setting global variables

### DIFF
--- a/src/chocolatey/infrastructure.app/ApplicationParameters.cs
+++ b/src/chocolatey/infrastructure.app/ApplicationParameters.cs
@@ -132,7 +132,6 @@ namespace chocolatey.infrastructure.app
         {
             public static readonly string CacheLocation = "cacheLocation";
             public static readonly string ContainsLegacyPackageInstalls = "containsLegacyPackageInstalls";
-            public static readonly string CommandExecutionTimeoutSeconds = "commandExecutionTimeoutSeconds";
             public static readonly string Proxy = "proxy";
             public static readonly string ProxyUser = "proxyUser";
             public static readonly string ProxyPassword = "proxyPassword";

--- a/src/chocolatey/infrastructure.app/builders/ConfigurationBuilder.cs
+++ b/src/chocolatey/infrastructure.app/builders/ConfigurationBuilder.cs
@@ -194,21 +194,13 @@ namespace chocolatey.infrastructure.app.builders
                 config.CacheLocation = fileSystem.combine_paths(ApplicationParameters.InstallLocation, "temp");
             }
 
-            var originalCommandTimeout = configFileSettings.CommandExecutionTimeoutSeconds;
-            var commandExecutionTimeoutSeconds = -1;
-            int.TryParse(
-                set_config_item(
-                    ApplicationParameters.ConfigSettings.CommandExecutionTimeoutSeconds,
-                    configFileSettings,
-                    originalCommandTimeout == 0 ?
-                        ApplicationParameters.DefaultWaitForExitInSeconds.to_string()
-                        : originalCommandTimeout.to_string(),
-                    "Default timeout for command execution."),
-                out commandExecutionTimeoutSeconds);
-            config.CommandExecutionTimeoutSeconds = commandExecutionTimeoutSeconds;
-            if (configFileSettings.CommandExecutionTimeoutSeconds <= 0)
+            if (configFileSettings.CommandExecutionTimeoutSeconds > 0)
             {
-                set_config_item(ApplicationParameters.ConfigSettings.CommandExecutionTimeoutSeconds, configFileSettings, ApplicationParameters.DefaultWaitForExitInSeconds.to_string(), "Default timeout for command execution.", forceSettingValue: true);
+                config.CommandExecutionTimeoutSeconds = configFileSettings.CommandExecutionTimeoutSeconds;
+            }
+            else
+            {
+                set_config_item(ApplicationParameters.DefaultWaitForExitInSeconds.to_string(), configFileSettings, ApplicationParameters.DefaultWaitForExitInSeconds.to_string(), "Default timeout for command execution.", forceSettingValue: true);
                 config.CommandExecutionTimeoutSeconds = ApplicationParameters.DefaultWaitForExitInSeconds;
             }
 

--- a/src/chocolatey/infrastructure.app/configuration/chocolatey.config
+++ b/src/chocolatey/infrastructure.app/configuration/chocolatey.config
@@ -3,7 +3,6 @@
   <config>
     <add key="cacheLocation" value="" />
     <add key="containsLegacyPackageInstalls" value="true" />
-    <add key="commandExecutionTimeoutSeconds" value="2700" />
     <add key="proxy" value="" />
     <add key="proxyUser" value="" />
     <add key="proxyPassword" value="" />


### PR DESCRIPTION
commandExecutionTimeoutSeconds was defined twice in the Chocolatey
configuration. With this pull request, only the primary key is used. This
fixes the incorrect behaviour that choco exhibited when changing this
value through `choco config`.

Closes #1059 #973.

For testing use the following commands:
```powershell
PS> choco config set commandExecutionTimeoutSeconds 7200
PS> choco config get commandExecutionTimeoutSeconds
```

In the old version, the default value of 2700 was displayed. In this change
the value will be set at the given value.