### PR TITLE
Dockerfile to Enable Mono Based Choco Builds

### DIFF
--- a/docker/Dockerfile.linux
+++ b/docker/Dockerfile.linux
@@ -1,0 +1,17 @@
+FROM mono:3.12.1
+
+MAINTAINER Justin Phelps <linuturk@onitato.com>
+
+COPY . /usr/local/src/choco/
+
+WORKDIR /usr/local/src/choco
+RUN chmod +x build.sh
+RUN chmod +x zip.sh
+RUN ./build.sh
+
+WORKDIR /usr/local/bin
+RUN ln -s /usr/local/src/choco/build_output/chocolatey
+
+COPY docker/choco_wrapper /usr/local/bin/choco
+
+WORKDIR /root

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,12 @@
+Building Docker Image
+=====================
+
+This directory contains the necessary Dockerfile and wrapper script for building a Docker Image. This is a Linux based image that builds and runs choco.exe with mono.
+
+To build this image yourself, follow these steps:
+
+1. Clone down the repository using `git clone https://github.com/chocolatey/choco.git`.
+1. Change directories to the root of the repository.
+1. Run the docker build command. `docker build -t mono-choco -f docker/Dockerfile.linux .` (the trailing . is important)
+1. Run your new image using the command `docker run -ti --rm mono-choco /bin/bash`
+1. Test choco by running `choco -h`. You should see the help message from choco.exe.

--- a/docker/choco_wrapper
+++ b/docker/choco_wrapper
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+mono /usr/local/bin/chocolatey/choco.exe "$@" --allow-unofficial


### PR DESCRIPTION
This PR provides a Dockerfile and choco_wrapper script to enable easy Linux based choco.exe usage.

The Dockerfile copies the entire source tree into the container and then builds choco.exe using the build.sh script.

The choco_wrapper is copied into /usr/local/bin/choco and allows for easier execution of choco.exe using mono.

I suggest linking the repository to Docker Hub and releasing various versions of the Docker image using their build process.