### PR TITLE
(GH-1237) Implemented choco list --id-only.

### DIFF
--- a/src/chocolatey.resources/helpers/ChocolateyTabExpansion.ps1
+++ b/src/chocolatey.resources/helpers/ChocolateyTabExpansion.ps1
@@ -41,7 +41,7 @@ $proNewOptions = " --file='' --build-package --file64='' --from-programs-and-fea
 $proUninstallOptions = " --from-programs-and-features"
 
 $commandOptions = @{
-  list = "--lo --pre --exact --by-id-only --id-starts-with --detailed --approved-only --not-broken --source='' --user= --password= --local-only --prerelease --include-programs --page= --page-size= --order-by-popularity --download-cache-only" + $allcommands
+  list = "--lo --id-only --pre --exact --by-id-only --id-starts-with --detailed --approved-only --not-broken --source='' --user= --password= --local-only --prerelease --include-programs --page= --page-size= --order-by-popularity --download-cache-only" + $allcommands
   search = "--pre --exact --by-id-only --id-starts-with --detailed --approved-only --not-broken --source='' --user= --password= --local-only --prerelease --include-programs --page= --page-size= --order-by-popularity --download-cache-only" + $allcommands
   info = "--pre --lo --source='' --user= --password= --local-only --prerelease" + $allcommands
   install = "-y -whatif -? --pre --version= --params='' --install-arguments='' --override-arguments --ignore-dependencies --source='' --source='windowsfeatures' --source='webpi' --user= --password= --prerelease --forcex86 --not-silent --package-parameters='' --allow-downgrade --force-dependencies --require-checksums --use-package-exit-codes --ignore-package-exit-codes --skip-automation-scripts --allow-multiple-versions --ignore-checksums --allow-empty-checksums --allow-empty-checksums-secure --download-checksum='' --download-checksum-type='' --download-checksum-x64='' --download-checksum-type-x64='' --stop-on-first-package-failure" + $proInstallUpgradeOptions + $allcommands

--- a/src/chocolatey.tests.integration/Scenario.cs
+++ b/src/chocolatey.tests.integration/Scenario.cs
@@ -175,6 +175,7 @@ namespace chocolatey.tests.integration
             config.UpgradeCommand.FailOnNotInstalled = false;
             config.PinCommand.Name = string.Empty;
             config.PinCommand.Command = PinCommandType.unknown;
+            config.ListCommand.IdOnly = false;
 
             return config;
         }

--- a/src/chocolatey.tests.integration/scenarios/ListScenarios.cs
+++ b/src/chocolatey.tests.integration/scenarios/ListScenarios.cs
@@ -290,6 +290,36 @@ namespace chocolatey.tests.integration.scenarios
         }
 
         [Concern(typeof(ChocolateyListCommand))]
+        public class when_listing_local_packages_with_id_only : ScenariosBase
+        {
+            public override void Context()
+            {
+                base.Context();
+                Configuration.ListCommand.LocalOnly = true;
+                Configuration.ListCommand.IdOnly = true;
+                Configuration.Sources = ApplicationParameters.PackagesLocation;
+            }
+
+            public override void Because()
+            {
+                MockLogger.reset();
+                Results = Service.list_run(Configuration).ToList();
+            }
+
+            [Fact]
+            public void should_contain_package_name()
+            {
+                MockLogger.contains_message("upgradepackage").ShouldBeTrue();
+            }
+
+            [Fact]
+            public void should_not_contain_any_version_number()
+            {
+                MockLogger.contains_message(".0").ShouldBeFalse();
+            }
+        }
+
+        [Concern(typeof(ChocolateyListCommand))]
         public class when_listing_local_packages_limiting_output : ScenariosBase
         {
             public override void Context()
@@ -339,6 +369,44 @@ namespace chocolatey.tests.integration.scenarios
                 MockLogger.contains_message("Running list with the following filter", LogLevel.Debug).ShouldBeFalse();
                 MockLogger.contains_message("Start of List", LogLevel.Debug).ShouldBeFalse();
                 MockLogger.contains_message("End of List", LogLevel.Debug).ShouldBeFalse();
+            }
+        }
+
+        [Concern(typeof(ChocolateyListCommand))]
+        public class when_listing_local_packages_limiting_output_with_id_only : ScenariosBase
+        {
+            public override void Context()
+            {
+                base.Context();
+
+                Configuration.ListCommand.LocalOnly = true;
+                Configuration.ListCommand.IdOnly = true;
+                Configuration.Sources = ApplicationParameters.PackagesLocation;
+                Configuration.RegularOutput = false;
+            }
+
+            public override void Because()
+            {
+                MockLogger.reset();
+                Results = Service.list_run(Configuration).ToList();
+            }
+
+            [Fact]
+            public void should_contain_packages_id()
+            {
+                MockLogger.contains_message("upgradepackage").ShouldBeTrue();
+            }
+
+            [Fact]
+            public void should_not_contain_any_version_number()
+            {
+                MockLogger.contains_message(".0").ShouldBeFalse();
+            }
+
+            [Fact]
+            public void should_not_contain_pipe()
+            {
+                MockLogger.contains_message("|").ShouldBeFalse();
             }
         }
 

--- a/src/chocolatey/infrastructure.app/commands/ChocolateyListCommand.cs
+++ b/src/chocolatey/infrastructure.app/commands/ChocolateyListCommand.cs
@@ -46,6 +46,9 @@ namespace chocolatey.infrastructure.app.commands
                 .Add("l|lo|localonly|local-only",
                      "LocalOnly - Only search against local machine items.",
                      option => configuration.ListCommand.LocalOnly = option != null)
+                .Add("io|idonly|id-only",
+                     "IdOnly - Only return package ids in the list.",
+                     option => configuration.ListCommand.IdOnly = option != null)
                 .Add("pre|prerelease",
                      "Prerelease - Include Prereleases? Defaults to false.",
                      option => configuration.Prerelease = option != null)

--- a/src/chocolatey/infrastructure.app/configuration/ChocolateyConfiguration.cs
+++ b/src/chocolatey/infrastructure.app/configuration/ChocolateyConfiguration.cs
@@ -380,6 +380,7 @@ NOTE: Hiding sensitive configuration data! Please double and triple
 
         // list
         public bool LocalOnly { get; set; }
+        public bool IdOnly { get; set; }
         public bool IncludeRegistryPrograms { get; set; }
         public int? Page { get; set; }
         public int PageSize { get; set; }

--- a/src/chocolatey/infrastructure.app/services/NugetService.cs
+++ b/src/chocolatey/infrastructure.app/services/NugetService.cs
@@ -149,16 +149,29 @@ namespace chocolatey.infrastructure.app.services
 
                 if (!config.QuietOutput)
                 {
+                    var logger = config.Verbose ? ChocolateyLoggers.Important : ChocolateyLoggers.Normal;
+
                     if (config.RegularOutput)
                     {
-                        this.Log().Info(config.Verbose ? ChocolateyLoggers.Important : ChocolateyLoggers.Normal, () => "{0} {1}{2}{3}{4}".format_with(
-                            package.Id,
-                            package.Version.to_string(),
-                            package.IsApproved ? " [Approved]" : string.Empty,
-                            package.IsDownloadCacheAvailable ? " Downloads cached for licensed users" : string.Empty,
-                            package.PackageTestResultStatus == "Failing" && package.IsDownloadCacheAvailable ? " - Possibly broken for FOSS users (due to original download location changes by vendor)" : package.PackageTestResultStatus == "Failing" ? " - Possibly broken" : string.Empty
-                            )
-                        );
+                        if (config.ListCommand.IdOnly)
+                        {
+                            this.Log().Info(logger, () => "{0}".format_with(
+                                    package.Id
+                                )
+                            );
+                        }
+                        else
+                        {
+                            this.Log().Info(logger, () => "{0} {1}{2}{3}{4}".format_with(
+                                    package.Id,
+                                    package.Version.to_string(),
+                                    package.IsApproved ? " [Approved]" : string.Empty,
+                                    package.IsDownloadCacheAvailable ? " Downloads cached for licensed users" : string.Empty,
+                                    package.PackageTestResultStatus == "Failing" && package.IsDownloadCacheAvailable ? " - Possibly broken for FOSS users (due to original download location changes by vendor)" : package.PackageTestResultStatus == "Failing" ? " - Possibly broken" : string.Empty
+                                )
+                            );
+                        }
+
                         if (config.Verbose) this.Log().Info(() =>
                             @" Title: {0} | Published: {1}{2}{3}
  Number of Downloads: {4} | Downloads for this version: {5}
@@ -201,7 +214,14 @@ namespace chocolatey.infrastructure.app.services
                     }
                     else
                     {
-                        this.Log().Info(config.Verbose ? ChocolateyLoggers.Important : ChocolateyLoggers.Normal, () => "{0}|{1}".format_with(package.Id, package.Version.to_string()));
+                        if (config.ListCommand.IdOnly)
+                        {
+                            this.Log().Info(logger, () => "{0}".format_with(package.Id));
+                        }
+                        else
+                        {
+                            this.Log().Info(logger, () => "{0}|{1}".format_with(package.Id, package.Version.to_string()));
+                        }
                     }
                 }
                 else


### PR DESCRIPTION
I named the option --id-only for consistency with the existing --by-id-only, used for searching, and for naming consistency with --local-only.

Closes #1237