### PR TITLE
FIX: Get-EnvironmentVariable does not return expanded vars when Prese…

### DIFF
--- a/src/chocolatey.resources/helpers/functions/Get-EnvironmentVariable.ps1
+++ b/src/chocolatey.resources/helpers/functions/Get-EnvironmentVariable.ps1
@@ -72,7 +72,11 @@ param(
     [string] $USER_ENVIRONMENT_REGISTRY_KEY_NAME = "Environment";
     [Microsoft.Win32.RegistryKey] $win32RegistryKey = [Microsoft.Win32.Registry]::CurrentUser.OpenSubKey($USER_ENVIRONMENT_REGISTRY_KEY_NAME)
   } elseif ($Scope -eq [System.EnvironmentVariableTarget]::Process) {
-    return [Environment]::GetEnvironmentVariable($Name, $Scope)
+    $processVariable = [Environment]::GetEnvironmentVariable($Name, $Scope)
+    if (-not $PreserveVariables) {
+        $processVariable = [Environment]::ExpandEnvironmentVariables($processVariable)
+    }
+    return $processVariable
   }
 
   [Microsoft.Win32.RegistryValueOptions] $registryValueOptions = [Microsoft.Win32.RegistryValueOptions]::None


### PR DESCRIPTION
FIX: Get-EnvironmentVariable does not return expanded vars when PreserveVariables=false and Scope=Process