### PR TITLE
(GH-1304) Wrapping HashTable calls inside parenthesis

### DIFF
--- a/src/chocolatey/infrastructure.app/templates/ChocolateyUninstallTemplate.cs
+++ b/src/chocolatey/infrastructure.app/templates/ChocolateyUninstallTemplate.cs
@@ -91,10 +91,10 @@ if ($key.Count -eq 1) {
 } elseif ($key.Count -eq 0) {
   Write-Warning ""$packageName has already been uninstalled by other means.""
 } elseif ($key.Count -gt 1) {
-  Write-Warning ""$key.Count matches found!""
+  Write-Warning ""$($key.Count) matches found!""
   Write-Warning ""To prevent accidental data loss, no programs will be uninstalled.""
   Write-Warning ""Please alert package maintainer the following keys were matched:""
-  $key | % {Write-Warning ""- $_.DisplayName""}
+  $key | % {Write-Warning ""- $($_.DisplayName)""}
 }
 
 


### PR DESCRIPTION
Previously when running choco new the generated uninstall script would
create a elseif statement which would output several warnings to the
user if more than the expected registry keys was found.
These warnings contains an incorrect use when calling properties
on a hashtable and would instead output the full registry key and their
subkeys instead of the number of keys found, and their display name.

With this change the uninstall template will correctly generate the
use of such properties and output the actual number of keys found
and their display name.

Closes #1304 