### PR TITLE
(GH-1313) Allow properties to be passed to 'pack'

### DIFF
--- a/Scenarios.md
+++ b/Scenarios.md
@@ -473,12 +473,17 @@
  * should contain tags
  * should not contain packages and versions with a pipe between them
 
-### ChocolateyPackCommand [ 2 Scenario(s), 4 Observation(s) ]
+### ChocolateyPackCommand [ 3 Scenario(s), 6 Observation(s) ]
 
 #### when packing with an output directory
 
  * generated package should be in specified output directory
  * sources should be set to specified output directory
+
+#### when packing with properties
+
+ * generated package should be in current directory
+ * property settings should be logged as debug messages
 
 #### when packing without specifying an output directory
 

--- a/src/chocolatey.tests/infrastructure.app/commands/ChocolateyPackCommandSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/commands/ChocolateyPackCommandSpecs.cs
@@ -25,6 +25,7 @@ namespace chocolatey.tests.infrastructure.app.commands
     using chocolatey.infrastructure.commandline;
     using Moq;
     using Should;
+    using System;
 
     public class ChocolateyPackCommandSpecs
     {
@@ -93,6 +94,11 @@ namespace chocolatey.tests.infrastructure.app.commands
             {
                 base.Context();
                 unparsedArgs.Add(nuspecPath);
+                unparsedArgs.Add("foo=1");
+                unparsedArgs.Add("bar='baz'");
+
+                // Make sure we storing only the first property name specified regardless of case.
+                unparsedArgs.Add("Foo=2");
             }
 
             public override void Because()
@@ -104,6 +110,26 @@ namespace chocolatey.tests.infrastructure.app.commands
             public void should_allow_a_path_to_the_nuspec_to_be_passed_in()
             {
                 configuration.Input.ShouldEqual(nuspecPath);
+            }
+
+            [Fact]
+            public void should_property_foo_equal_1()
+            {
+                configuration.PackCommand.Properties["foo"].ShouldEqual("1");
+            }
+
+            [Fact]
+            public void should_property_bar_equal_baz()
+            {
+                configuration.PackCommand.Properties["bar"].ShouldEqual("baz");
+            }
+
+            [Fact]
+            public void should_log_warning_on_duplicate_foo()
+            {
+                var warnings = MockLogger.MessagesFor(LogLevel.Warn);
+                warnings.Count.ShouldEqual(1);
+                warnings[0].ShouldEqual("A value for 'foo' has already been added with the value '1'. Ignoring foo='2'.", StringComparer.OrdinalIgnoreCase);
             }
         }
 

--- a/src/chocolatey/infrastructure.app/commands/ChocolateyNewCommand.cs
+++ b/src/chocolatey/infrastructure.app/commands/ChocolateyNewCommand.cs
@@ -77,7 +77,7 @@ namespace chocolatey.infrastructure.app.commands
             {
                 configuration.NewCommand.Name = unparsedArguments.DefaultIfEmpty(string.Empty).FirstOrDefault(arg => !arg.StartsWith("-") && !arg.contains("="));
                 var property = unparsedArguments.DefaultIfEmpty(string.Empty).FirstOrDefault().Split(new[] {'='}, StringSplitOptions.RemoveEmptyEntries);
-                if (property.Count() == 1)
+                if (property.Length == 1)
                 {
                     configuration.NewCommand.TemplateProperties.Add(TemplateValues.NamePropertyName, configuration.NewCommand.Name);
                 }
@@ -86,7 +86,7 @@ namespace chocolatey.infrastructure.app.commands
             foreach (var unparsedArgument in unparsedArguments.or_empty_list_if_null())
             {
                 var property = unparsedArgument.Split(new[] { '=' }, 2, StringSplitOptions.RemoveEmptyEntries);
-                if (property.Count() == 2)
+                if (property.Length == 2)
                 {
                     var propName = property[0].trim_safe();
                     var propValue = property[1].trim_safe().remove_surrounding_quotes();

--- a/src/chocolatey/infrastructure.app/configuration/ChocolateyConfiguration.cs
+++ b/src/chocolatey/infrastructure.app/configuration/ChocolateyConfiguration.cs
@@ -45,6 +45,7 @@ namespace chocolatey.infrastructure.app.configuration
             FeatureCommand = new FeatureCommandConfiguration();
             ConfigCommand = new ConfigCommandConfiguration();
             ApiKeyCommand = new ApiKeyCommandConfiguration();
+            PackCommand = new PackCommandConfiguration();
             PushCommand = new PushCommandConfiguration();
             PinCommand = new PinCommandConfiguration();
             OutdatedCommand = new OutdatedCommandConfiguration();
@@ -301,6 +302,14 @@ NOTE: Hiding sensitive configuration data! Please double and triple
         public ApiKeyCommandConfiguration ApiKeyCommand { get;  set; }
 
         /// <summary>
+        ///   Configuration related specifically to the Pack command.
+        /// </summary>
+        /// <remarks>
+        ///   On .NET 4.0, get error CS0200 when private set - see http://stackoverflow.com/a/23809226/18475
+        /// </remarks>
+        public PackCommandConfiguration PackCommand { get; set; }
+
+        /// <summary>
         ///   Configuration related specifically to Push command
         /// </summary>
         /// <remarks>
@@ -494,6 +503,17 @@ NOTE: Hiding sensitive configuration data! Please double and triple
     public sealed class ApiKeyCommandConfiguration
     {
         public string Key { get; set; }
+    }
+
+    [Serializable]
+    public sealed class PackCommandConfiguration
+    {
+        public PackCommandConfiguration()
+        {
+            Properties = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        }
+
+        public IDictionary<string, string> Properties { get; private set; }
     }
 
     [Serializable]


### PR DESCRIPTION
Passes properties through to the nuget pack command to replace variables
in the nuspec file.

Note that I have no yet cleared the CLA. I need to run this by our legal department but any preliminary feedback would be appreciated so the PR is ready to merge. Given it's a holiday weekend and I'm out on vacation next week, I may not be able to sign the CLA for a week or two. (I'm in the office one day next week so maybe I can get clearance if our legal reps are in.)

Closes #1313 