### PR TITLE
(GH-1301) Enable removal of API key via CLI

### DIFF
--- a/src/chocolatey.tests/infrastructure.app/commands/ChocolateyApiKeyCommandSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/commands/ChocolateyApiKeyCommandSpecs.cs
@@ -108,6 +108,18 @@ namespace chocolatey.tests.infrastructure.app.commands
             {
                 optionSet.Contains("k").ShouldBeTrue();
             }
+
+            [Fact]
+            public void should_add_remove_to_the_option_set()
+            {
+                optionSet.Contains("remove").ShouldBeTrue();
+            }
+
+            [Fact]
+            public void should_add_short_version_of_remove_to_the_option_set()
+            {
+                optionSet.Contains("rem").ShouldBeTrue();
+            }
         }
 
         public class when_handling_validation : ChocolateyApiKeyCommandSpecsBase
@@ -151,6 +163,37 @@ namespace chocolatey.tests.infrastructure.app.commands
             public void should_continue_when_both_source_and_key_are_set()
             {
                 configuration.ApiKeyCommand.Key = "bob";
+                configuration.Sources = "bob";
+                command.handle_validation(configuration);
+            }
+
+            [Fact]
+            public void should_throw_when_key_is_removed_without_a_source()
+            {
+                configuration.ApiKeyCommand.Remove = true;
+                configuration.Sources = "";
+                var errorred = false;
+                Exception error = null;
+
+                try
+                {
+                    command.handle_validation(configuration);
+                }
+                catch (Exception ex)
+                {
+                    errorred = true;
+                    error = ex;
+                }
+
+                errorred.ShouldBeTrue();
+                error.ShouldNotBeNull();
+                error.ShouldBeType<ApplicationException>();
+            }
+
+            [Fact]
+            public void should_continue_when_removing_and_source_is_set()
+            {
+                configuration.ApiKeyCommand.Remove = true;
                 configuration.Sources = "bob";
                 command.handle_validation(configuration);
             }

--- a/src/chocolatey/infrastructure.app/commands/ChocolateyApiKeyCommand.cs
+++ b/src/chocolatey/infrastructure.app/commands/ChocolateyApiKeyCommand.cs
@@ -26,8 +26,8 @@ namespace chocolatey.infrastructure.app.commands
     using logging;
     using services;
 
-    [CommandFor("apikey", "retrieves or saves an apikey for a particular source")]
-    [CommandFor("setapikey", "retrieves or saves an apikey for a particular source (alias for apikey)")]
+    [CommandFor("apikey", "retrieves, saves or deletes an apikey for a particular source")]
+    [CommandFor("setapikey", "retrieves, saves or deletes an apikey for a particular source (alias for apikey)")]
     public class ChocolateyApiKeyCommand : ICommand
     {
         private readonly IChocolateyConfigSettingsService _configSettingsService;
@@ -48,6 +48,9 @@ namespace chocolatey.infrastructure.app.commands
                 .Add("k=|key=|apikey=|api-key=",
                      "ApiKey - The API key for the source. This is the authentication that identifies you and allows you to push to a source. With some sources this is either a key or it could be a user name and password specified as 'user:password'.",
                      option => configuration.ApiKeyCommand.Key = option.remove_surrounding_quotes())
+                .Add("rem|remove",
+                    "Removes an API key from Chocolatey",
+                    option => configuration.ApiKeyCommand.Remove = true)
                 ;
         }
 
@@ -58,9 +61,15 @@ namespace chocolatey.infrastructure.app.commands
 
         public virtual void handle_validation(ChocolateyConfiguration configuration)
         {
-            if (!string.IsNullOrWhiteSpace(configuration.ApiKeyCommand.Key) && string.IsNullOrWhiteSpace(configuration.Sources))
+            if (!configuration.ApiKeyCommand.Remove && !string.IsNullOrWhiteSpace(configuration.ApiKeyCommand.Key) 
+                && string.IsNullOrWhiteSpace(configuration.Sources))
             {
-                throw new ApplicationException("You must specify both 'source' and 'key' to set an api key.");
+                throw new ApplicationException("You must specify both 'source' and 'key' to set an API key.");
+            }
+            if (configuration.ApiKeyCommand.Remove && string.IsNullOrWhiteSpace(configuration.Sources))
+            {
+                throw new ApplicationException("You must specify 'source' to remove an API key.");
+                
             }
         }
 
@@ -125,7 +134,11 @@ In order to save your API key for {0},
 
         public virtual void run(ChocolateyConfiguration configuration)
         {
-            if (string.IsNullOrWhiteSpace(configuration.ApiKeyCommand.Key))
+            if (configuration.ApiKeyCommand.Remove)
+            {
+                _configSettingsService.remove_api_key(configuration);
+            }
+            else if (string.IsNullOrWhiteSpace(configuration.ApiKeyCommand.Key))
             {
                 _configSettingsService.get_api_key(configuration, (key) =>
                     {

--- a/src/chocolatey/infrastructure.app/configuration/ChocolateyConfiguration.cs
+++ b/src/chocolatey/infrastructure.app/configuration/ChocolateyConfiguration.cs
@@ -506,6 +506,7 @@ NOTE: Hiding sensitive configuration data! Please double and triple
     public sealed class ApiKeyCommandConfiguration
     {
         public string Key { get; set; }
+        public bool Remove { get; set; }
     }
 
     [Serializable]

--- a/src/chocolatey/infrastructure.app/services/ChocolateyConfigSettingsService.cs
+++ b/src/chocolatey/infrastructure.app/services/ChocolateyConfigSettingsService.cs
@@ -330,6 +330,24 @@ namespace chocolatey.infrastructure.app.services
             }
         }
 
+        public void remove_api_key(ChocolateyConfiguration configuration)
+        {
+            var apiKey = configFileSettings.ApiKeys.FirstOrDefault(p => p.Source.is_equal_to(configuration.Sources));
+            if (apiKey != null)
+            {
+                configFileSettings.ApiKeys.RemoveWhere(x => x.Source.is_equal_to(configuration.Sources));
+
+                _xmlService.serialize(configFileSettings, ApplicationParameters.GlobalConfigFileLocation);
+
+                this.Log().Info(() => "Removed ApiKey for {0}".format_with(configuration.Sources));
+            }
+            else
+            {
+                this.Log().Info(() => "ApiKey was not found for {0}".format_with(configuration.Sources));
+            }
+
+        }
+
         public void config_list(ChocolateyConfiguration configuration)
         {
             this.Log().Info(ChocolateyLoggers.Important, "Settings");

--- a/src/chocolatey/infrastructure.app/services/IChocolateyConfigSettingsService.cs
+++ b/src/chocolatey/infrastructure.app/services/IChocolateyConfigSettingsService.cs
@@ -33,6 +33,7 @@ namespace chocolatey.infrastructure.app.services
         void feature_enable(ChocolateyConfiguration configuration);
         string get_api_key(ChocolateyConfiguration configuration, Action<ConfigFileApiKeySetting> keyAction);
         void set_api_key(ChocolateyConfiguration configuration);
+        void remove_api_key(ChocolateyConfiguration configuration);
         void config_list(ChocolateyConfiguration configuration);
         void config_get(ChocolateyConfiguration configuration);
         void config_set(ChocolateyConfiguration configuration);


### PR DESCRIPTION
Closes #1301

**Description**
Modified the ApiKey command to add a removal option. I added '-remove' and '-rem' as options that will delete the entry in chocolatey.config with the associated api key.

**Example usage**
Assuming there is an API key for a source 'http://internal_nexus' added, running `apikey -s "http://internal_nexus -rem` will delete it from chocolatey.config. "Removed ApiKey for http://internal_nexus" will be displayed to the user. If there is no API key associated with the provided source, "ApiKey was not found for http://internal_nexus" will be displayed to the user.