### PR TITLE
(GH-842) Detect wrong use of -version

### DIFF
--- a/src/chocolatey/infrastructure/commandline/Options.cs
+++ b/src/chocolatey/infrastructure/commandline/Options.cs
@@ -871,6 +871,8 @@ namespace chocolatey.infrastructure.commandline
             IDictionary<Option,string> normalOptions = new Dictionary<Option, string>();
 			if (f != "-")
 				return false;
+			if (n == "version")
+				throw new OptionException(localizer("Use --version instead of -version."), n);
 			for (int i = 0; i < n.Length; ++i) {
 				Option p;
 				string opt = f + n [i].ToString ();


### PR DESCRIPTION
Do not try to parse bundled options if the user most likely tried to use the --version option.

#842