### PR TITLE
(GH-1416) Incorrect documentation for Install-ChocolateyInstallPackage

### DIFF
--- a/src/chocolatey.resources/helpers/functions/Install-ChocolateyInstallPackage.ps1
+++ b/src/chocolatey.resources/helpers/functions/Install-ChocolateyInstallPackage.ps1
@@ -141,7 +141,7 @@ Install-ChocolateyInstallPackage 'bob' 'exe' '/S' "$(Split-Path -Parent $MyInvoc
 Install-ChocolateyInstallPackage -PackageName 'bob' -FileType 'exe' `
   -SilentArgs '/S' `
   -File "$(Split-Path -Parent $MyInvocation.MyCommand.Definition)\bob.exe" `
-  -ValidExitCodes = @(0)
+  -ValidExitCodes @(0)
 
 .LINK
 Install-ChocolateyPackage


### PR DESCRIPTION
The -ValidExitCodes should not have the "=" in it

Fix -ValidExitCodes = @(0) to -ValidExitCodes @(0)


Closes #1416