### PR TITLE
(GH-1496) Enable ability to create a trimmed down version of Chocolatey.Lib

### DIFF
--- a/.build.custom/ilmerge.replace.build
+++ b/.build.custom/ilmerge.replace.build
@@ -73,7 +73,7 @@
     <property name="args.ilmerge" value="${args.ilmerge} ${dlls.regular}" />
   </target>
 
-  <target name="run_ilmerge">
+  <target name="run_ilmerge" if="${msbuild.configuration != 'NoResources'}">
     <echo level="Warning" message="Merging the the contents of ${dirs.merge.from} into a single executable - ${dirs.merge.to}${path.separator}${file.merge.name}. This will fail if all dependencies are not resolved."/>
     <echo level="Warning" message="Running this: ${app.ilmerge} ${args.ilmerge}"/>
     <exec program="${app.ilmerge}"

--- a/src/chocolatey.console/Program.cs
+++ b/src/chocolatey.console/Program.cs
@@ -1,13 +1,13 @@
 ﻿// Copyright © 2017 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
-// 
+//
 // You may obtain a copy of the License at
-// 
+//
 // 	http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/chocolatey.console/Program.cs
+++ b/src/chocolatey.console/Program.cs
@@ -32,7 +32,9 @@ namespace chocolatey.console
     using infrastructure.logging;
     using infrastructure.registration;
     using infrastructure.tolerance;
+#if !NoResources
     using resources;
+#endif
     using Assembly = infrastructure.adapters.Assembly;
     using Console = System.Console;
     using Environment = System.Environment;
@@ -136,8 +138,9 @@ namespace chocolatey.console
                         "redirects",
                         "tools"
                     };
+#if !NoResources
                 AssemblyFileExtractor.extract_all_resources_to_relative_directory(fileSystem, Assembly.GetAssembly(typeof(ChocolateyResourcesAssembly)), ApplicationParameters.InstallLocation, folders, ApplicationParameters.ChocolateyFileResources, throwError: false);
-
+#endif
                 var application = new ConsoleApplication();
                 application.run(args, config, container);
             }

--- a/src/chocolatey.console/chocolatey.console.csproj
+++ b/src/chocolatey.console/chocolatey.console.csproj
@@ -78,6 +78,26 @@
   <PropertyGroup>
     <NoWin32Manifest>true</NoWin32Manifest>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'NoResources|x86'">
+    <OutputPath>bin\x86\NoResources\</OutputPath>
+    <DefineConstants>TRACE;NoResources</DefineConstants>
+    <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
+    <Optimize>true</Optimize>
+    <PlatformTarget>x86</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'NoResources|AnyCPU'">
+    <OutputPath>bin\NoResources\</OutputPath>
+    <DefineConstants>TRACE;NoResources</DefineConstants>
+    <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
+    <Optimize>true</Optimize>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <CodeAnalysisIgnoreBuiltInRuleSets>false</CodeAnalysisIgnoreBuiltInRuleSets>
+    <CodeAnalysisIgnoreBuiltInRules>false</CodeAnalysisIgnoreBuiltInRules>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="AlphaFS, Version=2.1.0.0, Culture=neutral, PublicKeyToken=4d31a58f7d7ad5c9, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
@@ -124,11 +144,17 @@
     <None Include="packages.config" />
     <None Include="targets\Microsoft.Application.targets" />
   </ItemGroup>
+  <Choose>
+    <When Condition=" '$(Configuration)' != 'NoResources' ">
+      <ItemGroup>
+        <ProjectReference Include="..\chocolatey.resources\chocolatey.resources.csproj">
+          <Project>{AF584111-FE32-448D-A1D0-63217AF8B43C}</Project>
+          <Name>chocolatey.resources</Name>
+        </ProjectReference>
+      </ItemGroup>
+    </When>
+  </Choose>
   <ItemGroup>
-    <ProjectReference Include="..\chocolatey.resources\chocolatey.resources.csproj">
-      <Project>{AF584111-FE32-448D-A1D0-63217AF8B43C}</Project>
-      <Name>chocolatey.resources</Name>
-    </ProjectReference>
     <ProjectReference Include="..\chocolatey\chocolatey.csproj">
       <Project>{5563DC61-35FD-4FAB-B331-9AE1FDB23F80}</Project>
       <Name>chocolatey</Name>

--- a/src/chocolatey.resources/chocolatey.resources.csproj
+++ b/src/chocolatey.resources/chocolatey.resources.csproj
@@ -30,6 +30,14 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'NoResources|AnyCPU'">
+    <OutputPath>bin\NoResources\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <Optimize>true</Optimize>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/src/chocolatey.sln
+++ b/src/chocolatey.sln
@@ -1,6 +1,8 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2010
+# Visual Studio 15
+VisualStudioVersion = 15.0.27130.2027
+MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "chocolatey.console", "chocolatey.console\chocolatey.console.csproj", "{E24E3386-244F-4404-9E6E-5B53818EA903}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "chocolatey.tests", "chocolatey.tests\chocolatey.tests.csproj", "{5C4C60F0-47B1-498E-ABF7-D315E1A94BC9}"
@@ -50,6 +52,9 @@ Global
 		Debug|Any CPU = Debug|Any CPU
 		Debug|Mixed Platforms = Debug|Mixed Platforms
 		Debug|x86 = Debug|x86
+		NoResources|Any CPU = NoResources|Any CPU
+		NoResources|Mixed Platforms = NoResources|Mixed Platforms
+		NoResources|x86 = NoResources|x86
 		Release|Any CPU = Release|Any CPU
 		Release|Mixed Platforms = Release|Mixed Platforms
 		Release|x86 = Release|x86
@@ -61,6 +66,9 @@ Global
 		{E24E3386-244F-4404-9E6E-5B53818EA903}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
 		{E24E3386-244F-4404-9E6E-5B53818EA903}.Debug|x86.ActiveCfg = Debug|x86
 		{E24E3386-244F-4404-9E6E-5B53818EA903}.Debug|x86.Build.0 = Debug|x86
+		{E24E3386-244F-4404-9E6E-5B53818EA903}.NoResources|Any CPU.ActiveCfg = NoResources|Any CPU
+		{E24E3386-244F-4404-9E6E-5B53818EA903}.NoResources|Mixed Platforms.ActiveCfg = NoResources|x86
+		{E24E3386-244F-4404-9E6E-5B53818EA903}.NoResources|x86.ActiveCfg = NoResources|x86
 		{E24E3386-244F-4404-9E6E-5B53818EA903}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{E24E3386-244F-4404-9E6E-5B53818EA903}.Release|Any CPU.Build.0 = Release|Any CPU
 		{E24E3386-244F-4404-9E6E-5B53818EA903}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
@@ -72,6 +80,9 @@ Global
 		{5C4C60F0-47B1-498E-ABF7-D315E1A94BC9}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
 		{5C4C60F0-47B1-498E-ABF7-D315E1A94BC9}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
 		{5C4C60F0-47B1-498E-ABF7-D315E1A94BC9}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{5C4C60F0-47B1-498E-ABF7-D315E1A94BC9}.NoResources|Any CPU.ActiveCfg = NoResources|Any CPU
+		{5C4C60F0-47B1-498E-ABF7-D315E1A94BC9}.NoResources|Mixed Platforms.ActiveCfg = NoResources|Any CPU
+		{5C4C60F0-47B1-498E-ABF7-D315E1A94BC9}.NoResources|x86.ActiveCfg = NoResources|Any CPU
 		{5C4C60F0-47B1-498E-ABF7-D315E1A94BC9}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{5C4C60F0-47B1-498E-ABF7-D315E1A94BC9}.Release|Any CPU.Build.0 = Release|Any CPU
 		{5C4C60F0-47B1-498E-ABF7-D315E1A94BC9}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
@@ -82,6 +93,12 @@ Global
 		{5563DC61-35FD-4FAB-B331-9AE1FDB23F80}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
 		{5563DC61-35FD-4FAB-B331-9AE1FDB23F80}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
 		{5563DC61-35FD-4FAB-B331-9AE1FDB23F80}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{5563DC61-35FD-4FAB-B331-9AE1FDB23F80}.NoResources|Any CPU.ActiveCfg = NoResources|Any CPU
+		{5563DC61-35FD-4FAB-B331-9AE1FDB23F80}.NoResources|Any CPU.Build.0 = NoResources|Any CPU
+		{5563DC61-35FD-4FAB-B331-9AE1FDB23F80}.NoResources|Mixed Platforms.ActiveCfg = NoResources|Any CPU
+		{5563DC61-35FD-4FAB-B331-9AE1FDB23F80}.NoResources|Mixed Platforms.Build.0 = NoResources|Any CPU
+		{5563DC61-35FD-4FAB-B331-9AE1FDB23F80}.NoResources|x86.ActiveCfg = NoResources|Any CPU
+		{5563DC61-35FD-4FAB-B331-9AE1FDB23F80}.NoResources|x86.Build.0 = NoResources|Any CPU
 		{5563DC61-35FD-4FAB-B331-9AE1FDB23F80}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{5563DC61-35FD-4FAB-B331-9AE1FDB23F80}.Release|Any CPU.Build.0 = Release|Any CPU
 		{5563DC61-35FD-4FAB-B331-9AE1FDB23F80}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
@@ -92,6 +109,9 @@ Global
 		{AF584111-FE32-448D-A1D0-63217AF8B43C}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
 		{AF584111-FE32-448D-A1D0-63217AF8B43C}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
 		{AF584111-FE32-448D-A1D0-63217AF8B43C}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{AF584111-FE32-448D-A1D0-63217AF8B43C}.NoResources|Any CPU.ActiveCfg = NoResources|Any CPU
+		{AF584111-FE32-448D-A1D0-63217AF8B43C}.NoResources|Mixed Platforms.ActiveCfg = NoResources|Any CPU
+		{AF584111-FE32-448D-A1D0-63217AF8B43C}.NoResources|x86.ActiveCfg = NoResources|Any CPU
 		{AF584111-FE32-448D-A1D0-63217AF8B43C}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{AF584111-FE32-448D-A1D0-63217AF8B43C}.Release|Any CPU.Build.0 = Release|Any CPU
 		{AF584111-FE32-448D-A1D0-63217AF8B43C}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
@@ -102,6 +122,9 @@ Global
 		{12ECAD4F-D463-4D72-A792-A4FCCFE9C456}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
 		{12ECAD4F-D463-4D72-A792-A4FCCFE9C456}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
 		{12ECAD4F-D463-4D72-A792-A4FCCFE9C456}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{12ECAD4F-D463-4D72-A792-A4FCCFE9C456}.NoResources|Any CPU.ActiveCfg = NoResources|Any CPU
+		{12ECAD4F-D463-4D72-A792-A4FCCFE9C456}.NoResources|Mixed Platforms.ActiveCfg = NoResources|Any CPU
+		{12ECAD4F-D463-4D72-A792-A4FCCFE9C456}.NoResources|x86.ActiveCfg = NoResources|Any CPU
 		{12ECAD4F-D463-4D72-A792-A4FCCFE9C456}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{12ECAD4F-D463-4D72-A792-A4FCCFE9C456}.Release|Any CPU.Build.0 = Release|Any CPU
 		{12ECAD4F-D463-4D72-A792-A4FCCFE9C456}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
@@ -115,7 +138,10 @@ Global
 		{5C4C60F0-47B1-498E-ABF7-D315E1A94BC9} = {7656D054-387D-409C-A9FB-62A44599AA77}
 		{12ECAD4F-D463-4D72-A792-A4FCCFE9C456} = {7656D054-387D-409C-A9FB-62A44599AA77}
 		{DAB29F30-149D-4005-A8D2-4FA56CF2784D} = {FB6236DD-17EF-4C36-943C-47792FBC3306}
-		{DD9689F3-1D2D-41AE-A672-063EE70C0C9A} = {FB6236DD-17EF-4C36-943C-47792FBC3306}
 		{E5C987F8-6B95-4835-BBDD-A25C9D370BB9} = {DAB29F30-149D-4005-A8D2-4FA56CF2784D}
+		{DD9689F3-1D2D-41AE-A672-063EE70C0C9A} = {FB6236DD-17EF-4C36-943C-47792FBC3306}
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {998CAC46-A2B8-447C-B4CC-3B11DC35ED46}
 	EndGlobalSection
 EndGlobal

--- a/src/chocolatey.tests.integration/chocolatey.tests.integration.csproj
+++ b/src/chocolatey.tests.integration/chocolatey.tests.integration.csproj
@@ -32,6 +32,15 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'NoResources|AnyCPU'">
+    <OutputPath>bin\NoResources\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <Optimize>true</Optimize>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="bdddoc">
       <HintPath>..\..\lib\bdddoc\bdddoc.dll</HintPath>

--- a/src/chocolatey.tests/chocolatey.tests.csproj
+++ b/src/chocolatey.tests/chocolatey.tests.csproj
@@ -31,6 +31,15 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'NoResources|AnyCPU'">
+    <OutputPath>bin\NoResources\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <Optimize>true</Optimize>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="log4net, Version=1.2.13.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
       <HintPath>..\packages\log4net.2.0.3\lib\net40-client\log4net.dll</HintPath>

--- a/src/chocolatey/GetChocolatey.cs
+++ b/src/chocolatey/GetChocolatey.cs
@@ -1,13 +1,13 @@
 ﻿// Copyright © 2017 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
-// 
+//
 // You may obtain a copy of the License at
-// 
+//
 // 	http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -183,7 +183,7 @@ namespace chocolatey
         }
 
         /// <summary>
-        /// Registers a container component. Does not require a dependency on Simple Injector. 
+        /// Registers a container component. Does not require a dependency on Simple Injector.
         /// Will override existing component if registered.
         /// </summary>
         /// <typeparam name="Service">The type of the service.</typeparam>
@@ -200,7 +200,7 @@ namespace chocolatey
         }
 
         /// <summary>
-        /// Registers a container component. 
+        /// Registers a container component.
         /// Will override existing component if registered.
         /// </summary>
         /// <typeparam name="Service">The type of the service.</typeparam>
@@ -219,7 +219,7 @@ namespace chocolatey
         }
 
         /// <summary>
-        /// Registers a container component. Does not require a dependency on Simple Injector. 
+        /// Registers a container component. Does not require a dependency on Simple Injector.
         /// Will override existing component if registered.
         /// </summary>
         /// <typeparam name="Service">The type of the ervice.</typeparam>
@@ -236,7 +236,7 @@ namespace chocolatey
         }
 
         /// <summary>
-        /// Register container components when you need to do multiple setups and want to work with the container directly. 
+        /// Register container components when you need to do multiple setups and want to work with the container directly.
         /// Will override existing components if registered.
         /// </summary>
         /// <param name="containerSetup">The container setup.</param>
@@ -255,7 +255,7 @@ namespace chocolatey
         }
 
         /// <summary>
-        /// Returns the Chocolatey container. 
+        /// Returns the Chocolatey container.
         /// WARNING: Once you call GetInstance of any kind, no more items can be registered on the container
         /// </summary>
         /// <returns>The IoC Container (implemented as a SimpleInjector.Container)</returns>
@@ -270,7 +270,7 @@ namespace chocolatey
         /// <summary>
         /// Call this method to run Chocolatey after you have set the options.
         /// WARNING: Once this is called, you will not be able to register additional container components.
-        /// WARNING: Ensure you don't nest additional calls to running Chocolatey here. 
+        /// WARNING: Ensure you don't nest additional calls to running Chocolatey here.
         /// Make a call, then finish up and make another call. This includes
         ///  - Run()
         ///  - RunConsole()
@@ -296,7 +296,7 @@ namespace chocolatey
         /// <summary>
         ///   Call this method to run chocolatey after you have set the options.
         /// WARNING: Once this is called, you will not be able to register additional container components.
-        /// WARNING: Ensure you don't nest additional calls to running Chocolatey here. 
+        /// WARNING: Ensure you don't nest additional calls to running Chocolatey here.
         /// Make a call, then finish up and make another call. This includes
         ///  - Run()
         ///  - RunConsole()
@@ -321,7 +321,7 @@ namespace chocolatey
         /// <summary>
         ///    Run chocolatey after setting the options, and list the results.
         /// WARNING: Once this is called, you will not be able to register additional container components.
-        /// WARNING: Ensure you don't nest additional calls to running Chocolatey here. 
+        /// WARNING: Ensure you don't nest additional calls to running Chocolatey here.
         /// Make a call, then finish up and make another call. This includes
         ///  - Run()
         ///  - RunConsole()
@@ -346,7 +346,7 @@ namespace chocolatey
         ///    Run chocolatey after setting the options,
         ///    and get the count of items that would be returned if you listed the results.
         /// WARNING: Once this is called, you will not be able to register additional container components.
-        /// WARNING: Ensure you don't nest additional calls to running Chocolatey here. 
+        /// WARNING: Ensure you don't nest additional calls to running Chocolatey here.
         /// Make a call, then finish up and make another call. This includes
         ///  - Run()
         ///  - RunConsole()
@@ -400,9 +400,9 @@ namespace chocolatey
         }
 
         /// <summary>
-        /// After the construction of GetChocolatey, we should have a ChocolateyConfiguration or LicensedChocolateyConfiguration loaded into the environment. 
-        /// We want that original configuration to live on between calls to the API. This function ensures that the 
-        /// original default configuration from new() is reset after each command finishes running, even as each command 
+        /// After the construction of GetChocolatey, we should have a ChocolateyConfiguration or LicensedChocolateyConfiguration loaded into the environment.
+        /// We want that original configuration to live on between calls to the API. This function ensures that the
+        /// original default configuration from new() is reset after each command finishes running, even as each command
         /// may make changes to the configuration it uses.
         /// </summary>
         /// <typeparam name="T"></typeparam>
@@ -438,7 +438,7 @@ namespace chocolatey
         }
 
         /// <summary>
-        /// Creates the configuration. 
+        /// Creates the configuration.
         /// This should never be called directly, as it can cause issues that are very difficult to debug.
         /// </summary>
         /// <param name="args">The arguments.</param>

--- a/src/chocolatey/GetChocolatey.cs
+++ b/src/chocolatey/GetChocolatey.cs
@@ -30,7 +30,9 @@ namespace chocolatey
     using infrastructure.logging;
     using infrastructure.registration;
     using infrastructure.synchronization;
+#if !NoResources
     using resources;
+#endif
     using Assembly = infrastructure.adapters.Assembly;
     using IFileSystem = infrastructure.filesystem.IFileSystem;
 
@@ -498,6 +500,7 @@ namespace chocolatey
                 "tools"
             };
 
+#if !NoResources
             try
             {
                 AssemblyFileExtractor.extract_all_resources_to_relative_directory(_container.GetInstance<IFileSystem>(), Assembly.GetAssembly(typeof(ChocolateyResourcesAssembly)), ApplicationParameters.InstallLocation, folders, ApplicationParameters.ChocolateyFileResources);
@@ -507,7 +510,7 @@ namespace chocolatey
                 this.Log().Warn(ChocolateyLoggers.Important, "Please ensure that ChocolateyInstall environment variable is set properly and you've run once as an administrator to ensure all resources are extracted.");
                 this.Log().Error("Unable to extract resources. Please ensure the ChocolateyInstall environment variable is set properly. You may need to run once as an admin to ensure all resources are extracted. Details:{0} {1}".format_with(Environment.NewLine, ex.ToString()));
             }
-
+#endif
         }
     }
 

--- a/src/chocolatey/chocolatey.csproj
+++ b/src/chocolatey/chocolatey.csproj
@@ -38,6 +38,18 @@
   <PropertyGroup>
     <ApplicationIcon>..\..\docs\logo\chocolatey.ico</ApplicationIcon>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'NoResources|AnyCPU'">
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>bin\NoResources\</OutputPath>
+    <DefineConstants>TRACE;NoResources</DefineConstants>
+    <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
+    <DocumentationFile>bin\Release\chocolatey.xml</DocumentationFile>
+    <Optimize>true</Optimize>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="AlphaFS, Version=2.1.0.0, Culture=neutral, PublicKeyToken=4d31a58f7d7ad5c9, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
@@ -328,12 +340,16 @@
       <Link>Properties\chocolatey.ico</Link>
     </None>
   </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\chocolatey.resources\chocolatey.resources.csproj">
-      <Project>{AF584111-FE32-448D-A1D0-63217AF8B43C}</Project>
-      <Name>chocolatey.resources</Name>
-    </ProjectReference>
-  </ItemGroup>
+  <Choose>
+    <When Condition=" '$(Configuration)' != 'NoResources' ">
+      <ItemGroup>
+        <ProjectReference Include="..\chocolatey.resources\chocolatey.resources.csproj">
+          <Project>{AF584111-FE32-448D-A1D0-63217AF8B43C}</Project>
+          <Name>chocolatey.resources</Name>
+        </ProjectReference>
+      </ItemGroup>
+    </When>
+  </Choose>
   <ItemGroup>
     <EmbeddedResource Include="infrastructure\logging\log4net.nocolor.config.xml" />
   </ItemGroup>

--- a/src/chocolatey/infrastructure.app/commands/ChocolateyUnpackSelfCommand.cs
+++ b/src/chocolatey/infrastructure.app/commands/ChocolateyUnpackSelfCommand.cs
@@ -27,13 +27,20 @@ namespace chocolatey.infrastructure.app.commands
     using filesystem;
     using infrastructure.commands;
     using logging;
+#if !NoResources
     using resources;
+#endif
 
     [CommandFor("unpackself", "have chocolatey set itself up")]
     public class ChocolateyUnpackSelfCommand : ICommand
     {
         private readonly IFileSystem _fileSystem;
+
+#if !NoResources
         private Lazy<IAssembly> _assemblyInitializer = new Lazy<IAssembly>(() => Assembly.GetAssembly(typeof (ChocolateyResourcesAssembly)));
+#else
+        private Lazy<IAssembly> _assemblyInitializer = new Lazy<IAssembly>();
+#endif
 
         [EditorBrowsable(EditorBrowsableState.Never)]
         public void initialize_with(Lazy<IAssembly> assembly_initializer)

--- a/src/chocolatey/infrastructure.app/commands/ChocolateyUnpackSelfCommand.cs
+++ b/src/chocolatey/infrastructure.app/commands/ChocolateyUnpackSelfCommand.cs
@@ -1,13 +1,13 @@
 ﻿// Copyright © 2017 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
-// 
+//
 // You may obtain a copy of the License at
-// 
+//
 // 	http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -67,11 +67,11 @@ namespace chocolatey.infrastructure.app.commands
         {
             this.Log().Info(ChocolateyLoggers.Important, "UnpackSelf Command");
             this.Log().Info(@"
-This will unpack files needed by choco. It will overwrite existing 
+This will unpack files needed by choco. It will overwrite existing
  files only if --force is specified.
 
-NOTE: This command should only be used when installing Chocolatey, not 
- during normal operation. 
+NOTE: This command should only be used when installing Chocolatey, not
+ during normal operation.
 
 ");
 


### PR DESCRIPTION
This includes:

* New Compilation Directive, `LibOnly` to control when certain pieces of code are compiled
* Conditional inclusion of referenced projects
* Modification to build process to only ilmerge certain projects, based on configuration

Fixes #1496 