### PR TITLE
(GH-474) Adding reset of console on abnormal exit

### DIFF
--- a/src/chocolatey/infrastructure/commandline/ExitScenarioHandler.cs
+++ b/src/chocolatey/infrastructure/commandline/ExitScenarioHandler.cs
@@ -72,6 +72,7 @@ namespace chocolatey.infrastructure.commandline
                     break;
             }
 
+            Console.ResetColor();
             Environment.Exit(-1);
 
             return true;


### PR DESCRIPTION
With this commit the console is always reset when an abnormal exit
has occurred. Without this change, all customizations of the console
may still be present when choco have exited.

While I've been unable to actually test the changes myself (due to the inability to actually compile choco) I believe this fixes #474 