### PR TITLE
(GH-1546) Fix undefined zipFileContentPath var

### DIFF
--- a/src/chocolatey.resources/helpers/functions/UnInstall-ChocolateyZipPackage.ps1
+++ b/src/chocolatey.resources/helpers/functions/UnInstall-ChocolateyZipPackage.ps1
@@ -68,7 +68,7 @@ param(
 
   # The Zip Content File may have previously existed under a different
   # name.  If *Install.txt doesn't exist, check for the old name
-  if(-Not (Test-Path -Path $zipFileContentPath)) {
+  if(-Not (Test-Path -Path $zipContentFile)) {
     $zipContentFile=(Join-Path $packagelibPath -ChildPath $zipFileName) + ".txt"
   }
 


### PR DESCRIPTION
Rename `zipFileContentPath` -> `zipContentFile` , so that `Test-Path -Path` input is not `null` Closes #1546 , and probably also closes #1550 .
Tested with `mingw` package, please also test before merge.