### PR TITLE
(maint) Fix a choco version command help typo

### DIFF
--- a/src/chocolatey/infrastructure.app/commands/ChocolateyVersionCommand.cs
+++ b/src/chocolatey/infrastructure.app/commands/ChocolateyVersionCommand.cs
@@ -84,7 +84,7 @@ DEPRECATION NOTICE - `choco version -lo` is deprecated. version command
             {
                 this.Log().Warn(ChocolateyLoggers.Important, @"
 DEPRECATION NOTICE - choco version command is deprecated and will be 
- removed in version 1.0.0. Please use `choco upgrade pgkname --noop` 
+ removed in version 1.0.0. Please use `choco upgrade pkgname --noop` 
  instead.");
 
             }


### PR DESCRIPTION
In choco version command help there is a **pgkname** used instead of **pkgname**. This PR fix this typo.
