### PR TITLE
(GH-1584) Fixed null reference exception in NugetCommon when source is null

### DIFF
--- a/src/chocolatey.tests/chocolatey.tests.csproj
+++ b/src/chocolatey.tests/chocolatey.tests.csproj
@@ -87,6 +87,7 @@
     <Compile Include="infrastructure.app\commands\ChocolateyUnpackSelfCommandSpecs.cs" />
     <Compile Include="infrastructure.app\commands\ChocolateyUpgradeCommandSpecs.cs" />
     <Compile Include="infrastructure.app\configuration\ConfigurationOptionsSpec.cs" />
+    <Compile Include="infrastructure.app\nuget\NugetCommonSpecs.cs" />
     <Compile Include="infrastructure.app\services\AutomaticUninstallerServiceSpecs.cs" />
     <Compile Include="infrastructure.app\services\FilesServiceSpecs.cs" />
     <Compile Include="infrastructure.app\services\NugetServiceSpecs.cs" />
@@ -127,9 +128,7 @@
       <Name>chocolatey.console</Name>
     </ProjectReference>
   </ItemGroup>
-  <ItemGroup>
-    <Folder Include="infrastructure.app\nuget\" />
-  </ItemGroup>
+  <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/src/chocolatey.tests/infrastructure.app/nuget/NugetCommonSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/nuget/NugetCommonSpecs.cs
@@ -1,0 +1,61 @@
+﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+// Copyright © 2011 - 2017 RealDimensions Software, LLC
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// 
+// You may obtain a copy of the License at
+// 
+// 	http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace chocolatey.tests.infrastructure.app.nuget
+{
+    using System;
+    using System.Linq;
+    using chocolatey.infrastructure.app.configuration;
+    using chocolatey.infrastructure.app.nuget;
+    using Moq;
+    using NuGet;
+    using Should;
+
+    public class NugetCommonSpecs 
+    {
+        private class when_gets_remote_repository : TinySpec
+        {
+            private Action because;
+            private readonly Mock<ILogger> nugetLogger = new Mock<ILogger>();
+            private readonly Mock<IPackageDownloader> packageDownloader = new Mock<IPackageDownloader>();
+            private ChocolateyConfiguration configuration;
+            private IPackageRepository packageRepository;
+
+            public override void Context()
+            {
+                configuration = new ChocolateyConfiguration();
+                nugetLogger.ResetCalls();
+                packageDownloader.ResetCalls();
+            }
+
+            public override void Because()
+            {
+                because = () => packageRepository = NugetCommon.GetRemoteRepository(configuration, nugetLogger.Object, packageDownloader.Object);
+            }
+
+            [Fact]
+            public void should_create_repository_when_source_is_null()
+            {
+                Context();
+                configuration.Sources = null;
+            
+                because();
+
+                ((AggregateRepository)packageRepository).Repositories.Count().ShouldEqual(0);
+            }
+        }
+    }
+}

--- a/src/chocolatey/infrastructure.app/nuget/NugetCommon.cs
+++ b/src/chocolatey/infrastructure.app/nuget/NugetCommon.cs
@@ -77,7 +77,7 @@ namespace chocolatey.infrastructure.app.nuget
                 };
             }
             
-            IEnumerable<string> sources = configuration.Sources.Split(new[] { ";", "," }, StringSplitOptions.RemoveEmptyEntries);
+            IEnumerable<string> sources = configuration.Sources.to_string().Split(new[] { ";", "," }, StringSplitOptions.RemoveEmptyEntries);
 
             IList<IPackageRepository> repositories = new List<IPackageRepository>();
 


### PR DESCRIPTION
* Added new unit test for NugetCommon
* Fixed possible null reference exception when parsing sources from chocolateyconfig

Closes #1584