### PR TITLE
(#3709) Add support for ordering strategies using a new `--order-by` argument on the search command

### DIFF
--- a/src/chocolatey.tests/MockLoggerExtensions.cs
+++ b/src/chocolatey.tests/MockLoggerExtensions.cs
@@ -1,0 +1,29 @@
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
+// Copyright © 2011 - 2017 RealDimensions Software, LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using FluentAssertions;
+
+namespace chocolatey.tests
+{
+    public static class MockLoggerExtensions
+    {
+        public static void ShouldHaveWarningContaining(this MockLogger logger, string expectedSubstring)
+        {
+            logger.Messages.Should().ContainKey(LogLevel.Warn.ToString())
+                .WhoseValue.Should().Contain(w => w.Contains(expectedSubstring));
+        }
+    }
+}

--- a/src/chocolatey.tests/chocolatey.tests.csproj
+++ b/src/chocolatey.tests/chocolatey.tests.csproj
@@ -184,6 +184,7 @@
     <Compile Include="infrastructure.app\services\ChocolateyConfigSettingsServiceSpecs.cs" />
     <Compile Include="infrastructure.app\services\ChocolateyPackageServiceSpecs.cs" />
     <Compile Include="infrastructure.app\services\FilesServiceSpecs.cs" />
+    <Compile Include="infrastructure.app\services\NugetListSpecs.cs" />
     <Compile Include="infrastructure.app\services\NugetServiceSpecs.cs" />
     <Compile Include="infrastructure.app\services\RegistryServiceSpecs.cs" />
     <Compile Include="infrastructure.app\services\RulesServiceSpecs.cs" />
@@ -205,6 +206,7 @@
     <Compile Include="infrastructure\tolerance\FaultToleranceSpecs.cs" />
     <Compile Include="infrastructure.app\utility\PackageUtilitySpecs.cs" />
     <Compile Include="MockLogger.cs" />
+    <Compile Include="MockLoggerExtensions.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="TinySpec.cs" />
     <Compile Include="UNCHelper.cs" />

--- a/src/chocolatey.tests/infrastructure.app/services/NugetListSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/services/NugetListSpecs.cs
@@ -1,0 +1,676 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using chocolatey.infrastructure.app.domain;
+using chocolatey.infrastructure.app.nuget;
+using FluentAssertions;
+using FluentAssertions.Execution;
+using Moq;
+using NuGet.Protocol.Core.Types;
+using NuGet.Versioning;
+
+namespace chocolatey.tests.infrastructure.app.services
+{
+    public class NugetListSpecs
+    {
+        public abstract class NuGetListReflectionSpecsBase : TinySpec
+        {
+            protected IPackageSearchMetadata CreateMetadata(
+                string id,
+                string title,
+                string version,
+                DateTimeOffset? published,
+                long? downloadCount,
+                int? versionDownloadCount)
+            {
+                var identity = new NuGet.Packaging.Core.PackageIdentity(id, NuGetVersion.Parse(version));
+
+                var mock = new Mock<IPackageSearchMetadata>();
+                mock.Setup(m => m.Identity).Returns(identity);
+                mock.Setup(m => m.Title).Returns(title);
+                mock.Setup(m => m.Published).Returns(published);
+                mock.Setup(m => m.DownloadCount).Returns(downloadCount);
+                mock.Setup(m => m.VersionDownloadCount).Returns(versionDownloadCount);
+
+                return mock.Object;
+            }
+
+            protected T InvokeStaticMethod<T>(Type type, string methodName, object[] parameters)
+            {
+                var method = type.GetMethod(methodName, BindingFlags.NonPublic | BindingFlags.Static);
+
+                if (method == null)
+                {
+                    throw new MissingMethodException($"Could not find static method '{methodName}' on type '{type.FullName}'");
+                }
+
+                return (T)method.Invoke(null, parameters);
+            }
+
+            protected IOrderedEnumerable<IPackageSearchMetadata> SortPackages(
+                IEnumerable<IPackageSearchMetadata> packages,
+                PackageOrder orderBy)
+            {
+                return InvokeStaticMethod<IOrderedEnumerable<IPackageSearchMetadata>>(
+                    typeof(NugetList),
+                    "ApplyPackageSort",
+                    new object[] { packages, orderBy });
+            }
+
+            protected SearchOrderBy? GetSortOrder(PackageOrder orderBy, bool useMultiVersionOrdering)
+            {
+                return InvokeStaticMethod<SearchOrderBy?>(
+                    typeof(NugetList),
+                    "GetSortOrder",
+                    new object[] { orderBy, useMultiVersionOrdering });
+            }
+        }
+
+
+        public class When_Sorting_By_Last_Published : NuGetListReflectionSpecsBase
+        {
+            private IPackageSearchMetadata[] _items;
+            private List<IPackageSearchMetadata> _result;
+
+            public override void Context()
+            {
+                _items = new[]
+                {
+                    CreateMetadata("A", "Title1", "1.0.0", new DateTimeOffset(2020, 1, 1, 0, 0, 0, TimeSpan.Zero), 100, 20),
+                    CreateMetadata("B", "Title1", "1.0.0", new DateTimeOffset(2022, 1, 1, 0, 0, 0, TimeSpan.Zero), 100, 20),
+                    CreateMetadata("C", "Title1", "1.0.1", new DateTimeOffset(2020, 1, 1, 0, 0, 0, TimeSpan.Zero), 100, 20),
+                };
+            }
+
+            public override void Because()
+            {
+                _result = SortPackages(_items, PackageOrder.LastPublished).ToList();
+            }
+
+            [Fact]
+            public void Should_Sort_Packages_By_LastPublished()
+            {
+                using (new AssertionScope())
+                {
+                    _result[0].Identity.Id.Should().Be("B");
+                    _result[1].Identity.Id.Should().Be("A");
+                    _result[1].Identity.Version.ToNormalizedString().Should().Be("1.0.0");
+                    _result[2].Identity.Version.ToNormalizedString().Should().Be("1.0.1");
+                }
+            }
+
+            [Fact]
+            public void Should_Not_Output_Any_Warnings()
+            {
+                MockLogger.Messages.Should().NotContainKey(LogLevel.Warn.ToString());
+            }
+        }
+
+        public class When_Sorting_By_Id : NuGetListReflectionSpecsBase
+        {
+            private IPackageSearchMetadata[] _items;
+            private List<IPackageSearchMetadata> _result;
+
+            public override void Context()
+            {
+                _items = new[]
+                {
+                    CreateMetadata("Zebra", "Alpha", "1.0.0", null, null, null),
+                    CreateMetadata("Alpha", "Beta", "1.0.0", null, null, null),
+                    CreateMetadata("Alpha", "Alpha", "0.9.0", null, null, null),
+                };
+            }
+
+            public override void Because()
+            {
+                _result = SortPackages(_items, PackageOrder.Id).ToList();
+            }
+
+            [Fact]
+            public void Should_Sort_By_Id_Then_Title_Then_Version()
+            {
+                using (new AssertionScope())
+                {
+                    _result[0].Identity.Id.Should().Be("Alpha");
+                    _result[0].Title.Should().Be("Alpha");
+                    _result[1].Title.Should().Be("Beta");
+                    _result[2].Identity.Id.Should().Be("Zebra");
+                }
+            }
+
+            [Fact]
+            public void Should_Not_Output_Any_Warnings()
+            {
+                MockLogger.Messages.Should().NotContainKey(LogLevel.Warn.ToString());
+            }
+        }
+
+        public class When_Sorting_By_Title : NuGetListReflectionSpecsBase
+        {
+            private IPackageSearchMetadata[] _items;
+            private List<IPackageSearchMetadata> _result;
+
+            public override void Context()
+            {
+                _items = new[]
+                {
+                    CreateMetadata("PackageB", "Gamma", "1.0.0", null, null, null),
+                    CreateMetadata("PackageA", "Alpha", "1.0.0", null, null, null),
+                    CreateMetadata("PackageC", "Gamma", "0.9.0", null, null, null),
+                };
+            }
+
+            public override void Because()
+            {
+                _result = SortPackages(_items, PackageOrder.Title).ToList();
+            }
+
+            [Fact]
+            public void Should_Sort_By_Title_Then_Id_Then_Version()
+            {
+                using (new AssertionScope())
+                {
+                    _result[0].Title.Should().Be("Alpha");
+                    _result[1].Title.Should().Be("Gamma");
+                    _result[1].Identity.Id.Should().Be("PackageB");
+                    _result[2].Identity.Id.Should().Be("PackageC");
+                }
+            }
+
+            [Fact]
+            public void Should_Not_Output_Any_Warnings()
+            {
+                MockLogger.Messages.Should().NotContainKey(LogLevel.Warn.ToString());
+            }
+        }
+
+        public class When_Sorting_By_Popularity : NuGetListReflectionSpecsBase
+        {
+            private IPackageSearchMetadata[] _items;
+            private List<IPackageSearchMetadata> _result;
+
+            public override void Context()
+            {
+                _items = new[]
+                {
+                    CreateMetadata("Alpha", "Alpha", "1.0.0", null, 1000, 50),
+                    CreateMetadata("Beta", "Beta", "1.0.0", null, 1500, 40),
+                    CreateMetadata("Gamma", "Gamma", "1.0.0", null, 1500, 100),
+                };
+            }
+
+            public override void Because()
+            {
+                _result = SortPackages(_items, PackageOrder.Popularity).ToList();
+            }
+
+            [Fact]
+            public void Should_Sort_By_DownloadCount_Then_VersionDownloadCount_Then_Id()
+            {
+                using (new AssertionScope())
+                {
+                    _result[0].Identity.Id.Should().Be("Gamma");
+                    _result[1].Identity.Id.Should().Be("Beta");
+                    _result[2].Identity.Id.Should().Be("Alpha");
+                }
+            }
+
+            [Fact]
+            public void Should_Not_Output_Any_Warnings()
+            {
+                MockLogger.Messages.Should().NotContainKey(LogLevel.Warn.ToString());
+            }
+        }
+
+        public class When_Sorting_With_Unsorted_Fallback : NuGetListReflectionSpecsBase
+        {
+            private IPackageSearchMetadata[] _items;
+            private List<IPackageSearchMetadata> _result;
+
+            public override void Context()
+            {
+                _items = new[]
+                {
+                    CreateMetadata("A", "X", "1.0.0", null, null, null),
+                    CreateMetadata("B", "Y", "1.0.0", null, null, null),
+                    CreateMetadata("C", "Z", "1.0.0", null, null, null),
+                };
+            }
+
+            public override void Because()
+            {
+                _result = SortPackages(_items, (PackageOrder)999).ToList(); // unknown value triggers fallback
+            }
+
+            [Fact]
+            public void Should_Apply_Default_Order_For_Unrecognized_Sort()
+            {
+                // fallback just applies OrderBy(_ => 0), which preserves input order
+                _result.Select(p => p.Identity.Id).Should().ContainInOrder("A", "B", "C");
+            }
+
+            [Fact]
+            public void Should_Not_Output_Any_Warnings()
+            {
+                MockLogger.Messages.Should().NotContainKey(LogLevel.Warn.ToString());
+            }
+        }
+
+        public class When_Getting_SortOrder_For_Popularity_With_MultiVersion_Disabled : NuGetListReflectionSpecsBase
+        {
+            private SearchOrderBy? _result;
+
+            public override void Context()
+            {
+                // No-op
+            }
+
+            public override void Because()
+            {
+                _result = GetSortOrder(PackageOrder.Popularity, false);
+            }
+
+            [Fact]
+            public void Should_Return_DownloadCount()
+            {
+                _result.Should().Be(SearchOrderBy.DownloadCount);
+            }
+
+            [Fact]
+            public void Should_Not_Output_Any_Warnings()
+            {
+                MockLogger.Messages.Should().NotContainKey(LogLevel.Warn.ToString());
+            }
+        }
+
+        public class When_Getting_SortOrder_For_Popularity_With_MultiVersion_Enabled : NuGetListReflectionSpecsBase
+        {
+            private SearchOrderBy? _result;
+
+            public override void Context()
+            {
+                // No-op
+            }
+
+            public override void Because()
+            {
+                _result = GetSortOrder(PackageOrder.Popularity, true);
+            }
+
+            [Fact]
+            public void Should_Return_DownloadCountAndVersion()
+            {
+                _result.Should().Be(SearchOrderBy.DownloadCountAndVersion);
+            }
+
+            [Fact]
+            public void Should_Not_Output_Any_Warnings()
+            {
+                MockLogger.Messages.Should().NotContainKey(LogLevel.Warn.ToString());
+            }
+        }
+
+        public class When_Getting_SortOrder_For_Id : NuGetListReflectionSpecsBase
+        {
+            private SearchOrderBy? _result;
+
+            public override void Context()
+            {
+                // No-op
+            }
+
+            public override void Because()
+            {
+                _result = GetSortOrder(PackageOrder.Id, false);
+            }
+
+            [Fact]
+            public void Should_Return_Id()
+            {
+                _result.Should().Be(SearchOrderBy.Id);
+            }
+
+            [Fact]
+            public void Should_Not_Output_Any_Warnings()
+            {
+                MockLogger.Messages.Should().NotContainKey(LogLevel.Warn.ToString());
+            }
+        }
+
+        public class When_Getting_SortOrder_For_Title : NuGetListReflectionSpecsBase
+        {
+            private SearchOrderBy? _result;
+
+            public override void Context()
+            {
+                // No-op
+            }
+
+            public override void Because()
+            {
+                _result = GetSortOrder(PackageOrder.Title, false);
+            }
+
+            [Fact]
+            public void Should_Return_Id()
+            {
+                _result.Should().Be(SearchOrderBy.Id);
+            }
+
+            [Fact]
+            public void Should_Not_Output_Any_Warnings()
+            {
+                MockLogger.Messages.Should().NotContainKey(LogLevel.Warn.ToString());
+            }
+        }
+
+        public class When_Getting_SortOrder_For_Unsorted : NuGetListReflectionSpecsBase
+        {
+            private SearchOrderBy? _result;
+
+            public override void Context()
+            {
+                // No-op
+            }
+
+            public override void Because()
+            {
+                _result = GetSortOrder(PackageOrder.Unsorted, false);
+            }
+
+            [Fact]
+            public void Should_Return_Null()
+            {
+                _result.Should().BeNull();
+            }
+
+            [Fact]
+            public void Should_Not_Output_Any_Warnings()
+            {
+                MockLogger.Messages.Should().NotContainKey(LogLevel.Warn.ToString());
+            }
+        }
+
+        public class When_Getting_SortOrder_For_LastPublished_With_Warning : NuGetListReflectionSpecsBase
+        {
+            private SearchOrderBy? _result;
+
+            public override void Context()
+            {
+                // Ensure logger is clean
+                MockLogger.Reset();
+            }
+
+            public override void Because()
+            {
+                _result = GetSortOrder(PackageOrder.LastPublished, false);
+            }
+
+            [Fact]
+            public void Should_Return_Null()
+            {
+                _result.Should().BeNull();
+            }
+
+            [Fact]
+            public void Should_Log_A_Warning_About_ClientSide_Sorting()
+            {
+                MockLogger.ShouldHaveWarningContaining("OrderBy 'LastPublished' is applied on the client side");
+            }
+        }
+
+        public class When_Sorting_An_Empty_List : NuGetListReflectionSpecsBase
+        {
+            private List<IPackageSearchMetadata> _result;
+
+            public override void Context()
+            {
+                // No items
+            }
+
+            public override void Because()
+            {
+                _result = SortPackages(Enumerable.Empty<IPackageSearchMetadata>(), PackageOrder.Title).ToList();
+            }
+
+            [Fact]
+            public void Should_Return_Empty_List()
+            {
+                _result.Should().BeEmpty();
+            }
+
+            [Fact]
+            public void Should_Not_Output_Any_Warnings()
+            {
+                MockLogger.Messages.Should().NotContainKey(LogLevel.Warn.ToString());
+            }
+        }
+
+        public class When_Sorting_Items_With_Null_Title : NuGetListReflectionSpecsBase
+        {
+            private List<IPackageSearchMetadata> _result;
+
+            public override void Context()
+            {
+                // One package has null Title
+            }
+
+            public override void Because()
+            {
+                var items = new[]
+                {
+                    CreateMetadata("PackageB", null, "1.0.0", null, null, null),
+                    CreateMetadata("PackageA", "Alpha", "1.0.0", null, null, null),
+                };
+
+                _result = SortPackages(items, PackageOrder.Title).ToList();
+            }
+
+            [Fact]
+            public void Should_Not_Throw()
+            {
+                _result.Should().HaveCount(2);
+            }
+
+            [Fact]
+            public void Should_Sort_By_Title_Or_Id_When_Title_Is_Null()
+            {
+                _result.Select(p => p.Identity.Id).Should().ContainInOrder("PackageA", "PackageB");
+            }
+
+            [Fact]
+            public void Should_Not_Output_Any_Warnings()
+            {
+                MockLogger.Messages.Should().NotContainKey(LogLevel.Warn.ToString());
+            }
+        }
+
+        public class When_Sorting_Items_With_Null_Published : NuGetListReflectionSpecsBase
+        {
+            private List<IPackageSearchMetadata> _result;
+
+            public override void Context()
+            {
+                // One package has null Published
+            }
+
+            public override void Because()
+            {
+                var items = new[]
+                {
+                    CreateMetadata("PackageA", "A", "1.0.0", null, null, null),
+                    CreateMetadata("PackageB", "B", "1.0.0", new DateTimeOffset(2022, 1, 1, 0, 0, 0, TimeSpan.Zero), null, null),
+                };
+
+                _result = SortPackages(items, PackageOrder.LastPublished).ToList();
+            }
+
+            [Fact]
+            public void Should_Not_Throw()
+            {
+                _result.Should().HaveCount(2);
+            }
+
+            [Fact]
+            public void Should_Order_By_Published_Descending_With_Nulls_Last()
+            {
+                _result.Select(p => p.Identity.Id).Should().ContainInOrder("PackageB", "PackageA");
+            }
+
+            [Fact]
+            public void Should_Not_Output_Any_Warnings()
+            {
+                MockLogger.Messages.Should().NotContainKey(LogLevel.Warn.ToString());
+            }
+        }
+
+        public class When_Sorting_Items_With_Null_DownloadCounts : NuGetListReflectionSpecsBase
+        {
+            private List<IPackageSearchMetadata> _result;
+
+            public override void Context()
+            {
+                // All download counts are null
+            }
+
+            public override void Because()
+            {
+                var items = new[]
+                {
+                    CreateMetadata("PackageA", "A", "1.0.0", null, null, null),
+                    CreateMetadata("PackageB", "B", "1.0.0", null, null, null),
+                };
+
+                _result = SortPackages(items, PackageOrder.Popularity).ToList();
+            }
+
+            [Fact]
+            public void Should_Not_Throw()
+            {
+                _result.Should().HaveCount(2);
+            }
+
+            [Fact]
+            public void Should_Order_By_Id_When_DownloadCounts_Are_Null()
+            {
+                _result.Select(p => p.Identity.Id).Should().ContainInOrder("PackageA", "PackageB");
+            }
+
+            [Fact]
+            public void Should_Not_Output_Any_Warnings()
+            {
+                MockLogger.Messages.Should().NotContainKey(LogLevel.Warn.ToString());
+            }
+        }
+
+        public class When_Getting_SortOrder_For_Title_With_MultiVersion_Enabled : NuGetListReflectionSpecsBase
+        {
+            private SearchOrderBy? _result;
+
+            public override void Context()
+            {
+                // No-op
+            }
+
+            public override void Because()
+            {
+                _result = GetSortOrder(PackageOrder.Title, true);
+            }
+
+            [Fact]
+            public void Should_Return_Version()
+            {
+                _result.Should().Be(SearchOrderBy.Version);
+            }
+
+            [Fact]
+            public void Should_Not_Output_Any_Warnings()
+            {
+                MockLogger.Messages.Should().NotContainKey(LogLevel.Warn.ToString());
+            }
+        }
+
+        public class When_Getting_SortOrder_For_Id_With_MultiVersion_Enabled : NuGetListReflectionSpecsBase
+        {
+            private SearchOrderBy? _result;
+
+            public override void Context()
+            {
+                // No-op
+            }
+
+            public override void Because()
+            {
+                _result = GetSortOrder(PackageOrder.Id, true);
+            }
+
+            [Fact]
+            public void Should_Return_Version()
+            {
+                _result.Should().Be(SearchOrderBy.Version);
+            }
+
+            [Fact]
+            public void Should_Not_Output_Any_Warnings()
+            {
+                MockLogger.Messages.Should().NotContainKey(LogLevel.Warn.ToString());
+            }
+        }
+
+        public class When_Getting_SortOrder_For_Unknown_Value_With_MultiVersion_Enabled : NuGetListReflectionSpecsBase
+        {
+            private SearchOrderBy? _result;
+
+            public override void Context()
+            {
+                MockLogger.Reset();
+            }
+
+            public override void Because()
+            {
+                _result = GetSortOrder((PackageOrder)999, true);
+            }
+
+            [Fact]
+            public void Should_Return_Version()
+            {
+                _result.Should().Be(SearchOrderBy.Version);
+            }
+
+            [Fact]
+            public void Should_Log_ClientSide_Warning()
+            {
+                MockLogger.ShouldHaveWarningContaining("OrderBy '999' is applied on the client side");
+            }
+        }
+
+        public class When_Getting_SortOrder_For_Unknown_Value_With_MultiVersion_Disabled : NuGetListReflectionSpecsBase
+        {
+            private SearchOrderBy? _result;
+
+            public override void Context()
+            {
+                MockLogger.Reset();
+            }
+
+            public override void Because()
+            {
+                _result = GetSortOrder((PackageOrder)999, false);
+            }
+
+            [Fact]
+            public void Should_Return_Null()
+            {
+                _result.Should().BeNull();
+            }
+
+            [Fact]
+            public void Should_Log_ClientSide_Warning()
+            {
+                MockLogger.ShouldHaveWarningContaining("OrderBy '999' is applied on the client side");
+            }
+        }
+
+    }
+}

--- a/src/chocolatey/chocolatey.csproj
+++ b/src/chocolatey/chocolatey.csproj
@@ -242,6 +242,7 @@
     <Compile Include="infrastructure.app\domain\installers\SquirrelInstaller.cs" />
     <Compile Include="infrastructure.app\domain\installers\WindowsUpdateInstaller.cs" />
     <Compile Include="infrastructure.app\domain\installers\WiseInstaller.cs" />
+    <Compile Include="infrastructure.app\domain\PackageOrder.cs" />
     <Compile Include="infrastructure.app\domain\RegistryHiveType.cs" />
     <Compile Include="infrastructure.app\domain\RegistryValueExtensions.cs" />
     <Compile Include="infrastructure.app\domain\RegistryValueKindType.cs" />

--- a/src/chocolatey/infrastructure.app/commands/ChocolateySearchCommand.cs
+++ b/src/chocolatey/infrastructure.app/commands/ChocolateySearchCommand.cs
@@ -24,6 +24,7 @@ using chocolatey.infrastructure.commands;
 using chocolatey.infrastructure.logging;
 using chocolatey.infrastructure.results;
 using chocolatey.infrastructure.app.services;
+using chocolatey.infrastructure.app.domain;
 
 namespace chocolatey.infrastructure.app.commands
 {
@@ -104,9 +105,43 @@ namespace chocolatey.infrastructure.app.commands
                  .Add("id-starts-with",
                      "IdStartsWith - Only return packages where the id starts with the search filter.",
                      option => configuration.ListCommand.IdStartsWith = option != null)
+                 .Add("order-by=",
+                     "OrderBy - Sort package results by Id (default), {0}. Available in 2.5.0+.".FormatWith(string.Join(", ", Enum.GetNames(typeof(PackageOrder)).Where(n => !n.IsEqualTo("Id")))),
+                     option =>
+                     {
+                        var validOptions = Enum.GetNames(typeof(PackageOrder));
+                         var formattedOptions = string.Join("', '", validOptions);
+                         var unquotedOption = option.UnquoteSafe();
+
+                         if (string.IsNullOrWhiteSpace(unquotedOption))
+                         {
+                             throw new ApplicationException(
+                                @"No '--order-by' clause was provided. Specify one of the supported clauses:
+ '{0}'.".FormatWith(formattedOptions));
+                         }
+
+                         if (!Enum.TryParse(unquotedOption, ignoreCase: true, out PackageOrder orderBy))
+                         {
+                            throw new ApplicationException(
+                                @"The '--order-by' clause '{0}' is not recognized. Use one of the supported clauses:
+ '{1}'.".FormatWith(unquotedOption, formattedOptions));
+                         }
+
+                         configuration.ListCommand.OrderBy = orderBy;
+                 })
                  .Add("order-by-popularity",
-                     "OrderByPopularity - Sort by package results by popularity.",
-                     option => configuration.ListCommand.OrderByPopularity = option != null)
+                     "(Deprecated) OrderByPopularity - Sort package results by popularity. Use '--order-by='Popularity'' instead.",
+                     option =>
+                     {
+                         if (option != null)
+                         {
+                             configuration.ListCommand.OrderByPopularity = true;
+
+                             this.Log().Warn(
+                                 @"'--order-by-popularity' is deprecated and will be removed in a future release.
+ Use '--order-by='Popularity'' instead.");
+                         }
+                     })
                  .Add("approved-only",
                     "ApprovedOnly - Only return approved packages - this option will filter out results not from the community repository.",
                      option => configuration.ListCommand.ApprovedOnly = option != null)

--- a/src/chocolatey/infrastructure.app/configuration/ChocolateyConfiguration.cs
+++ b/src/chocolatey/infrastructure.app/configuration/ChocolateyConfiguration.cs
@@ -607,6 +607,7 @@ NOTE: Hiding sensitive configuration data! Please double and triple
         public ListCommandConfiguration()
         {
             PageSize = 25;
+            OrderBy = PackageOrder.Id;
         }
 
         // list
@@ -620,7 +621,28 @@ NOTE: Hiding sensitive configuration data! Please double and triple
         public bool ByIdOnly { get; set; }
         public bool ByTagOnly { get; set; }
         public bool IdStartsWith { get; set; }
-        public bool OrderByPopularity { get; set; }
+        public PackageOrder OrderBy { get; set; }
+
+        [Obsolete("This property is deprecated and will be removed in version 3.0. Use the 'OrderBy' property instead.")]
+        public bool OrderByPopularity
+        {
+            get
+            {
+                return OrderBy == PackageOrder.Popularity;
+            }
+            set
+            {
+                if (value)
+                {
+                    OrderBy = PackageOrder.Popularity;
+                }
+                else
+                {
+                    OrderBy = PackageOrder.Id;
+                }
+            }
+        }
+
         public bool ApprovedOnly { get; set; }
         public bool DownloadCacheAvailable { get; set; }
         public bool NotBroken { get; set; }

--- a/src/chocolatey/infrastructure.app/domain/PackageOrder.cs
+++ b/src/chocolatey/infrastructure.app/domain/PackageOrder.cs
@@ -1,0 +1,46 @@
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
+// Copyright © 2011 - 2017 RealDimensions Software, LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace chocolatey.infrastructure.app.domain
+{
+    public enum PackageOrder
+    {
+        /// <summary>
+        /// Sort by package ID (also commonly referred to as name), in ascending order.
+        /// </summary>
+        Id,
+
+        /// <summary>
+        /// Sort by package title in ascending order.
+        /// </summary>
+        Title,
+
+        /// <summary>
+        /// Sort by popularity, with the most popular packages first.
+        /// </summary>
+        Popularity,
+
+        /// <summary>
+        /// Sort by last published date, from newest to oldest.
+        /// </summary>
+        LastPublished,
+
+        /// <summary>
+        /// Do not sort; return packages in the order received from the source.
+        /// </summary>
+        Unsorted
+    }
+}

--- a/src/chocolatey/infrastructure.app/nuget/NugetList.cs
+++ b/src/chocolatey/infrastructure.app/nuget/NugetList.cs
@@ -55,7 +55,7 @@ namespace chocolatey.infrastructure.app.nuget
             var searchFilter = new SearchFilter(configuration.Prerelease)
             {
                 IncludeDelisted = configuration.ListCommand.LocalOnly,
-                OrderBy = SearchOrderBy.DownloadCount
+                OrderBy = GetSortOrder(configuration.ListCommand.OrderBy, configuration.AllVersions)
             };
 
             var totalCount = 0;
@@ -76,16 +76,13 @@ namespace chocolatey.infrastructure.app.nuget
             var packageRepositoryResources = NugetCommon.GetRepositoryResources(configuration, nugetLogger, filesystem, cacheContext);
             var searchTermLower = configuration.Input.ToLowerSafe();
 
+            NuGetVersion version = !string.IsNullOrWhiteSpace(configuration.Version) ? NuGetVersion.Parse(configuration.Version) : null;
+
             var searchFilter = new SearchFilter(configuration.Prerelease)
             {
                 IncludeDelisted = configuration.ListCommand.LocalOnly,
-                OrderBy = SearchOrderBy.Id
+                OrderBy = GetSortOrder(configuration.ListCommand.OrderBy, configuration.AllVersions || !(version is null))
             };
-
-            if (configuration.ListCommand.OrderByPopularity)
-            {
-                searchFilter.OrderBy = SearchOrderBy.DownloadCount;
-            }
 
             if (configuration.ListCommand.ByIdOnly)
             {
@@ -100,13 +97,6 @@ namespace chocolatey.infrastructure.app.nuget
             if (configuration.ListCommand.IdStartsWith)
             {
                 searchFilter.IdStartsWith = true;
-            }
-
-            NuGetVersion version = !string.IsNullOrWhiteSpace(configuration.Version) ? NuGetVersion.Parse(configuration.Version) : null;
-
-            if (version != null)
-            {
-                searchFilter.OrderBy = SearchOrderBy.Version;
             }
 
             var results = new HashSet<IPackageSearchMetadata>(new ComparePackageSearchMetadata());
@@ -330,9 +320,7 @@ namespace chocolatey.infrastructure.app.nuget
                 results = results.Where(p => (p.IsDownloadCacheAvailable && configuration.Information.IsLicensedVersion) || p.PackageTestResultStatus != "Failing").ToHashSet();
             }
 
-            results = configuration.ListCommand.OrderByPopularity ?
-                 results.OrderByDescending(p => p.DownloadCount).ThenBy(p => p.Identity.Id).ToHashSet()
-                 : results.OrderBy(p => p.Identity.Id).ThenByDescending(p => p.Identity.Version).ToHashSet();
+            results = ApplyPackageSort(results, configuration.ListCommand.OrderBy).ToHashSet();
 
             return results.AsQueryable();
         }
@@ -463,6 +451,112 @@ namespace chocolatey.infrastructure.app.nuget
             }
 
             return packagesList.OrderByDescending(p => p.Identity.Version).FirstOrDefault();
+        }
+
+        private static IOrderedEnumerable<IPackageSearchMetadata> ApplyPackageSort(IEnumerable<IPackageSearchMetadata> query, domain.PackageOrder orderBy)
+        {
+            switch (orderBy)
+            {
+                case domain.PackageOrder.LastPublished:
+                    return query
+                        .OrderByDescending(q => q.Published)
+                        .ThenBy(q => q.Identity.Id)
+                        .ThenBy(q => q.Identity.Version);
+
+                case domain.PackageOrder.Id:
+                    return query.OrderBy(q => q.Identity.Id)
+                        .ThenBy(q => q.Title)
+                        .ThenBy(q => q.Identity.Version);
+
+                case domain.PackageOrder.Popularity:
+                    return query
+                        .OrderByDescending(q => q.DownloadCount)
+                        .ThenByDescending(q => q.VersionDownloadCount)
+                        .ThenBy(q => q.Identity.Id);
+
+                case domain.PackageOrder.Title:
+                    return query
+                        // Fallback to Id if Title is missing
+                        .OrderBy(q => q.Title ?? q.Identity.Id)
+                        .ThenBy(q => q.Identity.Id)
+                        .ThenBy(q => q.Identity.Version);
+
+                default:
+                    // Since we return an IOrderedEnumerable, some form of ordering must be applied,
+                    // even when the user has not explicitly requested a sort order.
+                    //
+                    // This fallback also applies when the user has explicitly set the package order to 'Unsorted'.
+                    // In both cases, we apply a default order to satisfy the contract of the return type.
+
+                    return query.OrderBy(_ => 0);
+            }
+        }
+
+        private static SearchOrderBy? GetSortOrder(domain.PackageOrder orderBy, bool useMultiVersionOrdering)
+        {
+            switch (orderBy)
+            {
+                case domain.PackageOrder.Popularity:
+                    if (useMultiVersionOrdering)
+                    {
+                        return SearchOrderBy.DownloadCountAndVersion;
+                    }
+                    else
+                    {
+                        return SearchOrderBy.DownloadCount;
+                    }
+
+                case domain.PackageOrder.Id:
+                // Ideally, we would order by the package title,
+                // but this is not currently supported by the NuGet client libraries.
+                // Since ordering by Id typically produces a similar result,
+                // we explicitly sort by Id here and defer title-based sorting
+                // to the client side later.
+                case domain.PackageOrder.Title:
+                    if (useMultiVersionOrdering)
+                    {
+                        return SearchOrderBy.Version;
+                    }
+                    else
+                    {
+                        return SearchOrderBy.Id;
+                    }
+
+                default:
+                    if (orderBy != domain.PackageOrder.Unsorted)
+                    {
+                        // Inform the user that ordering is performed on the client side,
+                        // which may result in inconsistent ordering due to server-side paging.
+                        //
+                        // Although the user may not explicitly request paging, Chocolatey
+                        // performs paging automatically. Since we only receive a limited
+                        // subset of packages from the server, client-side sorting may not
+                        // produce fully consistent results across pages.
+                        //
+                        // Ideally, server-side ordering would be supported, but the current
+                        // NuGet client libraries do not yet provide this capability.
+
+
+                        "chocolatey".Log().Warn(
+                            @"OrderBy '{0}' is applied on the client side. Because results are paged by the
+ server, this may lead to inconsistent ordering.",
+                            orderBy);
+
+                        if (useMultiVersionOrdering)
+                        {
+                            // We will be explicit about ordering by version
+                            // in this case. This has to do with historical
+                            // reasons to prevent inconsistent results being
+                            // returned when a version is specified.
+                            return SearchOrderBy.Version;
+                        }
+                    }
+
+                    // Anything else, we are currently not able to tell the server
+                    // what sorting method to use, so let us fall back to either
+                    // defaults in the NuGet library, or unsorted on the server side.
+                    return null;
+            }
         }
 
 #pragma warning disable IDE0022, IDE1006


### PR DESCRIPTION
## Description Of Changes

This change adds a new command line option "order-by", allowing the user to specify a few sorting strategies. By default the results will be sorted by id.

## Motivation and Context

To allow uses to decide how they want the results being sorted when we can.

## Testing

These tests assume you only have the Chocolatey Community Repository enabled as a source.

1. Do a search using `choco search chrome --order-by='id'`
2. Verify the resulting set is ordered by the Identifier with the first entry being 1password-chrome
3. Do the same search using `--order-by='title'`
4. Verify the first entry is `choco-protocol-support` (It is prefixed with `(unofficial)` in the title, and is expected to be the first result in this case.
5. Search again using `--order-by='popularity'`
6. Verify the package with most downloads is returned first (at this time it is `GoogleChrome`).
7. Search again using `--order-by='unsorted'`
8. Go to https://community.chocolatey.org/packages` and enter `chrome` in the search box and hit enter.
9. Verify the order of the search on Chocolatey Community Repository and the results from Chocolatey CLI is in the same/similar order.
10. Search again using `--order-by='LastPublished'`.
11. Verify a yellow warning is outputted with the text `Order By 'LastPublished' has been specified. This order is done on client side and may lead to inconsistently ordered results.`
12. Go to the website search previously made, and change the dropdown for the order to `Recent`.
13. Verify the order of packages is similar to the output from the Chocolatey CLI output (they may not be exactly the same due to client sort).
14. Search again using `--order-by='other'`.
15. Verify an error is outputted with the message `Error: The order-by clause 'other' is not recognized. Use one of the supported clauses: 'Id', 'LastPublished', 'Popularity', 'Title', 'Unsorted'.`.

### Operating Systems Testing

- Windows 11

## Change Types Made

* [x] Feature / Enhancement (non-breaking change).

## Change Checklist

* [x] Requires a change to the documentation.
* [x] Tests to cover my changes, have been added.
* [x] All new and existing tests passed?

## Related Issue
Fixes #3709

## Additional Information

Note that some results may appear out-of-order, this is caused by the NuGet server returning them in the incorrect order, see https://github.com/chocolatey/NuGet.Server-chocolatey/issues/2