### PR TITLE
(GH-1623) Change $host.Version to $PSVersionTable.PSVersion

### DIFF
--- a/src/chocolatey.resources/helpers/functions/Get-ChocolateyWebFile.ps1
+++ b/src/chocolatey.resources/helpers/functions/Get-ChocolateyWebFile.ps1
@@ -305,7 +305,7 @@ param(
     try {
       $headers = Get-WebHeaders -Url $url -ErrorAction "Stop"
     } catch {
-      if ($host.Version -lt (New-Object 'Version' 3,0)) {
+      if ($PSVersionTable.PSVersion -lt (New-Object 'Version' 3,0)) {
         Write-Debug "Converting Security Protocol to SSL3 only for Powershell v2"
         # this should last for the entire duration
         $originalProtocol = [System.Net.ServicePointManager]::SecurityProtocol


### PR DESCRIPTION
With the latest release of Powershell, this line throws an SetValueInvocationException: "The requested security protocol is not supported."
Change the SecurityProtocol to SystemDefault ensures backwards compatibility and is necessary since Ssl3 is deprecated.


Fixes GH-1623