### PR TITLE
(doc) .NET Framework 3.5 Feature Required for windows builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ There is a `build.bat`/`build.sh` file that creates a necessary generated file n
 #### Windows
 Prerequisites:
 
+ * .NET Framework 3.5 (This is a windows feature installation).
  * .NET Framework 4+
  * Visual Studio is helpful for working on source.
  * ReSharper is immensely helpful (and there is a `.sln.DotSettings` file to help with code conventions).


### PR DESCRIPTION
In order to build on a windows machine you must have .NET Framework 3.5 installed ( typically done via the windows feature functionality ).  Once installed building will continue to work.  I assume this might be installed by default on desktop O/S's but not the default on newer Windows Server O/S's due to reducing the attack surface of a box.

This Closes #1650
