### PR TITLE
(GH-1652) Fix unused local variable msbuild warnings

### DIFF
--- a/src/chocolatey.tests/infrastructure/tolerance/FaultToleranceSpecs.cs
+++ b/src/chocolatey.tests/infrastructure/tolerance/FaultToleranceSpecs.cs
@@ -51,7 +51,6 @@ namespace chocolatey.tests.infrastructure.tolerance
                     0,
                     () =>
                     {
-                        var dude = 1;
                     });
             }
 

--- a/src/chocolatey/infrastructure.app/services/RegistryService.cs
+++ b/src/chocolatey/infrastructure.app/services/RegistryService.cs
@@ -248,12 +248,8 @@ namespace chocolatey.infrastructure.app.services
             key.Dispose();
         }
 
-        private int _componentLoopCount = 0;
-
         private void get_msi_information(RegistryApplicationKey appKey, RegistryKey key)
         {
-            _componentLoopCount = 0;
-
             var userDataProductKeyId = get_msi_user_data_key(key.Name);
             if (string.IsNullOrWhiteSpace(userDataProductKeyId)) return;
 
@@ -290,7 +286,7 @@ namespace chocolatey.infrastructure.app.services
                      appKey.Version = set_if_empty(appKey.Version, msiProductKey.get_value_as_string("Version"));
                      appKey.VersionMajor = set_if_empty(appKey.VersionMajor, msiProductKey.get_value_as_string("VersionMajor"));
                      appKey.VersionMinor = set_if_empty(appKey.VersionMinor, msiProductKey.get_value_as_string("VersionMinor"));
-
+                     // int _componentLoopCount = 0;
                      // search components for install location if still empty
                      // the performance of this is very bad - without this the query is sub-second
                      // with this it takes about 15 seconds with around 200 apps installed


### PR DESCRIPTION
This removes all warnings that are not chocolatey deprecation specific.  One test could have used an empty lambda instead of an unused local variable and another unused variable was from code that got commented out.

Closes #1652 