### PR TITLE
(doc) Fix example in Install-ChocolateyShortcut.ps1

### DIFF
--- a/src/chocolatey.resources/helpers/functions/Install-ChocolateyShortcut.ps1
+++ b/src/chocolatey.resources/helpers/functions/Install-ChocolateyShortcut.ps1
@@ -89,7 +89,7 @@ Install-ChocolateyShortcut -ShortcutFilePath "C:\test.lnk" -TargetPath "C:\test.
 Install-ChocolateyShortcut `
   -ShortcutFilePath "C:\notepad.lnk" `
   -TargetPath "C:\Windows\System32\notepad.exe" `
-  -WorkDirectory "C:\" `
+  -WorkingDirectory "C:\" `
   -Arguments "C:\test.txt" `
   -IconLocation "C:\test.ico" `
   -Description "This is the description"


### PR DESCRIPTION
Fix one example which had wrong param - `WorkDirectory` -> `WorkingDirectory`.
