### PR TITLE
(GH-661) allow local only without sources

### DIFF
--- a/src/chocolatey/infrastructure.app/services/ChocolateyPackageService.cs
+++ b/src/chocolatey/infrastructure.app/services/ChocolateyPackageService.cs
@@ -161,7 +161,7 @@ Did you know Pro / Business automatically syncs with Programs and
 
         public IEnumerable<PackageResult> list_run(ChocolateyConfiguration config)
         {
-            if (string.IsNullOrWhiteSpace(config.Sources))
+            if (string.IsNullOrWhiteSpace(config.Sources) && !config.ListCommand.LocalOnly)
             {
                 this.Log().Error(ChocolateyLoggers.Important, @"Unable to search for packages when there are no sources enabled for
  packages and none were passed as arguments.");


### PR DESCRIPTION
When no sources are active and someone is searching a local source,
allow that to continue without throwing an error. This will allow the
sources to be configured to the local source a littler further in and
then return results instead of throwing an error.

Closes #661