### PR TITLE
(GH-1604) Fix DateTime formatting issue in Env:ChocolateyLastPathUpdate

### DIFF
--- a/src/chocolatey.resources/helpers/functions/Set-EnvironmentVariable.ps1
+++ b/src/chocolatey.resources/helpers/functions/Set-EnvironmentVariable.ps1
@@ -118,7 +118,7 @@ public static extern IntPtr SendMessageTimeout(
 
     # Set a user environment variable making the system refresh
     $setx = "$($env:SystemRoot)\System32\setx.exe"
-    & "$setx" ChocolateyLastPathUpdate `"$(Get-Date -UFormat %c)`" | Out-Null
+    & "$setx" ChocolateyLastPathUpdate `"$((Get-Date).ToFileTime())`" | Out-Null
   } catch {
     Write-Warning "Failure attempting to let Explorer know about updated environment settings.`n  $($_.Exception.Message)"
   }


### PR DESCRIPTION
(GH-1604) Fix DateTime formatting issue in Env:ChocolateyLastPathUpdate

Due to the DateTime format used this would cause all kinds of issues when a tool or environment uses the environment variables. For example, a python script that reads all environment variables on a system with a Swedish DateTime culture set and tries to serialize the key/values as JSON would/could error out when a ÅÄ or Ö is written by choco into ChocolateyLastPathUpdate, it's also a hard bug to track down since in the Swedish case it would only trigger on a Saturday, Sunday or Monday where mentioned chars would appear. 

This change changes the formatting used to force it to a long in the form of using ToFileTime() on the returned Date object instead of the formatting flags used before the change. 

Closes #1604