### PR TITLE
(GH-1234) Fix typo in Parameter definition of Context Based Help

### DIFF
--- a/src/chocolatey.resources/helpers/functions/Install-ChocolateyShortcut.ps1
+++ b/src/chocolatey.resources/helpers/functions/Install-ChocolateyShortcut.ps1
@@ -1,4 +1,4 @@
-﻿# Copyright © 2017 Chocolatey Software, Inc.
+# Copyright © 2017 Chocolatey Software, Inc.
 # Copyright © 2015 - 2017 RealDimensions Software, LLC
 # Copyright © 2011 - 2015 RealDimensions Software, LLC & original authors/contributors from https://github.com/chocolatey/chocolatey
 #
@@ -89,7 +89,7 @@ Install-ChocolateyShortcut -ShortcutFilePath "C:\test.lnk" -TargetPath "C:\test.
 Install-ChocolateyShortcut `
   -ShortcutFilePath "C:\notepad.lnk" `
   -TargetPath "C:\Windows\System32\notepad.exe" `
-  -WorkDirectory "C:\" `
+  -WorkingDirectory "C:\" `
   -Arguments "C:\test.txt" `
   -IconLocation "C:\test.ico" `
   -Description "This is the description"

--- a/src/chocolatey.resources/helpers/functions/Install-ChocolateyShortcut.ps1
+++ b/src/chocolatey.resources/helpers/functions/Install-ChocolateyShortcut.ps1
@@ -1,4 +1,4 @@
-# Copyright © 2017 Chocolatey Software, Inc.
+﻿# Copyright © 2017 Chocolatey Software, Inc.
 # Copyright © 2015 - 2017 RealDimensions Software, LLC
 # Copyright © 2011 - 2015 RealDimensions Software, LLC & original authors/contributors from https://github.com/chocolatey/chocolatey
 #
@@ -57,7 +57,7 @@ shortcut.
 OPTIONAL - A text description to be associated with the new description.
 
 .PARAMETER WindowStyle
-OPTIONAL - Type of windows target application should open with. 
+OPTIONAL - Type of windows target application should open with.
 Available in 0.9.10+.
 0 = Hidden, 1 = Normal Size, 3 = Maximized, 7 - Minimized.
 Full list table 3.9 here: https://technet.microsoft.com/en-us/library/ee156605.aspx


### PR DESCRIPTION
This is a small fix to the Parameter definition in the CBH of Install-ChocolateyShortcut.ps1. This aligns $WorkingDirectory to be the same name in the CBH and Param() block. This will also fix the upstream documentation for the command on chocolatey.org.

Fixes #1234 