### PR TITLE
Request headers in `Get-WebHeaders`

### DIFF
--- a/src/chocolatey.resources/helpers/functions/Get-ChocolateyWebFile.ps1
+++ b/src/chocolatey.resources/helpers/functions/Get-ChocolateyWebFile.ps1
@@ -269,7 +269,7 @@ param(
   if ($url.StartsWith('http:')) {
     try {
       $httpsUrl = $url.Replace("http://", "https://")
-      Get-WebHeaders -Url $httpsUrl -ErrorAction "Stop" | Out-Null
+      Get-WebHeaders -Url $httpsUrl -ErrorAction "Stop" -Options $options | Out-Null
       $url = $httpsUrl
       Write-Warning "Url has SSL/TLS available, switching to HTTPS for download"
     } catch {
@@ -303,7 +303,7 @@ param(
   $headers = @{}
   if ($url.StartsWith('http')) {
     try {
-      $headers = Get-WebHeaders -Url $url -ErrorAction "Stop"
+      $headers = Get-WebHeaders -Url $url -ErrorAction "Stop" -Options $options
     } catch {
       if ($PSVersionTable.PSVersion -lt (New-Object 'Version' 3,0)) {
         Write-Debug "Converting Security Protocol to SSL3 only for Powershell v2"
@@ -311,7 +311,7 @@ param(
         $originalProtocol = [System.Net.ServicePointManager]::SecurityProtocol
         [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]::Ssl3
         try {
-          $headers = Get-WebHeaders -Url $url -ErrorAction "Stop"
+          $headers = Get-WebHeaders -Url $url -ErrorAction "Stop" -Options $options
         } catch {
           Write-Host "Attempt to get headers for $url failed.`n  $($_.Exception.Message)"
           [System.Net.ServicePointManager]::SecurityProtocol = $originalProtocol


### PR DESCRIPTION
[ci skip] Request headers in `Get-WebHeaders`

Request headers support in `Get-WebHeaders` is required for fixing bug in `Get-ChocolateyWebFile`.

When no checksum is passed to `Get-ChocolateyWebFile`, it's check file length: response headers is fetched by `Get-WebHeaders` using `HEAD` request and then compared with file length which got from file fetched with `GET` request.

File length check should succeed, because `HEAD` request to equal URL, using same request headers as `GET` request, will return same `Content-Length`.

Actually file length check will not succeed, because `Get-WebHeaders` does not support request headers except `User-Agent`, and therefore headers accepted by `Get-ChocolateyWebFile` is not passed to `Get-WebHeaders`.

Monkey-patched version of `Get-ChocolateyWebFile` is used by [`AU`](https://github.com/majkinetor/au) for generating checksums on-the-fly. This PR is part of effort introducing support of request headers in `AU`.

Request headers passed as `-Options @{Headers=@{}}`, not as just `-Headers @{}`, for mantaining consistency with others `Chocolatey`'s helper functions, such as `Get-ChocolateyWebFile`.