### PR TITLE
(GH-1788) Use LiteralPath in Get-UninstallRegistryKey

### DIFF
--- a/src/chocolatey.resources/helpers/functions/Get-UninstallRegistryKey.ps1
+++ b/src/chocolatey.resources/helpers/functions/Get-UninstallRegistryKey.ps1
@@ -134,13 +134,13 @@ param(
 
     $keyPaths = $keys | Select-Object -ExpandProperty PSPath
     try {
-      [array]$foundKey = Get-ItemProperty -Path $keyPaths -ErrorAction Stop | ? { $_.DisplayName -like $softwareName }
+      [array]$foundKey = Get-ItemProperty -LiteralPath $keyPaths -ErrorAction Stop | ? { $_.DisplayName -like $softwareName }
       $success = $true
     } catch {
       Write-Debug "Found bad key."
       foreach ($key in $keys){
         try {
-          Get-ItemProperty $key.PsPath > $null
+          Get-ItemProperty -LiteralPath $key.PsPath > $null
         } catch {
           $badKey = $key.PsPath
         }


### PR DESCRIPTION
This fixes cases where registry keys contains some characters(eg `[` or `]`) where `Get-ItemProperty -Path` wouldn't accept.

I'm not sure the badKeys check is still required or not though, because I think this fixes the problem that it was trying to fix there.

Fixes #1788 