### PR TITLE
 (GH-1603) Ensure full path to log is used

### DIFF
--- a/src/chocolatey.console/Program.cs
+++ b/src/chocolatey.console/Program.cs
@@ -83,7 +83,7 @@ namespace chocolatey.console
 
                 if (!string.IsNullOrWhiteSpace(config.AdditionalLogFileLocation))
                 {
-                  Log4NetAppenderConfiguration.configure_additional_log_file(config.AdditionalLogFileLocation);
+                  Log4NetAppenderConfiguration.configure_additional_log_file(fileSystem.get_full_path(config.AdditionalLogFileLocation));
                 }
 
                 report_version_and_exit_if_requested(args, config);


### PR DESCRIPTION
Use helper method in IFileSystem implementation to ensure that the full
path to the requested log file is used, rather than making it relative
to where Chocolatey is currently located.

Fixes #1603 