### PR TITLE
(GH-1581) add more tolerance, logging around bad registry snapshots

### DIFF
--- a/src/chocolatey/infrastructure.app/domain/RegistryValueExtensions.cs
+++ b/src/chocolatey/infrastructure.app/domain/RegistryValueExtensions.cs
@@ -16,6 +16,7 @@
 
 namespace chocolatey.infrastructure.app.domain
 {
+    using System.Security;
     using Microsoft.Win32;
 
     public static class RegistryValueExtensions
@@ -26,9 +27,11 @@ namespace chocolatey.infrastructure.app.domain
 
             // Since it is possible that registry keys contain characters that are not valid
             // in XML files, ensure that all content is escaped, prior to serialization
-            var escapedXml = System.Security.SecurityElement.Escape(key.GetValue(name).to_string()).Replace("&quot;","\"").Replace("&apos;","'");
-
-            return escapedXml == null ? string.Empty : escapedXml.Replace("\0", string.Empty);
+            // https://docs.microsoft.com/en-us/dotnet/api/system.security.securityelement.escape?view=netframework-4.0
+            return SecurityElement.Escape(key.GetValue(name).to_string()).to_string()
+                                  .Replace("&quot;", "\"")
+                                  .Replace("&apos;", "'")
+                                  .Replace("\0", string.Empty);
         }
     }
 }

--- a/src/chocolatey/infrastructure.app/domain/RegistryValueExtensions.cs
+++ b/src/chocolatey/infrastructure.app/domain/RegistryValueExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2019 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/services/ChocolateyPackageInformationService.cs
+++ b/src/chocolatey/infrastructure.app/services/ChocolateyPackageInformationService.cs
@@ -87,6 +87,7 @@ A corrupt .registry file exists at {0}.
  Instead, you can use the following PowerShell command:
  Move-Item .\.registry.bad .\.registry
 ".format_with(_fileSystem.combine_paths(pkgStorePath, REGISTRY_SNAPSHOT_BAD_FILE));
+
             try
             {
                 if (_fileSystem.file_exists(_fileSystem.combine_paths(pkgStorePath, REGISTRY_SNAPSHOT_BAD_FILE)))

--- a/src/chocolatey/infrastructure.app/services/ChocolateyPackageInformationService.cs
+++ b/src/chocolatey/infrastructure.app/services/ChocolateyPackageInformationService.cs
@@ -98,8 +98,14 @@ A corrupt .registry file exists at {0}.
                     packageInformation.RegistrySnapshot = _registryService.read_from_file(_fileSystem.combine_paths(pkgStorePath, REGISTRY_SNAPSHOT_FILE));
                 }
             }
-            catch (Exception)
+            catch (Exception e)
             {
+                if (_config.RegularOutput) this.Log().Warn(@"A .registry file at '{0}'
+ has errored attempting to read it. This file will be renamed to 
+ '{1}' The error:
+ {2} 
+ ".format_with(_fileSystem.combine_paths(pkgStorePath, REGISTRY_SNAPSHOT_FILE), _fileSystem.combine_paths(pkgStorePath, REGISTRY_SNAPSHOT_BAD_FILE), e.ToString()));
+
                 FaultTolerance.try_catch_with_logging_exception(
                     () =>
                     {

--- a/src/chocolatey/infrastructure.app/services/RegistryService.cs
+++ b/src/chocolatey/infrastructure.app/services/RegistryService.cs
@@ -394,7 +394,7 @@ namespace chocolatey.infrastructure.app.services
                 return null;
             }
 
-            return _xmlService.deserialize<Registry>(filePath, 1);
+            return _xmlService.deserialize<Registry>(filePath, 2);
         }
 
         private void get_values(RegistryKey key, string subKeyName, IList<GenericRegistryValue> values, bool expandValues)

--- a/src/chocolatey/infrastructure/tolerance/FaultTolerance.cs
+++ b/src/chocolatey/infrastructure/tolerance/FaultTolerance.cs
@@ -79,7 +79,7 @@ namespace chocolatey.infrastructure.tolerance
         public static T retry<T>(int numberOfTries, Func<T> function, int waitDurationMilliseconds = 100, int increaseRetryByMilliseconds = 0, bool isSilent = false)
         {
             if (function == null) return default(T);
-            if (numberOfTries == 0) throw new ApplicationException("You must specify a number of retries greater than zero.");
+            if (numberOfTries == 0) throw new ApplicationException("You must specify a number of tries greater than zero.");
             var returnValue = default(T);
 
             var debugging = log_is_in_debug_mode();


### PR DESCRIPTION
Relates to #1581

Right now what causes a .registry file to be renamed to a .registry.bad file is not easily 
identifiable. Provide more logging surrounding that. Bump up the number of attempts 
to deserialize the file as well from one to two. This will add a little more fault tolerance 
in case something times out.