### PR TITLE
(GH-1772) Ensure chocolateyForceX86 is only set when requested

### DIFF
--- a/src/chocolatey/infrastructure.app/services/PowershellService.cs
+++ b/src/chocolatey/infrastructure.app/services/PowershellService.cs
@@ -391,6 +391,7 @@ namespace chocolatey.infrastructure.app.services
             Environment.SetEnvironmentVariable("chocolateyChecksumType32", null);
             Environment.SetEnvironmentVariable("chocolateyChecksum64", null);
             Environment.SetEnvironmentVariable("chocolateyChecksumType64", null);
+            Environment.SetEnvironmentVariable("chocolateyForceX86", null);
 
             // we only want to pass the following args to packages that would apply. 
             // like choco install git --params '' should pass those params to git.install, 


### PR DESCRIPTION
When the Chocolatey library is called multiple times (eg. by Boxstarter), then don't persist the `chocolateyForceX86` environment variable between invocations

- Fixes #1772
