### PR TITLE
(GH-1800) Prefer 32-bit in ARM64 emulated PowerShell

### DIFF
--- a/src/chocolatey.resources/helpers/functions/Get-OSArchitectureWidth.ps1
+++ b/src/chocolatey.resources/helpers/functions/Get-OSArchitectureWidth.ps1
@@ -66,6 +66,10 @@ param(
   if ($processorArchitecture -and $processorArchitecture -eq 'ARM64') {
     $bits = 32
   }
+  $processorArchiteW6432 = $env:PROCESSOR_ARCHITEW6432
+  if ($processorArchiteW6432 -and $processorArchiteW6432 -eq 'ARM64') {
+    $bits = 32
+  }
 
   # Return bool|int
   if ("$compare" -ne '' -and $compare -eq $bits) {


### PR DESCRIPTION
https://github.com/chocolatey/choco/issues/1800 was fixed by @ferventcoder in https://github.com/chocolatey/choco/commit/b30427d620f1ea27a4a3dbc205cb528247dd2d0a. However, the fix does not work because PowerShell runs as an emulated x86 binary in ARM64. Thus, it is also necessary to check the `PROCESSOR_ARCHITEW6432` to determine if Chocolatey should prefer 32-bit packages.

Ref: https://github.com/chocolatey/choco/issues/1800#issuecomment-486038173
