### PR TITLE
(GH-1816) Add NuGet.Config beside sln file

### DIFF
--- a/src/NuGet.Config
+++ b/src/NuGet.Config
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <add key="NuGet Official v2 Package Source" value="https://www.nuget.org/api/v2/" />
+  </packageSources>
+</configuration>


### PR DESCRIPTION
Depending on the end user setup, the machine level NuGet Configuration
file can include an entry for the v3 NuGet feed.  This causes problems
when restoring packages for the Chocolatey build, since two packages
(NUnit.Runners and coveralls) do not restore from the v3 feed, only the
v2 feed.  By specifying this feed in the solution level NuGet.Config
file, should mean that they restore correctly on any machine.

NOTE: The existing NuGet.Config file in the .nuget folder actually
doesn't seem to be being used at all.  Based on the documentation here:

https://docs.microsoft.com/en-us/nuget/consume-packages/configuring-nuget-behavior

A NuGet.Config file is looked for at the location of the sln file,
upwards to the root of the drive.  As a result, the existing file is
being ignored.

Fixes #1816 