### PR TITLE
(GH-1804) Added pre parameter to outdated

### DIFF
--- a/src/chocolatey/infrastructure.app/commands/ChocolateyOutdatedCommand.cs
+++ b/src/chocolatey/infrastructure.app/commands/ChocolateyOutdatedCommand.cs
@@ -52,6 +52,9 @@ namespace chocolatey.infrastructure.app.commands
                 .Add("cp=|certpassword=",
                      "Certificate Password - the client certificate's password to the source. Defaults to empty. Available in 0.9.10+.",
                      option => configuration.SourceCommand.CertificatePassword = option.remove_surrounding_quotes())
+                .Add("pre|prerelease",
+                    "Prerelease - Include Prereleases? Defaults to false. Available in 0.10.14+.",
+                    option => configuration.Prerelease = option != null)
                 .Add("ignore-pinned",
                      "Ignore Pinned - Ignore pinned packages. Defaults to false. Available in 0.10.6+.",
                      option => configuration.OutdatedCommand.IgnorePinned = option != null)


### PR DESCRIPTION
With the pre parameter added to the outdated command, you are able to
list outdated packages that have a pre-release available. As all the
code was already available, only the parameter was added to the
outdated command.

Merging this fixes #1804 

Preview of `choco outdated --pre`
![image](https://user-images.githubusercontent.com/834643/58381322-2900ac80-7fbc-11e9-9c2a-22686d06e85b.png)
