### PR TITLE
 (GH-1837) Handle potential for null package

### DIFF
--- a/src/chocolatey/infrastructure.app/nuget/NugetList.cs
+++ b/src/chocolatey/infrastructure.app/nuget/NugetList.cs
@@ -65,9 +65,13 @@ namespace chocolatey.infrastructure.app.nuget
 
             if (configuration.ListCommand.Exact)
             {
+                var exactPackage = find_package(searchTermLower, version, configuration, packageRepository);
+
+                if (exactPackage == null) return new List<IPackage>().AsQueryable();
+
                 return new List<IPackage>()
                 {
-                    find_package(searchTermLower, version, configuration, packageRepository)
+                    exactPackage
                 }.AsQueryable();
             }
 

--- a/src/chocolatey/infrastructure.app/nuget/NugetList.cs
+++ b/src/chocolatey/infrastructure.app/nuget/NugetList.cs
@@ -1,13 +1,13 @@
 ﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
-// 
+//
 // You may obtain a copy of the License at
-// 
+//
 // 	http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -62,7 +62,7 @@ namespace chocolatey.infrastructure.app.nuget
             IQueryable<IPackage> results = packageRepository.Search(searchTermLower, configuration.Prerelease);
 
             SemanticVersion version = !string.IsNullOrWhiteSpace(configuration.Version) ? new SemanticVersion(configuration.Version) : null;
-            
+
             if (configuration.ListCommand.Exact)
             {
                 return new List<IPackage>()
@@ -143,7 +143,7 @@ namespace chocolatey.infrastructure.app.nuget
                         .AsQueryable();
             }
 
-            results = configuration.ListCommand.OrderByPopularity ? 
+            results = configuration.ListCommand.OrderByPopularity ?
                  results.OrderByDescending(p => p.DownloadCount).ThenBy(p => p.Id)
                  : results;
 


### PR DESCRIPTION
find_package will either return the package that was found, or null.
The case for null being returned needs to be handled, so that upstream
callers are not affected.

Fixes #1837 