### PR TITLE
(GH-1859) Fix error message for missing 32-bit URL

### DIFF
--- a/src/chocolatey.resources/helpers/functions/Get-ChocolateyWebFile.ps1
+++ b/src/chocolatey.resources/helpers/functions/Get-ChocolateyWebFile.ps1
@@ -262,7 +262,7 @@ param(
   # If we're on 32 bit or attempting to force 32 bit and there is no
   # 32 bit url, we need to throw an error.
   if ($url -eq $null -or $url -eq '') {
-    throw "This package does not support $bitWidth bit architecture."
+    throw "This package does not support $bitPackage architecture."
   }
 
   # determine if the url can be SSL/TLS


### PR DESCRIPTION
For 64-bit-only packages, when running Get-ChocolateyWebFile.ps1 on a
64-bit system having `$Env:ChocolateyForceX86 = $true`, the error
message would read: "This package does not support 64 bit architecture."
Instead, the message should inform that the package does not support
32-bit systems.

Closes #1859