### PR TITLE
(GH-1889) Fixes Equals implementation of ConfigFileApiKeySettings

### DIFF
--- a/src/chocolatey/infrastructure.app/configuration/ConfigFileApiKeySetting.cs
+++ b/src/chocolatey/infrastructure.app/configuration/ConfigFileApiKeySetting.cs
@@ -43,7 +43,7 @@ namespace chocolatey.infrastructure.app.configuration
             var item = (ConfigFileApiKeySetting) obj;
 
             return (Source == item.Source)
-                   && (Key == item.Source);
+                   && (Key == item.Key);
         }
 
         public override int GetHashCode()


### PR DESCRIPTION
Fixes `Equals` implementation of `ConfigFileApiKeySettings`.

This is the line which failed due to `Equals` not working correctly:
https://github.com/chocolatey/choco/blob/98f80533574bd4b7bd8c59698ee2441a164ccebc/src/chocolatey/infrastructure.app/services/ChocolateyConfigSettingsService.cs#L338

Closes #1889.