### PR TITLE
(doc) Add security.md file

### DIFF
--- a/.github/ISSUE_TEMPLATE/SecurityDisclosure.md
+++ b/.github/ISSUE_TEMPLATE/SecurityDisclosure.md
@@ -1,8 +1,0 @@
----
-name: Security Disclosure / Report
-about: Found a security issue?
----
-
-STOP RIGHT HERE - DO NOT CREATE A TICKET FOR A SECURITY FINDING IN THE OPEN (HERE OR IN ANY COMMUNITY)
-
-Security reports should never start out in the open. Please follow up directly with the team if you have a contact. If not you can always start with the information at https://chocolatey.org/security to see instructions on how to provide the disclosure. Thank you!

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,6 @@
+# Security Policies and Procedures
+
+Security reports should never start out in the open. Please follow up directly
+with the team if you have a contact. If not you can always start with the
+information at https://chocolatey.org/security to see instructions on how to
+provide the disclosure. Thank you!


### PR DESCRIPTION
This addition, changes the following:

![image](https://user-images.githubusercontent.com/1271146/63410126-7ee1c680-c3ea-11e9-90c1-64c81bc1e919.png)

To this:

![image](https://user-images.githubusercontent.com/1271146/63410143-8acd8880-c3ea-11e9-8489-733ea0ee1987.png)

Which, once you click on it, show the policy, rather than starting to create a new issue:

![image](https://user-images.githubusercontent.com/1271146/63410183-9de05880-c3ea-11e9-8633-47734b713673.png)

We might want to expand on the content a little bit.  For example, this is what @AdmiringWorm (who I am stealing the idea from) is using:

https://github.com/WormieCorp/.github/blob/master/.github/SECURITY.md

And also another example here:

https://github.com/standard/.github/blob/master/SECURITY.md

Thoughts?