### PR TITLE
(#798) Add pin-version parameter for choco install command to execute choco pin at the end

### DIFF
--- a/src/chocolatey.tests/infrastructure.app/commands/ChocolateyInstallCommandSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/commands/ChocolateyInstallCommandSpecs.cs
@@ -25,7 +25,9 @@ namespace chocolatey.tests.infrastructure.app.commands
     using chocolatey.infrastructure.app.domain;
     using chocolatey.infrastructure.app.services;
     using chocolatey.infrastructure.commandline;
+    using chocolatey.infrastructure.commands;
     using Moq;
+    using NuGet;
     using Should;
 
     public class ChocolateyInstallCommandSpecs
@@ -34,12 +36,16 @@ namespace chocolatey.tests.infrastructure.app.commands
         {
             protected ChocolateyInstallCommand command;
             protected Mock<IChocolateyPackageService> packageService = new Mock<IChocolateyPackageService>();
+            protected Mock<ICommand> chocolateyInstallCommand = new Mock<ICommand>();
+            protected Mock<INugetService> nugetService = new Mock<INugetService>();
+            protected Mock<ILogger> nugetLogger = new Mock<ILogger>();
             protected ChocolateyConfiguration configuration = new ChocolateyConfiguration();
 
             public override void Context()
             {
                 configuration.Sources = "bob";
-                command = new ChocolateyInstallCommand(packageService.Object);
+                var chocolateyPinCommand = new ChocolateyPinCommand(packageService.Object, nugetLogger.Object, nugetService.Object);
+                command = new ChocolateyInstallCommand(packageService.Object, chocolateyPinCommand, chocolateyInstallCommand.Object);
             }
         }
 

--- a/src/chocolatey.tests/infrastructure.app/commands/ChocolateyInstallCommandSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/commands/ChocolateyInstallCommandSpecs.cs
@@ -241,6 +241,12 @@ namespace chocolatey.tests.infrastructure.app.commands
             {
                 optionSet.Contains("p").ShouldBeTrue();
             }
+
+            [Fact]
+            public void should_add_pinVersion_to_the_option_set()
+            {
+                optionSet.Contains("pin-version").ShouldBeTrue();
+            }
         }
 
         public class when_handling_additional_argument_parsing : ChocolateyInstallCommandSpecsBase

--- a/src/chocolatey.tests/infrastructure.app/commands/ChocolateyInstallCommandSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/commands/ChocolateyInstallCommandSpecs.cs
@@ -36,7 +36,7 @@ namespace chocolatey.tests.infrastructure.app.commands
         {
             protected ChocolateyInstallCommand command;
             protected Mock<IChocolateyPackageService> packageService = new Mock<IChocolateyPackageService>();
-            protected Mock<ICommand> chocolateyInstallCommand = new Mock<ICommand>();
+            protected Mock<IChocolateyPackageInformationService> chocolateyPackageInformationService = new Mock<IChocolateyPackageInformationService>();
             protected Mock<INugetService> nugetService = new Mock<INugetService>();
             protected Mock<ILogger> nugetLogger = new Mock<ILogger>();
             protected ChocolateyConfiguration configuration = new ChocolateyConfiguration();
@@ -44,8 +44,8 @@ namespace chocolatey.tests.infrastructure.app.commands
             public override void Context()
             {
                 configuration.Sources = "bob";
-                var chocolateyPinCommand = new ChocolateyPinCommand(packageService.Object, nugetLogger.Object, nugetService.Object);
-                command = new ChocolateyInstallCommand(packageService.Object, chocolateyPinCommand, chocolateyInstallCommand.Object);
+                var chocolateyPinCommand = new ChocolateyPinCommand(chocolateyPackageInformationService.Object, nugetLogger.Object, nugetService.Object);
+                command = new ChocolateyInstallCommand(packageService.Object, chocolateyPinCommand, nugetLogger.Object);
             }
         }
 

--- a/src/chocolatey/infrastructure.app/configuration/ChocolateyConfiguration.cs
+++ b/src/chocolatey/infrastructure.app/configuration/ChocolateyConfiguration.cs
@@ -396,6 +396,7 @@ NOTE: Hiding sensitive configuration data! Please double and triple
         public bool ExitOnRebootDetected { get; set; }
         public bool LogValidationResultsOnWarnings { get; set; }
         public bool UsePackageRepositoryOptimizations { get; set; }
+        public bool PinVersion { get; set; }
 
         //todo remove in 0.11.0
         public bool ScriptsCheckLastExitCode { get; set; }

--- a/src/chocolatey/infrastructure.app/registration/ContainerBinding.cs
+++ b/src/chocolatey/infrastructure.app/registration/ContainerBinding.cs
@@ -81,7 +81,7 @@ namespace chocolatey.infrastructure.app.registration
                         {
                             new ChocolateyListCommand(container.GetInstance<IChocolateyPackageService>()),
                             new ChocolateyInfoCommand(container.GetInstance<IChocolateyPackageService>()),
-                            new ChocolateyInstallCommand(container.GetInstance<IChocolateyPackageService>()),
+                            new ChocolateyInstallCommand(container.GetInstance<IChocolateyPackageService>(), container.GetInstance<ChocolateyPinCommand>(), container.GetInstance<ILogger>()),
                             new ChocolateyPinCommand(container.GetInstance<IChocolateyPackageInformationService>(), container.GetInstance<ILogger>(), container.GetInstance<INugetService>()),
                             new ChocolateyOutdatedCommand(container.GetInstance<IChocolateyPackageService>()),
                             new ChocolateyUpgradeCommand(container.GetInstance<IChocolateyPackageService>()),


### PR DESCRIPTION
Fixes https://github.com/chocolatey/choco/issues/798

This is the first minimum viable implementation. I haven't tested it yet as I'd like to see if it would pass the build validation and more importantly I would like to get early feedback on the implementation (as to whether the high level approach is OK) before writing more complex tests with which I'd appreciate help