### PR TITLE
(GH-1923) Fix Typo on Non-Admin installation link

### DIFF
--- a/src/chocolatey/infrastructure.app/runners/GenericRunner.cs
+++ b/src/chocolatey/infrastructure.app/runners/GenericRunner.cs
@@ -306,7 +306,7 @@ Chocolatey is not an official build (bypassed with --allow-unofficial).
  attempting to use Chocolatey in a non-administrator setting, you
  must select a different location other than the default install
  location. See 
- https://chocolatey.org/install#non-administrative-install for details.
+ https://chocolatey.org/docs/installation#non-administrative-install for details.
 ");
                 var selection = InteractivePrompt.prompt_for_confirmation(@"
  Do you want to continue?", new[] { "yes", "no" },


### PR DESCRIPTION
Changed the link to the non-administrative install instructions from 
https://chocolatey.org/install#non-administrative-install to 
https://chocolatey.org/docs/installation#non-administrative-install

Fix #1923 