### PR TITLE
WIP Fix Travis CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,4 @@
 language: csharp
-mono:
-  - 3.12.0
 install:
   - sudo apt-get install mono-devel mono-gmcs
   - nuget restore src/chocolatey.sln


### PR DESCRIPTION
The current versions of mono dependencies are incompatible and causing build failures.