### PR TITLE
(GH-1949) New official release build configuration

### DIFF
--- a/.uppercut
+++ b/.uppercut
@@ -53,7 +53,7 @@
   <property name="app.strongname" value="C:${path.separator}Program Files${path.separator}Microsoft SDKs${path.separator}Windows${path.separator}v7.0A${path.separator}Bin${path.separator}sn.exe" />
   <property name="app.strongname" value="C:${path.separator}Program Files (x86)${path.separator}Microsoft SDKs${path.separator}Windows${path.separator}v7.0A${path.separator}Bin${path.separator}sn.exe" if="${not file::exists(app.strongname)}" />
 
-  <property name="path.key.name.private" value="${environment::get-variable('CHOCOLATEY_OFFICIAL_KEY')}" if="${environment::variable-exists('CHOCOLATEY_OFFICIAL_KEY')}" />
+  <property name="path.key.name.private" value="${environment::get-variable('CHOCOLATEY_OFFICIAL_KEY')}" if="${environment::variable-exists('CHOCOLATEY_OFFICIAL_KEY') and msbuild.configuration == 'ReleaseOfficial'}" />
 
   <property name="app.signtool" value="C:${path.separator}Program Files${path.separator}Microsoft SDKs${path.separator}Windows${path.separator}v7.0A${path.separator}Bin${path.separator}signtool.exe" />
   <property name="app.signtool" value="C:${path.separator}Program Files (x86)${path.separator}Microsoft SDKs${path.separator}Windows${path.separator}v7.0A${path.separator}Bin${path.separator}signtool.exe" if="${not file::exists(app.signtool)}" />

--- a/build.official.bat
+++ b/build.official.bat
@@ -13,7 +13,7 @@ SET BUILD_DIR=%~d0%~p0%
 SET NANT="%BUILD_DIR%lib\Nant\nant.exe"
 SET build.config.settings="%DIR%\.uppercut"
 
-%NANT% /logger:"NAnt.Core.DefaultLogger" /quiet /nologo /f:"%BUILD_DIR%.build\default.build" -D:build.config.settings=%build.config.settings% -D:msbuild.configuration="Release" %*
+%NANT% /logger:"NAnt.Core.DefaultLogger" /quiet /nologo /f:"%BUILD_DIR%.build\default.build" -D:build.config.settings=%build.config.settings% -D:msbuild.configuration="ReleaseOfficial" %*
 
 if %ERRORLEVEL% NEQ 0 goto errors
 
@@ -23,7 +23,7 @@ goto finish
 
 :usage
 echo.
-echo Usage: build.bat
+echo Usage: build.official.bat
 echo.
 goto finish
 

--- a/src/chocolatey.console/Program.cs
+++ b/src/chocolatey.console/Program.cs
@@ -191,7 +191,11 @@ namespace chocolatey.console
 
                 // There are things that are ILMerged into Chocolatey. Anything with
                 // the right public key except licensed should use the choco/chocolatey assembly
-                if (requestedAssembly.get_public_key_token().is_equal_to(ApplicationParameters.OfficialChocolateyPublicKey)
+                if ((requestedAssembly.get_public_key_token().is_equal_to(ApplicationParameters.OfficialChocolateyPublicKey)
+#if !FORCE_CHOCOLATEY_OFFICIAL_KEY
+                || requestedAssembly.get_public_key_token().is_equal_to(ApplicationParameters.UnofficialChocolateyPublicKey)
+#endif
+                )
                     && !requestedAssembly.Name.is_equal_to(ApplicationParameters.LicensedChocolateyAssemblySimpleName)
                     && !requestedAssembly.Name.EndsWith(".resources", StringComparison.OrdinalIgnoreCase))
                 {
@@ -200,13 +204,17 @@ namespace chocolatey.console
 
                 try
                 {
-                    if (requestedAssembly.get_public_key_token().is_equal_to(ApplicationParameters.OfficialChocolateyPublicKey)
+                    if ((requestedAssembly.get_public_key_token().is_equal_to(ApplicationParameters.OfficialChocolateyPublicKey)
+#if !FORCE_CHOCOLATEY_OFFICIAL_KEY
+                    || requestedAssembly.get_public_key_token().is_equal_to(ApplicationParameters.UnofficialChocolateyPublicKey)
+#endif
+                    )
                         && requestedAssembly.Name.is_equal_to(ApplicationParameters.LicensedChocolateyAssemblySimpleName))
                     {
                         "chocolatey".Log().Debug(() => "Resolving reference to chocolatey.licensed...");
                         return AssemblyResolution.resolve_or_load_assembly(
                             ApplicationParameters.LicensedChocolateyAssemblySimpleName,
-                            ApplicationParameters.OfficialChocolateyPublicKey,
+                            requestedAssembly.get_public_key_token(),
                             ApplicationParameters.LicensedAssemblyLocation).UnderlyingType;
                     }
                 }

--- a/src/chocolatey.console/chocolatey.console.csproj
+++ b/src/chocolatey.console/chocolatey.console.csproj
@@ -98,6 +98,26 @@
     <CodeAnalysisIgnoreBuiltInRuleSets>false</CodeAnalysisIgnoreBuiltInRuleSets>
     <CodeAnalysisIgnoreBuiltInRules>false</CodeAnalysisIgnoreBuiltInRules>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'ReleaseOfficial|x86'">
+    <OutputPath>bin\x86\ReleaseOfficial\</OutputPath>
+    <DefineConstants>TRACE;FORCE_CHOCOLATEY_OFFICIAL_KEY</DefineConstants>
+    <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
+    <Optimize>true</Optimize>
+    <PlatformTarget>x86</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'ReleaseOfficial|AnyCPU'">
+    <OutputPath>bin\ReleaseOfficial\</OutputPath>
+    <DefineConstants>TRACE;FORCE_CHOCOLATEY_OFFICIAL_KEY</DefineConstants>
+    <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
+    <Optimize>true</Optimize>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <CodeAnalysisIgnoreBuiltInRuleSets>false</CodeAnalysisIgnoreBuiltInRuleSets>
+    <CodeAnalysisIgnoreBuiltInRules>false</CodeAnalysisIgnoreBuiltInRules>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="AlphaFS, Version=2.1.0.0, Culture=neutral, PublicKeyToken=4d31a58f7d7ad5c9, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>

--- a/src/chocolatey.resources/chocolatey.resources.csproj
+++ b/src/chocolatey.resources/chocolatey.resources.csproj
@@ -38,6 +38,14 @@
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'ReleaseOfficial|AnyCPU'">
+    <OutputPath>bin\ReleaseOfficial\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <Optimize>true</Optimize>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/src/chocolatey.sln
+++ b/src/chocolatey.sln
@@ -1,6 +1,8 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2010
+# Visual Studio 15
+VisualStudioVersion = 15.0.28307.902
+MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "chocolatey.console", "chocolatey.console\chocolatey.console.csproj", "{E24E3386-244F-4404-9E6E-5B53818EA903}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "chocolatey.tests", "chocolatey.tests\chocolatey.tests.csproj", "{5C4C60F0-47B1-498E-ABF7-D315E1A94BC9}"
@@ -52,6 +54,9 @@ Global
 		NoResources|Any CPU = NoResources|Any CPU
 		NoResources|Mixed Platforms = NoResources|Mixed Platforms
 		NoResources|x86 = NoResources|x86
+		ReleaseOfficial|Any CPU = ReleaseOfficial|Any CPU
+		ReleaseOfficial|Mixed Platforms = ReleaseOfficial|Mixed Platforms
+		ReleaseOfficial|x86 = ReleaseOfficial|x86
 		Release|Any CPU = Release|Any CPU
 		Release|Mixed Platforms = Release|Mixed Platforms
 		Release|x86 = Release|x86
@@ -66,6 +71,12 @@ Global
 		{E24E3386-244F-4404-9E6E-5B53818EA903}.NoResources|Any CPU.ActiveCfg = NoResources|Any CPU
 		{E24E3386-244F-4404-9E6E-5B53818EA903}.NoResources|Mixed Platforms.ActiveCfg = NoResources|x86
 		{E24E3386-244F-4404-9E6E-5B53818EA903}.NoResources|x86.ActiveCfg = NoResources|x86
+		{E24E3386-244F-4404-9E6E-5B53818EA903}.ReleaseOfficial|Any CPU.ActiveCfg = ReleaseOfficial|Any CPU
+		{E24E3386-244F-4404-9E6E-5B53818EA903}.ReleaseOfficial|Any CPU.Build.0 = ReleaseOfficial|Any CPU
+		{E24E3386-244F-4404-9E6E-5B53818EA903}.ReleaseOfficial|Mixed Platforms.ActiveCfg = ReleaseOfficial|x86
+		{E24E3386-244F-4404-9E6E-5B53818EA903}.ReleaseOfficial|Mixed Platforms.Build.0 = ReleaseOfficial|x86
+		{E24E3386-244F-4404-9E6E-5B53818EA903}.ReleaseOfficial|x86.ActiveCfg = ReleaseOfficial|x86
+		{E24E3386-244F-4404-9E6E-5B53818EA903}.ReleaseOfficial|x86.Build.0 = ReleaseOfficial|x86
 		{E24E3386-244F-4404-9E6E-5B53818EA903}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{E24E3386-244F-4404-9E6E-5B53818EA903}.Release|Any CPU.Build.0 = Release|Any CPU
 		{E24E3386-244F-4404-9E6E-5B53818EA903}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
@@ -80,6 +91,12 @@ Global
 		{5C4C60F0-47B1-498E-ABF7-D315E1A94BC9}.NoResources|Any CPU.ActiveCfg = NoResources|Any CPU
 		{5C4C60F0-47B1-498E-ABF7-D315E1A94BC9}.NoResources|Mixed Platforms.ActiveCfg = NoResources|Any CPU
 		{5C4C60F0-47B1-498E-ABF7-D315E1A94BC9}.NoResources|x86.ActiveCfg = NoResources|Any CPU
+		{5C4C60F0-47B1-498E-ABF7-D315E1A94BC9}.ReleaseOfficial|Any CPU.ActiveCfg = ReleaseOfficial|Any CPU
+		{5C4C60F0-47B1-498E-ABF7-D315E1A94BC9}.ReleaseOfficial|Any CPU.Build.0 = ReleaseOfficial|Any CPU
+		{5C4C60F0-47B1-498E-ABF7-D315E1A94BC9}.ReleaseOfficial|Mixed Platforms.ActiveCfg = ReleaseOfficial|Any CPU
+		{5C4C60F0-47B1-498E-ABF7-D315E1A94BC9}.ReleaseOfficial|Mixed Platforms.Build.0 = ReleaseOfficial|Any CPU
+		{5C4C60F0-47B1-498E-ABF7-D315E1A94BC9}.ReleaseOfficial|x86.ActiveCfg = ReleaseOfficial|Any CPU
+		{5C4C60F0-47B1-498E-ABF7-D315E1A94BC9}.ReleaseOfficial|x86.Build.0 = ReleaseOfficial|Any CPU
 		{5C4C60F0-47B1-498E-ABF7-D315E1A94BC9}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{5C4C60F0-47B1-498E-ABF7-D315E1A94BC9}.Release|Any CPU.Build.0 = Release|Any CPU
 		{5C4C60F0-47B1-498E-ABF7-D315E1A94BC9}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
@@ -96,6 +113,12 @@ Global
 		{5563DC61-35FD-4FAB-B331-9AE1FDB23F80}.NoResources|Mixed Platforms.Build.0 = NoResources|Any CPU
 		{5563DC61-35FD-4FAB-B331-9AE1FDB23F80}.NoResources|x86.ActiveCfg = NoResources|Any CPU
 		{5563DC61-35FD-4FAB-B331-9AE1FDB23F80}.NoResources|x86.Build.0 = NoResources|Any CPU
+		{5563DC61-35FD-4FAB-B331-9AE1FDB23F80}.ReleaseOfficial|Any CPU.ActiveCfg = ReleaseOfficial|Any CPU
+		{5563DC61-35FD-4FAB-B331-9AE1FDB23F80}.ReleaseOfficial|Any CPU.Build.0 = ReleaseOfficial|Any CPU
+		{5563DC61-35FD-4FAB-B331-9AE1FDB23F80}.ReleaseOfficial|Mixed Platforms.ActiveCfg = ReleaseOfficial|Any CPU
+		{5563DC61-35FD-4FAB-B331-9AE1FDB23F80}.ReleaseOfficial|Mixed Platforms.Build.0 = ReleaseOfficial|Any CPU
+		{5563DC61-35FD-4FAB-B331-9AE1FDB23F80}.ReleaseOfficial|x86.ActiveCfg = ReleaseOfficial|Any CPU
+		{5563DC61-35FD-4FAB-B331-9AE1FDB23F80}.ReleaseOfficial|x86.Build.0 = ReleaseOfficial|Any CPU
 		{5563DC61-35FD-4FAB-B331-9AE1FDB23F80}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{5563DC61-35FD-4FAB-B331-9AE1FDB23F80}.Release|Any CPU.Build.0 = Release|Any CPU
 		{5563DC61-35FD-4FAB-B331-9AE1FDB23F80}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
@@ -109,6 +132,12 @@ Global
 		{AF584111-FE32-448D-A1D0-63217AF8B43C}.NoResources|Any CPU.ActiveCfg = NoResources|Any CPU
 		{AF584111-FE32-448D-A1D0-63217AF8B43C}.NoResources|Mixed Platforms.ActiveCfg = NoResources|Any CPU
 		{AF584111-FE32-448D-A1D0-63217AF8B43C}.NoResources|x86.ActiveCfg = NoResources|Any CPU
+		{AF584111-FE32-448D-A1D0-63217AF8B43C}.ReleaseOfficial|Any CPU.ActiveCfg = ReleaseOfficial|Any CPU
+		{AF584111-FE32-448D-A1D0-63217AF8B43C}.ReleaseOfficial|Any CPU.Build.0 = ReleaseOfficial|Any CPU
+		{AF584111-FE32-448D-A1D0-63217AF8B43C}.ReleaseOfficial|Mixed Platforms.ActiveCfg = ReleaseOfficial|Any CPU
+		{AF584111-FE32-448D-A1D0-63217AF8B43C}.ReleaseOfficial|Mixed Platforms.Build.0 = ReleaseOfficial|Any CPU
+		{AF584111-FE32-448D-A1D0-63217AF8B43C}.ReleaseOfficial|x86.ActiveCfg = ReleaseOfficial|Any CPU
+		{AF584111-FE32-448D-A1D0-63217AF8B43C}.ReleaseOfficial|x86.Build.0 = ReleaseOfficial|Any CPU
 		{AF584111-FE32-448D-A1D0-63217AF8B43C}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{AF584111-FE32-448D-A1D0-63217AF8B43C}.Release|Any CPU.Build.0 = Release|Any CPU
 		{AF584111-FE32-448D-A1D0-63217AF8B43C}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
@@ -122,6 +151,12 @@ Global
 		{12ECAD4F-D463-4D72-A792-A4FCCFE9C456}.NoResources|Any CPU.ActiveCfg = NoResources|Any CPU
 		{12ECAD4F-D463-4D72-A792-A4FCCFE9C456}.NoResources|Mixed Platforms.ActiveCfg = NoResources|Any CPU
 		{12ECAD4F-D463-4D72-A792-A4FCCFE9C456}.NoResources|x86.ActiveCfg = NoResources|Any CPU
+		{12ECAD4F-D463-4D72-A792-A4FCCFE9C456}.ReleaseOfficial|Any CPU.ActiveCfg = ReleaseOfficial|Any CPU
+		{12ECAD4F-D463-4D72-A792-A4FCCFE9C456}.ReleaseOfficial|Any CPU.Build.0 = ReleaseOfficial|Any CPU
+		{12ECAD4F-D463-4D72-A792-A4FCCFE9C456}.ReleaseOfficial|Mixed Platforms.ActiveCfg = ReleaseOfficial|Any CPU
+		{12ECAD4F-D463-4D72-A792-A4FCCFE9C456}.ReleaseOfficial|Mixed Platforms.Build.0 = ReleaseOfficial|Any CPU
+		{12ECAD4F-D463-4D72-A792-A4FCCFE9C456}.ReleaseOfficial|x86.ActiveCfg = ReleaseOfficial|Any CPU
+		{12ECAD4F-D463-4D72-A792-A4FCCFE9C456}.ReleaseOfficial|x86.Build.0 = ReleaseOfficial|Any CPU
 		{12ECAD4F-D463-4D72-A792-A4FCCFE9C456}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{12ECAD4F-D463-4D72-A792-A4FCCFE9C456}.Release|Any CPU.Build.0 = Release|Any CPU
 		{12ECAD4F-D463-4D72-A792-A4FCCFE9C456}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
@@ -135,8 +170,8 @@ Global
 		{5C4C60F0-47B1-498E-ABF7-D315E1A94BC9} = {7656D054-387D-409C-A9FB-62A44599AA77}
 		{12ECAD4F-D463-4D72-A792-A4FCCFE9C456} = {7656D054-387D-409C-A9FB-62A44599AA77}
 		{DAB29F30-149D-4005-A8D2-4FA56CF2784D} = {FB6236DD-17EF-4C36-943C-47792FBC3306}
-		{DD9689F3-1D2D-41AE-A672-063EE70C0C9A} = {FB6236DD-17EF-4C36-943C-47792FBC3306}
 		{E5C987F8-6B95-4835-BBDD-A25C9D370BB9} = {DAB29F30-149D-4005-A8D2-4FA56CF2784D}
+		{DD9689F3-1D2D-41AE-A672-063EE70C0C9A} = {FB6236DD-17EF-4C36-943C-47792FBC3306}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {998CAC46-A2B8-447C-B4CC-3B11DC35ED46}

--- a/src/chocolatey.tests.integration/chocolatey.tests.integration.csproj
+++ b/src/chocolatey.tests.integration/chocolatey.tests.integration.csproj
@@ -41,6 +41,15 @@
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'ReleaseOfficial|AnyCPU'">
+    <OutputPath>bin\ReleaseOfficial\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <Optimize>true</Optimize>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="bdddoc">
       <HintPath>..\..\lib\bdddoc\bdddoc.dll</HintPath>

--- a/src/chocolatey.tests/chocolatey.tests.csproj
+++ b/src/chocolatey.tests/chocolatey.tests.csproj
@@ -40,6 +40,15 @@
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'ReleaseOfficial|AnyCPU'">
+    <OutputPath>bin\ReleaseOfficial\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <Optimize>true</Optimize>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="log4net, Version=1.2.13.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
       <HintPath>..\packages\log4net.2.0.3\lib\net40-client\log4net.dll</HintPath>

--- a/src/chocolatey/GetChocolatey.cs
+++ b/src/chocolatey/GetChocolatey.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2019 Chocolatey Software, Inc
+// Copyright © 2017 - 2019 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -68,7 +68,11 @@ namespace chocolatey
 
                 // There are things that are ILMerged into Chocolatey. Anything with 
                 // the right public key except licensed should use the choco/chocolatey assembly
-                if (requestedAssembly.get_public_key_token().is_equal_to(ApplicationParameters.OfficialChocolateyPublicKey)
+                if ((requestedAssembly.get_public_key_token().is_equal_to(ApplicationParameters.OfficialChocolateyPublicKey)
+#if !FORCE_CHOCOLATEY_OFFICIAL_KEY
+                || requestedAssembly.get_public_key_token().is_equal_to(ApplicationParameters.UnofficialChocolateyPublicKey)
+#endif
+                )
                     && !requestedAssembly.Name.is_equal_to(ApplicationParameters.LicensedChocolateyAssemblySimpleName)
                     && !requestedAssembly.Name.EndsWith(".resources", StringComparison.OrdinalIgnoreCase))
                 {
@@ -77,13 +81,17 @@ namespace chocolatey
 
                 try
                 {
-                    if (requestedAssembly.get_public_key_token().is_equal_to(ApplicationParameters.OfficialChocolateyPublicKey)
+                    if ((requestedAssembly.get_public_key_token().is_equal_to(ApplicationParameters.OfficialChocolateyPublicKey)
+#if !FORCE_CHOCOLATEY_OFFICIAL_KEY
+                    || requestedAssembly.get_public_key_token().is_equal_to(ApplicationParameters.UnofficialChocolateyPublicKey)
+#endif
+                    )
                         && requestedAssembly.Name.is_equal_to(ApplicationParameters.LicensedChocolateyAssemblySimpleName))
                     {
                         _logger.Debug("Resolving reference to chocolatey.licensed...");
                         return AssemblyResolution.resolve_or_load_assembly(
                             ApplicationParameters.LicensedChocolateyAssemblySimpleName,
-                            ApplicationParameters.OfficialChocolateyPublicKey,
+                            requestedAssembly.get_public_key_token(),
                             ApplicationParameters.LicensedAssemblyLocation).UnderlyingType;
                     }
                 }

--- a/src/chocolatey/GetChocolatey.cs
+++ b/src/chocolatey/GetChocolatey.cs
@@ -1,13 +1,13 @@
-// Copyright © 2017 - 2019 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2019 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
-// 
+//
 // You may obtain a copy of the License at
-// 
+//
 // 	http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -66,7 +66,7 @@ namespace chocolatey
             {
                 var requestedAssembly = new AssemblyName(args.Name);
 
-                // There are things that are ILMerged into Chocolatey. Anything with 
+                // There are things that are ILMerged into Chocolatey. Anything with
                 // the right public key except licensed should use the choco/chocolatey assembly
                 if ((requestedAssembly.get_public_key_token().is_equal_to(ApplicationParameters.OfficialChocolateyPublicKey)
 #if !FORCE_CHOCOLATEY_OFFICIAL_KEY

--- a/src/chocolatey/chocolatey.csproj
+++ b/src/chocolatey/chocolatey.csproj
@@ -50,6 +50,18 @@
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'ReleaseOfficial|AnyCPU'">
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>bin\ReleaseOfficial\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
+    <DocumentationFile>bin\Release\chocolatey.xml</DocumentationFile>
+    <Optimize>true</Optimize>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="AlphaFS, Version=2.1.0.0, Culture=neutral, PublicKeyToken=4d31a58f7d7ad5c9, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>

--- a/src/chocolatey/infrastructure.app/ApplicationParameters.cs
+++ b/src/chocolatey/infrastructure.app/ApplicationParameters.cs
@@ -58,6 +58,7 @@ namespace chocolatey.infrastructure.app
         public static readonly string LicensedConfigurationBuilder = @"chocolatey.licensed.infrastructure.app.builders.ConfigurationBuilder";
         public static readonly string LicensedEnvironmentSettings = @"chocolatey.licensed.infrastructure.app.configuration.EnvironmentSettings";
         public static readonly string PackageNamesSeparator = ";";
+        public static readonly string UnofficialChocolateyPublicKey = "fd112f53c3ab578c";
         public static readonly string OfficialChocolateyPublicKey = "79d02ea9cad655eb";
 
         public static string PackagesLocation = _fileSystem.combine_paths(InstallLocation, "lib");

--- a/src/chocolatey/infrastructure/licensing/License.cs
+++ b/src/chocolatey/infrastructure/licensing/License.cs
@@ -1,13 +1,13 @@
-// Copyright © 2017 - 2019 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2019 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
-// 
+//
 // You may obtain a copy of the License at
-// 
+//
 // 	http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -51,15 +51,15 @@ namespace chocolatey.infrastructure.licensing
                 {
                     "chocolatey".Log().Error(
 @"Error when attempting to load chocolatey licensed assembly. Ensure
- that chocolatey.licensed.dll exists at 
+ that chocolatey.licensed.dll exists at
  '{0}'.
  The error message itself may be helpful:{1} {2}".format_with(
                     ApplicationParameters.LicensedAssemblyLocation,
                     Environment.NewLine,
                     ex.Message
                     ));
-                    "chocolatey".Log().Warn(ChocolateyLoggers.Important,@" Install the Chocolatey Licensed Extension package with 
- `choco install chocolatey.extension` to remove this license warning. 
+                    "chocolatey".Log().Warn(ChocolateyLoggers.Important,@" Install the Chocolatey Licensed Extension package with
+ `choco install chocolatey.extension` to remove this license warning.
  TRIALS: If you have a trial license, you cannot use the above command
  as is and be successful. You need to download nupkgs from the links in
  the trial email as your license will not be registered on the licensed

--- a/src/chocolatey/infrastructure/licensing/License.cs
+++ b/src/chocolatey/infrastructure/licensing/License.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2019 Chocolatey Software, Inc
+// Copyright © 2017 - 2019 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -33,6 +33,13 @@ namespace chocolatey.infrastructure.licensing
                 try
                 {
                     var licensedAssembly = AssemblyResolution.resolve_or_load_assembly(ApplicationParameters.LicensedChocolateyAssemblySimpleName, ApplicationParameters.OfficialChocolateyPublicKey, ApplicationParameters.LicensedAssemblyLocation);
+
+#if !FORCE_CHOCOLATEY_OFFICIAL_KEY
+                    if (licensedAssembly == null)
+                    {
+                        licensedAssembly = AssemblyResolution.resolve_or_load_assembly(ApplicationParameters.LicensedChocolateyAssemblySimpleName, ApplicationParameters.UnofficialChocolateyPublicKey, ApplicationParameters.LicensedAssemblyLocation);
+                    }
+#endif
                     if (licensedAssembly == null) throw new ApplicationException("Unable to load licensed assembly.");
                     license.AssemblyLoaded = true;
                     license.Assembly = licensedAssembly;


### PR DESCRIPTION
This will be used when preparing for an official release of Chocolatey,
to ensure that the correct strong name key is being used, and also that
the necessary checks are being done when loading the Chocolatey Licensed
assembly into the Chocolatey process.  The FORCE_CHOCOLATEY_OFFICIAL_KEY
compilation symbol if used in if/def statements to make this logic
happen.

A new build.official.bat file was also created to make the calling of
this specific build easier to do as well.

Relates to #1949 