### PR TITLE
(GH-1716) - User chocolateyPackageName as default parameter for packageName

### DIFF
--- a/src/chocolatey.resources/helpers/functions/Get-ChocolateyUnzip.ps1
+++ b/src/chocolatey.resources/helpers/functions/Get-ChocolateyUnzip.ps1
@@ -90,7 +90,7 @@ param(
   [alias("file")][parameter(Mandatory=$false, Position=0)][string] $fileFullPath,
   [parameter(Mandatory=$true, Position=1)][string] $destination,
   [parameter(Mandatory=$false, Position=2)][string] $specificFolder,
-  [parameter(Mandatory=$false, Position=3)][string] $packageName,
+  [parameter(Mandatory=$false, Position=3)][string] $packageName = $env:chocolateyPackageName,
   [alias("file64")][parameter(Mandatory=$false)][string] $fileFullPath64,
   [parameter(ValueFromRemainingArguments = $true)][Object[]] $ignoredArguments
 )

--- a/src/chocolatey.resources/helpers/functions/Install-ChocolateyZipPackage.ps1
+++ b/src/chocolatey.resources/helpers/functions/Install-ChocolateyZipPackage.ps1
@@ -173,7 +173,7 @@ Get-ChocolateyWebFile
 Get-ChocolateyUnzip
 #>
 param(
-  [parameter(Mandatory=$true, Position=0)][string] $packageName,
+  [parameter(Mandatory=$false, Position=0)][string] $packageName = $env:chocolateyPackageName,
   [parameter(Mandatory=$false, Position=1)][string] $url = '',
   [parameter(Mandatory=$true, Position=2)]
   [alias("destination")][string] $unzipLocation,


### PR DESCRIPTION
This sets the default value of `$packageName` to `$env:chocolateyPackageName` for` Install-ChocolateyZipPackage` and `Get-ChocolateyUnzip`. This is usually the value used as default in install scripts, so this can reduce the number of necessary parameters specified.

I followed what was stated in the ticket, but thought there might be some more scripts where this could be useful, such as `Install-ChocolateyPackage`. Should I add the defaults there as well?