### PR TITLE
(#1962) Use different message on error

### DIFF
--- a/src/chocolatey/infrastructure.app/services/ChocolateyPackageService.cs
+++ b/src/chocolatey/infrastructure.app/services/ChocolateyPackageService.cs
@@ -336,7 +336,9 @@ Did you know Pro / Business automatically syncs with Programs and
             EnvironmentSettings.reset_environment_variables(config);
             set_pending(packageResult, config);
 
-            this.Log().Info("{0} package files {1} completed. Continuing, performing other installation steps.".format_with(packageResult.Name, commandName.to_string()));
+            this.Log().Info(packageResult.ExitCode == 0
+                ? "{0} package files {1} completed. Performing other installation steps.".format_with(packageResult.Name, commandName.to_string())
+                : "{0} package files {1} failed with exit code {2}. Performing other installation steps.".format_with(packageResult.Name, commandName.to_string(), packageResult.ExitCode));
 
             var pkgInfo = get_package_information(packageResult, config);
 


### PR DESCRIPTION
Currently, the method logs that the command was "completed" even if it failed. A log that says the step failed would make more sense to the user in this case.

Closes #1962.