### PR TITLE
(GH-1983) exit-on-reboot-detected environment variable

### DIFF
--- a/src/chocolatey/infrastructure.app/ApplicationParameters.cs
+++ b/src/chocolatey/infrastructure.app/ApplicationParameters.cs
@@ -122,6 +122,7 @@ namespace chocolatey.infrastructure.app
             public static readonly string ChocolateyCheckLastExitCode = "ChocolateyCheckLastExitCode";
             public static readonly string ChocolateyPowerShellHost = "ChocolateyPowerShellHost";
             public static readonly string ChocolateyForce = "ChocolateyForce";
+            public static readonly string ChocolateyExitOnRebootDetected = "ChocolateyExitOnRebootDetected";
         }
 
         /// <summary>

--- a/src/chocolatey/infrastructure.app/configuration/EnvironmentSettings.cs
+++ b/src/chocolatey/infrastructure.app/configuration/EnvironmentSettings.cs
@@ -56,6 +56,7 @@ namespace chocolatey.infrastructure.app.configuration
             Environment.SetEnvironmentVariable(ApplicationParameters.Environment.ChocolateyAllowEmptyChecksumsSecure, null);
             Environment.SetEnvironmentVariable(ApplicationParameters.Environment.ChocolateyPowerShellHost, null);
             Environment.SetEnvironmentVariable(ApplicationParameters.Environment.ChocolateyForce, null);
+            Environment.SetEnvironmentVariable(ApplicationParameters.Environment.ChocolateyExitOnRebootDetected, null);
 
             Environment.SetEnvironmentVariable("chocolateyProxyLocation", null);
             Environment.SetEnvironmentVariable("chocolateyProxyBypassList", null);
@@ -127,6 +128,7 @@ namespace chocolatey.infrastructure.app.configuration
 
             if (config.Features.UsePowerShellHost) Environment.SetEnvironmentVariable(ApplicationParameters.Environment.ChocolateyPowerShellHost, "true");
             if (config.Force) Environment.SetEnvironmentVariable(ApplicationParameters.Environment.ChocolateyForce, "true");
+            if (config.Features.ExitOnRebootDetected) Environment.SetEnvironmentVariable(ApplicationParameters.Environment.ChocolateyExitOnRebootDetected, "true");
             set_licensed_environment(config);
         }
 

--- a/src/chocolatey/infrastructure.app/templates/ChocolateyReadMeTemplate.cs
+++ b/src/chocolatey/infrastructure.app/templates/ChocolateyReadMeTemplate.cs
@@ -108,6 +108,7 @@ Some environment variables are set based on options that are passed, configurati
 
  * ChocolateyEnvironmentDebug - Was `--debug` passed? If using the built-in PowerShell host, this is always true (but only logs debug messages to console if `--debug` was passed) (0.9.10+)
  * ChocolateyEnvironmentVerbose - Was `--verbose` passed? If using the built-in PowerShell host, this is always true (but only logs verbose messages to console if `--verbose` was passed). (0.9.10+)
+ * ChocolateyExitOnRebootDetected - Are we exiting on a detected reboot? Set by ` --exit-when-reboot-detected`  or the feature `exitOnRebootDetected` (0.10.16+)
  * ChocolateyForce - Was `--force` passed? (0.9.10+)
  * ChocolateyForceX86 - Was `-x86` passed? (CHECK)
  * ChocolateyRequestTimeout - How long before a web request will time out. Set by config `webRequestTimeoutSeconds` (CHECK)


### PR DESCRIPTION
(GH-1983) exit-on-reboot-detected environment variable

These changes would allow a package to validate if the user
has set the exit-on-reboot-detected flag or is using the feature
exitOnRebootDetected. This allows a package maintainer to
provide a warning when this is not set.

Merging this resolves #1983 