### PR TITLE
(GH-1986) Use unique temp file names in RefreshEnv.cmd

### DIFF
--- a/src/chocolatey.resources/redirects/RefreshEnv.cmd
+++ b/src/chocolatey.resources/redirects/RefreshEnv.cmd
@@ -11,20 +11,26 @@
 ::echo "RefreshEnv.cmd only works from cmd.exe, please install the Chocolatey Profile to take advantage of refreshenv from PowerShell"
 echo | set /p dummy="Refreshing environment variables from registry for cmd.exe. Please wait..."
 
+:: Generate unique file names
+for /F "tokens=* usebackq" %%F IN (`powershell -command "[guid]::NewGuid().ToString()"`) do set REFRESHENV_GUID=%%F
+set REFRESHENV_ENVSET_TMP="%TEMP%\refreshenv_envset_%REFRESHENV_GUID%.tmp"
+set REFRESHENV_ENVGET_TMP="%TEMP%\refreshenv_envget_%REFRESHENV_GUID%.tmp"
+set REFRESHENV_ENV_CMD="%TEMP%\refreshenv_env_%REFRESHENV_GUID%.cmd"
+
 goto main
 
 :: Set one environment variable from registry key
 :SetFromReg
-    "%WinDir%\System32\Reg" QUERY "%~1" /v "%~2" > "%TEMP%\_envset.tmp" 2>NUL
-    for /f "usebackq skip=2 tokens=2,*" %%A IN ("%TEMP%\_envset.tmp") do (
+    "%WinDir%\System32\Reg" QUERY "%~1" /v "%~2" > %REFRESHENV_ENVSET_TMP% 2>NUL
+    for /f "usebackq skip=2 tokens=2,*" %%A IN (%REFRESHENV_ENVSET_TMP%) do (
         echo/set "%~3=%%B"
     )
     goto :EOF
 
 :: Get a list of environment variables from registry
 :GetRegEnv
-    "%WinDir%\System32\Reg" QUERY "%~1" > "%TEMP%\_envget.tmp"
-    for /f "usebackq skip=2" %%A IN ("%TEMP%\_envget.tmp") do (
+    "%WinDir%\System32\Reg" QUERY "%~1" > %REFRESHENV_ENVGET_TMP%
+    for /f "usebackq skip=2" %%A IN (%REFRESHENV_ENVGET_TMP%) do (
         if /I not "%%~A"=="Path" (
             call :SetFromReg "%~1" "%%~A" "%%~A"
         )
@@ -32,32 +38,36 @@ goto main
     goto :EOF
 
 :main
-    echo/@echo off >"%TEMP%\_env.cmd"
+    echo/@echo off >%REFRESHENV_ENV_CMD%
 
     :: Slowly generating final file
-    call :GetRegEnv "HKLM\System\CurrentControlSet\Control\Session Manager\Environment" >> "%TEMP%\_env.cmd"
-    call :GetRegEnv "HKCU\Environment">>"%TEMP%\_env.cmd" >> "%TEMP%\_env.cmd"
+    call :GetRegEnv "HKLM\System\CurrentControlSet\Control\Session Manager\Environment" >> %REFRESHENV_ENV_CMD%
+    call :GetRegEnv "HKCU\Environment">>%REFRESHENV_ENV_CMD% >> %REFRESHENV_ENV_CMD%
 
     :: Special handling for PATH - mix both User and System
-    call :SetFromReg "HKLM\System\CurrentControlSet\Control\Session Manager\Environment" Path Path_HKLM >> "%TEMP%\_env.cmd"
-    call :SetFromReg "HKCU\Environment" Path Path_HKCU >> "%TEMP%\_env.cmd"
+    call :SetFromReg "HKLM\System\CurrentControlSet\Control\Session Manager\Environment" Path Path_HKLM >> %REFRESHENV_ENV_CMD%
+    call :SetFromReg "HKCU\Environment" Path Path_HKCU >> %REFRESHENV_ENV_CMD%
 
     :: Caution: do not insert space-chars before >> redirection sign
-    echo/set "Path=%%Path_HKLM%%;%%Path_HKCU%%" >> "%TEMP%\_env.cmd"
+    echo/set "Path=%%Path_HKLM%%;%%Path_HKCU%%" >> %REFRESHENV_ENV_CMD%
 
     :: Cleanup
-    del /f /q "%TEMP%\_envset.tmp" 2>nul
-    del /f /q "%TEMP%\_envget.tmp" 2>nul
+    del /f /q %REFRESHENV_ENVSET_TMP% 2>nul
+    del /f /q %REFRESHENV_ENVGET_TMP% 2>nul
+    set REFRESHENV_GUID=
+    set REFRESHENV_ENVSET_TMP=
+    set REFRESHENV_ENVGET_TMP=
 
     :: capture user / architecture
     SET "OriginalUserName=%USERNAME%"
     SET "OriginalArchitecture=%PROCESSOR_ARCHITECTURE%"
 
     :: Set these variables
-    call "%TEMP%\_env.cmd"
+    call %REFRESHENV_ENV_CMD%
 
     :: Cleanup
-    del /f /q "%TEMP%\_env.cmd" 2>nul
+    del /f /q %REFRESHENV_ENV_CMD% 2>nul
+    set REFRESHENV_ENV_CMD=
 
     :: reset user / architecture
     SET "USERNAME=%OriginalUserName%"


### PR DESCRIPTION
Fix the issue with generating a GUID (with Powershell [guid]::NewGuid() function) and using it as a part of temporary file names.

Tried first %RANDOM% but it's not random enough. It didn't pass the test script which launches two refreshenv terminals almost at the same time. %TIME% worked better but but it's not 100% reliable either. Besides the format is locale specific so in certain countries it includes characters (colon) that can't be used in file names.