### PR TITLE
(GH-2023) Install git in the docker container.

### DIFF
--- a/docker/Dockerfile.linux
+++ b/docker/Dockerfile.linux
@@ -2,6 +2,8 @@ FROM mono:5.20.1.19
 
 MAINTAINER Justin Phelps <linuturk@onitato.com>
 
+RUN apt-get update && apt-get install git -y
+
 COPY . /usr/local/src/choco/
 
 WORKDIR /usr/local/src/choco


### PR DESCRIPTION
Installs git in the docker container before building chocolatey so the build script is able to get version information.
