### PR TITLE
(#2052) Outdated: filter by package id

### DIFF
--- a/src/chocolatey.tests/infrastructure.app/services/NugetServiceSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/services/NugetServiceSpecs.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+// Copyright © 2017 - 2018 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -324,6 +324,43 @@ namespace chocolatey.tests.infrastructure.app.services
                 infos.Count.ShouldEqual(1);
                 infos[0].ShouldEqual("Chocolatey would have searched for a nuspec file in \"c:\\packages\" and attempted to compile it.");
             }
+        }
+
+        public class when_NugetService_get_outdated: NugetServiceSpecsBase
+        {
+            private Action because;
+            private readonly ChocolateyConfiguration config = new ChocolateyConfiguration();
+
+            public override void Context()
+            {
+                base.Context();
+
+                // Ideally we should mock the FindPackage method, however, it belongs to PackageRepositoryExtensions, which can not 
+                // be mocked. So use one name that can never exist here. 
+                config.PackageNames = "!!!";
+            }
+
+            public override void Because()
+            {
+                because = () => service.get_outdated(config);
+            }
+
+            public override void AfterEachSpec()
+            {
+                MockLogger.reset();
+            }
+
+            [Fact]
+            public void not_founded_package_should_be_warned()
+            {
+                Context();
+                because();
+
+                var infos = MockLogger.MessagesFor(LogLevel.Warn);
+                infos.Count.ShouldEqual(1);
+                infos[0].Trim().ShouldEqual("Package !!! was not founded.");
+            }
+
         }
     }
 }

--- a/src/chocolatey/infrastructure.app/services/ChocolateyPackageService.cs
+++ b/src/chocolatey/infrastructure.app/services/ChocolateyPackageService.cs
@@ -628,7 +628,11 @@ Would have determined packages that are out of date based on what is
  Output is package name | current version | available version | pinned?
 ");
 
-            config.PackageNames = ApplicationParameters.AllPackages;
+            if (config.PackageNames.Length == 0)
+            {
+                config.PackageNames = ApplicationParameters.AllPackages;
+            }
+
             config.UpgradeCommand.NotifyOnlyAvailableUpgrades = true;
 
             var output = config.RegularOutput;


### PR DESCRIPTION
Resolves #2052 

The changed code enables the `outdated` command to run against one specific package. 