### PR TITLE
(GH-1364) Template create .nuspec encoded without BOM

### DIFF
--- a/src/chocolatey.tests/infrastructure.app/services/TemplateServiceSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/services/TemplateServiceSpecs.cs
@@ -231,6 +231,7 @@ namespace chocolatey.tests.infrastructure.app.services
             private readonly ChocolateyConfiguration config = new ChocolateyConfiguration();
             private readonly List<string> files = new List<string>();
             private readonly HashSet<string> directoryCreated = new HashSet<string>(StringComparer.InvariantCultureIgnoreCase);
+            private readonly UTF8Encoding utf8WithoutBOM = new UTF8Encoding(false);
 
             public override void Context()
             {
@@ -249,6 +250,8 @@ namespace chocolatey.tests.infrastructure.app.services
                         });
                 fileSystem.Setup(x => x.directory_exists(It.IsAny<string>())).Returns<string>(dirPath => dirPath.EndsWith("templates\\default"));
                 fileSystem.Setup(x => x.write_file(It.IsAny<string>(), It.IsAny<string>(), Encoding.UTF8))
+                    .Callback((string filePath, string fileContent, Encoding encoding) => files.Add(filePath));
+                fileSystem.Setup(x => x.write_file(It.IsAny<string>(), It.IsAny<string>(), utf8WithoutBOM))
                     .Callback((string filePath, string fileContent, Encoding encoding) => files.Add(filePath));
                 fileSystem.Setup(x => x.delete_directory_if_exists(It.IsAny<string>(), true));
                 fileSystem.Setup(x => x.create_directory_if_not_exists(It.IsAny<string>())).Callback(
@@ -322,6 +325,7 @@ namespace chocolatey.tests.infrastructure.app.services
             private readonly ChocolateyConfiguration config = new ChocolateyConfiguration();
             private readonly List<string> files = new List<string>();
             private readonly HashSet<string> directoryCreated = new HashSet<string>(StringComparer.InvariantCultureIgnoreCase);
+            private readonly UTF8Encoding utf8WithoutBOM = new UTF8Encoding(false);
 
             public override void Context()
             {
@@ -340,6 +344,8 @@ namespace chocolatey.tests.infrastructure.app.services
                         });
                 fileSystem.Setup(x => x.directory_exists(It.IsAny<string>())).Returns<string>(dirPath => dirPath.EndsWith("templates\\test"));
                 fileSystem.Setup(x => x.write_file(It.IsAny<string>(), It.IsAny<string>(), Encoding.UTF8))
+                    .Callback((string filePath, string fileContent, Encoding encoding) => files.Add(filePath));
+                fileSystem.Setup(x => x.write_file(It.IsAny<string>(), It.IsAny<string>(), utf8WithoutBOM))
                     .Callback((string filePath, string fileContent, Encoding encoding) => files.Add(filePath));
                 fileSystem.Setup(x => x.delete_directory_if_exists(It.IsAny<string>(), true));
                 fileSystem.Setup(x => x.get_files(It.IsAny<string>(), "*.*", SearchOption.AllDirectories))


### PR DESCRIPTION
Fixes #1364 

Changes the encoding of `.nuspec` files created from templates to UTF8 with BOM to UTF8 without BOM according to best practices in the [Creating Chocolatey Packages](https://chocolatey.org/docs/create-packages#character-encoding) documentation. Applies to both the default template and to custom templates.

Adjusted template services tests to include UTF8 no BOM files, otherwise nuspec files would not be detected anymore.

I moved only the nuspec over to no BOM for both the default template and custom templates. The other `.txt` files from the default template could be moved over to no BOM very easily if that is wanted. 