### PR TITLE
(GH-2092) Take all registry keys into account

### DIFF
--- a/src/chocolatey/infrastructure.app/services/ChocolateyPackageService.cs
+++ b/src/chocolatey/infrastructure.app/services/ChocolateyPackageService.cs
@@ -210,16 +210,14 @@ Did you know Pro / Business automatically syncs with Programs and
 
         private IEnumerable<PackageResult> report_registry_programs(ChocolateyConfiguration config, IEnumerable<IPackage> list)
         {
-            var itemsToRemoveFromMachine = list.Select(package => _packageInfoService.get_package_information(package)).
-                                                Where(p => p.RegistrySnapshot != null).
-                                                Select(p => p.RegistrySnapshot.RegistryKeys.FirstOrDefault()).
-                                                Where(p => p != null).
-                                                Select(p => p.DisplayName).ToList();
+            var itemsToRemoveFromMachine = list.Select(package => _packageInfoService.get_package_information(package)).Where(p => p.RegistrySnapshot != null).ToList();
 
             var count = 0;
-            var machineInstalled = _registryService.get_installer_keys().RegistryKeys.
-                                                Where((p) => p.is_in_programs_and_features() && !itemsToRemoveFromMachine.Contains(p.DisplayName) && !p.KeyPath.contains("choco-")).
-                                                OrderBy((p) => p.DisplayName).Distinct();
+            var machineInstalled = _registryService.get_installer_keys().RegistryKeys.Where(
+                p => p.is_in_programs_and_features() &&
+                     !itemsToRemoveFromMachine.Any(pkg => pkg.RegistrySnapshot.RegistryKeys.Any(k => k.DisplayName.is_equal_to(p.DisplayName))) &&
+                     !p.KeyPath.contains("choco-")).OrderBy(p => p.DisplayName).Distinct();
+
             this.Log().Info(() => "");
             foreach (var key in machineInstalled)
             {


### PR DESCRIPTION
It is possible that the installation of an application can generate
multiple registry keys within the snapshot file that is craeted.  Rather
than looking at only the first registry key when deciding if an installed
application is covered by a Chocolatey package, look at all keys within
the snapshot file.

Fixes #2092 