### PR TITLE
(GH-2105) Update link to Chocolatey workshop

### DIFF
--- a/src/chocolatey/infrastructure.app/templates/ChocolateyTodoTemplate.cs
+++ b/src/chocolatey/infrastructure.app/templates/ChocolateyTodoTemplate.cs
@@ -137,7 +137,7 @@ namespace chocolatey.infrastructure.app.templates
  https://github.com/chocolatey/chocolatey-test-environment
 
 6. Learn more about Chocolatey packaging - go through the workshop at
- https://github.com/ferventcoder/chocolatey-workshop
+ https://github.com/chocolatey/chocolatey-workshop
  You will learn about
  - General packaging
  - Customizing package behavior at runtime (package parameters)


### PR DESCRIPTION
This used to be housed within ferventcoder's GitHub profile, but this
has now been moved under the Chocolatey GitHub Organisation.

Fixes #2105 
