### PR TITLE
(#2049) Note --version as a switch in the help menu

### DIFF
--- a/src/chocolatey/infrastructure.app/builders/ConfigurationBuilder.cs
+++ b/src/chocolatey/infrastructure.app/builders/ConfigurationBuilder.cs
@@ -355,7 +355,7 @@ namespace chocolatey.infrastructure.app.builders
                         .Add("trace",
                              "Trace - Show trace messaging. Very, very verbose trace messaging. Avoid except when needing super low-level .NET Framework debugging. Available in 0.10.4+.",
                              option => config.Trace = option != null)
-                        .Add("v|version",
+                        .Add("version",
                              "Version - Prints out the Chocolatey version.",
                              option => {})
                         .Add("nocolor|no-color",

--- a/src/chocolatey/infrastructure.app/builders/ConfigurationBuilder.cs
+++ b/src/chocolatey/infrastructure.app/builders/ConfigurationBuilder.cs
@@ -355,6 +355,9 @@ namespace chocolatey.infrastructure.app.builders
                         .Add("trace",
                              "Trace - Show trace messaging. Very, very verbose trace messaging. Avoid except when needing super low-level .NET Framework debugging. Available in 0.10.4+.",
                              option => config.Trace = option != null)
+                        .Add("version",
+                             "Version - Prints out the Chocolatey version.",
+                             option => config.Version = option != null)
                         .Add("nocolor|no-color",
                              "No Color - Do not show colorization in logging output. This overrides the feature '{0}', set to '{1}'. Available in 0.10.9+.".format_with(ApplicationParameters.Features.LogWithoutColor, config.Features.LogWithoutColor),
                              option => config.Features.LogWithoutColor = option != null)

--- a/src/chocolatey/infrastructure.app/builders/ConfigurationBuilder.cs
+++ b/src/chocolatey/infrastructure.app/builders/ConfigurationBuilder.cs
@@ -355,9 +355,9 @@ namespace chocolatey.infrastructure.app.builders
                         .Add("trace",
                              "Trace - Show trace messaging. Very, very verbose trace messaging. Avoid except when needing super low-level .NET Framework debugging. Available in 0.10.4+.",
                              option => config.Trace = option != null)
-                        .Add("version",
+                        .Add("v|version",
                              "Version - Prints out the Chocolatey version.",
-                             option => config.Version = option != null)
+                             option => {})
                         .Add("nocolor|no-color",
                              "No Color - Do not show colorization in logging output. This overrides the feature '{0}', set to '{1}'. Available in 0.10.9+.".format_with(ApplicationParameters.Features.LogWithoutColor, config.Features.LogWithoutColor),
                              option => config.Features.LogWithoutColor = option != null)


### PR DESCRIPTION
Resolves #2049 

I added the --version switch to the help menu.
I'm not very familiar with C# but digging through the code it seems the version doesn't need any config options to be set, so I put an empty function in the option_set not sure if that's the right way of doing it.

I tried adding the -v shorthand but it complained about duplicate key, as it is also used for --verbose. But in ConfigurationOptions.cs on line 105 it looks like the shorthand can also be used for --version.