### PR TITLE
(GH-2044) Fix for changing $env:Temp

### DIFF
--- a/src/chocolatey.resources/helpers/functions/Update-SessionEnvironment.ps1
+++ b/src/chocolatey.resources/helpers/functions/Update-SessionEnvironment.ps1
@@ -80,10 +80,10 @@ None
 
   #Path gets special treatment b/c it munges the two together
   $paths = 'Machine', 'User' |
-    % {
+    ForEach-Object {
       (Get-EnvironmentVariable -Name 'PATH' -Scope $_) -split ';'
     } |
-    Select -Unique
+    Select-Object -Unique
   $Env:PATH = $paths -join ';'
 
   # PSModulePath is almost always updated by process, so we want to preserve it.

--- a/src/chocolatey.resources/helpers/functions/Update-SessionEnvironment.ps1
+++ b/src/chocolatey.resources/helpers/functions/Update-SessionEnvironment.ps1
@@ -56,9 +56,9 @@ None
   }
 
   if ($refreshEnv) {
-    Write-Output "Refreshing environment variables from the registry for powershell.exe. Please wait..."
+    Write-Output 'Refreshing environment variables from the registry for powershell.exe. Please wait...'
   } else {
-    Write-Verbose "Refreshing environment variables from the registry."
+    Write-Verbose 'Refreshing environment variables from the registry.'
   }
 
   $userName = $env:USERNAME
@@ -94,7 +94,7 @@ None
   if ($architecture) { $env:PROCESSOR_ARCHITECTURE = $architecture; }
 
   if ($refreshEnv) {
-    Write-Output "Finished"
+    Write-Output 'Finished'
   }
 }
 


### PR DESCRIPTION
(GH-2044) This fixes a problem when a package is installed under the System credentials (typically how centralized management software -- e.g. SCCM -- operate):

Running as `SYSTEM`, the `$env:Temp` variable is normally *C:\Windows\Temp*. If the **first** package to ever use `Update-SessionEnvironment.ps1` happens to be running as `SYSTEM`, the location of `$env:Temp` changes to *C:\Windows\system32\config\systemprofile\AppData\Local\Temp* for the duration of the session.  This change to `$env:Temp` does not occur in subsequent calls to `Update-SessionEnvironment.ps1`.  It is unknown why this change occurs at all and likewise is unknown why it occurs for only the first time.

The `Update-SessionEnvironment.ps1` normally gives priority to user-scope environment variables over machine-scope environment variables.  Changes in this commit eliminates the gathering of the `User` scope environment variables when running as the `SYSTEM` account on the belief that reason to be operating under the `SYSTEM` account is to do machine-wide activities, and there is no reason to see `SYSTEM` as a "user".  On a clean system, the only User-scope environment variables under `SYSTEM` are *path*, *temp*, and *tmp* which are already defined under the Machine-scope, and in general, there shouldn't be any new User-scope variables for the SYSTEM account because it's not a "normal" account.  Basically, there should be little reason to expect this change to break anything.

