### PR TITLE
Escape illegal xml characters when using `choco new`

### DIFF
--- a/src/chocolatey/infrastructure.app/templates/ChocolateyBeforeModifyTemplate.cs
+++ b/src/chocolatey/infrastructure.app/templates/ChocolateyBeforeModifyTemplate.cs
@@ -18,6 +18,7 @@ namespace chocolatey.infrastructure.app.templates
 {
     public class ChocolateyBeforeModifyTemplate
     {
+        public static TemplateLanguage Language = TemplateLanguage.PlainText;
         public static string Template =
             @"# This runs in 0.9.10+ before upgrade and uninstall.
 # Use this file to do things like stop services prior to upgrade or uninstall.

--- a/src/chocolatey/infrastructure.app/templates/ChocolateyInstallTemplate.cs
+++ b/src/chocolatey/infrastructure.app/templates/ChocolateyInstallTemplate.cs
@@ -18,6 +18,7 @@ namespace chocolatey.infrastructure.app.templates
 {
     public class ChocolateyInstallTemplate
     {
+        public static TemplateLanguage Language = TemplateLanguage.PlainText;
         public static string Template =
             @"# IMPORTANT: Before releasing this package, copy/paste the next 2 lines into PowerShell to remove all comments from this file:
 #   $f='c:\path\to\thisFile.ps1'

--- a/src/chocolatey/infrastructure.app/templates/ChocolateyLicenseFileTemplate.cs
+++ b/src/chocolatey/infrastructure.app/templates/ChocolateyLicenseFileTemplate.cs
@@ -18,6 +18,7 @@ namespace chocolatey.infrastructure.app.templates
 {
     public class ChocolateyLicenseFileTemplate
     {
+        public static TemplateLanguage Language = TemplateLanguage.PlainText;
         public static string Template =
             @"
 Note: Include this file if including binaries you have the right to distribute. 

--- a/src/chocolatey/infrastructure.app/templates/ChocolateyReadMeTemplate.cs
+++ b/src/chocolatey/infrastructure.app/templates/ChocolateyReadMeTemplate.cs
@@ -18,6 +18,7 @@ namespace chocolatey.infrastructure.app.templates
 {
     public class ChocolateyReadMeTemplate
     {
+        public static TemplateLanguage Language = TemplateLanguage.PlainText;
         public static string Template =
             @"## Summary
 How do I create packages? See https://chocolatey.org/docs/create-packages

--- a/src/chocolatey/infrastructure.app/templates/ChocolateyTodoTemplate.cs
+++ b/src/chocolatey/infrastructure.app/templates/ChocolateyTodoTemplate.cs
@@ -18,6 +18,7 @@ namespace chocolatey.infrastructure.app.templates
 {
     public class ChocolateyTodoTemplate
     {
+        public static TemplateLanguage Language = TemplateLanguage.PlainText;
         public static string Template =
             @"TODO
 

--- a/src/chocolatey/infrastructure.app/templates/ChocolateyUninstallTemplate.cs
+++ b/src/chocolatey/infrastructure.app/templates/ChocolateyUninstallTemplate.cs
@@ -18,6 +18,7 @@ namespace chocolatey.infrastructure.app.templates
 {
     public class ChocolateyUninstallTemplate
     {
+        public static TemplateLanguage Language = TemplateLanguage.PlainText;
         public static string Template =
             @"# IMPORTANT: Before releasing this package, copy/paste the next 2 lines into PowerShell to remove all comments from this file:
 #   $f='c:\path\to\thisFile.ps1'

--- a/src/chocolatey/infrastructure.app/templates/ChocolateyVerificationFileTemplate.cs
+++ b/src/chocolatey/infrastructure.app/templates/ChocolateyVerificationFileTemplate.cs
@@ -18,6 +18,7 @@ namespace chocolatey.infrastructure.app.templates
 {
     public class ChocolateyVerificationFileTemplate
     {
+        public static TemplateLanguage Language = TemplateLanguage.PlainText;
         public static string Template = @"
 Note: Include this file if including binaries you have the right to distribute. 
 Otherwise delete. this file. If you are the software author, you can change this

--- a/src/chocolatey/infrastructure.app/templates/ITokenEscaper.cs
+++ b/src/chocolatey/infrastructure.app/templates/ITokenEscaper.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace chocolatey.infrastructure.app.templates
+{
+    public interface ITokenEscaper
+    {
+        string escape(string toEscape);
+    }
+}

--- a/src/chocolatey/infrastructure.app/templates/NuspecTemplate.cs
+++ b/src/chocolatey/infrastructure.app/templates/NuspecTemplate.cs
@@ -18,6 +18,7 @@ namespace chocolatey.infrastructure.app.templates
 {
     public class NuspecTemplate
     {
+        public static TemplateLanguage Language = TemplateLanguage.XML;
         public static string Template =
             @"<?xml version=""1.0"" encoding=""utf-8""?>
 <!-- Read this before creating packages: https://chocolatey.org/docs/create-packages -->

--- a/src/chocolatey/infrastructure.app/templates/PlaintextTokenEscaper.cs
+++ b/src/chocolatey/infrastructure.app/templates/PlaintextTokenEscaper.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace chocolatey.infrastructure.app.templates
+{
+    // Represents the escaping strategy of not escaping anything
+    class PlaintextTokenEscaper : ITokenEscaper
+    {
+        public string escape(string toEscape)
+        {
+            return toEscape;
+        }
+    }
+}

--- a/src/chocolatey/infrastructure.app/templates/TemplateLanguage.cs
+++ b/src/chocolatey/infrastructure.app/templates/TemplateLanguage.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+// Copyright © 2020 Chocolatey Software, Inc
+// Copyright © 2020 RealDimensions Software, LLC
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// 
+// You may obtain a copy of the License at
+// 
+// 	http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+namespace chocolatey.infrastructure.app.templates
+{
+    public static class Extensions
+    {
+        // get the escaper used for a given language
+        public static ITokenEscaper GetTokenEscaper(this TemplateLanguage language)
+        {
+            switch (language) {
+                case TemplateLanguage.XML:
+                    return new XMLTokenEscaper();
+                default:
+                    return new PlaintextTokenEscaper();
+            }
+        }
+    }
+    public enum TemplateLanguage
+    {
+        XML,
+        PlainText
+    }
+}

--- a/src/chocolatey/infrastructure.app/templates/XMLTokenEscaper.cs
+++ b/src/chocolatey/infrastructure.app/templates/XMLTokenEscaper.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Security;
+
+namespace chocolatey.infrastructure.app.templates
+{
+    //escape strings so that
+    class XMLTokenEscaper : ITokenEscaper
+    {
+        public string escape(string toEscape)
+        {
+            return SecurityElement.Escape(toEscape);
+        }
+    }
+}

--- a/src/chocolatey/infrastructure/tokens/TokenReplacer.cs
+++ b/src/chocolatey/infrastructure/tokens/TokenReplacer.cs
@@ -16,18 +16,21 @@
 
 namespace chocolatey.infrastructure.tokens
 {
+    using chocolatey.infrastructure.app.templates;
     using System.Collections.Generic;
     using System.Reflection;
     using System.Text.RegularExpressions;
 
     public sealed class TokenReplacer
     {
-        public static string replace_tokens<TConfig>(TConfig configuration, string textToReplace, string tokenPrefix = "[[", string tokenSuffix = "]]")
+        public static string replace_tokens<TConfig>(TConfig configuration, string textToReplace, string tokenPrefix = "[[", string tokenSuffix = "]]", TemplateLanguage targetLanguage = TemplateLanguage.PlainText)
         {
             if (string.IsNullOrEmpty(textToReplace)) return string.Empty;
 
             IDictionary<string, string> dictionary = create_dictionary_from_configuration(configuration);
             if (dictionary.Count == 0) return textToReplace;
+
+            ITokenEscaper tokenEscaper = targetLanguage.GetTokenEscaper();
 
             var regex = new Regex("{0}(?<key>\\w+){1}".format_with(Regex.Escape(tokenPrefix), Regex.Escape(tokenSuffix)));
 
@@ -43,7 +46,7 @@ namespace chocolatey.infrastructure.tokens
                     }
 
                     string value = dictionary[key];
-                    return value;
+                    return tokenEscaper.escape(value);
                 });
 
             return output;


### PR DESCRIPTION
This pull request makes it so that template replacements remove XML-unsafe characters if the template they're being replaced into is for an XML file. 
Fixes #1534
