### PR TITLE
(#886) added support for force and timeout in packages.config file

### DIFF
--- a/src/chocolatey/infrastructure.app/commands/ChocolateyInstallCommand.cs
+++ b/src/chocolatey/infrastructure.app/commands/ChocolateyInstallCommand.cs
@@ -370,7 +370,7 @@ NOTE: The filename is only required to end in .config, the name is not required 
       <package id=""alloptions"" version=""0.1.1""
                source=""https://somewhere/api/v2/"" installArguments=""""
                packageParameters="""" forceX86=""false"" allowMultipleVersions=""false""
-               ignoreDependencies=""false""
+               ignoreDependencies=""false"" commandExecutionTimeoutSeconds=""1000"" force=""false""
                />
     </packages>
 

--- a/src/chocolatey/infrastructure.app/configuration/PackagesConfigFilePackageSetting.cs
+++ b/src/chocolatey/infrastructure.app/configuration/PackagesConfigFilePackageSetting.cs
@@ -58,5 +58,12 @@ namespace chocolatey.infrastructure.app.configuration
 
         [XmlAttribute(AttributeName = "disabled")]
         public bool Disabled { get; set; }
+
+        [System.ComponentModel.DefaultValue(-1)]
+        [XmlAttribute(AttributeName = "commandExecutionTimeoutSeconds")]
+        public int CommandExecutionTimeoutSeconds { get; set; }
+
+        [XmlAttribute(AttributeName = "force")]
+        public bool Force { get; set; }
     }
 }

--- a/src/chocolatey/infrastructure.app/services/ChocolateyPackageService.cs
+++ b/src/chocolatey/infrastructure.app/services/ChocolateyPackageService.cs
@@ -737,6 +737,8 @@ Would have determined packages that are out of date based on what is
                     if (pkgSettings.ApplyPackageParametersToDependencies) packageConfig.ApplyPackageParametersToDependencies = true;
                     SourceType sourceType;
                     if (Enum.TryParse(pkgSettings.Source, true, out sourceType)) packageConfig.SourceType = sourceType;
+                    if (pkgSettings.Force) packageConfig.Force = true;
+                    packageConfig.CommandExecutionTimeoutSeconds = pkgSettings.CommandExecutionTimeoutSeconds == -1 ? packageConfig.CommandExecutionTimeoutSeconds : pkgSettings.CommandExecutionTimeoutSeconds;
 
                     this.Log().Info(ChocolateyLoggers.Important, @"{0}".format_with(packageConfig.PackageNames));
                     packageConfigs.Add(packageConfig);


### PR DESCRIPTION
Added support to timeout and force in packages.config

This is now supported
```
<package id="packagename" timeout="1000" force="true" />
```

Relates to #886.

Other PR's will be required to bring in the other options that can then be controlled via the packages.config file.