### PR TITLE
(#2190) Clarify help for SpecificFolder parameter

### DIFF
--- a/src/chocolatey.resources/helpers/functions/Get-ChocolateyUnzip.ps1
+++ b/src/chocolatey.resources/helpers/functions/Get-ChocolateyUnzip.ps1
@@ -68,7 +68,8 @@ This is a directory where you would like the unzipped files to end up.
 If it does not exist, it will be created.
 
 .PARAMETER SpecificFolder
-OPTIONAL - This is a specific directory within zip file to extract.
+OPTIONAL - This is a specific directory within zip file to extract. The
+folder and its contents will be extracted to the destination.
 
 .PARAMETER PackageName
 OPTIONAL - This will facilitate logging unzip activity for subsequent

--- a/src/chocolatey.resources/helpers/functions/Install-ChocolateyZipPackage.ps1
+++ b/src/chocolatey.resources/helpers/functions/Install-ChocolateyZipPackage.ps1
@@ -54,6 +54,10 @@ a 32 bit installation on a 64 bit system.
 
 Prefer HTTPS when available. Can be HTTP, FTP, or File URIs.
 
+.PARAMETER SpecificFolder
+OPTIONAL - This is a specific directory within zip file to extract. The
+folder and its contents will be extracted to the destination.
+
 .PARAMETER Url64bit
 OPTIONAL - If there is a 64 bit resource available, use this
 parameter. Chocolatey will automatically determine if the user is


### PR DESCRIPTION
Add / clarify the SpecificFolder parameter for the PowerShell helper functions.

Closes #2190.