### PR TITLE
(#2051) Make parameter description consistent

### DIFF
--- a/src/chocolatey.resources/helpers/functions/Start-ChocolateyProcessAsAdmin.ps1
+++ b/src/chocolatey.resources/helpers/functions/Start-ChocolateyProcessAsAdmin.ps1
@@ -65,8 +65,8 @@ Array of exit codes indicating success. Defaults to `@(0)`.
 
 .PARAMETER WorkingDirectory
 The working directory for the running process. Defaults to
-`Get-Location`. If current location is a UNC path, uses
-`$env:TEMP` for default as of 0.10.14.
+`$null`. If current location is a UNC path, uses `$env:TEMP` for default
+ as of 0.10.14.
 
 Available in 0.10.1+.
 


### PR DESCRIPTION
In an earlier commit, the default value of the WorkingDirectory
parameter was changed to be $null, but the parameter description wasn't
updated.