### PR TITLE
(#2236) Mono test work with merged usr systems

### DIFF
--- a/src/chocolatey.tests/infrastructure/filesystem/DotNetFileSystemSpecs.cs
+++ b/src/chocolatey.tests/infrastructure/filesystem/DotNetFileSystemSpecs.cs
@@ -214,10 +214,17 @@ namespace chocolatey.tests.infrastructure.filesystem
             [Fact]
             public void GetExecutablePath_should_find_existing_executable()
             {
-                FileSystem.get_executable_path("ls").ShouldEqual(
-                    Platform.get_platform() != PlatformType.Windows
-                        ? "/bin/ls"
-                        : "ls");
+                if (Platform.get_platform() == PlatformType.Windows)
+                {
+                    FileSystem.get_executable_path("ls").ShouldEqual("ls");
+                }
+                else
+                {
+                    new string[]
+                    {
+                        "/bin/ls", "/usr/bin/ls"
+                    }.ShouldContain(FileSystem.get_executable_path("ls"));
+                }
             }
 
             [Fact]


### PR DESCRIPTION
The should_find_existing_executable() test has a hardcoded path to the
ls executable, which is incorrect on systems with a merged usr
directory, as they have binaries under /usr/bin instead of under /bin
Switches the test to work with both path.

Fixes: #2236 

I'm pretty sure `ShouldBeInRange` is the correct thing to use, but feel free to correct if there is a better method to use.