### PR TITLE
(#2111) Deep copy config

### DIFF
--- a/src/chocolatey/infrastructure.app/services/NugetService.cs
+++ b/src/chocolatey/infrastructure.app/services/NugetService.cs
@@ -435,7 +435,7 @@ folder.");
                 uninstallSuccessAction: null,
                 addUninstallHandler: true);
 
-            var originalConfig = config;
+            var originalConfig = config.deep_copy();
 
             foreach (string packageName in packageNames.or_empty_list_if_null())
             {
@@ -614,7 +614,7 @@ Please see https://docs.chocolatey.org/en-us/troubleshooting for more
             set_package_names_if_all_is_specified(config, () => { config.IgnoreDependencies = true; });
             config.IgnoreDependencies = configIgnoreDependencies;
 
-            var originalConfig = config;
+            var originalConfig = config.deep_copy();
 
             foreach (string packageName in config.PackageNames.Split(new[] { ApplicationParameters.PackageNamesSeparator }, StringSplitOptions.RemoveEmptyEntries).or_empty_list_if_null())
             {
@@ -890,7 +890,7 @@ Please see https://docs.chocolatey.org/en-us/troubleshooting for more
             set_package_names_if_all_is_specified(config, () => { config.IgnoreDependencies = true; });
             var packageNames = config.PackageNames.Split(new[] { ApplicationParameters.PackageNamesSeparator }, StringSplitOptions.RemoveEmptyEntries).or_empty_list_if_null().ToList();
 
-            var originalConfig = config;
+            var originalConfig = config.deep_copy();
 
             foreach (var packageName in packageNames)
             {
@@ -1357,7 +1357,7 @@ Please see https://docs.chocolatey.org/en-us/troubleshooting for more
                     config.ForceDependencies = false;
                 });
 
-            var originalConfig = config;
+            var originalConfig = config.deep_copy();
 
             foreach (string packageName in config.PackageNames.Split(new[] { ApplicationParameters.PackageNamesSeparator }, StringSplitOptions.RemoveEmptyEntries).or_empty_list_if_null())
             {


### PR DESCRIPTION
Always deep copy the config when making a backup originalConfig. This
ensures that when the config is reset it gets fully reset. Fixes issues
with reuse of arguments when useRememberedArgumentsForUpgrades is
enabled.

Hopefully fixes: #1443
Fixes: #2111

I have tested this with the procedure in [this comment](https://github.com/chocolatey/choco/issues/2111#issuecomment-759124896), and with this patch, it no longer upgrades python3 to a prerelease build, while without this patch it does.