### PR TITLE
(#2241) Set install location to package dir for portable packages

### DIFF
--- a/src/chocolatey/infrastructure.app/services/ChocolateyPackageService.cs
+++ b/src/chocolatey/infrastructure.app/services/ChocolateyPackageService.cs
@@ -342,6 +342,9 @@ Did you know Pro / Business automatically syncs with Programs and
 
             var pkgInfo = get_package_information(packageResult, config);
 
+            // initialize this here so it can be used for the install location later
+            bool powerShellRan = false;
+
             if (packageResult.Success && config.Information.PlatformType == PlatformType.Windows)
             {
                 if (!config.SkipPackageInstallProvider)
@@ -349,7 +352,7 @@ Did you know Pro / Business automatically syncs with Programs and
                     var installersBefore = _registryService.get_installer_keys();
                     var environmentBefore = get_environment_before(config, allowLogging: false);
 
-                    var powerShellRan = _powershellService.install(config, packageResult);
+                    powerShellRan = _powershellService.install(config, packageResult);
                     if (powerShellRan)
                     {
                         // we don't care about the exit code
@@ -411,6 +414,11 @@ Did you know Pro / Business automatically syncs with Programs and
                 {
                     Environment.SetEnvironmentVariable(ApplicationParameters.Environment.ChocolateyPackageInstallLocation, toolsLocation, EnvironmentVariableTarget.Process);
                 }
+            }
+
+            if (!powerShellRan && string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable(ApplicationParameters.Environment.ChocolateyPackageInstallLocation)))
+            {
+                Environment.SetEnvironmentVariable(ApplicationParameters.Environment.ChocolateyPackageInstallLocation, packageResult.InstallLocation, EnvironmentVariableTarget.Process);
             }
 
             if (pkgInfo.RegistrySnapshot != null && pkgInfo.RegistrySnapshot.RegistryKeys.Any(k => !string.IsNullOrWhiteSpace(k.InstallLocation)))


### PR DESCRIPTION
Set the install location to the package folder under lib for nuget
packages that do not have a chocolateyinstall.ps1. This will display
the install location correctly for portable packages that just include
binary(s) that get automatically shimmed.

Fixes: #2241 

This is definitely up for discussion on the implementation
This might be related to #1370.

This has been tested in a debug build, installing a number of packages, with everything working as expected:
- Packages that are "purely" portable, without an install script: `curl`, `balcon`, `sumatrapdf.portable` , `iperf2`. These all reported the install location correctly as being inside the `lib` directory. This is the one changed behavior I found, as expected.
- Packages that extract an archive: `wget`, `curl`. These all reported the install location as normal inside their respective `tools` directories.
- Packages that install an installer and correctly show the install location: `4k-video-downloader` This one still showed the correct install location under "program files"
- Packages that manually specify install location with `$env:ChocolateyPackageInstallLocation`: `dolphin-dev`, `pcsx2-dev`. These all displayed the install location as specified in the install script.
- Packages with install scripts and where the install location is "not explicitly set": `vcredist140`, `KB3035131`, `KB3033929`. These all still showed as the installation location being not set.
- Packages with install scripts and where "Software installed as 'x, install location is likely default.": `4k-slideshow-maker` Still showed the same message
- Template packages: `msi.template` This one showed as being installed in a subfolder under the templates directory.
- Extension packages: `chocolatey-core.extension`, `chocolatey-windowsupdate.extension`. These showed as being installed in their subfolder under the extensions directory.