### PR TITLE
(#2263) Pack on Mono pass absolute path to PackageBuilder

### DIFF
--- a/src/chocolatey/infrastructure.app/services/NugetService.cs
+++ b/src/chocolatey/infrastructure.app/services/NugetService.cs
@@ -287,14 +287,7 @@ namespace chocolatey.infrastructure.app.services
             // Initialize the property provider based on what was passed in using the properties flag
             var propertyProvider = new DictionaryPropertyProvider(properties);
 
-            var basePath = nuspecDirectory;
-            if (config.Information.PlatformType != PlatformType.Windows)
-            {
-                //bug with nuspec and tools/** folder location on Windows.
-                basePath = "./";
-            }
-
-            var builder = new PackageBuilder(nuspecFilePath, basePath, propertyProvider, includeEmptyDirectories: true);
+            var builder = new PackageBuilder(nuspecFilePath, nuspecDirectory, propertyProvider, includeEmptyDirectories: true);
             if (!string.IsNullOrWhiteSpace(config.Version))
             {
                 builder.Version = new SemanticVersion(config.Version);


### PR DESCRIPTION
When using a relative path, pack only works if the current directory is
the same as the directory containing the nuspec. This switches the
relative path to an absolute path for non-windows platforms (windows
already uses an absolute path). This change allows pack to work from
any directory.

Previously, in c0b23a6 and e5a02a0, non-windows platforms were switched
to using a relative path for files, so that the default files separator
in the nuspec files element could be switched to a backslash (#2166)
However, the issue with forward/back slashes is fixed by
chocolatey/nuget-chocolatey#19, so the previous change can now be
reverted.

Fixes #2263 