### PR TITLE
(#2261) Updates License Headers Copyright to 2021

### DIFF
--- a/.uppercut
+++ b/.uppercut
@@ -22,7 +22,7 @@
   <property name="version.nuget.prerelease" value="beta" overwrite="false" />
   <property name="version.use.build_date" value="true" overwrite="false" />
   <property name="assembly.description" value="${project.name} is a product of ${company.name} - All Rights Reserved." overwrite="false" />
-  <property name="assembly.copyright" value="Copyright © 2017 - 2020 ${company.name} Copyright © 2011 - 2017, RealDimensions Software, LLC - All Rights Reserved." overwrite="false" />
+  <property name="assembly.copyright" value="Copyright © 2017 - 2021 ${company.name} Copyright © 2011 - 2017, RealDimensions Software, LLC - All Rights Reserved." overwrite="false" />
   <property name="sign.project_with_key" value="true" overwrite="false" />
 
   <!-- Build Features Overrides -->

--- a/NOTICE
+++ b/NOTICE
@@ -1,4 +1,4 @@
-   Copyright (c) 2017 - 2018 Chocolatey Software, Inc.
+   Copyright (c) 2017 - 2021 Chocolatey Software, Inc.
    Copyright (c) 2011 - 2017 RealDimensions Software, LLC
 
    Licensed under the Apache License, Version 2.0 (the "License");

--- a/nuget/chocolatey.lib/chocolatey.lib.nuspec
+++ b/nuget/chocolatey.lib/chocolatey.lib.nuspec
@@ -10,7 +10,7 @@
     <iconUrl>https://raw.githubusercontent.com/chocolatey/choco/master/docs/logo/chocolateyicon.gif</iconUrl>
     <licenseUrl>https://raw.githubusercontent.com/chocolatey/choco/master/LICENSE</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <copyright>2017-2019 Chocolatey Software, Inc, 2011- 2017 RealDimensions Software, LLC</copyright>
+    <copyright>2017-2021 Chocolatey Software, Inc, 2011- 2017 RealDimensions Software, LLC</copyright>
     <tags>apt-get machine repository chocolatey</tags>
     <summary>Chocolatey is the package manager for Windows (like apt-get but for Windows)</summary>
     <description>

--- a/nuget/chocolatey.lib/chocolatey.lib.nuspec
+++ b/nuget/chocolatey.lib/chocolatey.lib.nuspec
@@ -10,7 +10,7 @@
     <iconUrl>https://raw.githubusercontent.com/chocolatey/choco/master/docs/logo/chocolateyicon.gif</iconUrl>
     <licenseUrl>https://raw.githubusercontent.com/chocolatey/choco/master/LICENSE</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <copyright>2017-2021 Chocolatey Software, Inc, 2011- 2017 RealDimensions Software, LLC</copyright>
+    <copyright>2017-2021 Chocolatey Software, Inc, 2011-2017 RealDimensions Software, LLC</copyright>
     <tags>apt-get machine repository chocolatey</tags>
     <summary>Chocolatey is the package manager for Windows (like apt-get but for Windows)</summary>
     <description>

--- a/nuget/chocolatey/chocolatey.nuspec
+++ b/nuget/chocolatey/chocolatey.nuspec
@@ -11,7 +11,7 @@
     <iconUrl>https://raw.githubusercontent.com/chocolatey/choco/master/docs/logo/chocolateyicon.gif</iconUrl>
     <licenseUrl>https://raw.githubusercontent.com/chocolatey/choco/master/LICENSE</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <copyright>2017-2021 Chocolatey Software, Inc, 2011- 2017 RealDimensions Software, LLC</copyright>
+    <copyright>2017-2021 Chocolatey Software, Inc, 2011-2017 RealDimensions Software, LLC</copyright>
     <!--<projectSourceUrl>https://github.com/chocolatey/choco</projectSourceUrl>
     <docsUrl>https://docs.chocolatey.org/en-us/</docsUrl>
     <mailingListUrl>https://groups.google.com/forum/#!forum/chocolatey</mailingListUrl>

--- a/nuget/chocolatey/chocolatey.nuspec
+++ b/nuget/chocolatey/chocolatey.nuspec
@@ -11,7 +11,7 @@
     <iconUrl>https://raw.githubusercontent.com/chocolatey/choco/master/docs/logo/chocolateyicon.gif</iconUrl>
     <licenseUrl>https://raw.githubusercontent.com/chocolatey/choco/master/LICENSE</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <copyright>2017-2019 Chocolatey Software, Inc, 2011- 2017 RealDimensions Software, LLC</copyright>
+    <copyright>2017-2021 Chocolatey Software, Inc, 2011- 2017 RealDimensions Software, LLC</copyright>
     <!--<projectSourceUrl>https://github.com/chocolatey/choco</projectSourceUrl>
     <docsUrl>https://docs.chocolatey.org/en-us/</docsUrl>
     <mailingListUrl>https://groups.google.com/forum/#!forum/chocolatey</mailingListUrl>

--- a/src/chocolatey.console/Program.cs
+++ b/src/chocolatey.console/Program.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey.console/Properties/AssemblyInfo.cs
+++ b/src/chocolatey.console/Properties/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey.resources/ChocolateyResourcesAssembly.cs
+++ b/src/chocolatey.resources/ChocolateyResourcesAssembly.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey.resources/Properties/AssemblyInfo.cs
+++ b/src/chocolatey.resources/Properties/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey.resources/helpers/ChocolateyTabExpansion.ps1
+++ b/src/chocolatey.resources/helpers/ChocolateyTabExpansion.ps1
@@ -1,4 +1,4 @@
-﻿# Copyright © 2017 Chocolatey Software, Inc.
+﻿# Copyright © 2017 - 2021 Chocolatey Software, Inc.
 # Copyright © 2011 - 2017 RealDimensions Software, LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey.resources/helpers/chocolateyInstaller.psm1
+++ b/src/chocolatey.resources/helpers/chocolateyInstaller.psm1
@@ -1,4 +1,4 @@
-# Copyright © 2017 Chocolatey Software, Inc.
+# Copyright © 2017 - 2021 Chocolatey Software, Inc.
 # Copyright © 2015 - 2017 RealDimensions Software, LLC
 # Copyright © 2011 - 2015 RealDimensions Software, LLC & original authors/contributors from https://github.com/chocolatey/chocolatey
 #

--- a/src/chocolatey.resources/helpers/chocolateyProfile.psm1
+++ b/src/chocolatey.resources/helpers/chocolateyProfile.psm1
@@ -1,4 +1,4 @@
-﻿# Copyright © 2017 Chocolatey Software, Inc.
+﻿# Copyright © 2017 - 2021 Chocolatey Software, Inc.
 # Copyright © 2011 - 2017 RealDimensions Software, LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey.resources/helpers/functions/Format-FileSize.ps1
+++ b/src/chocolatey.resources/helpers/functions/Format-FileSize.ps1
@@ -1,4 +1,4 @@
-﻿# Copyright © 2017 Chocolatey Software, Inc.
+﻿# Copyright © 2017 - 2021 Chocolatey Software, Inc.
 # Copyright © 2011 - 2017 RealDimensions Software, LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey.resources/helpers/functions/Get-CheckSumValid.ps1
+++ b/src/chocolatey.resources/helpers/functions/Get-CheckSumValid.ps1
@@ -1,4 +1,4 @@
-﻿# Copyright © 2017 Chocolatey Software, Inc.
+﻿# Copyright © 2017 - 2021 Chocolatey Software, Inc.
 # Copyright © 2015 - 2017 RealDimensions Software, LLC
 # Copyright © 2011 - 2015 RealDimensions Software, LLC & original authors/contributors from https://github.com/chocolatey/chocolatey
 #

--- a/src/chocolatey.resources/helpers/functions/Get-ChocolateyUnzip.ps1
+++ b/src/chocolatey.resources/helpers/functions/Get-ChocolateyUnzip.ps1
@@ -1,4 +1,4 @@
-﻿# Copyright © 2017 Chocolatey Software, Inc.
+﻿# Copyright © 2017 - 2021 Chocolatey Software, Inc.
 # Copyright © 2015 - 2017 RealDimensions Software, LLC
 # Copyright © 2011 - 2015 RealDimensions Software, LLC & original authors/contributors from https://github.com/chocolatey/chocolatey
 #

--- a/src/chocolatey.resources/helpers/functions/Get-ChocolateyWebFile.ps1
+++ b/src/chocolatey.resources/helpers/functions/Get-ChocolateyWebFile.ps1
@@ -1,4 +1,4 @@
-﻿# Copyright © 2017 Chocolatey Software, Inc.
+﻿# Copyright © 2017 - 2021 Chocolatey Software, Inc.
 # Copyright © 2015 - 2017 RealDimensions Software, LLC
 # Copyright © 2011 - 2015 RealDimensions Software, LLC & original authors/contributors from https://github.com/chocolatey/chocolatey
 #

--- a/src/chocolatey.resources/helpers/functions/Get-EnvironmentVariable.ps1
+++ b/src/chocolatey.resources/helpers/functions/Get-EnvironmentVariable.ps1
@@ -1,4 +1,4 @@
-﻿# Copyright © 2017 Chocolatey Software, Inc.
+﻿# Copyright © 2017 - 2021 Chocolatey Software, Inc.
 # Copyright © 2015 - 2017 RealDimensions Software, LLC
 # Copyright © 2011 - 2015 RealDimensions Software, LLC & original authors/contributors from https://github.com/chocolatey/chocolatey
 #

--- a/src/chocolatey.resources/helpers/functions/Get-EnvironmentVariableNames.ps1
+++ b/src/chocolatey.resources/helpers/functions/Get-EnvironmentVariableNames.ps1
@@ -1,4 +1,4 @@
-﻿# Copyright © 2017 Chocolatey Software, Inc.
+﻿# Copyright © 2017 - 2021 Chocolatey Software, Inc.
 # Copyright © 2015 - 2017 RealDimensions Software, LLC
 # Copyright © 2011 - 2015 RealDimensions Software, LLC & original authors/contributors from https://github.com/chocolatey/chocolatey
 #

--- a/src/chocolatey.resources/helpers/functions/Get-OSArchitectureWidth.ps1
+++ b/src/chocolatey.resources/helpers/functions/Get-OSArchitectureWidth.ps1
@@ -1,4 +1,4 @@
-﻿# Copyright © 2017 Chocolatey Software, Inc.
+﻿# Copyright © 2017 - 2021 Chocolatey Software, Inc.
 # Copyright © 2015 - 2017 RealDimensions Software, LLC
 # Copyright © 2011 - 2015 RealDimensions Software, LLC & original authors/contributors from https://github.com/chocolatey/chocolatey
 #

--- a/src/chocolatey.resources/helpers/functions/Get-PackageParameters.ps1
+++ b/src/chocolatey.resources/helpers/functions/Get-PackageParameters.ps1
@@ -1,4 +1,4 @@
-﻿# Copyright © 2017 Chocolatey Software, Inc.
+﻿# Copyright © 2017 - 2021 Chocolatey Software, Inc.
 # Copyright © 2016 - 2017 Original authors from https://github.com/chocolatey/chocolatey-coreteampackages
 # Copyright © 2016 Miodrag Milić - https://github.com/majkinetor/au-packages/commit/bf95d56fe5851ee2e4f6f15f79c1a2877a7950a1
 #

--- a/src/chocolatey.resources/helpers/functions/Get-ToolsLocation.ps1
+++ b/src/chocolatey.resources/helpers/functions/Get-ToolsLocation.ps1
@@ -1,4 +1,4 @@
-﻿# Copyright © 2017 Chocolatey Software, Inc.
+﻿# Copyright © 2017 - 2021 Chocolatey Software, Inc.
 # Copyright © 2011 - 2017 RealDimensions Software, LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey.resources/helpers/functions/Get-UACEnabled.ps1
+++ b/src/chocolatey.resources/helpers/functions/Get-UACEnabled.ps1
@@ -1,4 +1,4 @@
-﻿# Copyright © 2017 Chocolatey Software, Inc.
+﻿# Copyright © 2017 - 2021 Chocolatey Software, Inc.
 # Copyright © 2015 - 2017 RealDimensions Software, LLC
 # Copyright © 2011 - 2015 RealDimensions Software, LLC & original authors/contributors from https://github.com/chocolatey/chocolatey
 #

--- a/src/chocolatey.resources/helpers/functions/Get-UninstallRegistryKey.ps1
+++ b/src/chocolatey.resources/helpers/functions/Get-UninstallRegistryKey.ps1
@@ -1,4 +1,4 @@
-﻿# Copyright © 2017 Chocolatey Software, Inc.
+﻿# Copyright © 2017 - 2021 Chocolatey Software, Inc.
 # Copyright © 2011 - 2017 RealDimensions Software, LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey.resources/helpers/functions/Get-VirusCheckValid.ps1
+++ b/src/chocolatey.resources/helpers/functions/Get-VirusCheckValid.ps1
@@ -1,4 +1,4 @@
-﻿# Copyright © 2017 Chocolatey Software, Inc.
+﻿# Copyright © 2017 - 2021 Chocolatey Software, Inc.
 # Copyright © 2015 - 2017 RealDimensions Software, LLC
 # Copyright © 2011 - 2015 RealDimensions Software, LLC & original authors/contributors from https://github.com/chocolatey/chocolatey
 #

--- a/src/chocolatey.resources/helpers/functions/Get-WebFileName.ps1
+++ b/src/chocolatey.resources/helpers/functions/Get-WebFileName.ps1
@@ -1,4 +1,4 @@
-﻿# Copyright © 2017 Chocolatey Software, Inc.
+﻿# Copyright © 2017 - 2021 Chocolatey Software, Inc.
 # Copyright © 2011 - 2017 RealDimensions Software, LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey.resources/helpers/functions/Get-WebHeaders.ps1
+++ b/src/chocolatey.resources/helpers/functions/Get-WebHeaders.ps1
@@ -1,4 +1,4 @@
-﻿# Copyright © 2017 Chocolatey Software, Inc.
+﻿# Copyright © 2017 - 2021 Chocolatey Software, Inc.
 # Copyright © 2015 - 2017 RealDimensions Software, LLC
 # Copyright © 2011 - 2015 RealDimensions Software, LLC & original authors/contributors from https://github.com/chocolatey/chocolatey
 #

--- a/src/chocolatey.resources/helpers/functions/Install-BinFile.ps1
+++ b/src/chocolatey.resources/helpers/functions/Install-BinFile.ps1
@@ -1,4 +1,4 @@
-﻿# Copyright © 2017 Chocolatey Software, Inc.
+﻿# Copyright © 2017 - 2021 Chocolatey Software, Inc.
 # Copyright © 2015 - 2017 RealDimensions Software, LLC
 # Copyright © 2011 - 2015 RealDimensions Software, LLC & original authors/contributors from https://github.com/chocolatey/chocolatey
 #

--- a/src/chocolatey.resources/helpers/functions/Install-ChocolateyDesktopLink.ps1
+++ b/src/chocolatey.resources/helpers/functions/Install-ChocolateyDesktopLink.ps1
@@ -1,4 +1,4 @@
-﻿# Copyright © 2017 Chocolatey Software, Inc.
+﻿# Copyright © 2017 - 2021 Chocolatey Software, Inc.
 # Copyright © 2015 - 2017 RealDimensions Software, LLC
 # Copyright © 2011 - 2015 RealDimensions Software, LLC & original authors/contributors from https://github.com/chocolatey/chocolatey
 #

--- a/src/chocolatey.resources/helpers/functions/Install-ChocolateyEnvironmentVariable.ps1
+++ b/src/chocolatey.resources/helpers/functions/Install-ChocolateyEnvironmentVariable.ps1
@@ -1,4 +1,4 @@
-﻿# Copyright © 2017 Chocolatey Software, Inc.
+﻿# Copyright © 2017 - 2021 Chocolatey Software, Inc.
 # Copyright © 2015 - 2017 RealDimensions Software, LLC
 # Copyright © 2011 - 2015 RealDimensions Software, LLC & original authors/contributors from https://github.com/chocolatey/chocolatey
 #

--- a/src/chocolatey.resources/helpers/functions/Install-ChocolateyExplorerMenuItem.ps1
+++ b/src/chocolatey.resources/helpers/functions/Install-ChocolateyExplorerMenuItem.ps1
@@ -1,4 +1,4 @@
-﻿# Copyright © 2017 Chocolatey Software, Inc.
+﻿# Copyright © 2017 - 2021 Chocolatey Software, Inc.
 # Copyright © 2015 - 2017 RealDimensions Software, LLC
 # Copyright © 2011 - 2015 RealDimensions Software, LLC & original authors/contributors from https://github.com/chocolatey/chocolatey
 #

--- a/src/chocolatey.resources/helpers/functions/Install-ChocolateyFileAssociation.ps1
+++ b/src/chocolatey.resources/helpers/functions/Install-ChocolateyFileAssociation.ps1
@@ -1,4 +1,4 @@
-﻿# Copyright © 2017 Chocolatey Software, Inc.
+﻿# Copyright © 2017 - 2021 Chocolatey Software, Inc.
 # Copyright © 2015 - 2017 RealDimensions Software, LLC
 # Copyright © 2011 - 2015 RealDimensions Software, LLC & original authors/contributors from https://github.com/chocolatey/chocolatey
 #

--- a/src/chocolatey.resources/helpers/functions/Install-ChocolateyInstallPackage.ps1
+++ b/src/chocolatey.resources/helpers/functions/Install-ChocolateyInstallPackage.ps1
@@ -1,4 +1,4 @@
-﻿# Copyright © 2017 Chocolatey Software, Inc.
+﻿# Copyright © 2017 - 2021 Chocolatey Software, Inc.
 # Copyright © 2015 - 2017 RealDimensions Software, LLC
 # Copyright © 2011 - 2015 RealDimensions Software, LLC & original authors/contributors from https://github.com/chocolatey/chocolatey
 #

--- a/src/chocolatey.resources/helpers/functions/Install-ChocolateyPackage.ps1
+++ b/src/chocolatey.resources/helpers/functions/Install-ChocolateyPackage.ps1
@@ -1,4 +1,4 @@
-﻿# Copyright © 2017 Chocolatey Software, Inc.
+﻿# Copyright © 2017 - 2021 Chocolatey Software, Inc.
 # Copyright © 2015 - 2017 RealDimensions Software, LLC
 # Copyright © 2011 - 2015 RealDimensions Software, LLC & original authors/contributors from https://github.com/chocolatey/chocolatey
 #

--- a/src/chocolatey.resources/helpers/functions/Install-ChocolateyPath.ps1
+++ b/src/chocolatey.resources/helpers/functions/Install-ChocolateyPath.ps1
@@ -1,4 +1,4 @@
-﻿# Copyright © 2017 Chocolatey Software, Inc.
+﻿# Copyright © 2017 - 2021 Chocolatey Software, Inc.
 # Copyright © 2015 - 2017 RealDimensions Software, LLC
 # Copyright © 2011 - 2015 RealDimensions Software, LLC & original authors/contributors from https://github.com/chocolatey/chocolatey
 #

--- a/src/chocolatey.resources/helpers/functions/Install-ChocolateyPinnedTaskBarItem.ps1
+++ b/src/chocolatey.resources/helpers/functions/Install-ChocolateyPinnedTaskBarItem.ps1
@@ -1,4 +1,4 @@
-﻿# Copyright © 2017 Chocolatey Software, Inc.
+﻿# Copyright © 2017 - 2021 Chocolatey Software, Inc.
 # Copyright © 2015 - 2017 RealDimensions Software, LLC
 # Copyright © 2011 - 2015 RealDimensions Software, LLC & original authors/contributors from https://github.com/chocolatey/chocolatey
 #

--- a/src/chocolatey.resources/helpers/functions/Install-ChocolateyPowershellCommand.ps1
+++ b/src/chocolatey.resources/helpers/functions/Install-ChocolateyPowershellCommand.ps1
@@ -1,4 +1,4 @@
-﻿# Copyright © 2017 Chocolatey Software, Inc.
+﻿# Copyright © 2017 - 2021 Chocolatey Software, Inc.
 # Copyright © 2015 - 2017 RealDimensions Software, LLC
 # Copyright © 2011 - 2015 RealDimensions Software, LLC & original authors/contributors from https://github.com/chocolatey/chocolatey
 #

--- a/src/chocolatey.resources/helpers/functions/Install-ChocolateyShortcut.ps1
+++ b/src/chocolatey.resources/helpers/functions/Install-ChocolateyShortcut.ps1
@@ -1,4 +1,4 @@
-﻿# Copyright © 2017 Chocolatey Software, Inc.
+﻿# Copyright © 2017 - 2021 Chocolatey Software, Inc.
 # Copyright © 2015 - 2017 RealDimensions Software, LLC
 # Copyright © 2011 - 2015 RealDimensions Software, LLC & original authors/contributors from https://github.com/chocolatey/chocolatey
 #

--- a/src/chocolatey.resources/helpers/functions/Install-ChocolateyVsixPackage.ps1
+++ b/src/chocolatey.resources/helpers/functions/Install-ChocolateyVsixPackage.ps1
@@ -1,4 +1,4 @@
-﻿# Copyright © 2017 Chocolatey Software, Inc.
+﻿# Copyright © 2017 - 2021 Chocolatey Software, Inc.
 # Copyright © 2015 - 2017 RealDimensions Software, LLC
 # Copyright © 2011 - 2015 RealDimensions Software, LLC & original authors/contributors from https://github.com/chocolatey/chocolatey
 #

--- a/src/chocolatey.resources/helpers/functions/Install-ChocolateyZipPackage.ps1
+++ b/src/chocolatey.resources/helpers/functions/Install-ChocolateyZipPackage.ps1
@@ -1,4 +1,4 @@
-﻿# Copyright © 2017 Chocolatey Software, Inc.
+﻿# Copyright © 2017 - 2021 Chocolatey Software, Inc.
 # Copyright © 2015 - 2017 RealDimensions Software, LLC
 # Copyright © 2011 - 2015 RealDimensions Software, LLC & original authors/contributors from https://github.com/chocolatey/chocolatey
 #

--- a/src/chocolatey.resources/helpers/functions/Install-Vsix.ps1
+++ b/src/chocolatey.resources/helpers/functions/Install-Vsix.ps1
@@ -1,4 +1,4 @@
-﻿# Copyright © 2017 Chocolatey Software, Inc.
+﻿# Copyright © 2017 - 2021 Chocolatey Software, Inc.
 # Copyright © 2015 - 2017 RealDimensions Software, LLC
 # Copyright © 2011 - 2015 RealDimensions Software, LLC & original authors/contributors from https://github.com/chocolatey/chocolatey
 #

--- a/src/chocolatey.resources/helpers/functions/Set-EnvironmentVariable.ps1
+++ b/src/chocolatey.resources/helpers/functions/Set-EnvironmentVariable.ps1
@@ -1,4 +1,4 @@
-﻿# Copyright © 2017 Chocolatey Software, Inc.
+﻿# Copyright © 2017 - 2021 Chocolatey Software, Inc.
 # Copyright © 2015 - 2017 RealDimensions Software, LLC
 # Copyright © 2011 - 2015 RealDimensions Software, LLC & original authors/contributors from https://github.com/chocolatey/chocolatey
 #

--- a/src/chocolatey.resources/helpers/functions/Set-PowerShellExitCode.ps1
+++ b/src/chocolatey.resources/helpers/functions/Set-PowerShellExitCode.ps1
@@ -1,4 +1,4 @@
-﻿# Copyright © 2017 Chocolatey Software, Inc.
+﻿# Copyright © 2017 - 2021 Chocolatey Software, Inc.
 # Copyright © 2011 - 2017 RealDimensions Software, LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey.resources/helpers/functions/Start-ChocolateyProcessAsAdmin.ps1
+++ b/src/chocolatey.resources/helpers/functions/Start-ChocolateyProcessAsAdmin.ps1
@@ -1,4 +1,4 @@
-﻿# Copyright © 2017 Chocolatey Software, Inc.
+﻿# Copyright © 2017 - 2021 Chocolatey Software, Inc.
 # Copyright © 2015 - 2017 RealDimensions Software, LLC
 # Copyright © 2011 - 2015 RealDimensions Software, LLC & original authors/contributors from https://github.com/chocolatey/chocolatey
 #

--- a/src/chocolatey.resources/helpers/functions/Test-ProcessAdminRights.ps1
+++ b/src/chocolatey.resources/helpers/functions/Test-ProcessAdminRights.ps1
@@ -1,4 +1,4 @@
-﻿# Copyright © 2017 Chocolatey Software, Inc.
+﻿# Copyright © 2017 - 2021 Chocolatey Software, Inc.
 # Copyright © 2015 - 2017 RealDimensions Software, LLC
 # Copyright © 2011 - 2015 RealDimensions Software, LLC & original authors/contributors from https://github.com/chocolatey/chocolatey
 #

--- a/src/chocolatey.resources/helpers/functions/UnInstall-ChocolateyZipPackage.ps1
+++ b/src/chocolatey.resources/helpers/functions/UnInstall-ChocolateyZipPackage.ps1
@@ -1,4 +1,4 @@
-﻿# Copyright © 2017 Chocolatey Software, Inc.
+﻿# Copyright © 2017 - 2021 Chocolatey Software, Inc.
 # Copyright © 2015 - 2017 RealDimensions Software, LLC
 # Copyright © 2011 - 2015 RealDimensions Software, LLC & original authors/contributors from https://github.com/chocolatey/chocolatey
 #

--- a/src/chocolatey.resources/helpers/functions/Uninstall-BinFile.ps1
+++ b/src/chocolatey.resources/helpers/functions/Uninstall-BinFile.ps1
@@ -1,4 +1,4 @@
-﻿# Copyright © 2017 Chocolatey Software, Inc.
+﻿# Copyright © 2017 - 2021 Chocolatey Software, Inc.
 # Copyright © 2015 - 2017 RealDimensions Software, LLC
 # Copyright © 2011 - 2015 RealDimensions Software, LLC & original authors/contributors from https://github.com/chocolatey/chocolatey
 #

--- a/src/chocolatey.resources/helpers/functions/Uninstall-ChocolateyEnvironmentVariable.ps1
+++ b/src/chocolatey.resources/helpers/functions/Uninstall-ChocolateyEnvironmentVariable.ps1
@@ -1,4 +1,4 @@
-﻿# Copyright © 2017 Chocolatey Software, Inc.
+﻿# Copyright © 2017 - 2021 Chocolatey Software, Inc.
 # Copyright © 2011 - 2017 RealDimensions Software, LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey.resources/helpers/functions/Uninstall-ChocolateyPackage.ps1
+++ b/src/chocolatey.resources/helpers/functions/Uninstall-ChocolateyPackage.ps1
@@ -1,4 +1,4 @@
-﻿# Copyright © 2017 Chocolatey Software, Inc.
+﻿# Copyright © 2017 - 2021 Chocolatey Software, Inc.
 # Copyright © 2015 - 2017 RealDimensions Software, LLC
 # Copyright © 2011 - 2015 RealDimensions Software, LLC & original authors/contributors from https://github.com/chocolatey/chocolatey
 #

--- a/src/chocolatey.resources/helpers/functions/Update-SessionEnvironment.ps1
+++ b/src/chocolatey.resources/helpers/functions/Update-SessionEnvironment.ps1
@@ -1,4 +1,4 @@
-﻿# Copyright © 2017 Chocolatey Software, Inc.
+﻿# Copyright © 2017 - 2021 Chocolatey Software, Inc.
 # Copyright © 2015 - 2017 RealDimensions Software, LLC
 # Copyright © 2011 - 2015 RealDimensions Software, LLC & original authors/contributors from https://github.com/chocolatey/chocolatey
 #

--- a/src/chocolatey.resources/helpers/functions/Write-ChocolateyFailure.ps1
+++ b/src/chocolatey.resources/helpers/functions/Write-ChocolateyFailure.ps1
@@ -1,4 +1,4 @@
-﻿# Copyright © 2017 Chocolatey Software, Inc.
+﻿# Copyright © 2017 - 2021 Chocolatey Software, Inc.
 # Copyright © 2015 - 2017 RealDimensions Software, LLC
 # Copyright © 2011 - 2015 RealDimensions Software, LLC & original authors/contributors from https://github.com/chocolatey/chocolatey
 #

--- a/src/chocolatey.resources/helpers/functions/Write-ChocolateySuccess.ps1
+++ b/src/chocolatey.resources/helpers/functions/Write-ChocolateySuccess.ps1
@@ -1,4 +1,4 @@
-﻿# Copyright © 2017 Chocolatey Software, Inc.
+﻿# Copyright © 2017 - 2021 Chocolatey Software, Inc.
 # Copyright © 2015 - 2017 RealDimensions Software, LLC
 # Copyright © 2011 - 2015 RealDimensions Software, LLC & original authors/contributors from https://github.com/chocolatey/chocolatey
 #

--- a/src/chocolatey.resources/helpers/functions/Write-FileUpdateLog.ps1
+++ b/src/chocolatey.resources/helpers/functions/Write-FileUpdateLog.ps1
@@ -1,4 +1,4 @@
-﻿# Copyright © 2017 Chocolatey Software, Inc.
+﻿# Copyright © 2017 - 2021 Chocolatey Software, Inc.
 # Copyright © 2015 - 2017 RealDimensions Software, LLC
 # Copyright © 2011 - 2015 RealDimensions Software, LLC & original authors/contributors from https://github.com/chocolatey/chocolatey
 #

--- a/src/chocolatey.resources/helpers/functions/Write-FunctionCallLogMessage.ps1
+++ b/src/chocolatey.resources/helpers/functions/Write-FunctionCallLogMessage.ps1
@@ -1,4 +1,4 @@
-﻿# Copyright © 2017 Chocolatey Software, Inc.
+﻿# Copyright © 2017 - 2021 Chocolatey Software, Inc.
 # Copyright © 2011 - 2017 RealDimensions Software, LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey.tests.integration/MockEventSubscriptionManager.cs
+++ b/src/chocolatey.tests.integration/MockEventSubscriptionManager.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey.tests.integration/NUnitSetup.cs
+++ b/src/chocolatey.tests.integration/NUnitSetup.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey.tests.integration/Properties/AssemblyInfo.cs
+++ b/src/chocolatey.tests.integration/Properties/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey.tests.integration/Scenario.cs
+++ b/src/chocolatey.tests.integration/Scenario.cs
@@ -1,4 +1,4 @@
-// Copyright © 2017 - 2018 Chocolatey Software, Inc
+// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey.tests.integration/TODO.cs
+++ b/src/chocolatey.tests.integration/TODO.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey.tests.integration/infrastructure.app/services/FilesServiceSpecs.cs
+++ b/src/chocolatey.tests.integration/infrastructure.app/services/FilesServiceSpecs.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey.tests.integration/infrastructure/commands/CommandExecutorSpecs.cs
+++ b/src/chocolatey.tests.integration/infrastructure/commands/CommandExecutorSpecs.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey.tests.integration/infrastructure/cryptography/CrytpoHashProviderSpecs.cs
+++ b/src/chocolatey.tests.integration/infrastructure/cryptography/CrytpoHashProviderSpecs.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey.tests.integration/infrastructure/filesystem/DotNetFileSystemSpecs.cs
+++ b/src/chocolatey.tests.integration/infrastructure/filesystem/DotNetFileSystemSpecs.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey.tests.integration/scenarios/InstallScenarios.cs
+++ b/src/chocolatey.tests.integration/scenarios/InstallScenarios.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey.tests.integration/scenarios/ListScenarios.cs
+++ b/src/chocolatey.tests.integration/scenarios/ListScenarios.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey.tests.integration/scenarios/PackScenarios.cs
+++ b/src/chocolatey.tests.integration/scenarios/PackScenarios.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey.tests.integration/scenarios/PinScenarios.cs
+++ b/src/chocolatey.tests.integration/scenarios/PinScenarios.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey.tests.integration/scenarios/UninstallScenarios.cs
+++ b/src/chocolatey.tests.integration/scenarios/UninstallScenarios.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey.tests.integration/scenarios/UpgradeScenarios.cs
+++ b/src/chocolatey.tests.integration/scenarios/UpgradeScenarios.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey.tests/MockLogger.cs
+++ b/src/chocolatey.tests/MockLogger.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey.tests/Properties/AssemblyInfo.cs
+++ b/src/chocolatey.tests/Properties/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey.tests/infrastructure.app/attributes/CommandForAttributeSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/attributes/CommandForAttributeSpecs.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey.tests/infrastructure.app/commands/ChocolateyApiKeyCommandSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/commands/ChocolateyApiKeyCommandSpecs.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey.tests/infrastructure.app/commands/ChocolateyConfigCommandSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/commands/ChocolateyConfigCommandSpecs.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey.tests/infrastructure.app/commands/ChocolateyExportCommandSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/commands/ChocolateyExportCommandSpecs.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey.tests/infrastructure.app/commands/ChocolateyFeatureCommandSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/commands/ChocolateyFeatureCommandSpecs.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey.tests/infrastructure.app/commands/ChocolateyHelpCommandSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/commands/ChocolateyHelpCommandSpecs.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey.tests/infrastructure.app/commands/ChocolateyInfoCommandSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/commands/ChocolateyInfoCommandSpecs.cs
@@ -1,4 +1,4 @@
-// Copyright © 2017 - 2018 Chocolatey Software, Inc
+// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey.tests/infrastructure.app/commands/ChocolateyInstallCommandSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/commands/ChocolateyInstallCommandSpecs.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey.tests/infrastructure.app/commands/ChocolateyListCommandSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/commands/ChocolateyListCommandSpecs.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey.tests/infrastructure.app/commands/ChocolateyNewCommandSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/commands/ChocolateyNewCommandSpecs.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey.tests/infrastructure.app/commands/ChocolateyOutdatedCommandSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/commands/ChocolateyOutdatedCommandSpecs.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey.tests/infrastructure.app/commands/ChocolateyPackCommandSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/commands/ChocolateyPackCommandSpecs.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey.tests/infrastructure.app/commands/ChocolateyPinCommandSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/commands/ChocolateyPinCommandSpecs.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey.tests/infrastructure.app/commands/ChocolateyPushCommandSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/commands/ChocolateyPushCommandSpecs.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey.tests/infrastructure.app/commands/ChocolateySourceCommandSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/commands/ChocolateySourceCommandSpecs.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey.tests/infrastructure.app/commands/ChocolateyUninstallCommandSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/commands/ChocolateyUninstallCommandSpecs.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey.tests/infrastructure.app/commands/ChocolateyUnpackSelfCommandSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/commands/ChocolateyUnpackSelfCommandSpecs.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey.tests/infrastructure.app/commands/ChocolateyUpgradeCommandSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/commands/ChocolateyUpgradeCommandSpecs.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey.tests/infrastructure.app/configuration/ConfigurationOptionsSpec.cs
+++ b/src/chocolatey.tests/infrastructure.app/configuration/ConfigurationOptionsSpec.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey.tests/infrastructure.app/nuget/NugetCommonSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/nuget/NugetCommonSpecs.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey.tests/infrastructure.app/services/AutomaticUninstallerServiceSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/services/AutomaticUninstallerServiceSpecs.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey.tests/infrastructure.app/services/FilesServiceSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/services/FilesServiceSpecs.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey.tests/infrastructure.app/services/NugetServiceSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/services/NugetServiceSpecs.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey.tests/infrastructure.app/services/RegistryServiceSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/services/RegistryServiceSpecs.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey.tests/infrastructure.app/services/TemplateServiceSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/services/TemplateServiceSpecs.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey.tests/infrastructure/commandline/InteractivePromptSpecs.cs
+++ b/src/chocolatey.tests/infrastructure/commandline/InteractivePromptSpecs.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey.tests/infrastructure/commands/CommandExecutorSpecs.cs
+++ b/src/chocolatey.tests/infrastructure/commands/CommandExecutorSpecs.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey.tests/infrastructure/commands/ExternalCommandArgsBuilderSpecs.cs
+++ b/src/chocolatey.tests/infrastructure/commands/ExternalCommandArgsBuilderSpecs.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey.tests/infrastructure/commands/PowershellExecutorSpecs.cs
+++ b/src/chocolatey.tests/infrastructure/commands/PowershellExecutorSpecs.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey.tests/infrastructure/configuration/ConfigSpecs.cs
+++ b/src/chocolatey.tests/infrastructure/configuration/ConfigSpecs.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey.tests/infrastructure/cryptography/CrytpoHashProviderSpecs.cs
+++ b/src/chocolatey.tests/infrastructure/cryptography/CrytpoHashProviderSpecs.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey.tests/infrastructure/events/EventSubscriptionManagerSpecs.cs
+++ b/src/chocolatey.tests/infrastructure/events/EventSubscriptionManagerSpecs.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey.tests/infrastructure/events/context/FakeEvent.cs
+++ b/src/chocolatey.tests/infrastructure/events/context/FakeEvent.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey.tests/infrastructure/events/context/FakeSubscriber.cs
+++ b/src/chocolatey.tests/infrastructure/events/context/FakeSubscriber.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey.tests/infrastructure/filesystem/DotNetFileSystemSpecs.cs
+++ b/src/chocolatey.tests/infrastructure/filesystem/DotNetFileSystemSpecs.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey.tests/infrastructure/guards/EnsureSpecs.cs
+++ b/src/chocolatey.tests/infrastructure/guards/EnsureSpecs.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey.tests/infrastructure/information/VersionInformationSpecs.cs
+++ b/src/chocolatey.tests/infrastructure/information/VersionInformationSpecs.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey.tests/infrastructure/platforms/PlatformSpecs.cs
+++ b/src/chocolatey.tests/infrastructure/platforms/PlatformSpecs.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey.tests/infrastructure/tokens/TokenReplacerSpecs.cs
+++ b/src/chocolatey.tests/infrastructure/tokens/TokenReplacerSpecs.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey.tests/infrastructure/tolerance/FaultToleranceSpecs.cs
+++ b/src/chocolatey.tests/infrastructure/tolerance/FaultToleranceSpecs.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/AssemblyExtensions.cs
+++ b/src/chocolatey/AssemblyExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/EnumExtensions.cs
+++ b/src/chocolatey/EnumExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/EnumerableExtensions.cs
+++ b/src/chocolatey/EnumerableExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/GetChocolatey.cs
+++ b/src/chocolatey/GetChocolatey.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2019 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/ILogExtensions.cs
+++ b/src/chocolatey/ILogExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/LogExtensions.cs
+++ b/src/chocolatey/LogExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/ObjectExtensions.cs
+++ b/src/chocolatey/ObjectExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/Properties/AssemblyInfo.cs
+++ b/src/chocolatey/Properties/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/StringExtensions.cs
+++ b/src/chocolatey/StringExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/TypeExtensions.cs
+++ b/src/chocolatey/TypeExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/ApplicationParameters.cs
+++ b/src/chocolatey/infrastructure.app/ApplicationParameters.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/attributes/CommandForAttribute.cs
+++ b/src/chocolatey/infrastructure.app/attributes/CommandForAttribute.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/builders/ConfigurationBuilder.cs
+++ b/src/chocolatey/infrastructure.app/builders/ConfigurationBuilder.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/commands/ChocolateyApiKeyCommand.cs
+++ b/src/chocolatey/infrastructure.app/commands/ChocolateyApiKeyCommand.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/commands/ChocolateyConfigCommand.cs
+++ b/src/chocolatey/infrastructure.app/commands/ChocolateyConfigCommand.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/commands/ChocolateyExportCommand.cs
+++ b/src/chocolatey/infrastructure.app/commands/ChocolateyExportCommand.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/commands/ChocolateyFeatureCommand.cs
+++ b/src/chocolatey/infrastructure.app/commands/ChocolateyFeatureCommand.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/commands/ChocolateyHelpCommand.cs
+++ b/src/chocolatey/infrastructure.app/commands/ChocolateyHelpCommand.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/commands/ChocolateyInfoCommand.cs
+++ b/src/chocolatey/infrastructure.app/commands/ChocolateyInfoCommand.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/commands/ChocolateyInstallCommand.cs
+++ b/src/chocolatey/infrastructure.app/commands/ChocolateyInstallCommand.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/commands/ChocolateyListCommand.cs
+++ b/src/chocolatey/infrastructure.app/commands/ChocolateyListCommand.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/commands/ChocolateyNewCommand.cs
+++ b/src/chocolatey/infrastructure.app/commands/ChocolateyNewCommand.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/commands/ChocolateyOutdatedCommand.cs
+++ b/src/chocolatey/infrastructure.app/commands/ChocolateyOutdatedCommand.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/commands/ChocolateyPackCommand.cs
+++ b/src/chocolatey/infrastructure.app/commands/ChocolateyPackCommand.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/commands/ChocolateyPinCommand.cs
+++ b/src/chocolatey/infrastructure.app/commands/ChocolateyPinCommand.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/commands/ChocolateyPushCommand.cs
+++ b/src/chocolatey/infrastructure.app/commands/ChocolateyPushCommand.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/commands/ChocolateySourceCommand.cs
+++ b/src/chocolatey/infrastructure.app/commands/ChocolateySourceCommand.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/commands/ChocolateyUninstallCommand.cs
+++ b/src/chocolatey/infrastructure.app/commands/ChocolateyUninstallCommand.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/commands/ChocolateyUnpackSelfCommand.cs
+++ b/src/chocolatey/infrastructure.app/commands/ChocolateyUnpackSelfCommand.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/commands/ChocolateyUpdateCommand.cs
+++ b/src/chocolatey/infrastructure.app/commands/ChocolateyUpdateCommand.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/commands/ChocolateyUpgradeCommand.cs
+++ b/src/chocolatey/infrastructure.app/commands/ChocolateyUpgradeCommand.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/commands/ChocolateyVersionCommand.cs
+++ b/src/chocolatey/infrastructure.app/commands/ChocolateyVersionCommand.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/configuration/ChocolateyConfiguration.cs
+++ b/src/chocolatey/infrastructure.app/configuration/ChocolateyConfiguration.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/configuration/ChocolateySource.cs
+++ b/src/chocolatey/infrastructure.app/configuration/ChocolateySource.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/configuration/ConfigFileApiKeySetting.cs
+++ b/src/chocolatey/infrastructure.app/configuration/ConfigFileApiKeySetting.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/configuration/ConfigFileConfigSetting.cs
+++ b/src/chocolatey/infrastructure.app/configuration/ConfigFileConfigSetting.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/configuration/ConfigFileFeatureSetting.cs
+++ b/src/chocolatey/infrastructure.app/configuration/ConfigFileFeatureSetting.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/configuration/ConfigFileSettings.cs
+++ b/src/chocolatey/infrastructure.app/configuration/ConfigFileSettings.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/configuration/ConfigFileSourceSetting.cs
+++ b/src/chocolatey/infrastructure.app/configuration/ConfigFileSourceSetting.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/configuration/ConfigurationOptions.cs
+++ b/src/chocolatey/infrastructure.app/configuration/ConfigurationOptions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/configuration/EnvironmentSettings.cs
+++ b/src/chocolatey/infrastructure.app/configuration/EnvironmentSettings.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/configuration/PackagesConfigFilePackageSetting.cs
+++ b/src/chocolatey/infrastructure.app/configuration/PackagesConfigFilePackageSetting.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/configuration/PackagesConfigFileSettings.cs
+++ b/src/chocolatey/infrastructure.app/configuration/PackagesConfigFileSettings.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/domain/ChocolateyPackageInformation.cs
+++ b/src/chocolatey/infrastructure.app/domain/ChocolateyPackageInformation.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/domain/CommandNameType.cs
+++ b/src/chocolatey/infrastructure.app/domain/CommandNameType.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/domain/ConfigCommandType.cs
+++ b/src/chocolatey/infrastructure.app/domain/ConfigCommandType.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/domain/FeatureCommandType.cs
+++ b/src/chocolatey/infrastructure.app/domain/FeatureCommandType.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/domain/GenericRegistryKey.cs
+++ b/src/chocolatey/infrastructure.app/domain/GenericRegistryKey.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/domain/GenericRegistryValue.cs
+++ b/src/chocolatey/infrastructure.app/domain/GenericRegistryValue.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/domain/InstallTokens.cs
+++ b/src/chocolatey/infrastructure.app/domain/InstallTokens.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/domain/InstallerType.cs
+++ b/src/chocolatey/infrastructure.app/domain/InstallerType.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/domain/PackageFile.cs
+++ b/src/chocolatey/infrastructure.app/domain/PackageFile.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/domain/PackageFiles.cs
+++ b/src/chocolatey/infrastructure.app/domain/PackageFiles.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/domain/PinCommandType.cs
+++ b/src/chocolatey/infrastructure.app/domain/PinCommandType.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/domain/Registry.cs
+++ b/src/chocolatey/infrastructure.app/domain/Registry.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/domain/RegistryApplicationKey.cs
+++ b/src/chocolatey/infrastructure.app/domain/RegistryApplicationKey.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/domain/RegistryHiveType.cs
+++ b/src/chocolatey/infrastructure.app/domain/RegistryHiveType.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/domain/RegistryValueExtensions.cs
+++ b/src/chocolatey/infrastructure.app/domain/RegistryValueExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2019 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/domain/RegistryValueKindType.cs
+++ b/src/chocolatey/infrastructure.app/domain/RegistryValueKindType.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/domain/SourceCommandType.cs
+++ b/src/chocolatey/infrastructure.app/domain/SourceCommandType.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/domain/SourceType.cs
+++ b/src/chocolatey/infrastructure.app/domain/SourceType.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/domain/installers/BitRockInstaller.cs
+++ b/src/chocolatey/infrastructure.app/domain/installers/BitRockInstaller.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/domain/installers/CustomInstaller.cs
+++ b/src/chocolatey/infrastructure.app/domain/installers/CustomInstaller.cs
@@ -1,4 +1,4 @@
-// Copyright © 2017 - 2018 Chocolatey Software, Inc
+// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/domain/installers/GhostInstaller.cs
+++ b/src/chocolatey/infrastructure.app/domain/installers/GhostInstaller.cs
@@ -1,4 +1,4 @@
-// Copyright © 2017 - 2018 Chocolatey Software, Inc
+// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/domain/installers/IInstaller.cs
+++ b/src/chocolatey/infrastructure.app/domain/installers/IInstaller.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/domain/installers/InnoSetupInstaller.cs
+++ b/src/chocolatey/infrastructure.app/domain/installers/InnoSetupInstaller.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/domain/installers/InstallForJInstaller.cs
+++ b/src/chocolatey/infrastructure.app/domain/installers/InstallForJInstaller.cs
@@ -1,4 +1,4 @@
-// Copyright © 2017 - 2018 Chocolatey Software, Inc
+// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/domain/installers/InstallShieldInstaller.cs
+++ b/src/chocolatey/infrastructure.app/domain/installers/InstallShieldInstaller.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/domain/installers/InstallerBase.cs
+++ b/src/chocolatey/infrastructure.app/domain/installers/InstallerBase.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/domain/installers/IzPackInstaller.cs
+++ b/src/chocolatey/infrastructure.app/domain/installers/IzPackInstaller.cs
@@ -1,4 +1,4 @@
-// Copyright © 2017 - 2018 Chocolatey Software, Inc
+// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/domain/installers/MsiInstaller.cs
+++ b/src/chocolatey/infrastructure.app/domain/installers/MsiInstaller.cs
@@ -1,4 +1,4 @@
-// Copyright © 2017 - 2018 Chocolatey Software, Inc
+// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/domain/installers/MsiPatchInstaller.cs
+++ b/src/chocolatey/infrastructure.app/domain/installers/MsiPatchInstaller.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/domain/installers/NsisInstaller.cs
+++ b/src/chocolatey/infrastructure.app/domain/installers/NsisInstaller.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/domain/installers/PackageForTheWebInstaller.cs
+++ b/src/chocolatey/infrastructure.app/domain/installers/PackageForTheWebInstaller.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/domain/installers/QtInstaller.cs
+++ b/src/chocolatey/infrastructure.app/domain/installers/QtInstaller.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/domain/installers/SetupFactoryInstaller.cs
+++ b/src/chocolatey/infrastructure.app/domain/installers/SetupFactoryInstaller.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/domain/installers/SquirrelInstaller.cs
+++ b/src/chocolatey/infrastructure.app/domain/installers/SquirrelInstaller.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/domain/installers/WindowsUpdateInstaller.cs
+++ b/src/chocolatey/infrastructure.app/domain/installers/WindowsUpdateInstaller.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/domain/installers/WiseInstaller.cs
+++ b/src/chocolatey/infrastructure.app/domain/installers/WiseInstaller.cs
@@ -1,4 +1,4 @@
-// Copyright © 2017 - 2018 Chocolatey Software, Inc
+// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/events/HandlePackageResultCompletedMessage.cs
+++ b/src/chocolatey/infrastructure.app/events/HandlePackageResultCompletedMessage.cs
@@ -1,4 +1,4 @@
-// Copyright © 2017 - 2018 Chocolatey Software, Inc
+// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/events/PostRunMessage.cs
+++ b/src/chocolatey/infrastructure.app/events/PostRunMessage.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/events/PreRunMessage.cs
+++ b/src/chocolatey/infrastructure.app/events/PreRunMessage.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/nuget/ChocolateyClientCertificateProvider.cs
+++ b/src/chocolatey/infrastructure.app/nuget/ChocolateyClientCertificateProvider.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/nuget/ChocolateyLocalPackageRepository.cs
+++ b/src/chocolatey/infrastructure.app/nuget/ChocolateyLocalPackageRepository.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/nuget/ChocolateyNugetCredentialProvider.cs
+++ b/src/chocolatey/infrastructure.app/nuget/ChocolateyNugetCredentialProvider.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/nuget/ChocolateyNugetLogger.cs
+++ b/src/chocolatey/infrastructure.app/nuget/ChocolateyNugetLogger.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/nuget/ChocolateyPackagePathResolver.cs
+++ b/src/chocolatey/infrastructure.app/nuget/ChocolateyPackagePathResolver.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/nuget/ChocolateyPhysicalFileSystem.cs
+++ b/src/chocolatey/infrastructure.app/nuget/ChocolateyPhysicalFileSystem.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/nuget/DictionaryPropertyProvider.cs
+++ b/src/chocolatey/infrastructure.app/nuget/DictionaryPropertyProvider.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/nuget/NuGetFileSystemExtensions.cs
+++ b/src/chocolatey/infrastructure.app/nuget/NuGetFileSystemExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/nuget/NugetCommon.cs
+++ b/src/chocolatey/infrastructure.app/nuget/NugetCommon.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/nuget/NugetEncryptionUtility.cs
+++ b/src/chocolatey/infrastructure.app/nuget/NugetEncryptionUtility.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/nuget/NugetList.cs
+++ b/src/chocolatey/infrastructure.app/nuget/NugetList.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/nuget/NugetPack.cs
+++ b/src/chocolatey/infrastructure.app/nuget/NugetPack.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/nuget/NugetPush.cs
+++ b/src/chocolatey/infrastructure.app/nuget/NugetPush.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/registration/ContainerBinding.cs
+++ b/src/chocolatey/infrastructure.app/registration/ContainerBinding.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/runners/ConsoleApplication.cs
+++ b/src/chocolatey/infrastructure.app/runners/ConsoleApplication.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/runners/GenericRunner.cs
+++ b/src/chocolatey/infrastructure.app/runners/GenericRunner.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/services/AutomaticUninstallerService.cs
+++ b/src/chocolatey/infrastructure.app/services/AutomaticUninstallerService.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/services/ChocolateyConfigSettingsService.cs
+++ b/src/chocolatey/infrastructure.app/services/ChocolateyConfigSettingsService.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/services/ChocolateyPackageInformationService.cs
+++ b/src/chocolatey/infrastructure.app/services/ChocolateyPackageInformationService.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/services/ChocolateyPackageService.cs
+++ b/src/chocolatey/infrastructure.app/services/ChocolateyPackageService.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/services/ConfigTransformService.cs
+++ b/src/chocolatey/infrastructure.app/services/ConfigTransformService.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/services/CygwinService.cs
+++ b/src/chocolatey/infrastructure.app/services/CygwinService.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/services/FilesService.cs
+++ b/src/chocolatey/infrastructure.app/services/FilesService.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -135,4 +135,4 @@ namespace chocolatey.infrastructure.app.services
             return new PackageFile { Path = file, Checksum = hash };
         }
     }
-}
+}

--- a/src/chocolatey/infrastructure.app/services/IAutomaticUninstallerService.cs
+++ b/src/chocolatey/infrastructure.app/services/IAutomaticUninstallerService.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/services/IChocolateyConfigSettingsService.cs
+++ b/src/chocolatey/infrastructure.app/services/IChocolateyConfigSettingsService.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/services/IChocolateyPackageInformationService.cs
+++ b/src/chocolatey/infrastructure.app/services/IChocolateyPackageInformationService.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/services/IChocolateyPackageService.cs
+++ b/src/chocolatey/infrastructure.app/services/IChocolateyPackageService.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/services/IConfigTransformService.cs
+++ b/src/chocolatey/infrastructure.app/services/IConfigTransformService.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/services/IFilesService.cs
+++ b/src/chocolatey/infrastructure.app/services/IFilesService.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/services/INugetService.cs
+++ b/src/chocolatey/infrastructure.app/services/INugetService.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2019 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/services/IPendingRebootService.cs
+++ b/src/chocolatey/infrastructure.app/services/IPendingRebootService.cs
@@ -1,4 +1,4 @@
-// Copyright © 2017 - 2018 Chocolatey Software, Inc
+// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/services/IPowershellService.cs
+++ b/src/chocolatey/infrastructure.app/services/IPowershellService.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/services/IRegistryService.cs
+++ b/src/chocolatey/infrastructure.app/services/IRegistryService.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/services/IShimGenerationService.cs
+++ b/src/chocolatey/infrastructure.app/services/IShimGenerationService.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/services/ISourceRunner.cs
+++ b/src/chocolatey/infrastructure.app/services/ISourceRunner.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/services/ITemplateService.cs
+++ b/src/chocolatey/infrastructure.app/services/ITemplateService.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/services/NugetService.cs
+++ b/src/chocolatey/infrastructure.app/services/NugetService.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/services/PendingRebootService.cs
+++ b/src/chocolatey/infrastructure.app/services/PendingRebootService.cs
@@ -1,4 +1,4 @@
-// Copyright © 2017 - 2018 Chocolatey Software, Inc
+// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/services/PowershellService.cs
+++ b/src/chocolatey/infrastructure.app/services/PowershellService.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/services/PythonService.cs
+++ b/src/chocolatey/infrastructure.app/services/PythonService.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/services/RegistryService.cs
+++ b/src/chocolatey/infrastructure.app/services/RegistryService.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/services/RubyGemsService.cs
+++ b/src/chocolatey/infrastructure.app/services/RubyGemsService.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/services/ShimGenerationService.cs
+++ b/src/chocolatey/infrastructure.app/services/ShimGenerationService.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/services/TemplateService.cs
+++ b/src/chocolatey/infrastructure.app/services/TemplateService.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/services/WebPiService.cs
+++ b/src/chocolatey/infrastructure.app/services/WebPiService.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/services/WindowsFeatureService.cs
+++ b/src/chocolatey/infrastructure.app/services/WindowsFeatureService.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/tasks/RemovePendingPackagesTask.cs
+++ b/src/chocolatey/infrastructure.app/tasks/RemovePendingPackagesTask.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/templates/ChocolateyBeforeModifyTemplate.cs
+++ b/src/chocolatey/infrastructure.app/templates/ChocolateyBeforeModifyTemplate.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/templates/ChocolateyInstallTemplate.cs
+++ b/src/chocolatey/infrastructure.app/templates/ChocolateyInstallTemplate.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/templates/ChocolateyLicenseFileTemplate.cs
+++ b/src/chocolatey/infrastructure.app/templates/ChocolateyLicenseFileTemplate.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/templates/ChocolateyReadMeTemplate.cs
+++ b/src/chocolatey/infrastructure.app/templates/ChocolateyReadMeTemplate.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/templates/ChocolateyTodoTemplate.cs
+++ b/src/chocolatey/infrastructure.app/templates/ChocolateyTodoTemplate.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/templates/ChocolateyUninstallTemplate.cs
+++ b/src/chocolatey/infrastructure.app/templates/ChocolateyUninstallTemplate.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/templates/ChocolateyVerificationFileTemplate.cs
+++ b/src/chocolatey/infrastructure.app/templates/ChocolateyVerificationFileTemplate.cs
@@ -1,4 +1,4 @@
-// Copyright © 2017 - 2018 Chocolatey Software, Inc
+// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/templates/NuspecTemplate.cs
+++ b/src/chocolatey/infrastructure.app/templates/NuspecTemplate.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/templates/TemplateValues.cs
+++ b/src/chocolatey/infrastructure.app/templates/TemplateValues.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/utility/ArgumentsUtility.cs
+++ b/src/chocolatey/infrastructure.app/utility/ArgumentsUtility.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/utility/PackageUtility.cs
+++ b/src/chocolatey/infrastructure.app/utility/PackageUtility.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/validations/GlobalConfigurationValidation.cs
+++ b/src/chocolatey/infrastructure.app/validations/GlobalConfigurationValidation.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/validations/SystemStateValidation.cs
+++ b/src/chocolatey/infrastructure.app/validations/SystemStateValidation.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure/adapters/Console.cs
+++ b/src/chocolatey/infrastructure/adapters/Console.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure/adapters/CustomString.cs
+++ b/src/chocolatey/infrastructure/adapters/CustomString.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure/adapters/DateTime.cs
+++ b/src/chocolatey/infrastructure/adapters/DateTime.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure/adapters/Environment.cs
+++ b/src/chocolatey/infrastructure/adapters/Environment.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure/adapters/HashAlgorithm.cs
+++ b/src/chocolatey/infrastructure/adapters/HashAlgorithm.cs
@@ -1,4 +1,4 @@
-// Copyright © 2017 - 2018 Chocolatey Software, Inc
+// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure/adapters/IAssembly.cs
+++ b/src/chocolatey/infrastructure/adapters/IAssembly.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure/adapters/IConsole.cs
+++ b/src/chocolatey/infrastructure/adapters/IConsole.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure/adapters/IDateTime.cs
+++ b/src/chocolatey/infrastructure/adapters/IDateTime.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure/adapters/IEncryptionUtility.cs
+++ b/src/chocolatey/infrastructure/adapters/IEncryptionUtility.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2019 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure/adapters/IEnvironment.cs
+++ b/src/chocolatey/infrastructure/adapters/IEnvironment.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure/adapters/IHashAlgorithm.cs
+++ b/src/chocolatey/infrastructure/adapters/IHashAlgorithm.cs
@@ -1,4 +1,4 @@
-// Copyright © 2017 - 2018 Chocolatey Software, Inc
+// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure/adapters/IProcess.cs
+++ b/src/chocolatey/infrastructure/adapters/IProcess.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure/adapters/Process.cs
+++ b/src/chocolatey/infrastructure/adapters/Process.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure/commandline/ExitScenarioHandler.cs
+++ b/src/chocolatey/infrastructure/commandline/ExitScenarioHandler.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure/commandline/InteractivePrompt.cs
+++ b/src/chocolatey/infrastructure/commandline/InteractivePrompt.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure/commandline/ReadKeyTimeout.cs
+++ b/src/chocolatey/infrastructure/commandline/ReadKeyTimeout.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure/commandline/ReadLineTimeout.cs
+++ b/src/chocolatey/infrastructure/commandline/ReadLineTimeout.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure/commands/CommandExecutor.cs
+++ b/src/chocolatey/infrastructure/commands/CommandExecutor.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure/commands/Execute.cs
+++ b/src/chocolatey/infrastructure/commands/Execute.cs
@@ -1,4 +1,4 @@
-// Copyright © 2017 - 2018 Chocolatey Software, Inc
+// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure/commands/ExternalCommandArgsBuilder.cs
+++ b/src/chocolatey/infrastructure/commands/ExternalCommandArgsBuilder.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure/commands/ExternalCommandArgument.cs
+++ b/src/chocolatey/infrastructure/commands/ExternalCommandArgument.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure/commands/ICommand.cs
+++ b/src/chocolatey/infrastructure/commands/ICommand.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure/commands/ICommandExecutor.cs
+++ b/src/chocolatey/infrastructure/commands/ICommandExecutor.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure/commands/IListCommand.cs
+++ b/src/chocolatey/infrastructure/commands/IListCommand.cs
@@ -1,4 +1,4 @@
-// Copyright © 2017 - 2018 Chocolatey Software, Inc
+// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure/commands/PowershellExecutor.cs
+++ b/src/chocolatey/infrastructure/commands/PowershellExecutor.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure/configuration/Config.cs
+++ b/src/chocolatey/infrastructure/configuration/Config.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure/cryptography/CryptoHashProvider.cs
+++ b/src/chocolatey/infrastructure/cryptography/CryptoHashProvider.cs
@@ -1,4 +1,4 @@
-// Copyright © 2017 - 2018 Chocolatey Software, Inc
+// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure/cryptography/CryptoHashProviderType.cs
+++ b/src/chocolatey/infrastructure/cryptography/CryptoHashProviderType.cs
@@ -1,4 +1,4 @@
-// Copyright © 2017 - 2018 Chocolatey Software, Inc
+// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure/cryptography/DefaultEncryptionUtility.cs
+++ b/src/chocolatey/infrastructure/cryptography/DefaultEncryptionUtility.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2019 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure/cryptography/IHashProvider.cs
+++ b/src/chocolatey/infrastructure/cryptography/IHashProvider.cs
@@ -1,4 +1,4 @@
-// Copyright © 2017 - 2018 Chocolatey Software, Inc
+// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure/events/EventManager.cs
+++ b/src/chocolatey/infrastructure/events/EventManager.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure/events/IMessage.cs
+++ b/src/chocolatey/infrastructure/events/IMessage.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure/extractors/AssemblyFileExtractor.cs
+++ b/src/chocolatey/infrastructure/extractors/AssemblyFileExtractor.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure/filesystem/DotNetFileSystem.cs
+++ b/src/chocolatey/infrastructure/filesystem/DotNetFileSystem.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure/filesystem/FileSystem.cs
+++ b/src/chocolatey/infrastructure/filesystem/FileSystem.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2019 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure/filesystem/IFileSystem.cs
+++ b/src/chocolatey/infrastructure/filesystem/IFileSystem.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure/guards/Ensure.cs
+++ b/src/chocolatey/infrastructure/guards/Ensure.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure/information/ProcessInformation.cs
+++ b/src/chocolatey/infrastructure/information/ProcessInformation.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure/information/VersionInformation.cs
+++ b/src/chocolatey/infrastructure/information/VersionInformation.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure/licensing/ChocolateyLicense.cs
+++ b/src/chocolatey/infrastructure/licensing/ChocolateyLicense.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure/licensing/ChocolateyLicenseType.cs
+++ b/src/chocolatey/infrastructure/licensing/ChocolateyLicenseType.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure/licensing/License.cs
+++ b/src/chocolatey/infrastructure/licensing/License.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2019 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure/licensing/LicenseValidation.cs
+++ b/src/chocolatey/infrastructure/licensing/LicenseValidation.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure/logging/AggregateLog.cs
+++ b/src/chocolatey/infrastructure/logging/AggregateLog.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure/logging/ChocolateyLoggers.cs
+++ b/src/chocolatey/infrastructure/logging/ChocolateyLoggers.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure/logging/ILog.cs
+++ b/src/chocolatey/infrastructure/logging/ILog.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure/logging/Log.cs
+++ b/src/chocolatey/infrastructure/logging/Log.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure/logging/Log4NetAppenderConfiguration.cs
+++ b/src/chocolatey/infrastructure/logging/Log4NetAppenderConfiguration.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure/logging/Log4NetLog.cs
+++ b/src/chocolatey/infrastructure/logging/Log4NetLog.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure/logging/LogLevelType.cs
+++ b/src/chocolatey/infrastructure/logging/LogLevelType.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure/logging/LogMessage.cs
+++ b/src/chocolatey/infrastructure/logging/LogMessage.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure/logging/LogSinkLog.cs
+++ b/src/chocolatey/infrastructure/logging/LogSinkLog.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure/logging/NullLog.cs
+++ b/src/chocolatey/infrastructure/logging/NullLog.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure/logging/TraceLog.cs
+++ b/src/chocolatey/infrastructure/logging/TraceLog.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure/platforms/Platform.cs
+++ b/src/chocolatey/infrastructure/platforms/Platform.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure/platforms/PlatformType.cs
+++ b/src/chocolatey/infrastructure/platforms/PlatformType.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure/powershell/PoshHost.cs
+++ b/src/chocolatey/infrastructure/powershell/PoshHost.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure/powershell/PoshHostRawUserInterface.cs
+++ b/src/chocolatey/infrastructure/powershell/PoshHostRawUserInterface.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure/powershell/PoshHostUserInterface.cs
+++ b/src/chocolatey/infrastructure/powershell/PoshHostUserInterface.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure/registration/AssemblyResolution.cs
+++ b/src/chocolatey/infrastructure/registration/AssemblyResolution.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2019 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure/registration/Bootstrap.cs
+++ b/src/chocolatey/infrastructure/registration/Bootstrap.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure/registration/SecurityProtocol.cs
+++ b/src/chocolatey/infrastructure/registration/SecurityProtocol.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure/registration/SimpleInjectorContainer.cs
+++ b/src/chocolatey/infrastructure/registration/SimpleInjectorContainer.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure/registration/SimpleInjectorContainerResolutionBehavior.cs
+++ b/src/chocolatey/infrastructure/registration/SimpleInjectorContainerResolutionBehavior.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure/results/IResult.cs
+++ b/src/chocolatey/infrastructure/results/IResult.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure/results/PackageResult.cs
+++ b/src/chocolatey/infrastructure/results/PackageResult.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure/results/PowerShellExecutionResults.cs
+++ b/src/chocolatey/infrastructure/results/PowerShellExecutionResults.cs
@@ -1,4 +1,4 @@
-// Copyright © 2017 - 2018 Chocolatey Software, Inc
+// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure/results/Result.cs
+++ b/src/chocolatey/infrastructure/results/Result.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure/results/ResultMessage.cs
+++ b/src/chocolatey/infrastructure/results/ResultMessage.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure/results/ResultType.cs
+++ b/src/chocolatey/infrastructure/results/ResultType.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure/services/EventSubscriptionManagerService.cs
+++ b/src/chocolatey/infrastructure/services/EventSubscriptionManagerService.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure/services/IDateTimeService.cs
+++ b/src/chocolatey/infrastructure/services/IDateTimeService.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure/services/IEventSubscriptionManagerService.cs
+++ b/src/chocolatey/infrastructure/services/IEventSubscriptionManagerService.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure/services/IRegularExpressionService.cs
+++ b/src/chocolatey/infrastructure/services/IRegularExpressionService.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure/services/IXmlService.cs
+++ b/src/chocolatey/infrastructure/services/IXmlService.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure/services/RegularExpressionService.cs
+++ b/src/chocolatey/infrastructure/services/RegularExpressionService.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure/services/SystemDateTimeService.cs
+++ b/src/chocolatey/infrastructure/services/SystemDateTimeService.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure/services/SystemDateTimeUtcService.cs
+++ b/src/chocolatey/infrastructure/services/SystemDateTimeUtcService.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure/services/XmlService.cs
+++ b/src/chocolatey/infrastructure/services/XmlService.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure/synchronization/GlobalMutex.cs
+++ b/src/chocolatey/infrastructure/synchronization/GlobalMutex.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure/tasks/ITask.cs
+++ b/src/chocolatey/infrastructure/tasks/ITask.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure/tokens/TokenReplacer.cs
+++ b/src/chocolatey/infrastructure/tokens/TokenReplacer.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure/tolerance/FaultTolerance.cs
+++ b/src/chocolatey/infrastructure/tolerance/FaultTolerance.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure/validations/IValidation.cs
+++ b/src/chocolatey/infrastructure/validations/IValidation.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure/validations/ValidationResult.cs
+++ b/src/chocolatey/infrastructure/validations/ValidationResult.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure/validations/ValidationStatus.cs
+++ b/src/chocolatey/infrastructure/validations/ValidationStatus.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2018 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure/xml/XmlCData.cs
+++ b/src/chocolatey/infrastructure/xml/XmlCData.cs
@@ -1,4 +1,4 @@
-// Copyright © 2017 - 2018 Chocolatey Software, Inc
+// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
As an initial change for #2261, this changes the Chocolatey Software, Inc copyright heading to - 2021 rather than other years.

It should probably be addressed by an automated GitHub Action (or similar) going forward.