### PR TITLE
(doc) fix typo in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ If you are using a [commercial edition of Chocolatey](https://chocolatey.org/com
 ## Information
  * [Chocolatey Website and Community Package Repository](https://community.chocolatey.org)
  * [Mailing List](http://groups.google.com/group/chocolatey) / [Release Announcements Only Mailing List](https://groups.google.com/group/chocolatey-announce) / [Build Status Mailing List](http://groups.google.com/group/chocolatey-build-status)
- * [Twitter](https://twitter.com/chocolateynuget) / [Facebook](https://www.facebook.com/ChocolateySoftware) / [Github](https://github.com/chocolatey)
+ * [Twitter](https://twitter.com/chocolateynuget) / [Facebook](https://www.facebook.com/ChocolateySoftware) / [GitHub](https://github.com/chocolatey)
  * [Blog](https://blog.chocolatey.org/) / [Newsletter](https://chocolatey.us8.list-manage1.com/subscribe?u=86a6d80146a0da7f2223712e4&id=73b018498d)
  * [Documentation](https://docs.chocolatey.org/en-us/) / [Support](https://chocolatey.org/support)
 


### PR DESCRIPTION
Fixed GitHub format in README.md.
```diff
-  Github
+  GitHub
```
<!--
BEFORE YOU CREATE A PULL REQUEST:

Ensure you have read over CONTRIBUTING - https://github.com/chocolatey/choco/blob/master/CONTRIBUTING.md. We provide VERY defined guidance (as such, we strongly adhere to it).

A summary of our expectations:
 - You are not submitting a pull request from your MASTER branch.
 - You are able to sign the Contributor License Agreement (CLA).
 - YOUR GIT COMMIT MESSAGE FORMAT IS EXTREMELY IMPORTANT. We have a very defined expectation for this format and are sticklers about it. Really, READ the entire Contributing document. It will save you and us pain.
 - Do not reformat code, it makes it hard to see what has changed. Leave the formatting to us.

THANKS! We appreciate you reading the entire Contributing document and not just scanning through it.

DELETE EVERYTHING IN THIS COMMENT BLOCK
-->
