### PR TITLE
(#2076) Pack always truncate stream

### DIFF
--- a/src/chocolatey/infrastructure.app/nuget/NugetPack.cs
+++ b/src/chocolatey/infrastructure.app/nuget/NugetPack.cs
@@ -36,6 +36,11 @@ namespace chocolatey.infrastructure.app.nuget
             {
                 using (Stream stream = fileSystem.create_file(outputPath))
                 {
+                    // Truncate if needed, as Mono fails to truncate
+                    if (stream.Length > 0)
+                    {
+                        stream.SetLength(0);
+                    }
                     builder.Save(stream);
                 }
             }


### PR DESCRIPTION
Mono does not truncate streams in System.IO.Packaging.Package.Open
when using FileMode.Create, while .Net does. mono/mono#21055

This always truncates the stream at the start.

Fixes #2076

<!--
BEFORE YOU CREATE A PULL REQUEST:

Ensure you have read over CONTRIBUTING - https://github.com/chocolatey/choco/blob/master/CONTRIBUTING.md. We provide VERY defined guidance (as such, we strongly adhere to it).

A summary of our expectations:
 - You are not submitting a pull request from your MASTER branch.
 - You are able to sign the Contributor License Agreement (CLA).
 - YOUR GIT COMMIT MESSAGE FORMAT IS EXTREMELY IMPORTANT. We have a very defined expectation for this format and are sticklers about it. Really, READ the entire Contributing document. It will save you and us pain.
 - Do not reformat code, it makes it hard to see what has changed. Leave the formatting to us.

THANKS! We appreciate you reading the entire Contributing document and not just scanning through it.

DELETE EVERYTHING IN THIS COMMENT BLOCK
-->
