### PR TITLE
(#1541) Add priority ordering for repository optimizations

### DIFF
--- a/src/chocolatey.tests.integration/scenarios/InstallScenarios.cs
+++ b/src/chocolatey.tests.integration/scenarios/InstallScenarios.cs
@@ -2993,6 +2993,154 @@ namespace chocolatey.tests.integration.scenarios
         }
 
         [Concern(typeof(ChocolateyInstallCommand))]
+        public class when_installing_new_package_from_priority_source_with_repository_optimization : ScenariosBase
+        {
+            public override void Context()
+            {
+                base.Context();
+                Configuration.PackageNames = Configuration.Input = "upgradepackage";
+                Configuration.Features.UsePackageRepositoryOptimizations = true;
+                Configuration.Sources = Configuration.Sources + ";chocolatey"; // Needed, otherwise we can't do repository optimizations
+                Configuration.MachineSources.Add(new MachineSourceConfiguration
+                {
+                    Name = "chocolatey",
+                    Key = "https://community.chocolatey.org/api/v2"
+                });
+                Scenario.add_packages_to_source_location(Configuration, "upgradepackage.1.1.0*" + Constants.PackageExtension);
+                Scenario.add_packages_to_priority_source_location(Configuration, "upgradepackage.1.0.0*" + Constants.PackageExtension);
+            }
+
+            public override void Because()
+            {
+                Results = Service.install_run(Configuration);
+            }
+
+            [Fact]
+            public void should_install_where_install_location_reports()
+            {
+                foreach (var packageResult in Results)
+                {
+                    Directory.Exists(packageResult.Value.InstallLocation).ShouldBeTrue();
+                }
+            }
+
+            [Fact]
+            public void should_install_a_package_in_the_lib_directory()
+            {
+                var packageDir = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames);
+
+                Directory.Exists(packageDir).ShouldBeTrue();
+            }
+
+            [Fact]
+            public void should_install_lower_version_of_package()
+            {
+                foreach (var packageResult in Results)
+                {
+                    packageResult.Value.Version.ShouldEqual("1.0.0");
+                }
+            }
+
+            [Fact]
+            public void should_have_a_successful_package_result()
+            {
+                foreach (var packageResult in Results)
+                {
+                    packageResult.Value.Success.ShouldBeTrue();
+                }
+            }
+
+            [Fact]
+            public void should_not_have_inconclusive_package_result()
+            {
+                foreach (var packageResult in Results)
+                {
+                    packageResult.Value.Inconclusive.ShouldBeFalse();
+                }
+            }
+
+            [Fact]
+            public void should_not_have_warning_package_result()
+            {
+                foreach (var packageResult in Results)
+                {
+                    packageResult.Value.Warning.ShouldBeFalse();
+                }
+            }
+        }
+
+
+        [Concern(typeof(ChocolateyInstallCommand))]
+        public class when_installing_new_package_from_priority_source : ScenariosBase
+        {
+            public override void Context()
+            {
+                base.Context();
+                Configuration.PackageNames = Configuration.Input = "upgradepackage";
+                Scenario.add_packages_to_source_location(Configuration, "upgradepackage.1.1.0*" + Constants.PackageExtension);
+                Scenario.add_packages_to_priority_source_location(Configuration, "upgradepackage.1.0.0*" + Constants.PackageExtension);
+            }
+
+            public override void Because()
+            {
+                Results = Service.install_run(Configuration);
+            }
+
+            [Fact]
+            public void should_install_where_install_location_reports()
+            {
+                foreach (var packageResult in Results)
+                {
+                    Directory.Exists(packageResult.Value.InstallLocation).ShouldBeTrue();
+                }
+            }
+
+            [Fact]
+            public void should_install_a_package_in_the_lib_directory()
+            {
+                var packageDir = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames);
+
+                Directory.Exists(packageDir).ShouldBeTrue();
+            }
+
+            [Fact]
+            public void should_install_lower_version_of_package()
+            {
+                foreach (var packageResult in Results)
+                {
+                    packageResult.Value.Version.ShouldEqual("1.0.0");
+                }
+            }
+
+            [Fact]
+            public void should_have_a_successful_package_result()
+            {
+                foreach (var packageResult in Results)
+                {
+                    packageResult.Value.Success.ShouldBeTrue();
+                }
+            }
+
+            [Fact]
+            public void should_not_have_inconclusive_package_result()
+            {
+                foreach (var packageResult in Results)
+                {
+                    packageResult.Value.Inconclusive.ShouldBeFalse();
+                }
+            }
+
+            [Fact]
+            public void should_not_have_warning_package_result()
+            {
+                foreach (var packageResult in Results)
+                {
+                    packageResult.Value.Warning.ShouldBeFalse();
+                }
+            }
+        }
+
+        [Concern(typeof(ChocolateyInstallCommand))]
         public class when_installing_a_package_with_a_dependent_package_that_also_depends_on_a_less_constrained_but_still_valid_dependency_of_the_same_package : ScenariosBase
         {
             public override void Context()

--- a/src/chocolatey/chocolatey.csproj
+++ b/src/chocolatey/chocolatey.csproj
@@ -116,6 +116,7 @@
     <Compile Include="infrastructure.app\commands\ChocolateyExportCommand.cs" />
     <Compile Include="infrastructure.app\commands\ChocolateyInfoCommand.cs" />
     <Compile Include="infrastructure.app\commands\ChocolateyHelpCommand.cs" />
+    <Compile Include="infrastructure.app\nuget\PriorityAggregateRepository.cs" />
     <Compile Include="infrastructure\cryptography\DefaultEncryptionUtility.cs" />
     <Compile Include="infrastructure\adapters\IEncryptionUtility.cs" />
     <Compile Include="infrastructure.app\validations\GlobalConfigurationValidation.cs" />

--- a/src/chocolatey/infrastructure.app/nuget/PriorityAggregateRepository.cs
+++ b/src/chocolatey/infrastructure.app/nuget/PriorityAggregateRepository.cs
@@ -1,0 +1,160 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using chocolatey.infrastructure.app.configuration;
+using NuGet;
+
+namespace chocolatey.infrastructure.app.nuget
+{
+    /// <summary>
+    /// Helper file for grouping repositories with a distinct priory set.
+    /// </summary>
+    /// <seealso cref="NuGet.AggregateRepository" />
+    public class PriorityAggregateRepository : PackageRepositoryBase, IPackageLookup, IDependencyResolver
+    {
+        private const string SourceValue = "(Priority Aggregate source)";
+        private readonly ConcurrentDictionary<int, List<IPackageRepository>> _repositories = new ConcurrentDictionary<int, List<IPackageRepository>>();
+        private readonly ChocolateyConfiguration _configuration;
+
+        public ILogger Logger { get; set; }
+
+        public override string Source { get { return SourceValue; } }
+
+        public override bool SupportsPrereleasePackages
+        {
+            get
+            {
+                return _repositories.Any(r => r.Value.Any(p => p.SupportsPrereleasePackages));
+            }
+        }
+
+        public PriorityAggregateRepository(IPackageRepository repository, ChocolateyConfiguration configuration)
+        {
+            Logger = NullLogger.Instance;
+            _configuration = configuration;
+            AddRepository(0, repository);
+        }
+
+        public void AddRepository(int priority, IPackageRepository repository)
+        {
+            _repositories.AddOrUpdate(priority, (p) => new List<IPackageRepository> { repository }, (p, existingRepositories) =>
+             {
+                 existingRepositories.Add(repository);
+                 return existingRepositories;
+             });
+        }
+
+        public override IQueryable<IPackage> GetPackages()
+        {
+            return GetOrderedRepositories()
+                .SelectMany(r => r.Item2.SelectMany(i => i.GetPackages())).AsQueryable();
+        }
+
+        /// <summary>
+        /// Gets the ordered repositories in the order of priories that is wanted.
+        /// Will first return any positive non-zero integer in a descending order,
+        /// and will negative and zero integer priories in a descending order.
+        /// </summary>
+        public IEnumerable<Tuple<int,List<IPackageRepository>>> GetOrderedRepositories()
+        {
+            var result = new List<Tuple<int, List<IPackageRepository>>>();
+            foreach (var repository in _repositories.Where(r => r.Key > 0).OrderBy(r => r.Key))
+            {
+                result.Add(new Tuple<int, List<IPackageRepository>>(repository.Key, repository.Value));
+            }
+
+            foreach (var repository in _repositories.Where(r => r.Key <= 0).OrderByDescending(r => r.Key))
+            {
+                result.Add(new Tuple<int, List<IPackageRepository>>(repository.Key, repository.Value));
+            }
+
+            return result;
+        }
+
+        public bool Exists(string packageId, SemanticVersion version)
+        {
+            throw new NotImplementedException();
+        }
+
+        public IPackage FindPackage(string packageId, SemanticVersion version)
+        {
+            return NugetList.find_package(packageId, version, _configuration, this);
+        }
+
+        public IEnumerable<IPackage> FindPackagesById(string packageId)
+        {
+            foreach (var repository in GetOrderedRepositories())
+            {
+                var results = repository.Item2.SelectMany(i => i.FindPackagesById(packageId)).ToList();
+                if (results.Count > 0)
+                {
+                    return results;
+                }
+            }
+
+            return Enumerable.Empty<IPackage>();
+        }
+
+        public IPackage ResolveDependency(PackageDependency dependency, IPackageConstraintProvider constraintProvider, bool allowPrereleaseVersions, bool preferListedPackages, DependencyVersion dependencyVersion)
+        {
+            // Naive dependency resolving
+            foreach (var repositories in GetOrderedRepositories())
+            {
+                IPackage package = null;
+                foreach (var repository in repositories.Item2)
+                {
+                    var foundPackage = repository.ResolveDependency(dependency, constraintProvider, allowPrereleaseVersions, preferListedPackages, dependencyVersion);
+                    if (package == null)
+                    {
+                        package = foundPackage;
+                    }
+                    else if (foundPackage.Version > package.Version)
+                    {
+                        package = foundPackage;
+                    }
+                }
+
+                if (package != null)
+                {
+                    return package;
+                }
+            }
+
+            return null;
+        }
+
+        public AggregateRepository ToAggregateRepository()
+        {
+            var repositories = GetRepositories(GetOrderedRepositories().SelectMany(r => r.Item2));
+
+            return new AggregateRepository(repositories, ignoreFailingRepositories: true)
+            {
+                IgnoreFailingRepositories = true,
+                Logger = Logger,
+                ResolveDependenciesVertically = true
+            };
+        }
+
+        private IEnumerable<IPackageRepository> GetRepositories(IEnumerable<IPackageRepository> repositories)
+        {
+            var newRepositories = new List<IPackageRepository>();
+
+            foreach (var repository in repositories)
+            {
+                var aggregateRepository = repository as AggregateRepository;
+                if (aggregateRepository != null)
+                {
+                    newRepositories.AddRange(GetRepositories(aggregateRepository.Repositories));
+                }
+                else
+                {
+                    newRepositories.Add(repository);
+                }
+            }
+
+            return newRepositories;
+        }
+    }
+}


### PR DESCRIPTION
This pull requests re-adds the ability to order sources by priority when installing and upgrading packages.

fixes #1541
