### PR TITLE
(#2287) Improvements to Tab Expansion

### DIFF
--- a/src/chocolatey.resources/helpers/ChocolateyTabExpansion.ps1
+++ b/src/chocolatey.resources/helpers/ChocolateyTabExpansion.ps1
@@ -111,17 +111,17 @@ function ChocolateyTabExpansion($lastBlock) {
   switch -regex ($lastBlock -replace "^$(Get-AliasPattern choco) ","") {
 
     # Handles uninstall package names
-    "^uninstall\s+(?<package>[^\.][^-\s]*)$" {
+    "^uninstall.*\s+(?<package>[^-\.\s][^\s]*)$" {
       chocoLocalPackages $matches['package']
     }
 
     # Handles install package names
-    "^(install)\s+(?<package>[^\.][^-\s]+)$" {
+    "^(install).*\s+(?<package>[^-\.\s][^\s]*)$" {
       chocoRemotePackages $matches['package']
     }
 
     # Handles upgrade / uninstall package names
-    "^upgrade\s+(?<package>[^\.][^-\s]*)$" {
+    "^upgrade.*\s+(?<package>[^-\.\s][^\s]*)$" {
       chocoLocalPackagesUpgrade $matches['package']
     }
 


### PR DESCRIPTION
Previously, when installing, updating, or uninstalling packages, the
tab expansion would only occur for the first item. Further, the tab
expansion would not work if the search term contained a dash.

Now tab expansion works for all items, and items can contain dashes
as long as it does not start with dash.

