### PR TITLE
(#877) Set SourceType for packages parsed from config

### DIFF
--- a/src/chocolatey.tests/chocolatey.tests.csproj
+++ b/src/chocolatey.tests/chocolatey.tests.csproj
@@ -108,6 +108,7 @@
     <Compile Include="infrastructure.app\configuration\ConfigurationOptionsSpec.cs" />
     <Compile Include="infrastructure.app\nuget\NugetCommonSpecs.cs" />
     <Compile Include="infrastructure.app\services\AutomaticUninstallerServiceSpecs.cs" />
+    <Compile Include="infrastructure.app\services\ChocolateyPackageServiceSpecs.cs" />
     <Compile Include="infrastructure.app\services\FilesServiceSpecs.cs" />
     <Compile Include="infrastructure.app\services\NugetServiceSpecs.cs" />
     <Compile Include="infrastructure.app\services\RegistryServiceSpecs.cs" />

--- a/src/chocolatey.tests/infrastructure.app/services/ChocolateyPackageServiceSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/services/ChocolateyPackageServiceSpecs.cs
@@ -1,0 +1,145 @@
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+// Copyright © 2011 - 2017 RealDimensions Software, LLC
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// 
+// You may obtain a copy of the License at
+// 
+// 	http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using chocolatey.infrastructure.app.configuration;
+using chocolatey.infrastructure.app.domain;
+using chocolatey.infrastructure.app.services;
+using chocolatey.infrastructure.filesystem;
+using chocolatey.infrastructure.results;
+using chocolatey.infrastructure.services;
+using Moq;
+using NuGet;
+using NUnit.Framework;
+using Should;
+using IFileSystem = chocolatey.infrastructure.filesystem.IFileSystem;
+
+namespace chocolatey.tests.infrastructure.app.services
+{
+    public class ChocolateyPackageServiceSpecs
+    {
+        public abstract class ChocolateyPackageServiceSpecsBase : TinySpec
+        {
+            protected ChocolateyPackageService Service;
+            protected Mock<INugetService> NugetService = new Mock<INugetService>();
+            protected Mock<IPowershellService> PowershellService = new Mock<IPowershellService>();
+            protected List<ISourceRunner> SourceRunners = new List<ISourceRunner>();
+            protected Mock<IShimGenerationService> ShimGenerationService = new Mock<IShimGenerationService>();
+            protected Mock<IFileSystem> FileSystem = new Mock<IFileSystem>();
+            protected Mock<IRegistryService> RegistryService = new Mock<IRegistryService>();
+            protected Mock<IChocolateyPackageInformationService> ChocolateyPackageInformationService = new Mock<IChocolateyPackageInformationService>();
+            protected Mock<IFilesService> FilesService = new Mock<IFilesService>();
+            protected Mock<IAutomaticUninstallerService> AutomaticUninstallerService = new Mock<IAutomaticUninstallerService>();
+            protected Mock<IXmlService> XmlService = new Mock<IXmlService>();
+            protected Mock<IConfigTransformService> ConfigTransformService = new Mock<IConfigTransformService>();
+
+            protected ChocolateyConfiguration Configuration = new ChocolateyConfiguration();
+
+            public override void Context()
+            {
+                NugetService.ResetCalls();
+                PowershellService.ResetCalls();
+                ShimGenerationService.ResetCalls();
+                FileSystem.ResetCalls();
+                RegistryService.ResetCalls();
+                ChocolateyPackageInformationService.ResetCalls();
+                FilesService.ResetCalls();
+                AutomaticUninstallerService.ResetCalls();
+                XmlService.ResetCalls();
+                ConfigTransformService.ResetCalls();
+                Service = new ChocolateyPackageService(NugetService.Object, PowershellService.Object, SourceRunners, ShimGenerationService.Object, FileSystem.Object, RegistryService.Object, ChocolateyPackageInformationService.Object, FilesService.Object, AutomaticUninstallerService.Object, XmlService.Object, ConfigTransformService.Object);
+            }
+        }
+
+        public class when_ChocolateyPackageService_install_from_package_config_with_custom_sources : ChocolateyPackageServiceSpecsBase
+        {
+            protected Mock<ISourceRunner> FeaturesRunner = new Mock<ISourceRunner>();
+            protected Mock<ISourceRunner> NormalRunner = new Mock<ISourceRunner>();
+            private ConcurrentDictionary<string, PackageResult> result;
+
+            public override void Context()
+            {
+                base.Context();
+
+                Configuration.PackageNames = @"C:\test\packages.config";
+                Configuration.Sources = @"C:\test";
+
+                NormalRunner.Setup(r => r.SourceType).Returns(SourceType.normal);
+                FeaturesRunner.Setup(r => r.SourceType).Returns(SourceType.windowsfeatures);
+
+                var package = new Mock<IPackage>();
+                var expectedResult = new ConcurrentDictionary<string, PackageResult>();
+                expectedResult.TryAdd("test-feature", new PackageResult(package.Object, "windowsfeatures", null));
+
+                FeaturesRunner.Setup(r => r.install_run(It.IsAny<ChocolateyConfiguration>(), It.IsAny<Action<PackageResult>>()))
+                    .Returns(expectedResult);
+                NormalRunner.Setup(r => r.install_run(It.IsAny<ChocolateyConfiguration>(), It.IsAny<Action<PackageResult>>()))
+                    .Returns(new ConcurrentDictionary<string, PackageResult>());
+                SourceRunners.AddRange(new []{ NormalRunner.Object, FeaturesRunner.Object });
+
+                FileSystem.Setup(f => f.get_full_path(Configuration.PackageNames)).Returns(Configuration.PackageNames);
+                FileSystem.Setup(f => f.file_exists(Configuration.PackageNames)).Returns(true);
+
+                XmlService.Setup(x => x.deserialize<PackagesConfigFileSettings>(Configuration.PackageNames))
+                    .Returns(new PackagesConfigFileSettings
+                    {
+                        Packages = new HashSet<PackagesConfigFilePackageSetting>
+                        {
+                            new PackagesConfigFilePackageSetting
+                            {
+                                Id = "test-feature",
+                                Source = "windowsfeatures"
+                            }
+                        }
+                    });
+            }
+
+            public override void Because()
+            {
+                result = Service.install_run(Configuration);
+            }
+
+            [Test]
+            public void should_return_package_that_should_have_been_installed()
+            {
+                result.Keys.ShouldContain("test-feature");
+            }
+
+            [Test]
+            public void should_have_called_runner_for_windows_features_source()
+            {
+                FeaturesRunner.Verify(r => r.install_run(It.Is<ChocolateyConfiguration>(c => c.PackageNames == "test-feature"), It.IsAny<Action<PackageResult>>()), Times.Once);
+            }
+
+            [Test]
+            public void should_not_have_called_runner_for_windows_features_source_with_other_package_names()
+            {
+                FeaturesRunner.Verify(r => r.install_run(It.Is<ChocolateyConfiguration>(c => c.PackageNames != "test-feature"), It.IsAny<Action<PackageResult>>()), Times.Never);
+            }
+
+            [Test]
+            public void should_not_have_called_normal_source_runner_for_non_empty_packages()
+            {
+                // The normal source runners will be called with an argument
+                NormalRunner.Verify(r => r.install_run(It.Is<ChocolateyConfiguration>(c => c.PackageNames != string.Empty), It.IsAny<Action<PackageResult>>()), Times.Never);
+            }
+        }
+    }
+}

--- a/src/chocolatey/infrastructure.app/services/ChocolateyPackageService.cs
+++ b/src/chocolatey/infrastructure.app/services/ChocolateyPackageService.cs
@@ -722,6 +722,8 @@ Would have determined packages that are out of date based on what is
                     if (pkgSettings.IgnoreDependencies) packageConfig.IgnoreDependencies = true;
                     if (pkgSettings.ApplyInstallArgumentsToDependencies) packageConfig.ApplyInstallArgumentsToDependencies = true;
                     if (pkgSettings.ApplyPackageParametersToDependencies) packageConfig.ApplyPackageParametersToDependencies = true;
+                    SourceType sourceType;
+                    if (Enum.TryParse(pkgSettings.Source, true, out sourceType)) packageConfig.SourceType = sourceType;
 
                     this.Log().Info(ChocolateyLoggers.Important, @"{0}".format_with(packageConfig.PackageNames));
                     packageConfigs.Add(packageConfig);


### PR DESCRIPTION
This commit updates the handling of packages when they are read from
a `.config` file to make sure that the SourceType property will be
correctly set.

This was needed for subsequent code to resolve the Source Runner correctly
when the specified source is not a normal Chocolatey package source.

fixes #877

## How has this been tested?

The following packages.config file was created:

```
<?xml version="1.0" encoding="utf-8"?>
<packages>
  <package id="IIS-WebServerRole" source="windowsfeatures" />
  <package id="windirstat" version="1.1.2.20161210" />
</packages>
```

And then the command `choco install test.config` file was run.

When running with current released version of Chocolatey, this causes an error, since the IIS-WebServerRole package can't be found.

When running with the code from this branch, the feature was correctly installed, as well as the windirstat package.