### PR TITLE
(#2304) Make list --exact --all-versions to filter out prereleases by default

### DIFF
--- a/Scenarios.md
+++ b/Scenarios.md
@@ -400,7 +400,7 @@
  * should not have inconclusive package result
  * should not have warning package result
 
-### ChocolateyListCommand [ 11 Scenario(s), 48 Observation(s) ]
+### ChocolateyListCommand [ 13 Scenario(s), 56 Observation(s) ]
 
 #### when listing local packages
 
@@ -447,6 +447,20 @@
  * should contain debugging messages
  * should contain packages and versions with a space between them
  * should not contain packages that do not match
+
+#### when searching for all packages including prerelease with exact id
+
+ * should find all versions in descending order
+ * should find only packages with exact id
+ * should find three results
+ * should not error
+
+#### when searching for all packages with exact id
+
+ * should find all non prerelease versions in descending order
+ * should find only packages with exact id
+ * should find two results
+ * should not error
 
 #### when searching for an exact package
 

--- a/src/chocolatey.tests.integration/chocolatey.tests.integration.csproj
+++ b/src/chocolatey.tests.integration/chocolatey.tests.integration.csproj
@@ -235,6 +235,12 @@
     <None Include="context\exactpackage\exactpackage.dontfind\1.0.0\exactpackage.dontfind.nuspec">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
+    <None Include="context\exactpackage\exactpackage\0.9.0\exactpackage.nuspec">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Include="context\exactpackage\exactpackage\1.0.0-beta1\exactpackage.nuspec">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
     <None Include="context\exactpackage\exactpackage\1.0.0\exactpackage.nuspec">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
@@ -477,6 +483,12 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
     <Content Include="context\exactpackage\exactpackage.dontfind\1.0.0\tools\purpose.txt">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="context\exactpackage\exactpackage\0.9.0\tools\purpose.txt">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="context\exactpackage\exactpackage\1.0.0-beta1\tools\purpose.txt">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
     <Content Include="context\exactpackage\exactpackage\1.0.0\tools\purpose.txt">

--- a/src/chocolatey.tests.integration/context/exactpackage/exactpackage/0.9.0/exactpackage.nuspec
+++ b/src/chocolatey.tests.integration/context/exactpackage/exactpackage/0.9.0/exactpackage.nuspec
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+  <metadata>
+    <id>exactpackage</id>
+    <version>0.9.0</version>
+    <title>exactpackage</title>
+    <authors>__REPLACE_AUTHORS_OF_SOFTWARE__</authors>
+    <owners>__REPLACE_YOUR_NAME__</owners>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <description>__REPLACE__</description>
+    <summary>__REPLACE__</summary>
+    <releaseNotes />
+    <tags>exactpackage admin</tags>
+  </metadata>
+  <files>
+    <file src="tools\**" target="tools" />
+  </files>
+</package>

--- a/src/chocolatey.tests.integration/context/exactpackage/exactpackage/0.9.0/tools/purpose.txt
+++ b/src/chocolatey.tests.integration/context/exactpackage/exactpackage/0.9.0/tools/purpose.txt
@@ -1,0 +1,1 @@
+when running choco list exactpackage -e --all, this package should be in the resulting list.

--- a/src/chocolatey.tests.integration/context/exactpackage/exactpackage/1.0.0-beta1/exactpackage.nuspec
+++ b/src/chocolatey.tests.integration/context/exactpackage/exactpackage/1.0.0-beta1/exactpackage.nuspec
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+  <metadata>
+    <id>exactpackage</id>
+    <version>1.0.0-beta1</version>
+    <title>exactpackage</title>
+    <authors>__REPLACE_AUTHORS_OF_SOFTWARE__</authors>
+    <owners>__REPLACE_YOUR_NAME__</owners>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <description>__REPLACE__</description>
+    <summary>__REPLACE__</summary>
+    <releaseNotes />
+    <tags>exactpackage admin</tags>
+  </metadata>
+  <files>
+    <file src="tools\**" target="tools" />
+  </files>
+</package>

--- a/src/chocolatey.tests.integration/context/exactpackage/exactpackage/1.0.0-beta1/tools/purpose.txt
+++ b/src/chocolatey.tests.integration/context/exactpackage/exactpackage/1.0.0-beta1/tools/purpose.txt
@@ -1,0 +1,1 @@
+When running choco list exactpackage -a --all --pre, this package should be in the returned results.

--- a/src/chocolatey.tests.integration/scenarios/ListScenarios.cs
+++ b/src/chocolatey.tests.integration/scenarios/ListScenarios.cs
@@ -496,8 +496,8 @@ namespace chocolatey.tests.integration.scenarios
                 MockLogger.contains_message("Start of List", LogLevel.Debug).ShouldBeTrue();
                 MockLogger.contains_message("End of List", LogLevel.Debug).ShouldBeTrue();
             }
-        }        
-        
+        }
+
         [Concern(typeof(ChocolateyListCommand))]
         public class when_searching_for_an_exact_package_with_zero_results : ScenariosBase
         {

--- a/src/chocolatey.tests.integration/scenarios/ListScenarios.cs
+++ b/src/chocolatey.tests.integration/scenarios/ListScenarios.cs
@@ -553,5 +553,104 @@ namespace chocolatey.tests.integration.scenarios
                 MockLogger.contains_message("End of List", LogLevel.Debug).ShouldBeTrue();
             }
         }
+
+        [Concern(typeof(ChocolateyListCommand))]
+        public class when_searching_for_all_packages_with_exact_id : ScenariosBase
+        {
+            public override void Context()
+            {
+                Configuration = Scenario.list();
+                Scenario.reset(Configuration);
+                Scenario.add_packages_to_source_location(Configuration, "exactpackage*" + Constants.PackageExtension);
+                Service = NUnitSetup.Container.GetInstance<IChocolateyPackageService>();
+
+                Configuration.ListCommand.Exact = true;
+                Configuration.AllVersions = true;
+                Configuration.Input = Configuration.PackageNames = "exactpackage";
+            }
+
+            public override void Because()
+            {
+                MockLogger.reset();
+                Results = Service.list_run(Configuration).ToList();
+            }
+
+            [Fact]
+            public void should_not_error()
+            {
+                // nothing necessary here
+            }
+
+            [Fact]
+            public void should_find_two_results()
+            {
+                Results.Count.ShouldEqual(2);
+            }
+
+            [Fact]
+            public void should_find_only_packages_with_exact_id()
+            {
+                Results[0].Package.Id.ShouldEqual("exactpackage");
+                Results[1].Package.Id.ShouldEqual("exactpackage");
+            }
+
+            [Fact]
+            public void should_find_all_non_prerelease_versions_in_descending_order()
+            {
+                Results[0].Package.Version.ToNormalizedString().ShouldEqual("1.0.0");
+                Results[1].Package.Version.ToNormalizedString().ShouldEqual("0.9.0");
+            }
+        }
+
+        [Concern(typeof(ChocolateyListCommand))]
+        public class when_searching_for_all_packages_including_prerelease_with_exact_id : ScenariosBase
+        {
+            public override void Context()
+            {
+                Configuration = Scenario.list();
+                Scenario.reset(Configuration);
+                Scenario.add_packages_to_source_location(Configuration, "exactpackage*" + Constants.PackageExtension);
+                Service = NUnitSetup.Container.GetInstance<IChocolateyPackageService>();
+
+                Configuration.ListCommand.Exact = true;
+                Configuration.AllVersions = true;
+                Configuration.Prerelease = true;
+                Configuration.Input = Configuration.PackageNames = "exactpackage";
+            }
+
+            public override void Because()
+            {
+                MockLogger.reset();
+                Results = Service.list_run(Configuration).ToList();
+            }
+
+            [Fact]
+            public void should_not_error()
+            {
+                // nothing necessary here
+            }
+
+            [Fact]
+            public void should_find_three_results()
+            {
+                Results.Count.ShouldEqual(3);
+            }
+
+            [Fact]
+            public void should_find_only_packages_with_exact_id()
+            {
+                Results[0].Package.Id.ShouldEqual("exactpackage");
+                Results[1].Package.Id.ShouldEqual("exactpackage");
+                Results[2].Package.Id.ShouldEqual("exactpackage");
+            }
+
+            [Fact]
+            public void should_find_all_versions_in_descending_order()
+            {
+                Results[0].Package.Version.ToNormalizedString().ShouldEqual("1.0.0");
+                Results[1].Package.Version.ToNormalizedString().ShouldEqual("1.0.0-beta1");
+                Results[2].Package.Version.ToNormalizedString().ShouldEqual("0.9.0");
+            }
+        }
     }
 }


### PR DESCRIPTION
Due to a prior fix in the logic for `list -e -a`, all packages with the target ID were being returned, regardless of whether the user uses the `--pre` flag or not. Since the same search without `--exact` does not return prerelease versions unless the `--pre` option is also passed, the behaviour for `list -e -a` should match this.

This fix modifies the search logic used when listing all package versions with `--exact` to also check for and respect the `--pre` flag from the configuration context, much like other list commands use the setting in this file in other places.

## Changes

- (breaking) `choco list $x --all --exact` no longer lists prerelease packages by default
- `choco list $x --all --exact --pre` lists everything, prereleases included

Fixes #2304 

## Manual Testing / Verification

You can either build choco from this branch or modify the configuration in VS to start choco in debug mode with specific arguments. You will need to ensure you have access to the community repository in your configuration (and ideally nothing else, for the purposes of this particular test).

- Run choco with arguments `list python3 --exact --all`
- Verify all packages returned are stable (non-prerelease) versions
- Run choco with arguments `list python3 --exact --all --pre`
- Verify:
  - The second command returns many more packages than the first.
  - The second command includes the results from the first command + prerelease versions of the same package.
- Run choco with arguments `list python3 --exact`
- The latest stable version of `python3` should be returned.
- Run choco with arguments `list python3 --exact --pre`
- The latest pre-release or stable version of `python3` should be returned.
- Confirm results by checking the python3 package page on the Community Repository and the versions currently available.