### PR TITLE
Prevent failing builds on Ubuntu

### DIFF
--- a/.build/compile.step
+++ b/.build/compile.step
@@ -75,7 +75,7 @@
       if="${platform::is-unix()}"
       >
       <arg value='"${app.nuget}"' />
-      <arg value='restore "${solution.path}"' />
+      <arg value='restore "${solution.path}" -DisableParallelProcessing' />
     </exec>
   </target>
 


### PR DESCRIPTION
Add flag to invocation of NuGet.exe when running on Ubuntu to prevent failures when restoring packages

Closes #2313 