### PR TITLE
(#2322) Use PNG for nuspec iconUrl

### DIFF
--- a/nuget/chocolatey.lib/chocolatey.lib.nuspec
+++ b/nuget/chocolatey.lib/chocolatey.lib.nuspec
@@ -7,7 +7,7 @@
     <title>Chocolatey Core [PREVIEW]</title>
     <authors>Chocolatey Software, Inc</authors>
     <projectUrl>https://github.com/chocolatey/choco</projectUrl>
-    <iconUrl>https://raw.githubusercontent.com/chocolatey/choco/master/docs/logo/chocolateyicon.gif</iconUrl>
+    <iconUrl>https://chocolatey.org/assets/images/nupkg/chocolateyicon.png</iconUrl>
     <licenseUrl>https://raw.githubusercontent.com/chocolatey/choco/master/LICENSE</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <copyright>2017-2021 Chocolatey Software, Inc, 2011-2017 RealDimensions Software, LLC</copyright>

--- a/nuget/chocolatey/chocolatey.nuspec
+++ b/nuget/chocolatey/chocolatey.nuspec
@@ -8,7 +8,7 @@
     <title>Chocolatey</title>
     <authors>Chocolatey Software, Inc</authors>
     <projectUrl>https://github.com/chocolatey/choco</projectUrl>
-    <iconUrl>https://raw.githubusercontent.com/chocolatey/choco/master/docs/logo/chocolateyicon.gif</iconUrl>
+    <iconUrl>https://chocolatey.org/assets/images/nupkg/chocolateyicon.png</iconUrl>
     <licenseUrl>https://raw.githubusercontent.com/chocolatey/choco/master/LICENSE</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <copyright>2017-2021 Chocolatey Software, Inc, 2011-2017 RealDimensions Software, LLC</copyright>


### PR DESCRIPTION
Use PNG instead of GIF for the iconUrl in the nuspec. The PNG icon 
is also available next to the GIF icon, and it is able to be used with 
integrations that may not recognize GIF files.

Closes #2322

(recreated from ferventcoder fork - did not feel comfortable force pushing to upstream)