### PR TITLE
(#2333) Disable loading of DLL under extensions path

### DIFF
--- a/src/chocolatey.resources/helpers/chocolateyInstaller.psm1
+++ b/src/chocolatey.resources/helpers/chocolateyInstaller.psm1
@@ -56,36 +56,6 @@ $currentAssemblies = [System.AppDomain]::CurrentDomain.GetAssemblies()
 $extensionsPath = Join-Path "$helpersPath" '..\extensions'
 if (Test-Path($extensionsPath)) {
   Write-Debug 'Loading community extensions'
-  Get-ChildItem $extensionsPath -recurse -filter "*.dll" | Select -ExpandProperty FullName | % {
-    $path = $_;
-    if ($path.Contains("extensions\chocolatey\lib-synced")) { continue }
-
-    try {
-      Write-Debug "Importing '$path'";
-      $fileNameWithoutExtension = $([System.IO.Path]::GetFileNameWithoutExtension($path))
-      Write-Debug "Loading '$fileNameWithoutExtension' extension.";
-      $loaded = $false
-      $currentAssemblies | % {
-        $name = $_.GetName().Name
-        if ($name -eq $fileNameWithoutExtension) {
-          Import-Module $_
-          $loaded = $true
-        }
-      }
-
-      if (!$loaded) {
-        if ($fileNameWithoutExtension -ne "chocolateygui.licensed") {
-          Import-Module $path;
-        }
-      }
-    } catch {
-      if ($env:ChocolateyPowerShellHost -eq 'true') {
-        Write-Warning "Import failed for '$path'.  Error: '$_'"
-      } else {
-        Write-Warning "Import failed for '$path'. If it depends on a newer version of the .NET framework, please make sure you are using the built-in PowerShell Host. Error: '$_'"
-      }
-    }
-  }
   #Resolve-Path $extensionsPath\**\*\*.psm1 | % { Write-Debug "Importing `'$_`'"; Import-Module $_.ProviderPath }
   Get-ChildItem $extensionsPath -recurse -filter "*.psm1" | Select -ExpandProperty FullName | % { Write-Debug "Importing `'$_`'"; Import-Module $_; }
 }


### PR DESCRIPTION
Disables loading of DLL's under the Chocolatey helpers extension path.

Closes #2333 