### PR TITLE
(#2333) Disable loading of DLL under extensions path

### DIFF
--- a/src/chocolatey.resources/helpers/chocolateyInstaller.psm1
+++ b/src/chocolatey.resources/helpers/chocolateyInstaller.psm1
@@ -56,36 +56,6 @@ $currentAssemblies = [System.AppDomain]::CurrentDomain.GetAssemblies()
 $extensionsPath = Join-Path "$helpersPath" '..\extensions'
 if (Test-Path($extensionsPath)) {
   Write-Debug 'Loading community extensions'
-  Get-ChildItem $extensionsPath -recurse -filter "*.dll" | Select -ExpandProperty FullName | % {
-    $path = $_;
-    if ($path.Contains("extensions\chocolatey\lib-synced")) { continue }
-
-    try {
-      Write-Debug "Importing '$path'";
-      $fileNameWithoutExtension = $([System.IO.Path]::GetFileNameWithoutExtension($path))
-      Write-Debug "Loading '$fileNameWithoutExtension' extension.";
-      $loaded = $false
-      $currentAssemblies | % {
-        $name = $_.GetName().Name
-        if ($name -eq $fileNameWithoutExtension) {
-          Import-Module $_
-          $loaded = $true
-        }
-      }
-
-      if (!$loaded) {
-        if ($fileNameWithoutExtension -ne "chocolateygui.licensed") {
-          Import-Module $path;
-        }
-      }
-    } catch {
-      if ($env:ChocolateyPowerShellHost -eq 'true') {
-        Write-Warning "Import failed for '$path'.  Error: '$_'"
-      } else {
-        Write-Warning "Import failed for '$path'. If it depends on a newer version of the .NET framework, please make sure you are using the built-in PowerShell Host. Error: '$_'"
-      }
-    }
-  }
   #Resolve-Path $extensionsPath\**\*\*.psm1 | % { Write-Debug "Importing `'$_`'"; Import-Module $_.ProviderPath }
   Get-ChildItem $extensionsPath -recurse -filter "*.psm1" | Select -ExpandProperty FullName | % { Write-Debug "Importing `'$_`'"; Import-Module $_; }
 }


### PR DESCRIPTION
## Description Of Changes

Removed the code section where we load extension DLLs directly when preparing for a chocolatey package installation.

## Motivation and Context

As there isn't a way to determine whether a DLL is a usable PowerShell module without loading it into memory, we're better off not loading DLLs directly, as it has caused issues several times in the past (see: #2078, #1041).

This has previously required us to create an ever-expanding list of exceptions to the loading behaviour.

Instead, if folks want to load DLLs as powershell modules, they can package them alongside a PSM1 file that handles the DLL import itself. (See #2333 for some examples)

This removes the need for Chocolatey to guess which dlls are powershell modules and which should not be loaded.

## What Have I Done To Test This

- Create a new chocolatey package in `C:\Packages`:
   ```powershell
   New-Item C:\Packages -ErrorAction SilentlyContinue
   Set-Location C:\Packages
   choco new test-package
   [xml]$packageInfo = Get-Content "C:\Packages\test-package\test-package.nuspec"
   $packageInfo.package.metadata.version = '0.1.0'
   $packageInfo.OuterXml | Set-Content "C:\Packages\test-package\test-package.nuspec
   choco pack .\test-package\test-package.nuspec
   ```
- Create a dummy extension DLL in chocolatey's extensions folder:
   ```powershell
   # Ensure you set $env:ChocolateyInstall for the session if you're not wanting to use your system's chocolatey install
   $folder = New-Item -Type Directory -Path "$env:ChocolateyInstall\extensions\test"
   New-Item -Path "$($folder.FullName)\test.dll"
   ```
- Using a current stable build/install of choco, attempt to install the package:
   ```powershell
   choco install test-package -y --debug --source c:\packages
   ```
- You should see debug messages about loading DLLs, including the `test.dll`, which should emit a failure warning. Log messages look like this:
   ```log
   Loading community extensions
   Importing 'C:\ProgramData\chocolatey\extensions\test\test.dll'
   Loading 'test' extension.
   WARNING: Import failed for 'C:\ProgramData\chocolatey\extensions\test\test.dll'.  Error: 'Could not load file or assembly 'file:///C:\ProgramData\chocolatey\extensions\test\test.dll' or one of its dependencies. The module was expected to contain an assembly manifest.'
   ```
- The package install will fail, this is expected, we don't care about the package install in this case.
- Build `choco` from this PR branch and rerun the above tests, ensuring the dummy extension dll is in the correct folder if you're running `choco` from a non-default location.
- Examine the log, you should not see any messages about loading the extension dll or failing to load it after the line `Loading community extensions`

## Change Types Made

* [ ] Bug fix (non-breaking change)
* [ ] Feature / Enhancement (non-breaking change)
* [x] Breaking change (fix or feature that could cause existing functionality to change)

## Related Issue

#2333

## Change Checklist

* [x] Requires a change to the documentation
* [ ] Documentation has been updated
* [x] Tests to cover my changes, have been added
* [ ] All new and existing tests passed.