### PR TITLE
(#2336) Remove quotes from InstallLocation

### DIFF
--- a/src/chocolatey/infrastructure.app/services/AutomaticUninstallerService.cs
+++ b/src/chocolatey/infrastructure.app/services/AutomaticUninstallerService.cs
@@ -131,7 +131,7 @@ namespace chocolatey.infrastructure.app.services
 
             this.Log().Debug(() => " Preparing uninstall key '{0}' for '{1}'".format_with(key.UninstallString.to_string().escape_curly_braces(), key.DisplayName.to_string().escape_curly_braces()));
 
-            if ((!string.IsNullOrWhiteSpace(key.InstallLocation) && !_fileSystem.directory_exists(key.InstallLocation)) || !_registryService.installer_value_exists(key.KeyPath, ApplicationParameters.RegistryValueInstallLocation))
+            if ((!string.IsNullOrWhiteSpace(key.InstallLocation) && !_fileSystem.directory_exists(key.InstallLocation.to_string().remove_surrounding_quotes())) || !_registryService.installer_value_exists(key.KeyPath, ApplicationParameters.RegistryValueInstallLocation))
             {
                 this.Log().Info(" Skipping auto uninstaller - '{0}' appears to have been uninstalled already by other means.".format_with(!string.IsNullOrEmpty(key.DisplayName.to_string()) ? key.DisplayName.to_string().escape_curly_braces() : "The application"));
                 this.Log().Debug(() => " Searched for install path '{0}' - found? {1}".format_with(key.InstallLocation.to_string().escape_curly_braces(), _fileSystem.directory_exists(key.InstallLocation)));


### PR DESCRIPTION
## Description

The InstallLocation can sometimes have quotes around the file path. When this happens we don't detect the directory as existing even when it does. As such, the uninstall doesn't actually happen. This change removes the quotes before we ask the File System Provider if the directory exists.

## Testing

Tested this by Installing the Lastpass Chocolatey package then running `choco uninstall --fromprograms` (This is a licensed feature) and confirmed that it successfully called the uninstaller.

I have created a test package `uninstall-from-programs` that can be used for testing this as well (it creates an install entry with quotes and does not successfully uninstall without this change).

Fixes #2336 

The manual testing documentation for chocolatey.extension has been updated to include testing the `uninstall-from-programs` package.