### PR TITLE
Fix typo in setting Authorization header

### DIFF
--- a/src/chocolatey.resources/helpers/functions/Get-WebFile.ps1
+++ b/src/chocolatey.resources/helpers/functions/Get-WebFile.ps1
@@ -186,7 +186,7 @@ param(
         'Cookie' {$req.CookieContainer.SetCookies($uri, $options.headers.$key)}
         'Referer' {$req.Referer = $options.headers.$key}
         'User-Agent' {$req.UserAgent = $options.headers.$key}
-        'Authorization' {$re.Authorization = $options.headers.$key}
+        'Authorization' {$req.Authorization = $options.headers.$key}
         Default {$req.Headers.Add($key, $options.headers.$key)}
       }
     }


### PR DESCRIPTION
The explicitly added Authorization header does not get added to the request object (re instead of req).

That means downloading a file by choco, which requires an Authorization header to bet set, is currently not possible.
An error message like this will be shown: "The property 'Authorization' cannot be found on this object. Verify that the property exists and can be set."

