### PR TITLE
(test) Add unit tests for ArgumentsUtility class

### DIFF
--- a/src/chocolatey.tests/chocolatey.tests.csproj
+++ b/src/chocolatey.tests/chocolatey.tests.csproj
@@ -112,6 +112,7 @@
     <Compile Include="infrastructure.app\services\NugetServiceSpecs.cs" />
     <Compile Include="infrastructure.app\services\RegistryServiceSpecs.cs" />
     <Compile Include="infrastructure.app\services\TemplateServiceSpecs.cs" />
+    <Compile Include="infrastructure.app\utility\ArgumentsUtilitySpecs.cs" />
     <Compile Include="infrastructure\commands\ExternalCommandArgsBuilderSpecs.cs" />
     <Compile Include="infrastructure\commandline\InteractivePromptSpecs.cs" />
     <Compile Include="infrastructure\commands\CommandExecutorSpecs.cs" />

--- a/src/chocolatey.tests/infrastructure.app/utility/ArgumentsUtilitySpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/utility/ArgumentsUtilitySpecs.cs
@@ -1,0 +1,62 @@
+﻿namespace chocolatey.tests.infrastructure.app.utility
+{
+    using chocolatey.infrastructure.app.utility;
+    using NUnit.Framework;
+    using Should;
+
+    public class ArgumentsUtilitySpecs
+    {
+        public abstract class ArgumentsUtilitySpecsBase : TinySpec
+        {
+            public override void Context()
+            {
+            }
+        }
+
+        [TestFixture("choco install bob --package-parameters-sensitive=\"/test=bill\"", true)]
+        [TestFixture("choco install bob -package-parameters-sensitive=\"/test=bill\"", true)]
+        [TestFixture("choco install bob --install-arguments-sensitive=\"/test=bill\"", true)]
+        [TestFixture("choco install bob -install-arguments-sensitive=\"/test=bill\"", true)]
+        [TestFixture("choco apikey -k secretKey -s secretSource", true)]
+        [TestFixture("choco config set --name=proxyPassword --value=secretPassword", true)]
+        [TestFixture("choco push package.nupkg -k=secretKey", true)]
+        [TestFixture("choco source add -n=test -u=bob -p bill", true)]
+        [TestFixture("choco source add -n=test -u=bob -p=bill", true)]
+        [TestFixture("choco source add -n=test -u=bob -password=bill", true)]
+        [TestFixture("choco source add -n=test -cert=text.pfx -cp secretPassword", true)]
+        [TestFixture("choco source add -n=test -cert=text.pfx -cp=secretPassword", true)]
+        [TestFixture("choco source add -n=test -cert=text.pfx -certpassword=secretPassword", true)]
+        [TestFixture("choco push package.nupkg -k secretKey", true)]
+        [TestFixture("choco push package.nupkg -k=secretKey", true)]
+        [TestFixture("choco push package.nupkg -key secretKey", true)]
+        [TestFixture("choco push package.nupkg -key=secretKey", true)]
+        [TestFixture("choco install bob -apikey=secretKey", true)]
+        [TestFixture("choco install bob -apikey secretKey", true)]
+        [TestFixture("choco install bob -api-key=secretKey", true)]
+        [TestFixture("choco install bob -api-key secretKey", true)]
+        [TestFixture("choco install bob", false)]
+        public class when_ArgumentsUtility_is_testing_for_sensitive_parameters : ArgumentsUtilitySpecsBase
+        {
+            private bool _result;
+            private bool _expectedResult;
+            private string _commandArguments;
+
+            public when_ArgumentsUtility_is_testing_for_sensitive_parameters(string commandArguments, bool expectedResult)
+            {
+                _commandArguments = commandArguments;
+                _expectedResult = expectedResult;
+            }
+
+            public override void Because()
+            {
+                _result = ArgumentsUtility.arguments_contain_sensitive_information(_commandArguments);
+            }
+
+            [Fact]
+            public void should_return_expected_result()
+            {
+                _result.ShouldEqual(_expectedResult);
+            }
+        }
+    }
+}


### PR DESCRIPTION
This is starting to be used in other places, so we should have some
tests around the execution of the logic contained within this class to
ensure that there are no regressions if/when editing this class.

For now, all the current expectations are covered within the different
TestFixtures, but this should be extended if any changes are made to
the class.