### PR TITLE
Fix documentation for `Install-ChocolateyZipPackage` output

### DIFF
--- a/src/chocolatey.resources/helpers/functions/Install-ChocolateyZipPackage.ps1
+++ b/src/chocolatey.resources/helpers/functions/Install-ChocolateyZipPackage.ps1
@@ -38,7 +38,7 @@ internal packages.
 None
 
 .OUTPUTS
-None
+Returns the passed in $unzipLocation.
 
 .PARAMETER PackageName
 The name of the package - while this is an arbitrary value, it's


### PR DESCRIPTION
`Install-ChocolateyZipPackage` calls `Get-ChocolateyUnzip` which outputs
the passed in `$destination`. Consequently, `Install-ChocolateyZipPackage`
outputs the passed in `$unzipLocation`.

<!--
BEFORE YOU CREATE A PULL REQUEST:

Ensure you have read over CONTRIBUTING - https://github.com/chocolatey/choco/blob/master/CONTRIBUTING.md. We provide VERY defined guidance (as such, we strongly adhere to it).

A summary of our expectations:
 - You are not submitting a pull request from your MASTER branch.
 - You are able to sign the Contributor License Agreement (CLA).
 - YOUR GIT COMMIT MESSAGE FORMAT IS EXTREMELY IMPORTANT. We have a very defined expectation for this format and are sticklers about it. Really, READ the entire Contributing document. It will save you and us pain.
 - Do not reformat code, it makes it hard to see what has changed. Leave the formatting to us.

THANKS! We appreciate you reading the entire Contributing document and not just scanning through it.

DELETE EVERYTHING IN THIS COMMENT BLOCK
-->
