### PR TITLE
(#2358) Add official and debug Mono build scripts

### DIFF
--- a/build.debug.sh
+++ b/build.debug.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# stty -echo
+
+# ::Project UppercuT - http://uppercut.googlecode.com
+# ::No edits to this file are required - http://uppercut.pbwiki.com
+
+function usage
+{
+    echo ""
+    echo "Usage: build.debug.sh"
+    exit
+}
+
+function displayUsage
+{
+    case $1 in
+        "/?"|"-?"|"?"|"/help") usage ;;
+    esac
+}
+
+displayUsage $1
+
+# http://www.michaelruck.de/2010/03/solving-pkg-config-and-mono-35-profile.html
+# http://cloudgen.wordpress.com/2013/03/06/configure-nant-to-run-under-mono-3-06-beta-for-mac-osx/
+export PKG_CONFIG_PATH=/opt/local/lib/pkgconfig:/Library/Frameworks/Mono.framework/Versions/Current/lib/pkgconfig:$PKG_CONFIG_PATH
+
+#mono ./lib/NAnt/NAnt.exe /logger:"NAnt.Core.DefaultLogger" /nologo /quiet /f:"$(cd $(dirname "$0"); pwd)/.build/default.build" /D:build.config.settings="$(cd $(dirname "$0"); pwd)/.uppercut" /D:microsoft.framework="mono-3.5" $*
+mono --runtime=v4.0.30319 ./lib/NAnt/NAnt.exe /logger:"NAnt.Core.DefaultLogger" /nologo /quiet /f:"$(cd $(dirname "$0"); pwd)/.build/default.build" /D:build.config.settings="$(cd $(dirname "$0"); pwd)/.uppercut" /D:microsoft.framework="mono-4.5" /D:run.ilmerge="false" /D:run.nuget="false" /D:msbuild.configuration="Debug"  $*
+
+#/quiet /nologo /debug /verbose /t:"mono-4.5"

--- a/build.official.sh
+++ b/build.official.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# stty -echo
+
+# ::Project UppercuT - http://uppercut.googlecode.com
+# ::No edits to this file are required - http://uppercut.pbwiki.com
+
+function usage
+{
+    echo ""
+    echo "Usage: build.official.sh"
+    exit
+}
+
+function displayUsage
+{
+    case $1 in
+        "/?"|"-?"|"?"|"/help") usage ;;
+    esac
+}
+
+displayUsage $1
+
+# http://www.michaelruck.de/2010/03/solving-pkg-config-and-mono-35-profile.html
+# http://cloudgen.wordpress.com/2013/03/06/configure-nant-to-run-under-mono-3-06-beta-for-mac-osx/
+export PKG_CONFIG_PATH=/opt/local/lib/pkgconfig:/Library/Frameworks/Mono.framework/Versions/Current/lib/pkgconfig:$PKG_CONFIG_PATH
+
+#mono ./lib/NAnt/NAnt.exe /logger:"NAnt.Core.DefaultLogger" /nologo /quiet /f:"$(cd $(dirname "$0"); pwd)/.build/default.build" /D:build.config.settings="$(cd $(dirname "$0"); pwd)/.uppercut" /D:microsoft.framework="mono-3.5" $*
+mono --runtime=v4.0.30319 ./lib/NAnt/NAnt.exe /logger:"NAnt.Core.DefaultLogger" /nologo /quiet /f:"$(cd $(dirname "$0"); pwd)/.build/default.build" /D:build.config.settings="$(cd $(dirname "$0"); pwd)/.uppercut" /D:microsoft.framework="mono-4.5" /D:run.ilmerge="false" /D:run.nuget="false" /D:msbuild.configuration="ReleaseOfficial"  $*
+
+#/quiet /nologo /debug /verbose /t:"mono-4.5"


### PR DESCRIPTION
Fixes: #2358

I think we may have to dig into uppercut as well to get the code signing working on Mono.
