### PR TITLE
(#2364) Rework Linux Dockerfile

### DIFF
--- a/docker/Dockerfile.linux
+++ b/docker/Dockerfile.linux
@@ -1,21 +1,43 @@
-FROM mono:6.12
-
-MAINTAINER Justin Phelps <linuturk@onitato.com>
+ARG monoversion="6.12"
+FROM mono:${monoversion} as build
 
 RUN apt-get update && apt-get install git -y
 
 COPY . /usr/local/src/choco/
 
 WORKDIR /usr/local/src/choco
-RUN chmod +x build.sh
-RUN chmod +x zip.sh
-RUN ./build.sh
+RUN chmod +x *.sh
 
-WORKDIR /usr/local/bin
-RUN ln -s /usr/local/src/choco/code_drop/chocolatey
+ARG buildscript="build.sh"
+RUN ./$buildscript
 
-COPY docker/choco_wrapper /usr/local/bin/choco
+RUN if [ "$buildscript" = "build.official.sh" ]; then \
+    cp docker/choco_official_wrapper code_drop/chocolatey/console/choco_wrapper; \
+  else \
+    cp docker/choco_wrapper code_drop/chocolatey/console/choco_wrapper; \    
+  fi;
 
-ENV ChocolateyInstall /usr/local/bin/chocolatey
+
+ARG monoversion="6.12"
+FROM mono:${monoversion} as install
+
+ARG monoversion="6.12"
+LABEL org.opencontainers.image.url="https://chocolatey.org/"
+LABEL org.opencontainers.image.documentation="https://docs.chocolatey.org/"
+LABEL org.opencontainers.image.source="https://github.com/chocolatey/choco"
+LABEL org.opencontainers.image.vendor="Chocolatey Software, Inc"
+LABEL org.opencontainers.image.licenses="Apache-2.0"
+LABEL org.opencontainers.image.title="Chocolatey"
+LABEL org.opencontainers.image.description="Chocolatey Client running on Mono"
+LABEL org.opencontainers.image.authors="https://chocolatey.org/support"
+LABEL org.opencontainers.image.base.name="index.docker.io/library/mono:${monoversion}"
+
+ENV ChocolateyInstall /opt/chocolatey
+
+COPY --from=build /usr/local/src/choco/code_drop/chocolatey/console /opt/chocolatey
+
+RUN mkdir /opt/chocolatey/lib; \
+  cp /opt/chocolatey/choco_wrapper usr/local/bin/choco; \
+  cp /opt/chocolatey/choco_wrapper usr/local/bin/choco.exe;
 
 WORKDIR /root

--- a/docker/README.md
+++ b/docker/README.md
@@ -8,5 +8,9 @@ To build this image yourself, follow these steps:
 1. Clone down the repository using `git clone https://github.com/chocolatey/choco.git`.
 1. Change directories to the root of the repository.
 1. Run the docker build command. `docker build -t mono-choco -f docker/Dockerfile.linux .` (the trailing . is important)
+    To build a official version, add the argument `--build-arg buildscript=build.official.sh`
+    To build a debug version, add the argument `--build-arg buildscript=build.official.sh`
+    To change the version of mono used, add the argument `--build-arg monoversion=mono-tag`
 1. Run your new image using the command `docker run -ti --rm mono-choco /bin/bash`
 1. Test choco by running `choco -h`. You should see the help message from choco.exe.
+

--- a/docker/choco_official_wrapper
+++ b/docker/choco_official_wrapper
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+mono /opt/chocolatey/choco.exe "$@"

--- a/docker/choco_wrapper
+++ b/docker/choco_wrapper
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-mono /usr/local/bin/chocolatey/console/choco.exe "$@" --allow-unofficial
+mono /opt/chocolatey/choco.exe "$@" --allow-unofficial


### PR DESCRIPTION
Rework the Dockerfile for Linux. Move to a multi-stage build so the
source code is not brought along into the final image (#2364). Add
build args to select the build script and mono version to use. Remove
deprecated MAINTAINER instruction and add metadata with LABEL (#2361).
Add "choco.exe" to path, so both "choco" and "choco.exe" can be used,
like Windows supports (#2362). Change the install location to
"/opt/chocolatey" as that is more in line with the Linux filesystem
hierarchy (#2360). Create the "lib" directory to prevent the warning
about the directory not being found (#2363).

The choco_official_wrapper is used for official builds, where the
"--allow-unofficial" argument is not needed.

Fixes: #2360
Fixes: #2361 
Fixes: #2362 
Fixes: #2363 
Fixes: #2364 

The debug and official build scripts are in #2359
