### PR TITLE
(#2025) Document install process on other platforms.

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,5 +189,12 @@ chmod +x zip.sh
 
 Running the build on Mono produces an artifact similar to Windows but may have more rough edges. You may get a failure or two in the build script that can be safely ignored.
 
+### Installing on Other Platforms:
+
+ 1. Get a copy of the source code and build.
+ 1. Copy (or link) the contents of `./code_drop/chocolatey/console` to your preferred install directory. On Linux, the preferred directory is `/opt/chocolatey`
+ 1. Export the `ChocolateyInstall` environment variable, pointing to the install directory the build output was copied too.
+ 1. Copy `./docker/choco_wrapper` to a directory on the `$PATH`, rename to `choco`, and if the install directory is something else than `/opt/chocolatey`, then edit it to point to the correct path.
+
 ## Credits
 Chocolatey is brought to you by quite a few people and frameworks. See [CREDITS](https://github.com/chocolatey/choco/blob/master/docs/legal/CREDITS.md) (just LEGAL/Credits.md in the zip folder).


### PR DESCRIPTION
Fixes #2025

If another location for this documentation is more appropriate (perhaps somewhere in the docs repository), feel free to redirect this or point me in the right direction.