### PR TITLE
(#2369 #2370) Do not trim forward slashs prefixes on Linux

### DIFF
--- a/src/chocolatey/infrastructure.app/ApplicationParameters.cs
+++ b/src/chocolatey/infrastructure.app/ApplicationParameters.cs
@@ -21,6 +21,7 @@ namespace chocolatey.infrastructure.app
     using adapters;
     using filesystem;
     using Environment = System.Environment;
+    using chocolatey.infrastructure.platforms;
 
     /// <summary>
     ///   Application constants and settings for the application
@@ -46,9 +47,9 @@ namespace chocolatey.infrastructure.app
         // start from the assembly location and if unfound, head to the machine
         // locations instead. This is a merge of official and Debug modes.
         private static IAssembly _assemblyForLocation = Assembly.GetEntryAssembly().UnderlyingType != null ? Assembly.GetEntryAssembly() : Assembly.GetExecutingAssembly();
-        public static readonly string InstallLocation = _fileSystem.file_exists(_fileSystem.combine_paths(_fileSystem.get_directory_name(_assemblyForLocation.CodeBase.Replace("file:///", string.Empty)), "chocolatey.dll")) ||
-                                                        _fileSystem.file_exists(_fileSystem.combine_paths(_fileSystem.get_directory_name(_assemblyForLocation.CodeBase.Replace("file:///", string.Empty)), "choco.exe")) ?
-                _fileSystem.get_directory_name(_assemblyForLocation.CodeBase.Replace("file:///", string.Empty)) :
+        public static readonly string InstallLocation = _fileSystem.file_exists(_fileSystem.combine_paths(_fileSystem.get_directory_name(_assemblyForLocation.CodeBase.Replace(Platform.get_platform() == PlatformType.Windows ? "file:///" : "file://", string.Empty)), "chocolatey.dll")) ||
+                                                        _fileSystem.file_exists(_fileSystem.combine_paths(_fileSystem.get_directory_name(_assemblyForLocation.CodeBase.Replace(Platform.get_platform() == PlatformType.Windows ? "file:///" : "file://", string.Empty)), "choco.exe")) ?
+                _fileSystem.get_directory_name(_assemblyForLocation.CodeBase.Replace(Platform.get_platform() == PlatformType.Windows ? "file:///" : "file://", string.Empty)) :
                 !string.IsNullOrWhiteSpace(System.Environment.GetEnvironmentVariable(ChocolateyInstallEnvironmentVariableName)) ?
                     System.Environment.GetEnvironmentVariable(ChocolateyInstallEnvironmentVariableName) :
                     @"C:\ProgramData\Chocolatey"

--- a/src/chocolatey/infrastructure/filesystem/DotNetFileSystem.cs
+++ b/src/chocolatey/infrastructure/filesystem/DotNetFileSystem.cs
@@ -175,7 +175,7 @@ namespace chocolatey.infrastructure.filesystem
 
         public string get_current_assembly_path()
         {
-            return Assembly.GetExecutingAssembly().CodeBase.Replace("file:///", string.Empty);
+            return Assembly.GetExecutingAssembly().CodeBase.Replace(Platform.get_platform() == PlatformType.Windows ? "file:///" : "file://", string.Empty);
         }
 
         #endregion


### PR DESCRIPTION
Fixes #2370 
Fixes #2369 

This prevents absolute paths being converted to relatives paths by the removal of the leading forward slash.

Fix created by @AdmiringWorm, I just typed up a repro and packaged it up into commits.