### PR TITLE
(#2379) Correct pack files filter for Linux

### DIFF
--- a/src/chocolatey/infrastructure.app/nuget/NugetPack.cs
+++ b/src/chocolatey/infrastructure.app/nuget/NugetPack.cs
@@ -22,6 +22,7 @@ namespace chocolatey.infrastructure.app.nuget
     using System.Linq;
     using NuGet;
     using IFileSystem = filesystem.IFileSystem;
+    using chocolatey.infrastructure.platforms;
 
     // ReSharper disable InconsistentNaming
 
@@ -61,8 +62,9 @@ namespace chocolatey.infrastructure.app.nuget
             // Always exclude the nuspec file
             // Review: This exclusion should be done by the package builder because it knows which file would collide with the auto-generated
             // manifest file.
+            var filter = Platform.get_platform() == PlatformType.Windows ? @"**\*" : "**/*";
             var excludes = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-            var wildCards = excludes.Concat(new[] {@"**\*" + Constants.ManifestExtension, @"**\*" + Constants.PackageExtension});
+            var wildCards = excludes.Concat(new[] { filter + Constants.ManifestExtension, filter + Constants.PackageExtension });
 
             PathResolver.FilterPackageFiles(packageFiles, ResolvePath, wildCards);
         }


### PR DESCRIPTION
If there is not a <files> element in the .nuspec, then the pack command
will gather up a list of all of files the in the directory which is
used to include them in the package. However, the nuspec should not be
included in this list, because it is auto-regenerated. The .nupkg also
should not be included. Therefore, there is a filter to remove the
.nuspec and .nupkg from the list of files.

However, this filter has the directory separator hardcoded as a
backslash. This does not work correctly on platforms where the
directory separator is a forward slash. Therefore, this fixes
the directory separator to be correct depending on what platform choco
is running on.

This patch was written by @AdmiringWorm, I just created the reproduction and packaged it up into a commit.
https://github.com/AdmiringWorm/chocolatey-arch/blob/master/0003-Use-correct-exclude-filer-on-unix.patch

Fixes #2379 

I thought that the `partUri` issue was fixed by #2276, but it seems like there are actually two different problems that caused it.
