### PR TITLE
(#449) Add template command

### DIFF
--- a/src/chocolatey.tests/chocolatey.tests.csproj
+++ b/src/chocolatey.tests/chocolatey.tests.csproj
@@ -90,6 +90,7 @@
     <Compile Include="infrastructure.app\attributes\CommandForAttributeSpecs.cs" />
     <Compile Include="infrastructure.app\commands\ChocolateyApiKeyCommandSpecs.cs" />
     <Compile Include="infrastructure.app\commands\ChocolateyConfigCommandSpecs.cs" />
+    <Compile Include="infrastructure.app\commands\ChocolateyTemplateCommandSpecs.cs" />
     <Compile Include="infrastructure.app\commands\ChocolateyExportCommandSpecs.cs" />
     <Compile Include="infrastructure.app\commands\ChocolateyFeatureCommandSpecs.cs" />
     <Compile Include="infrastructure.app\commands\ChocolateyInfoCommandSpecs.cs" />

--- a/src/chocolatey.tests/infrastructure.app/commands/ChocolateyNewCommandSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/commands/ChocolateyNewCommandSpecs.cs
@@ -343,7 +343,7 @@ namespace chocolatey.tests.infrastructure.app.commands
             [Fact]
             public void should_call_service_noop()
             {
-                templateService.Verify(c => c.noop(configuration), Times.Once);
+                templateService.Verify(c => c.generate_noop(configuration), Times.Once);
             }
         }
 

--- a/src/chocolatey.tests/infrastructure.app/commands/ChocolateyTemplateCommandSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/commands/ChocolateyTemplateCommandSpecs.cs
@@ -1,0 +1,308 @@
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+// Copyright © 2011 - 2017 RealDimensions Software, LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace chocolatey.tests.infrastructure.app.commands
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using chocolatey.infrastructure.app.attributes;
+    using chocolatey.infrastructure.app.commands;
+    using chocolatey.infrastructure.app.configuration;
+    using chocolatey.infrastructure.app.domain;
+    using chocolatey.infrastructure.app.services;
+    using chocolatey.infrastructure.commandline;
+    using chocolatey.infrastructure.filesystem;
+    using Moq;
+    using Should;
+
+    public class ChocolateyTemplateCommandSpecs
+    {
+        public abstract class ChocolateyTemplateCommandSpecsBase : TinySpec
+        {
+            protected ChocolateyTemplateCommand command;
+            protected Mock<ITemplateService> templateService = new Mock<ITemplateService>();
+            protected ChocolateyConfiguration configuration = new ChocolateyConfiguration();
+
+            public override void Context()
+            {
+                command = new ChocolateyTemplateCommand(templateService.Object);
+            }
+
+            public void reset()
+            {
+                templateService.ResetCalls();
+            }
+        }
+
+        public class when_implementing_command_for : ChocolateyTemplateCommandSpecsBase
+        {
+            private List<string> results;
+
+            public override void Because()
+            {
+                results = command.GetType().GetCustomAttributes(typeof(CommandForAttribute), false).Cast<CommandForAttribute>().Select(a => a.CommandName).ToList();
+            }
+
+            [Fact]
+            public void should_implement_help()
+            {
+                results.ShouldContain("template");
+                results.ShouldContain("templates");
+            }
+        }
+
+        public class when_configurating_the_argument_parser : ChocolateyTemplateCommandSpecsBase
+        {
+            private OptionSet optionSet;
+
+            public override void Context()
+            {
+                base.Context();
+                optionSet = new OptionSet();
+            }
+
+            public override void Because()
+            {
+                command.configure_argument_parser(optionSet, configuration);
+            }
+
+            [Fact]
+            public void should_add_name_to_the_option_set()
+            {
+                optionSet.Contains("name").ShouldBeTrue();
+            }
+
+            [Fact]
+            public void should_add_short_version_of_name_to_the_option_set()
+            {
+                optionSet.Contains("n").ShouldBeTrue();
+            }
+        }
+
+
+        public class when_handling_additional_argument_parsing : ChocolateyTemplateCommandSpecsBase
+        {
+            private readonly IList<string> unparsedArgs = new List<string>();
+            private Action because;
+
+            public override void Because()
+            {
+                because = () => command.handle_additional_argument_parsing(unparsedArgs, configuration);
+            }
+
+            public new void reset()
+            {
+                configuration.TemplateCommand.Name = string.Empty;
+                configuration.TemplateCommand.Command = TemplateCommandType.unknown;
+                unparsedArgs.Clear();
+                base.reset();
+            }
+
+            [Fact]
+            public void should_use_the_first_unparsed_arg_as_the_subcommand()
+            {
+                reset();
+                unparsedArgs.Add("list");
+                because();
+
+                configuration.TemplateCommand.Command.ShouldEqual(TemplateCommandType.list);
+            }
+
+            [Fact]
+            public void should_throw_when_more_than_one_unparsed_arg_is_passed()
+            {
+                reset();
+                unparsedArgs.Add("badcommand");
+                unparsedArgs.Add("bbq");
+                var errorred = false;
+                Exception error = null;
+
+                try
+                {
+                    because();
+                }
+                catch (Exception ex)
+                {
+                    errorred = true;
+                    error = ex;
+                }
+
+                errorred.ShouldBeTrue();
+                error.ShouldNotBeNull();
+                error.ShouldBeType<ApplicationException>();
+                error.Message.ShouldContain("A single template command must be listed");
+            }
+
+            [Fact]
+            public void should_accept_list_as_the_subcommand()
+            {
+                reset();
+                unparsedArgs.Add("list");
+                because();
+
+                configuration.TemplateCommand.Command.ShouldEqual(TemplateCommandType.list);
+            }
+
+            [Fact]
+            public void should_accept_uppercase_list_as_the_subcommand()
+            {
+                reset();
+                unparsedArgs.Add("LIST");
+                because();
+
+                configuration.TemplateCommand.Command.ShouldEqual(TemplateCommandType.list);
+            }
+
+            [Fact]
+            public void should_accept_info_as_the_subcommand()
+            {
+                reset();
+                unparsedArgs.Add("info");
+                because();
+
+                configuration.TemplateCommand.Command.ShouldEqual(TemplateCommandType.info);
+            }
+
+            [Fact]
+            public void should_accept_uppercase_info_as_the_subcommand()
+            {
+                reset();
+                unparsedArgs.Add("INFO");
+                because();
+
+                configuration.TemplateCommand.Command.ShouldEqual(TemplateCommandType.info);
+            }
+
+            [Fact]
+            public void should_set_unrecognized_values_to_list_as_the_subcommand()
+            {
+                reset();
+                unparsedArgs.Add("badcommand");
+                because();
+
+                configuration.TemplateCommand.Command.ShouldEqual(TemplateCommandType.list);
+            }
+
+            [Fact]
+            public void should_default_to_list_as_the_subcommand()
+            {
+                reset();
+                because();
+
+                configuration.TemplateCommand.Command.ShouldEqual(TemplateCommandType.list);
+            }
+
+            [Fact]
+            public void should_handle_passing_in_an_empty_string()
+            {
+                reset();
+                unparsedArgs.Add(" ");
+                because();
+
+                configuration.TemplateCommand.Command.ShouldEqual(TemplateCommandType.list);
+            }
+        }
+
+        public class when_handling_validation : ChocolateyTemplateCommandSpecsBase
+        {
+            private Action because;
+
+            public override void Because()
+            {
+                because = () => command.handle_validation(configuration);
+            }
+
+            [Fact]
+            public void should_continue_when_command_is_list_and_name_is_set()
+            {
+                configuration.TemplateCommand.Command = TemplateCommandType.list;
+                configuration.TemplateCommand.Name = "bob";
+                because();
+            }
+
+            [Fact]
+            public void should_continue_when_command_is_list_and_name_is_not_set()
+            {
+                configuration.TemplateCommand.Command = TemplateCommandType.list;
+                configuration.TemplateCommand.Name = "";
+                because();
+            }
+
+            [Fact]
+            public void should_throw_when_command_is_info_and_name_is_not_set()
+            {
+                configuration.TemplateCommand.Command = TemplateCommandType.info;
+                configuration.TemplateCommand.Name = "";
+                var errorred = false;
+                Exception error = null;
+
+                try
+                {
+                    because();
+                }
+                catch (Exception ex)
+                {
+                    errorred = true;
+                    error = ex;
+                }
+
+                errorred.ShouldBeTrue();
+                error.ShouldNotBeNull();
+                error.ShouldBeType<ApplicationException>();
+                error.Message.ShouldEqual("When specifying the subcommand '{0}', you must also specify --name.".format_with(configuration.TemplateCommand.Command.to_string()));
+            }
+
+            [Fact]
+            public void should_continue_when_command_info_and_name_is_set()
+            {
+                configuration.TemplateCommand.Command = TemplateCommandType.info;
+                configuration.TemplateCommand.Name = "bob";
+                because();
+            }
+        }
+
+        public class when_noop_is_called : ChocolateyTemplateCommandSpecsBase
+        {
+            public override void Because()
+            {
+                configuration.TemplateCommand.Command = TemplateCommandType.list;
+                command.noop(configuration);
+            }
+
+            [Fact]
+            public void should_call_service_list_noop()
+            {
+                templateService.Verify(c => c.list_noop(configuration), Times.Once);
+            }
+        }
+
+        public class when_run_is_called : ChocolateyTemplateCommandSpecsBase
+        {
+            public override void Because()
+            {
+                configuration.TemplateCommand.Command = TemplateCommandType.list;
+                command.run(configuration);
+            }
+
+            [Fact]
+            public void should_call_service_list()
+            {
+                templateService.Verify(c => c.list(configuration), Times.Once);
+            }
+        }
+    }
+}

--- a/src/chocolatey.tests/infrastructure.app/services/TemplateServiceSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/services/TemplateServiceSpecs.cs
@@ -45,7 +45,7 @@ namespace chocolatey.tests.infrastructure.app.services
             }
         }
 
-        public class when_noop_is_called : TemplateServiceSpecsBase
+        public class when_generate_noop_is_called : TemplateServiceSpecsBase
         {
             private Action because;
             private readonly ChocolateyConfiguration config = new ChocolateyConfiguration();
@@ -61,7 +61,7 @@ namespace chocolatey.tests.infrastructure.app.services
 
             public override void Because()
             {
-                because = () => service.noop(config);
+                because = () => service.generate_noop(config);
             }
 
             public override void BeforeEachSpec()

--- a/src/chocolatey.tests/infrastructure.app/services/TemplateServiceSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/services/TemplateServiceSpecs.cs
@@ -824,5 +824,42 @@ namespace chocolatey.tests.infrastructure.app.services
                 config.NewCommand.TemplateName.ShouldEqual("zip");
             }
         }
+
+        public class when_list_noop_is_called : TemplateServiceSpecsBase
+        {
+            private Action because;
+            private readonly ChocolateyConfiguration config = new ChocolateyConfiguration();
+
+            public override void Because()
+            {
+                because = () => service.list_noop(config);
+            }
+
+            public override void BeforeEachSpec()
+            {
+                MockLogger.reset();
+            }
+
+            [Fact]
+            public void should_log_template_location_if_no_template_name()
+            {
+                because();
+
+                var infos = MockLogger.MessagesFor(LogLevel.Info);
+                infos.Count.ShouldEqual(1);
+                infos[0].ShouldEqual("Would have listed templates in {0}".format_with(ApplicationParameters.TemplatesLocation));
+            }
+
+            [Fact]
+            public void should_log_template_name_if_template_name()
+            {
+                config.TemplateCommand.Name = "msi";
+                because();
+
+                var infos = MockLogger.MessagesFor(LogLevel.Info);
+                infos.Count.ShouldEqual(1);
+                infos[0].ShouldEqual("Would have listed information about {0}".format_with(config.TemplateCommand.Name));
+            }
+        }
     }
 }

--- a/src/chocolatey/chocolatey.csproj
+++ b/src/chocolatey/chocolatey.csproj
@@ -113,6 +113,8 @@
       <Link>Properties\SolutionVersion.cs</Link>
     </Compile>
     <Compile Include="AssemblyExtensions.cs" />
+    <Compile Include="infrastructure.app\commands\ChocolateyTemplateCommand.cs" />
+    <Compile Include="infrastructure.app\domain\TemplateCommandType.cs" />
     <Compile Include="infrastructure.app\commands\ChocolateyExportCommand.cs" />
     <Compile Include="infrastructure.app\commands\ChocolateyInfoCommand.cs" />
     <Compile Include="infrastructure.app\commands\ChocolateyHelpCommand.cs" />

--- a/src/chocolatey/infrastructure.app/commands/ChocolateyExportCommand.cs
+++ b/src/chocolatey/infrastructure.app/commands/ChocolateyExportCommand.cs
@@ -85,6 +85,8 @@ Export all currently installed packages to a file.
 This is especially helpful when re-building a machine that was created
 using Chocolatey.  Export all packages to a file, and then re-install
 those packages onto new machine using `choco install packages.config`.
+
+NOTE: Available with 0.11.0+.
 ");
             "chocolatey".Log().Info(ChocolateyLoggers.Important, "Usage");
             "chocolatey".Log().Info(@"

--- a/src/chocolatey/infrastructure.app/commands/ChocolateyNewCommand.cs
+++ b/src/chocolatey/infrastructure.app/commands/ChocolateyNewCommand.cs
@@ -181,7 +181,7 @@ If you find other exit codes that we have not yet documented, please
 
         public virtual void noop(ChocolateyConfiguration configuration)
         {
-            _templateService.noop(configuration);
+            _templateService.generate_noop(configuration);
         }
 
         public virtual void run(ChocolateyConfiguration configuration)

--- a/src/chocolatey/infrastructure.app/commands/ChocolateyTemplateCommand.cs
+++ b/src/chocolatey/infrastructure.app/commands/ChocolateyTemplateCommand.cs
@@ -1,0 +1,157 @@
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+// Copyright © 2011 - 2017 RealDimensions Software, LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace chocolatey.infrastructure.app.commands
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using attributes;
+    using commandline;
+    using configuration;
+    using domain;
+    using infrastructure.commands;
+    using logging;
+    using services;
+    using templates;
+
+    [CommandFor("template", "get information about installed templates")]
+    [CommandFor("templates", "get information about installed templates (alias for template)")]
+    public class ChocolateyTemplateCommand : ICommand
+    {
+        private readonly ITemplateService _templateService;
+
+        public ChocolateyTemplateCommand(ITemplateService templateService)
+        {
+            _templateService = templateService;
+        }
+
+        public void configure_argument_parser(OptionSet optionSet, ChocolateyConfiguration configuration)
+        {
+            optionSet
+                .Add("n=|name=",
+                    "The name of the template to get information about.",
+                    option => configuration.TemplateCommand.Name = option.remove_surrounding_quotes().ToLower());
+            // TODO Allow for templates from external path? If PR 1477 is merged
+        }
+
+        public virtual void handle_additional_argument_parsing(IList<string> unparsedArguments, ChocolateyConfiguration configuration)
+        {
+            // don't set configuration.Input or it will be passed to list
+
+            if (unparsedArguments.Count > 1)
+            {
+                throw new ApplicationException("A single template command must be listed. Please see the help menu for those commands");
+            }
+
+            var command = TemplateCommandType.unknown;
+            string unparsedCommand = unparsedArguments.DefaultIfEmpty(string.Empty).FirstOrDefault();
+            Enum.TryParse(unparsedCommand, true, out command);
+
+            if (command == TemplateCommandType.unknown)
+            {
+                if (!string.IsNullOrWhiteSpace(unparsedCommand)) this.Log().Warn("Unknown command {0}. Setting to list.".format_with(unparsedCommand));
+                command = TemplateCommandType.list;
+            }
+
+            configuration.TemplateCommand.Command = command;
+        }
+
+        public virtual void handle_validation(ChocolateyConfiguration configuration)
+        {
+            if (configuration.TemplateCommand.Command != TemplateCommandType.list && string.IsNullOrWhiteSpace(configuration.TemplateCommand.Name))
+            {
+                throw new ApplicationException("When specifying the subcommand '{0}', you must also specify --name.".format_with(configuration.TemplateCommand.Command.to_string()));
+            }
+        }
+
+        public virtual void help_message(ChocolateyConfiguration configuration)
+        {
+            "chocolatey".Log().Info(ChocolateyLoggers.Important, "Template Command");
+            "chocolatey".Log().Info(@"
+List information installed templates.
+
+Both manually installed templates and templates installed via
+ .template packages are displayed.");
+
+            "chocolatey".Log().Info(ChocolateyLoggers.Important, "Usage");
+            "chocolatey".Log().Info(@"
+    choco pin [list]|info [<options/switches>]");
+
+            "chocolatey".Log().Info(ChocolateyLoggers.Important, "Examples");
+            "chocolatey".Log().Info(@"
+    choco template
+    choco templates
+    choco template list
+    choco template info --name msi
+    choco template list --reduce-output
+    choco template list --verbose
+
+NOTE: See scripting in the command reference (`choco -?`) for how to
+ write proper scripts and integrations.
+
+");
+
+            "chocolatey".Log().Info(ChocolateyLoggers.Important, "Exit Codes");
+            "chocolatey".Log().Info(@"
+Exit codes that normally result from running this command.
+
+Normal:
+ - 0: operation was successful, no issues detected
+ - -1 or 1: an error has occurred
+
+If you find other exit codes that we have not yet documented, please
+ file a ticket so we can document it at
+ https://github.com/chocolatey/choco/issues/new/choose.
+
+");
+
+            "chocolatey".Log().Info(ChocolateyLoggers.Important, "Options and Switches");
+        }
+
+        public virtual void noop(ChocolateyConfiguration configuration)
+        {
+            switch (configuration.TemplateCommand.Command)
+            {
+                case TemplateCommandType.list:
+                    _templateService.list_noop(configuration);
+                    break;
+                case TemplateCommandType.info:
+                    _templateService.list_noop(configuration);
+                    break;
+            }
+        }
+
+        public virtual void run(ChocolateyConfiguration configuration)
+        {
+            switch (configuration.TemplateCommand.Command)
+            {
+                case TemplateCommandType.list:
+                    _templateService.list(configuration);
+                    break;
+                case TemplateCommandType.info:
+                    configuration.Verbose = true;
+                    _templateService.list(configuration);
+                    break;
+            }
+        }
+
+        public virtual bool may_require_admin_access()
+        {
+            return false;
+        }
+    }
+}

--- a/src/chocolatey/infrastructure.app/commands/ChocolateyTemplateCommand.cs
+++ b/src/chocolatey/infrastructure.app/commands/ChocolateyTemplateCommand.cs
@@ -85,7 +85,10 @@ namespace chocolatey.infrastructure.app.commands
 List information installed templates.
 
 Both manually installed templates and templates installed via
- .template packages are displayed.");
+ .template packages are displayed.
+ 
+NOTE: Available with 0.12.0+."
+);
 
             "chocolatey".Log().Info(ChocolateyLoggers.Important, "Usage");
             "chocolatey".Log().Info(@"

--- a/src/chocolatey/infrastructure.app/configuration/ChocolateyConfiguration.cs
+++ b/src/chocolatey/infrastructure.app/configuration/ChocolateyConfiguration.cs
@@ -51,6 +51,7 @@ namespace chocolatey.infrastructure.app.configuration
             OutdatedCommand = new OutdatedCommandConfiguration();
             Proxy = new ProxyConfiguration();
             ExportCommand = new ExportCommandConfiguration();
+            TemplateCommand = new TemplateCommandConfiguration();
 #if DEBUG
             AllowUnofficialBuild = true;
 #endif
@@ -345,6 +346,14 @@ NOTE: Hiding sensitive configuration data! Please double and triple
         ///   On .NET 4.0, get error CS0200 when private set - see http://stackoverflow.com/a/23809226/18475
         /// </remarks>
         public ProxyConfiguration Proxy { get; set; }
+        
+        /// <summary>
+        ///   Configuration related specifically to Template command
+        /// </summary>
+        /// <remarks>
+        ///   On .NET 4.0, get error CS0200 when private set - see http://stackoverflow.com/a/23809226/18475
+        /// </remarks>
+        public TemplateCommandConfiguration TemplateCommand { get;  set; }
     }
 
     [Serializable]
@@ -556,5 +565,12 @@ NOTE: Hiding sensitive configuration data! Please double and triple
         public bool IncludeVersionNumbers { get; set; }
 
         public string OutputFilePath { get; set; }
+    }
+    
+    [Serializable]
+    public sealed class TemplateCommandConfiguration
+    {
+        public TemplateCommandType Command { get; set; }
+        public string Name { get; set; }
     }
 }

--- a/src/chocolatey/infrastructure.app/domain/TemplateCommandType.cs
+++ b/src/chocolatey/infrastructure.app/domain/TemplateCommandType.cs
@@ -1,0 +1,25 @@
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+// Copyright © 2011 - 2017 RealDimensions Software, LLC
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// 
+// You may obtain a copy of the License at
+// 
+// 	http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace chocolatey.infrastructure.app.domain
+{
+    public enum TemplateCommandType
+    {
+        unknown,
+        list,
+        info
+    }
+}

--- a/src/chocolatey/infrastructure.app/registration/ContainerBinding.cs
+++ b/src/chocolatey/infrastructure.app/registration/ContainerBinding.cs
@@ -97,7 +97,8 @@ namespace chocolatey.infrastructure.app.registration
                             new ChocolateyUnpackSelfCommand(container.GetInstance<IFileSystem>()),
                             new ChocolateyVersionCommand(container.GetInstance<IChocolateyPackageService>()),
                             new ChocolateyUpdateCommand(container.GetInstance<IChocolateyPackageService>()),
-                            new ChocolateyExportCommand(container.GetInstance<INugetService>(), container.GetInstance<IFileSystem>())
+                            new ChocolateyExportCommand(container.GetInstance<INugetService>(), container.GetInstance<IFileSystem>()),
+                            new ChocolateyTemplateCommand(container.GetInstance<ITemplateService>())
                         };
                     return list.AsReadOnly();
                 }, Lifestyle.Singleton);

--- a/src/chocolatey/infrastructure.app/services/ITemplateService.cs
+++ b/src/chocolatey/infrastructure.app/services/ITemplateService.cs
@@ -22,5 +22,7 @@ namespace chocolatey.infrastructure.app.services
     {
         void generate_noop(ChocolateyConfiguration configuration);
         void generate(ChocolateyConfiguration configuration);
+        void list_noop(ChocolateyConfiguration configuration);
+        void list(ChocolateyConfiguration configuration);
     }
 }

--- a/src/chocolatey/infrastructure.app/services/ITemplateService.cs
+++ b/src/chocolatey/infrastructure.app/services/ITemplateService.cs
@@ -20,7 +20,7 @@ namespace chocolatey.infrastructure.app.services
 
     public interface ITemplateService
     {
-        void noop(ChocolateyConfiguration configuration);
+        void generate_noop(ChocolateyConfiguration configuration);
         void generate(ChocolateyConfiguration configuration);
     }
 }

--- a/src/chocolatey/infrastructure.app/services/TemplateService.cs
+++ b/src/chocolatey/infrastructure.app/services/TemplateService.cs
@@ -19,24 +19,32 @@ namespace chocolatey.infrastructure.app.services
     using System;
     using System.Collections.Generic;
     using System.IO;
+    using System.Linq;
     using System.Reflection;
     using System.Text;
     using configuration;
-    using filesystem;
     using logging;
     using templates;
     using tokens;
+    using NuGet;
+    using nuget;
+    using IFileSystem = filesystem.IFileSystem;
 
     public class TemplateService : ITemplateService
     {
         private readonly UTF8Encoding utf8WithoutBOM = new UTF8Encoding(false);
         private readonly IFileSystem _fileSystem;
+        private readonly ILogger _nugetLogger;
+
         private readonly IList<string> _templateBinaryExtensions = new List<string> {
             ".exe", ".msi", ".msu", ".msp", ".mst",
             ".7z", ".zip", ".rar", ".gz", ".iso", ".tar", ".sfx",
             ".dmg",
             ".cer", ".crt", ".der", ".p7b", ".pfx", ".p12", ".pem"
             };
+
+        private readonly string _builtInTemplateOverrideName = "default";
+        private readonly string _builtInTemplateName = "built-in";
 
         public TemplateService(IFileSystem fileSystem)
         {
@@ -187,6 +195,155 @@ namespace chocolatey.infrastructure.app.services
             this.Log().Debug(() => "{0}".format_with(template));
             _fileSystem.create_directory_if_not_exists(_fileSystem.get_directory_name(fileLocation));
             _fileSystem.write_file(fileLocation, template, encoding);
+        }
+
+        public void list_noop(ChocolateyConfiguration configuration)
+        {
+            if (string.IsNullOrWhiteSpace(configuration.TemplateCommand.Name))
+            {
+                this.Log().Info(() => "Would have listed templates in {0}".format_with(ApplicationParameters.TemplatesLocation));
+            }
+            else
+            {
+                this.Log().Info(() => "Would have listed information about {0}".format_with(configuration.TemplateCommand.Name));
+            }
+        }
+
+        public void list(ChocolateyConfiguration configuration)
+        {
+            var packageManager = NugetCommon.GetPackageManager(configuration, _nugetLogger,
+                new PackageDownloader(),
+                installSuccessAction: null,
+                uninstallSuccessAction: null,
+                addUninstallHandler: false);
+
+            var templateDirList = _fileSystem.get_directories(ApplicationParameters.TemplatesLocation).ToList();
+            var isBuiltInTemplateOverriden = templateDirList.Contains(_fileSystem.combine_paths(ApplicationParameters.TemplatesLocation, _builtInTemplateOverrideName));
+            var isBuiltInOrDefaultTemplateDefault = string.IsNullOrWhiteSpace(configuration.DefaultTemplateName) || !templateDirList.Contains(_fileSystem.combine_paths(ApplicationParameters.TemplatesLocation, configuration.DefaultTemplateName));
+
+            if (string.IsNullOrWhiteSpace(configuration.TemplateCommand.Name))
+            {
+                if (templateDirList.Any())
+                {
+                    foreach (var templateDir in templateDirList)
+                    {
+                        configuration.TemplateCommand.Name = _fileSystem.get_file_name(templateDir);
+                        list_custom_template_info(configuration, packageManager);
+                    }
+
+                    this.Log().Info(configuration.RegularOutput ? "{0} Custom templates found at {1}{2}".format_with(templateDirList.Count(), ApplicationParameters.TemplatesLocation, Environment.NewLine) : string.Empty);
+                }
+                else
+                {
+                    this.Log().Info(configuration.RegularOutput ? "No custom templates installed in {0}{1}".format_with(ApplicationParameters.TemplatesLocation, Environment.NewLine) : string.Empty);
+                }
+
+                list_built_in_template_info(configuration, isBuiltInTemplateOverriden, isBuiltInOrDefaultTemplateDefault);
+            }
+            else
+            {
+                if (templateDirList.Contains(_fileSystem.combine_paths(ApplicationParameters.TemplatesLocation, configuration.TemplateCommand.Name)))
+                {
+                    list_custom_template_info(configuration, packageManager);
+                    if (configuration.TemplateCommand.Name == _builtInTemplateName || configuration.TemplateCommand.Name == _builtInTemplateOverrideName)
+                    {
+                        list_built_in_template_info(configuration, isBuiltInTemplateOverriden, isBuiltInOrDefaultTemplateDefault);
+                    }
+                }
+                else
+                {
+                    if (configuration.TemplateCommand.Name.ToLowerInvariant() == _builtInTemplateName || configuration.TemplateCommand.Name.ToLowerInvariant() == _builtInTemplateOverrideName)
+                    {
+                        // We know that the template is not overriden since the template directory was checked
+                        list_built_in_template_info(configuration, isBuiltInTemplateOverriden, isBuiltInOrDefaultTemplateDefault);
+                    }
+                    else
+                    {
+                        throw new ApplicationException("Unable to find requested template '{0}'".format_with(configuration.TemplateCommand.Name));
+                    }
+                }
+            }
+        }
+
+        protected void list_custom_template_info(ChocolateyConfiguration configuration, IPackageManager packageManager)
+        {
+            var pkg = packageManager.LocalRepository.FindPackage("{0}.template".format_with(configuration.TemplateCommand.Name));
+            var templateInstalledViaPackage = (pkg != null);
+
+            var pkgVersion = templateInstalledViaPackage ? pkg.Version.to_string() : "0.0.0";
+            var pkgTitle = templateInstalledViaPackage ? pkg.Title : "{0} (Unmanaged)".format_with(configuration.TemplateCommand.Name);
+            var pkgSummary = templateInstalledViaPackage ?
+                (pkg.Summary != null && !string.IsNullOrWhiteSpace(pkg.Summary.to_string()) ? "{0}".format_with(pkg.Summary.escape_curly_braces().to_string()) : string.Empty) : string.Empty;
+            var pkgDescription = templateInstalledViaPackage ? pkg.Description.escape_curly_braces().Replace("\n    ", "\n").Replace("\n", "\n  ") : string.Empty;
+            var pkgFiles = "  {0}".format_with(string.Join("{0}  "
+                .format_with(Environment.NewLine), _fileSystem.get_files(_fileSystem
+                    .combine_paths(ApplicationParameters.TemplatesLocation, configuration.TemplateCommand.Name), "*", SearchOption.AllDirectories)));
+            var isOverridingBuiltIn = configuration.TemplateCommand.Name == _builtInTemplateOverrideName;
+            var isDefault = string.IsNullOrWhiteSpace(configuration.DefaultTemplateName) ? isOverridingBuiltIn : (configuration.DefaultTemplateName == configuration.TemplateCommand.Name);
+
+            if (configuration.RegularOutput)
+            {
+                if (configuration.Verbose)
+                {
+                    this.Log().Info(@"Template name: {0}
+Version: {1}
+Default template: {2}
+{3}Title: {4}
+{5}{6}
+List of files:
+{7}
+".format_with(configuration.TemplateCommand.Name,
+                        pkgVersion,
+                        isDefault,
+                        isOverridingBuiltIn ? "This template is overriding the built in template{0}".format_with(Environment.NewLine) : string.Empty,
+                        pkgTitle,
+                        string.IsNullOrEmpty(pkgSummary) ? "Template not installed as a package" : "Summary: {0}".format_with(pkgSummary),
+                        string.IsNullOrEmpty(pkgDescription) ? string.Empty : "{0}Description:{0}  {1}".format_with(Environment.NewLine, pkgDescription),
+                        pkgFiles));
+                }
+                else
+                {
+                    this.Log().Info("{0} {1} {2}".format_with((isDefault ? '*' : ' '), configuration.TemplateCommand.Name, pkgVersion));
+                }
+            }
+            else
+            {
+                this.Log().Info("{0}|{1}".format_with(configuration.TemplateCommand.Name, pkgVersion));
+            }
+        }
+
+        protected void list_built_in_template_info(ChocolateyConfiguration configuration, bool isOverridden, bool isDefault)
+        {
+            if (configuration.RegularOutput)
+            {
+                if (isOverridden)
+                {
+                    this.Log().Info("Built-in template overriden by 'default' template.{0}".format_with(Environment.NewLine));
+                }
+                else
+                {
+                    if (isDefault)
+                    {
+                        this.Log().Info("Built-in template is default.{0}".format_with(Environment.NewLine));
+                    }
+                    else
+                    {
+                        this.Log().Info("Built-in template is not default, it can be specified if the --built-in parameter is used{0}".format_with(Environment.NewLine));
+                    }
+                }
+                if (configuration.Verbose)
+                {
+                    this.Log().Info("Help about the built-in template can be found with 'choco new --help'{0}".format_with(Environment.NewLine));
+                }
+            }
+            else
+            {
+                //If reduced output, only print out the built in template if it is not overriden
+                if (!isOverridden)
+                {
+                    this.Log().Info("built-in|0.0.0");
+                }
+            }
         }
     }
 }

--- a/src/chocolatey/infrastructure.app/services/TemplateService.cs
+++ b/src/chocolatey/infrastructure.app/services/TemplateService.cs
@@ -43,7 +43,7 @@ namespace chocolatey.infrastructure.app.services
             _fileSystem = fileSystem;
         }
 
-        public void noop(ChocolateyConfiguration configuration)
+        public void generate_noop(ChocolateyConfiguration configuration)
         {
             var templateLocation = _fileSystem.combine_paths(configuration.OutputDirectory ?? _fileSystem.get_current_directory(), configuration.NewCommand.Name);
             this.Log().Info(() => "Would have generated a new package specification at {0}".format_with(templateLocation));


### PR DESCRIPTION
## Description Of Changes

Renames noop to generate_noop in the template service.

Adds `template` command, and associated functions in the template service.

## Motivation and Context

This allows a user to get information about all installed templates, or
a specific template. The list subcommand lists all installed templates.
The info subcommand lists verbose information about a specific template

Usage with -r should output a machine parsable list of the installed
templates. Usage with verbose (implied with the info subcommand) 
outputs more information about the template(s).

The information displayed here can be gathered by running the list
command, config command and inspecting the contents of the
TemplatesLocation. However, this command allows the information to be
displayed in one location.

Both manually installed templates and templates installed via .template
packages are displayed. 

## Testing

There have not been unit tests added for the template service `list` method. This is because the correct methods to mock out the nuget information need to be found, see #2501.

Steps to setup templates to test with (run in CMD):
```
REM Clean out anything old
DEL /S /Q "C:\path\to\choco\src\chocolatey.console\bin\debug\lib"
DEL /S /Q "C:\path\to\choco\src\chocolatey.console\bin\debug\.chocolatey"
DEL /S /Q "C:\path\to\choco\src\chocolatey.console\bin\debug\templates"
REM Setup config
C:\path\to\choco\src\chocolatey.console\bin\debug\choco.exe feature disable -n showNonElevatedWarnings --allow-unofficial -y
C:\path\to\choco\src\chocolatey.console\bin\debug\choco.exe feature enable -n allowGlobalConfirmation --allow-unofficial -y
C:\path\to\choco\src\chocolatey.console\bin\debug\choco.exe feature enable -n useRememberedArgumentsForUpgrades
REM install msi and zip templates
C:\path\to\choco\src\chocolatey.console\bin\debug\choco.exe install msi.template
C:\path\to\choco\src\chocolatey.console\bin\debug\choco.exe install zip.template
REM copy msi template to emulate templates installed manually (e.g. outside of package)
xcopy "C:\path\to\choco\src\chocolatey.console\bin\debug\templates\msi" "C:\path\to\choco\src\chocolatey.console\bin\debug\templates\non-pkg\" /s /e
xcopy "C:\path\to\choco\src\chocolatey.console\bin\debug\templates\msi" "C:\path\to\choco\src\chocolatey.console\bin\debug\templates\default\" /s /e
```

Then run various commands to validate it lists out the correct information:
```
REM check that the command selects list as the default option
C:\path\to\choco\src\chocolatey.console\bin\debug\choco.exe template
REM check that the templates alias exists
C:\path\to\choco\src\chocolatey.console\bin\debug\choco.exe templates
REM check that the explicit list command works
C:\path\to\choco\src\chocolatey.console\bin\debug\choco.exe template list
REM check that verbose works
C:\path\to\choco\src\chocolatey.console\bin\debug\choco.exe template list --verbose
REM check that the --name argument works
C:\path\to\choco\src\chocolatey.console\bin\debug\choco.exe template list --verbose --name msi
REM check that the --name argument fails if the template does not exist
C:\path\to\choco\src\chocolatey.console\bin\debug\choco.exe template list --verbose --name notinstalled
REM check that info fails if --name is not passed
C:\path\to\choco\src\chocolatey.console\bin\debug\choco.exe template info
REM check that info works if --name is passed
C:\path\to\choco\src\chocolatey.console\bin\debug\choco.exe template info --name msi
REM check that the --name argument fails on info if the template does not exist
C:\path\to\choco\src\chocolatey.console\bin\debug\choco.exe template info --name notinstalled
REM check that listing the default template works
C:\path\to\choco\src\chocolatey.console\bin\debug\choco.exe template info --name default
```

Then delete all of the custom templates and check the behavior without any installed templates:
```
DEL /S /Q "C:\path\to\choco\src\chocolatey.console\bin\debug\templates"
REM check the behavior without any custom templates
C:\path\to\choco\src\chocolatey.console\bin\debug\choco.exe template
REM check the behavior if --name default is specified
C:\path\to\choco\src\chocolatey.console\bin\debug\choco.exe template info --name default
```

## Change Types Made

* [ ] Bug fix (non-breaking change)
* [x] Feature / Enhancement (non-breaking change)
* [ ] Breaking change (fix or feature that could cause existing functionality to change)

## Related Issue

Fixes #449
Depends on #2390 

## Change Checklist

* [x] Requires a change to the documentation
* [x] Documentation has been updated
* [x] Tests to cover my changes, have been added
* [x] All new and existing tests passed.
* [ ] PowerShell v2 compatibility checked. (Not applicable)


