### PR TITLE
(#2384) Remove building from linux note from template

### DIFF
--- a/src/chocolatey/infrastructure.app/templates/NuspecTemplate.cs
+++ b/src/chocolatey/infrastructure.app/templates/NuspecTemplate.cs
@@ -98,7 +98,6 @@ This is a nuspec. It mostly adheres to https://docs.nuget.org/create/Nuspec-Refe
   <files>
     <!-- this section controls what actually gets packaged into the Chocolatey package -->
     <file src=""tools\**"" target=""tools"" />
-    <!--Building from Linux? You may need this instead: <file src=""tools/**"" target=""tools"" />-->
   </files>
 </package>
 ";


### PR DESCRIPTION
Remove the "Building from Linux?" note from the built-in template nuspec.
Now that #502 has been fixed, it is not longer relevant.

Fixes #2384
