### PR TITLE
(#2383) Use "/" instead of SystemDrive on non-Windows platforms

### DIFF
--- a/src/chocolatey/infrastructure/filesystem/DotNetFileSystem.cs
+++ b/src/chocolatey/infrastructure/filesystem/DotNetFileSystem.cs
@@ -649,7 +649,10 @@ namespace chocolatey.infrastructure.filesystem
         public void move_directory(string directoryPath, string newDirectoryPath)
         {
             if (string.IsNullOrWhiteSpace(directoryPath) || string.IsNullOrWhiteSpace(newDirectoryPath)) throw new ApplicationException("You must provide a directory to move from or to.");
-            if (combine_paths(directoryPath, "").is_equal_to(combine_paths(Environment.GetEnvironmentVariable("SystemDrive"), ""))) throw new ApplicationException("Cannot move or delete the root of the system drive");
+            
+            //Linux/MacOS do not have a SystemDrive environment variable, instead, everything is under "/"
+            var systemDrive = Platform.get_platform() == PlatformType.Windows ? Environment.GetEnvironmentVariable("SystemDrive") : "/";
+            if (combine_paths(directoryPath, "").is_equal_to(combine_paths(systemDrive, ""))) throw new ApplicationException("Cannot move or delete the root of the system drive");
 
             try
             {
@@ -741,7 +744,10 @@ namespace chocolatey.infrastructure.filesystem
         public void delete_directory(string directoryPath, bool recursive, bool overrideAttributes, bool isSilent)
         {
             if (string.IsNullOrWhiteSpace(directoryPath)) throw new ApplicationException("You must provide a directory to delete.");
-            if (combine_paths(directoryPath, "").is_equal_to(combine_paths(Environment.GetEnvironmentVariable("SystemDrive"), ""))) throw new ApplicationException("Cannot move or delete the root of the system drive");
+
+            //Linux / MacOS do not have a SystemDrive environment variable, instead, everything is under "/"
+            var systemDrive = Platform.get_platform() == PlatformType.Windows ? Environment.GetEnvironmentVariable("SystemDrive") : "/";
+            if (combine_paths(directoryPath, "").is_equal_to(combine_paths(systemDrive, ""))) throw new ApplicationException("Cannot move or delete the root of the system drive");
 
             if (overrideAttributes)
             {


### PR DESCRIPTION
Linux and MacOS do not normally have a "SystemDrive" environment
variable since they have everything under a single root of "/".
This switches to use "/" instead of "SystemDrive" on non-Windows
platforms. These two instances are the only ones I see in the C#
codebase. There are a couple of uses of "SystemDrive" in the PowerShell
helpers, but those are not run on non-Windows platforms.

Fixes #2383 

How this PR was tested:

- Debugged with VS on Windows, validated that "systemDrive" variable was "C:"
- Built on Linux, ran `choco --verbose --debug` to validate the warning about not being able to cleanup NuGet temp folders went away.