### PR TITLE
(#2377) Add ability to configure default template name

### DIFF
--- a/src/chocolatey.tests/infrastructure.app/services/TemplateServiceSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/services/TemplateServiceSpecs.cs
@@ -1,13 +1,13 @@
 ﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
-// 
+//
 // You may obtain a copy of the License at
-// 
+//
 // 	http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/chocolatey/infrastructure.app/ApplicationParameters.cs
+++ b/src/chocolatey/infrastructure.app/ApplicationParameters.cs
@@ -174,6 +174,7 @@ namespace chocolatey.infrastructure.app
             public static readonly string ProxyBypassOnLocal = "proxyBypassOnLocal";
             public static readonly string WebRequestTimeoutSeconds = "webRequestTimeoutSeconds";
             public static readonly string UpgradeAllExceptions = "upgradeAllExceptions";
+            public static readonly string DefaultTemplateName = "defaultTemplateName";
         }
 
         public static class Features

--- a/src/chocolatey/infrastructure.app/builders/ConfigurationBuilder.cs
+++ b/src/chocolatey/infrastructure.app/builders/ConfigurationBuilder.cs
@@ -254,6 +254,7 @@ namespace chocolatey.infrastructure.app.builders
             config.Proxy.BypassList = set_config_item(ApplicationParameters.ConfigSettings.ProxyBypassList, configFileSettings, string.Empty, "Optional proxy bypass list. Comma separated. Available in 0.10.4+.");
             config.Proxy.BypassOnLocal = set_config_item(ApplicationParameters.ConfigSettings.ProxyBypassOnLocal, configFileSettings, "true", "Bypass proxy for local connections. Available in 0.10.4+.").is_equal_to(bool.TrueString);
             config.UpgradeCommand.PackageNamesToSkip = set_config_item(ApplicationParameters.ConfigSettings.UpgradeAllExceptions, configFileSettings, string.Empty, "A comma-separated list of package names that should not be upgraded when running `choco upgrade all'. Defaults to empty. Available in 0.10.14+.");
+            config.DefaultTemplateName = set_config_item(ApplicationParameters.ConfigSettings.DefaultTemplateName, configFileSettings, string.Empty, "Default template name used when running 'choco new' command. Available in 0.12.0+.");
         }
 
         private static string set_config_item(string configName, ConfigFileSettings configFileSettings, string defaultValue, string description, bool forceSettingValue = false)

--- a/src/chocolatey/infrastructure.app/configuration/ChocolateyConfiguration.cs
+++ b/src/chocolatey/infrastructure.app/configuration/ChocolateyConfiguration.cs
@@ -146,6 +146,7 @@ NOTE: Hiding sensitive configuration data! Please double and triple
         public bool ContainsLegacyPackageInstalls { get; set; }
         public int CommandExecutionTimeoutSeconds { get; set; }
         public int WebRequestTimeoutSeconds { get; set; }
+        public string DefaultTemplateName { get; set; }
 
         /// <summary>
         ///   One or more source locations set by configuration or by command line. Separated by semi-colon

--- a/src/chocolatey/infrastructure.app/services/TemplateService.cs
+++ b/src/chocolatey/infrastructure.app/services/TemplateService.cs
@@ -1,13 +1,13 @@
 ﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
-// 
+//
 // You may obtain a copy of the License at
-// 
+//
 // 	http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -31,7 +31,7 @@ namespace chocolatey.infrastructure.app.services
     {
         private readonly UTF8Encoding utf8WithoutBOM = new UTF8Encoding(false);
         private readonly IFileSystem _fileSystem;
-        private readonly IList<string> _templateBinaryExtensions = new List<string> { 
+        private readonly IList<string> _templateBinaryExtensions = new List<string> {
             ".exe", ".msi", ".msu", ".msp", ".mst",
             ".7z", ".zip", ".rar", ".gz", ".iso", ".tar", ".sfx",
             ".dmg",
@@ -122,7 +122,7 @@ namespace chocolatey.infrastructure.app.services
                 if (!_fileSystem.directory_exists(templatePath)) throw new ApplicationException("Unable to find path to requested template '{0}'. Path should be '{1}'".format_with(configuration.NewCommand.TemplateName, templatePath));
 
                 this.Log().Info(configuration.QuietOutput ? logger : ChocolateyLoggers.Important, "Generating package from custom template at '{0}'.".format_with(templatePath));
-                
+
                 // Create directory structure from template so as to include empty directories
                 foreach (var directory in _fileSystem.get_directories(templatePath, "*.*", SearchOption.AllDirectories))
                 {


### PR DESCRIPTION
## Description Of Changes

A new configuration value has been added to the chocolatey.config file, name `defaultTemplateName`.  This allows the user to specify the name of a template which should be used by default when executing the `choco new` command.

## Motivation and Context

While it is currently possible to override the files that are used by default when running `choco new`, this requires the user adding the files into a known location.  By adding this configuration option, it allows the user to run something like:

```
choco install zip.template
choco config set --name=defaultTemplateName --value=zip
```

And then, going forward, anytime that `choco new bob` is run, and new package called `bob` will be created using the zip template.

If the user were to run something like the following:

```
choco new bob --template-name=msi
```

Then the msi template would be used, and the defaultTemplateName would be ignored.

If the user were to override the default template in the required folder, then it will be used when nothing else is set.

However, if the user were to override the default template files in the required folder, _and_ set the defaultTemplateName configuration option, then the latter would win.

## Testing

The following things have been done to test this:

1. `choco install zip.template`
2. `choco install msi.template`
3. Run `choco new bob`
4. A new package with the name `bob` is created, using the standard template
5. Delete the newly created bob folder
5. Run `choco new bob --template-name=zip`
6. A new package with the name `bob` is created, using the zip template
7. Delete the newly created bob folder
8. Run `choco config set --name=defaultTemplateName --value=msi`
9. Run `choco new bob`
10. A new package with the name `bob` is created, using the msi template
11. Delete the newly created bob folder
12. Run `choco new bob --template-name=zip`
13. A new package with the name `bob` is created, using the zip template
14. Delete the newly created bob folder
15. Run `choco config unset --name=defaultTemplateName`
16. Copy the files from `C:\ProgramData\chocolatey\templates\msi` to `C:\ProgramData\chocolatey\templates\default`
17. Run `choco new bob`
18. A new package with the name `bob` is created, using the msi template
19. Delete the newly created bob folder
20. Run `choco new bob --template-name=zip`
21. A new package with the name `bob` is created, using the zip template
22. Delete the newly created bob folder
23. Run `choco config set --name=defaultTemplateName --value=zip`
24. Run `choco new bob`
25. A new package with name `bob` is created, using the zip template

## Change Types Made

* [ ] Bug fix (non-breaking change)
* [x] Feature / Enhancement (non-breaking change)
* [ ] Breaking change (fix or feature that could cause existing functionality to change)

## Related Issue

Fixes #2377

## Change Checklist

* [x] Requires a change to the documentation
* [x] Documentation has been updated - added to tracking issue here: https://github.com/chocolatey/choco/issues/2391
* [ ] Tests to cover my changes, have been added
* [x] All new and existing tests passed.