### PR TITLE
(doc) Update linux docker steps with new tags

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -7,10 +7,10 @@ To build this image yourself, follow these steps:
 
 1. Clone down the repository using `git clone https://github.com/chocolatey/choco.git`.
 1. Change directories to the root of the repository.
-1. Run the docker build command. `docker build -t mono-choco -f docker/Dockerfile.linux .` (the trailing . is important)
-    * To build a official version, add the argument `--build-arg buildscript=build.official.sh`
+1. Run the docker build command. `docker build -t choco:latest-linux -f docker/Dockerfile.linux .` (the trailing . is important)
+    * To build a official version, use this command: `docker build -t chocolatey/choco:latest-linux -f docker/Dockerfile.linux . --build-arg buildscript=build.official.sh`
     * To build a debug version, add the argument `--build-arg buildscript=build.debug.sh`
     * To change the version of mono used, add the argument `--build-arg monoversion=mono-tag`
-1. Run your new image using the command `docker run -ti --rm mono-choco /bin/bash`
+1. Run your new image using the command `docker run -ti --rm choco:latest-linux /bin/bash`
 1. Test choco by running `choco -h`. You should see the help message from choco.exe.
 


### PR DESCRIPTION
Changes the image name from "mono-choco" to "choco", and changes the
image tag from the implicit "latest" to "latest-linux" as discussed
in chocolatey/choco#1718. Also adjusts the official build to use
include the offical docker username of chocolatey in the image name.
