### PR TITLE
(#1003) Include empty directories from templates

### DIFF
--- a/src/chocolatey.tests/infrastructure.app/services/TemplateServiceSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/services/TemplateServiceSpecs.cs
@@ -26,7 +26,6 @@ namespace chocolatey.tests.infrastructure.app.services
     using chocolatey.infrastructure.app.templates;
     using chocolatey.infrastructure.filesystem;
     using Moq;
-    using NUnit.Framework;
     using Should;
 
     public class TemplateServiceSpecs
@@ -350,6 +349,8 @@ namespace chocolatey.tests.infrastructure.app.services
                 fileSystem.Setup(x => x.delete_directory_if_exists(It.IsAny<string>(), true));
                 fileSystem.Setup(x => x.get_files(It.IsAny<string>(), "*.*", SearchOption.AllDirectories))
                     .Returns(new[] { "templates\\test\\template.nuspec", "templates\\test\\random.txt", "templates\\test\\tools\\chocolateyInstall.ps1", "templates\\test\\tools\\lower\\another.ps1" });
+                fileSystem.Setup(x => x.get_directories(It.IsAny<string>(), "*.*", SearchOption.AllDirectories))
+                    .Returns(new[] { "templates\\test", "templates\\test\\tools", "templates\\test\\tools\\lower" });
                 fileSystem.Setup(x => x.create_directory_if_not_exists(It.IsAny<string>())).Callback(
                     (string directory) =>
                     {
@@ -379,8 +380,6 @@ namespace chocolatey.tests.infrastructure.app.services
             }
 
             [Fact]
-            [WindowsOnly]
-            [Platform(Exclude = "Mono")]
             public void should_generate_all_files_and_directories()
             {
                 because();
@@ -401,8 +400,6 @@ namespace chocolatey.tests.infrastructure.app.services
             }
 
             [Fact]
-            [WindowsOnly]
-            [Platform(Exclude = "Mono")]
             public void should_generate_all_files_and_directories_even_with_outputdirectory()
             {
                 config.OutputDirectory = "c:\\packages";
@@ -487,8 +484,6 @@ namespace chocolatey.tests.infrastructure.app.services
             }
 
             [Fact]
-            [WindowsOnly]
-            [Platform(Exclude = "Mono")]
             public void should_generate_all_files_and_directories()
             {
                 because();
@@ -511,8 +506,6 @@ namespace chocolatey.tests.infrastructure.app.services
             }
 
             [Fact]
-            [WindowsOnly]
-            [Platform(Exclude = "Mono")]
             public void should_generate_all_files_and_directories_even_with_outputdirectory()
             {
                 config.OutputDirectory = "c:\\packages";

--- a/src/chocolatey.tests/infrastructure.app/services/TemplateServiceSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/services/TemplateServiceSpecs.cs
@@ -424,5 +424,117 @@ namespace chocolatey.tests.infrastructure.app.services
                 MockLogger.MessagesFor(LogLevel.Info).Last().ShouldEqual(string.Format(@"Successfully generated Bob package specification files{0} at 'c:\packages\Bob'", Environment.NewLine));
             }
         }
+
+        public class when_generate_is_called_with_empty_nested_folders : TemplateServiceSpecsBase
+        {
+            private Action because;
+            private readonly ChocolateyConfiguration config = new ChocolateyConfiguration();
+            private readonly List<string> files = new List<string>();
+            private readonly HashSet<string> directoryCreated = new HashSet<string>(StringComparer.InvariantCultureIgnoreCase);
+            private readonly UTF8Encoding utf8WithoutBOM = new UTF8Encoding(false);
+
+            public override void Context()
+            {
+                base.Context();
+
+                fileSystem.Setup(x => x.get_current_directory()).Returns("c:\\chocolatey");
+                fileSystem.Setup(x => x.combine_paths(It.IsAny<string>(), It.IsAny<string>()))
+                    .Returns(
+                        (string a, string[] b) =>
+                        {
+                            if (a.EndsWith("templates") && b[0] == "test")
+                            {
+                                return "templates\\test";
+                            }
+                            return a + "\\" + b[0];
+                        });
+                fileSystem.Setup(x => x.directory_exists(It.IsAny<string>())).Returns<string>(dirPath => dirPath.EndsWith("templates\\test"));
+                fileSystem.Setup(x => x.write_file(It.IsAny<string>(), It.IsAny<string>(), Encoding.UTF8))
+                    .Callback((string filePath, string fileContent, Encoding encoding) => files.Add(filePath));
+                fileSystem.Setup(x => x.write_file(It.IsAny<string>(), It.IsAny<string>(), utf8WithoutBOM))
+                    .Callback((string filePath, string fileContent, Encoding encoding) => files.Add(filePath));
+                fileSystem.Setup(x => x.delete_directory_if_exists(It.IsAny<string>(), true));
+                fileSystem.Setup(x => x.get_files(It.IsAny<string>(), "*.*", SearchOption.AllDirectories))
+                    .Returns(new[] { "templates\\test\\template.nuspec", "templates\\test\\random.txt", "templates\\test\\tools\\chocolateyInstall.ps1", "templates\\test\\tools\\lower\\another.ps1" });
+                fileSystem.Setup(x => x.get_directories(It.IsAny<string>(), "*.*", SearchOption.AllDirectories))
+                    .Returns(new[] { "templates\\test", "templates\\test\\tools", "templates\\test\\tools\\lower", "templates\\test\\empty", "templates\\test\\empty\\nested" });
+                fileSystem.Setup(x => x.create_directory_if_not_exists(It.IsAny<string>())).Callback(
+                    (string directory) =>
+                    {
+                        if (!string.IsNullOrWhiteSpace(directory))
+                        {
+                            directoryCreated.Add(directory);
+                        }
+                    });
+                fileSystem.Setup(x => x.get_directory_name(It.IsAny<string>())).Returns<string>(file => Path.GetDirectoryName(file));
+                fileSystem.Setup(x => x.get_file_extension(It.IsAny<string>())).Returns<string>(file => Path.GetExtension(file));
+                fileSystem.Setup(x => x.read_file(It.IsAny<string>())).Returns(string.Empty);
+
+                config.NewCommand.Name = "Bob";
+                config.NewCommand.TemplateName = "test";
+            }
+
+            public override void Because()
+            {
+                because = () => service.generate(config);
+            }
+
+            public override void BeforeEachSpec()
+            {
+                MockLogger.reset();
+                files.Clear();
+                directoryCreated.Clear();
+            }
+
+            [Fact]
+            [WindowsOnly]
+            [Platform(Exclude = "Mono")]
+            public void should_generate_all_files_and_directories()
+            {
+                because();
+
+                var directories = directoryCreated.ToList();
+                directories.Count.ShouldEqual(5, "There should be 5 directories, but there was: " + string.Join(", ", directories));
+                directories[0].ShouldEqual("c:\\chocolatey\\Bob");
+                directories[1].ShouldEqual("c:\\chocolatey\\Bob\\tools");
+                directories[2].ShouldEqual("c:\\chocolatey\\Bob\\tools\\lower");
+                directories[3].ShouldEqual("c:\\chocolatey\\Bob\\empty");
+                directories[4].ShouldEqual("c:\\chocolatey\\Bob\\empty\\nested");
+
+                files.Count.ShouldEqual(4, "There should be 4 files, but there was: " + string.Join(", ", files));
+                files[0].ShouldEqual("c:\\chocolatey\\Bob\\__name_replace__.nuspec");
+                files[1].ShouldEqual("c:\\chocolatey\\Bob\\random.txt");
+                files[2].ShouldEqual("c:\\chocolatey\\Bob\\tools\\chocolateyInstall.ps1");
+                files[3].ShouldEqual("c:\\chocolatey\\Bob\\tools\\lower\\another.ps1");
+
+                MockLogger.MessagesFor(LogLevel.Info).Last().ShouldEqual(string.Format(@"Successfully generated Bob package specification files{0} at 'c:\chocolatey\Bob'", Environment.NewLine));
+            }
+
+            [Fact]
+            [WindowsOnly]
+            [Platform(Exclude = "Mono")]
+            public void should_generate_all_files_and_directories_even_with_outputdirectory()
+            {
+                config.OutputDirectory = "c:\\packages";
+
+                because();
+
+                var directories = directoryCreated.ToList();
+                directories.Count.ShouldEqual(5, "There should be 5 directories, but there was: " + string.Join(", ", directories));
+                directories[0].ShouldEqual("c:\\packages\\Bob");
+                directories[1].ShouldEqual("c:\\packages\\Bob\\tools");
+                directories[2].ShouldEqual("c:\\packages\\Bob\\tools\\lower");
+                directories[3].ShouldEqual("c:\\packages\\Bob\\empty");
+                directories[4].ShouldEqual("c:\\packages\\Bob\\empty\\nested");
+
+                files.Count.ShouldEqual(4, "There should be 4 files, but there was: " + string.Join(", ", files));
+                files[0].ShouldEqual("c:\\packages\\Bob\\__name_replace__.nuspec");
+                files[1].ShouldEqual("c:\\packages\\Bob\\random.txt");
+                files[2].ShouldEqual("c:\\packages\\Bob\\tools\\chocolateyInstall.ps1");
+                files[3].ShouldEqual("c:\\packages\\Bob\\tools\\lower\\another.ps1");
+
+                MockLogger.MessagesFor(LogLevel.Info).Last().ShouldEqual(string.Format(@"Successfully generated Bob package specification files{0} at 'c:\packages\Bob'", Environment.NewLine));
+            }
+        }
     }
 }

--- a/src/chocolatey/infrastructure.app/services/TemplateService.cs
+++ b/src/chocolatey/infrastructure.app/services/TemplateService.cs
@@ -122,6 +122,14 @@ namespace chocolatey.infrastructure.app.services
                 if (!_fileSystem.directory_exists(templatePath)) throw new ApplicationException("Unable to find path to requested template '{0}'. Path should be '{1}'".format_with(configuration.NewCommand.TemplateName, templatePath));
 
                 this.Log().Info(configuration.QuietOutput ? logger : ChocolateyLoggers.Important, "Generating package from custom template at '{0}'.".format_with(templatePath));
+                
+                // Create directory structure from template so as to include empty directories
+                foreach (var directory in _fileSystem.get_directories(templatePath, "*.*", SearchOption.AllDirectories))
+                {
+                    var packageDirectoryLocation = directory.Replace(templatePath, packageLocation);
+                    this.Log().Debug("Creating directory {0}".format_with(packageDirectoryLocation));
+                    _fileSystem.create_directory_if_not_exists(packageDirectoryLocation);
+                }
                 foreach (var file in _fileSystem.get_files(templatePath, "*.*", SearchOption.AllDirectories))
                 {
                     var packageFileLocation = file.Replace(templatePath, packageLocation);


### PR DESCRIPTION
## Description Of Changes

Create the full directory structure of a custom template before
the files are written. 

Tests still need to be added, but I want to get some feedback on if this change is good and how I should add tests first.

## Motivation and Context

This is so empty directories in the template are
replicated in the new package.

## Testing

1. Installed zip.template into debug build install location
2. Added two empty directories to root of zip template folder (`empty-1` and `empty-2`), and created an empty sub folder (`empty-1\empty-subdir`).  
3. Ran `choco new --template=zip --name=temp-pkg`
4. Validated that the empty directories were created under `temp-pkg`

## Change Types Made

* [ ] Bug fix (non-breaking change)
* [x] Feature / Enhancement (non-breaking change)
* [ ] Breaking change (fix or feature that could cause existing functionality to change)

## Related Issue

Fixes #1003

## Change Checklist

* [ ] Requires a change to the documentation
* [ ] Documentation has been updated
* [ ] Tests to cover my changes, have been added
* [ ] All new and existing tests passed.

