### PR TITLE
(#2382) Reference new NuGet.Core assembly in chocolatey.console

### DIFF
--- a/src/chocolatey.console/chocolatey.console.csproj
+++ b/src/chocolatey.console/chocolatey.console.csproj
@@ -129,9 +129,9 @@
     <Reference Include="Microsoft.Web.XmlTransform">
       <HintPath>..\packages\Microsoft.Web.Xdt.2.1.1\lib\net40\Microsoft.Web.XmlTransform.dll</HintPath>
     </Reference>
-    <Reference Include="NuGet.Core, Version=2.8.2.0, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
+    <Reference Include="NuGet.Core, Version=2.11.0.0, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\lib\Chocolatey-NuGet.Core.2.11.0.20210506\lib\net4\NuGet.Core.dll</HintPath>
+      <HintPath>..\..\lib\Chocolatey-NuGet.Core.2.11.0.20211014\lib\net4\NuGet.Core.dll</HintPath>
     </Reference>
     <Reference Include="SimpleInjector">
       <HintPath>..\packages\SimpleInjector.2.5.0\lib\net40-client\SimpleInjector.dll</HintPath>


### PR DESCRIPTION
In commit 545ca6c, the chocolatey.console cs project was not updated,
unlike the other projects. This updates that project in line with the
others.

This should fix the AppVeyor build. I'm not sure why the GitHub actions build was working, but not the AppVeyor build.

Relates to #2382