### PR TITLE
(#2398) Restore PowerShell v2 support

### DIFF
--- a/src/chocolatey.resources/helpers/functions/Install-ChocolateyInstallPackage.ps1
+++ b/src/chocolatey.resources/helpers/functions/Install-ChocolateyInstallPackage.ps1
@@ -249,7 +249,7 @@ Start-ChocolateyProcessAsAdmin
   }
 
   $installerTypeLower = $fileType.ToLower()
-  if ($installerTypeLower -notin 'msi', 'exe', 'msu', 'msp') {
+  if ('msi', 'exe', 'msu', 'msp' -notcontains $installerTypeLower) {
     Write-Warning "FileType '$fileType' is unrecognized, using 'exe' instead."
     $fileType = 'exe'
   }

--- a/src/chocolatey.resources/helpers/functions/Update-SessionEnvironment.ps1
+++ b/src/chocolatey.resources/helpers/functions/Update-SessionEnvironment.ps1
@@ -67,7 +67,7 @@ None
 
   #ordering is important here, $user should override $machine...
   $ScopeList = 'Process', 'Machine'
-  if ($userName -notin 'SYSTEM', "${env:COMPUTERNAME}`$") {
+  if ('SYSTEM', "${env:COMPUTERNAME}`$" -notcontains $userName) {
     # but only if not running as the SYSTEM/machine in which case user can be ignored.
     $ScopeList += 'User'
   }


### PR DESCRIPTION
## Description Of Changes

Commit c408d1299b6f5f7e3e285d17f9e2d1719dfac122 introduced a change to fix a bug with the `$env:TEMP` variable. As well, commit f68a242245defa7f9dc9189f1350f5ca6e6e922b introduced handling of msps in the install helper.

However, they both introduced PowerShell 3+ syntax. This changes those to work with PowerShell 2+.

## Motivation and Context

We currently support PowerShell 2+, so it's important that the PowerShell uses v2 compatible commands.

## What Have I Done To Test This

This one is specific to PowerShell 2 and the import of the `helpers\chocolateyInstaller.psm1`. It can be tested either on a Windows 7 with PowerShell 2 system (this is a multi-hour waiting game to build and update a system if you don't already have one), or on a newer Windows system with the PowerShell 2 compatibility feature enabled by running `powershell -version 2`.

From PowerShell 2 run: `Import-Module src\chocolatey.resources\helpers\chocolateyInstaller.psm1 -force` from the root of the repository. This should result in no errors and no output.

## Change Types Made

* [x] Bug fix (non-breaking change)
* [ ] Feature / Enhancement (non-breaking change)
* [ ] Breaking change (fix or feature that could cause existing functionality to change)

## Related Issue

Fix #2398 

## Change Checklist

* [ ] Requires a change to the documentation
* [ ] Documentation has been updated
* [ ] Tests to cover my changes, have been added
* [x] All new and existing tests passed.