### PR TITLE
(#2412) Change importing of Licensed extension to output warning

### DIFF
--- a/src/chocolatey.resources/helpers/chocolateyInstaller.psm1
+++ b/src/chocolatey.resources/helpers/chocolateyInstaller.psm1
@@ -62,18 +62,24 @@ if (Test-Path $extensionsPath) {
         Write-Debug "Importing '$licensedExtensionPath'"
         Write-Debug "Loading 'chocolatey.licensed' extension"
 
-        # Attempt to import module via already-loaded assembly
-        $licensedAssembly = $currentAssemblies |
-            Where-Object { $_.GetName().Name -eq 'chocolatey.licensed' } |
-            Select-Object -First 1
+        try {
+            # Attempt to import module via already-loaded assembly
+            $licensedAssembly = $currentAssemblies |
+                Where-Object { $_.GetName().Name -eq 'chocolatey.licensed' } |
+                Select-Object -First 1
 
-        if ($licensedAssembly) {
-            # It's already loaded, just import the existing assembly as a module for PowerShell to use
-            Import-Module $licensedAssembly
+            if ($licensedAssembly) {
+                # It's already loaded, just import the existing assembly as a module for PowerShell to use
+                Import-Module $licensedAssembly
+            }
+            else {
+                # Fallback: load the extension DLL from the path directly.
+                Import-Module $licensedExtensionPath
+            }
         }
-        else {
-            # Fallback: load the extension DLL from the path directly.
-            Import-Module $licensedExtensionPath
+        catch {
+            # Only write a warning if the Licensed extension failed to load in some way.
+            Write-Warning "Import failed for Chocolatey Licensed Extension. Error: '$_'"
         }
     }
 


### PR DESCRIPTION
## Description Of Changes

Version 0.11.1 introduced changes to how the Chocolatey Licensed Extension was loaded, and changed any failures of loading the extension away from being a warning to be a Error instead.

This pull request updates the importing to instead re-introduce the failure as a warning by wrapping the imports inside a try/catch block instead.

## Motivation and Context

To revert a breaking change that had been introduced in v0.11.1, and to keep it backwards compatible.

## What Have I Done To Test This

This have been tested with following scenarios in mind.

1. Manual importing of the `chocolateyInstaller.psm1` script, which did not use to write out an error.
2. Create a AU package, or import an existing one that uses `Get-ChocolateyWebFile`, and make sure any monkey patch is not already available. Try updating the package.
3. Load in an extension version we are sure that will fail to load (like loading official licensed extension, into an unofficial Chocolatey build).

## Change Types Made

* [x] Bug fix (non-breaking change)
* [ ] Feature / Enhancement (non-breaking change)
* [ ] Breaking change (fix or feature that could cause existing functionality to change)

## Related Issue

* fixes #2412
* [ZenDesk Issue](https://chocolatey.zendesk.com/agent/tickets/11912)

## Change Checklist

* [ ] Requires a change to the documentation
* [ ] Documentation has been updated
* [ ] Tests to cover my changes, have been added
* [x] All new and existing tests passed.