### PR TITLE
(#2083) Fix Powershell Core profile edit, minor indentation change

### DIFF
--- a/nuget/chocolatey/tools/chocolateysetup.psm1
+++ b/nuget/chocolatey/tools/chocolateysetup.psm1
@@ -622,7 +622,14 @@ param(
 
 # Adapted from http://www.west-wind.com/Weblog/posts/197245.aspx
 function Get-FileEncoding($Path) {
+  if ($PSVersionTable.PSVersion.Major -lt 6) {
+    Write-Debug "Detected Powershell version < 6 ; Using -Encoding byte parameter"
     $bytes = [byte[]](Get-Content $Path -Encoding byte -ReadCount 4 -TotalCount 4)
+  }
+  else {
+    Write-Debug "Detected Powershell version >= 6 ; Using -AsByteStream parameter"
+    $bytes = [byte[]](Get-Content $Path -AsByteStream -ReadCount 4 -TotalCount 4)
+    }
 
     if(!$bytes) { return 'utf8' }
 

--- a/nuget/chocolatey/tools/chocolateysetup.psm1
+++ b/nuget/chocolatey/tools/chocolateysetup.psm1
@@ -622,13 +622,13 @@ param(
 
 # Adapted from http://www.west-wind.com/Weblog/posts/197245.aspx
 function Get-FileEncoding($Path) {
-  if ($PSVersionTable.PSVersion.Major -lt 6) {
-    Write-Debug "Detected Powershell version < 6 ; Using -Encoding byte parameter"
-    $bytes = [byte[]](Get-Content $Path -Encoding byte -ReadCount 4 -TotalCount 4)
-  }
-  else {
-    Write-Debug "Detected Powershell version >= 6 ; Using -AsByteStream parameter"
-    $bytes = [byte[]](Get-Content $Path -AsByteStream -ReadCount 4 -TotalCount 4)
+    if ($PSVersionTable.PSVersion.Major -lt 6) {
+      Write-Debug "Detected Powershell version < 6 ; Using -Encoding byte parameter"
+      $bytes = [byte[]](Get-Content $Path -Encoding byte -ReadCount 4 -TotalCount 4)
+    }
+    else {
+      Write-Debug "Detected Powershell version >= 6 ; Using -AsByteStream parameter"
+      $bytes = [byte[]](Get-Content $Path -AsByteStream -ReadCount 4 -TotalCount 4)
     }
 
     if(!$bytes) { return 'utf8' }


### PR DESCRIPTION
**NOTE: I did not raise this PR. I'm adding this here, so we can get it moving and merged.**

## Description Of Changes

A check has been added to determine if it is running on Windows PowerShell or PowerShell Core and uses the correct encoding parameter.

## Motivation and Context

In PowerShell Core the `-Encoding` parameter from Windows PowerShell is actually `-AsByteStream`. To allow it to work in PowerShell Core _and_ Windows PowerShell we need to perform a check.

## Testing
I cannot confirm how this was tested. Neither this PR or the [original PR](https://github.com/chocolatey/choco/pull/2119), mention it.

## Change Types Made

* [x] Bug fix (non-breaking change)
* [ ] Feature / Enhancement (non-breaking change)
* [ ] Breaking change (fix or feature that could cause existing functionality to change)
* [x] PowerShell code changes.

## Related Issue

Fixes #2083

## Change Checklist

* [ ] Requires a change to the documentation
* [ ] Documentation has been updated
* [ ] Tests to cover my changes, have been added
* [ ] All new and existing tests passed.
* [ ] PowerShell v2 compatibility checked.
