### PR TITLE
(#2007) Push errors display more information

### DIFF
--- a/src/chocolatey/infrastructure.app/nuget/NugetPush.cs
+++ b/src/chocolatey/infrastructure.app/nuget/NugetPush.cs
@@ -1,13 +1,13 @@
 ﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
-// 
+//
 // You may obtain a copy of the License at
-// 
+//
 // 	http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -34,7 +34,7 @@ namespace chocolatey.infrastructure.app.nuget
             const bool disableBuffering = false;
 
             var packageServer = new PackageServer(config.Sources, ApplicationParameters.UserAgent);
-            
+
             packageServer.SendingRequest += (sender, e) => { if (config.Verbose) "chocolatey".Log().Info(ChocolateyLoggers.Verbose, "{0} {1}".format_with(e.Request.Method, e.Request.RequestUri)); };
 
             var package = new OptimizedZipPackage(nupkgFilePath);


### PR DESCRIPTION
## Description Of Changes

This checks the error message of a push error more thoroughly and will display the full
error message if it does not match a specific message and the push url
is not the CCR source.

Also, this improves the error message displayed if the package already
does exist and is immutable.

## Motivation and Context

Previously, if there was an error with pushing a package and the error
was a 406 or 409, then it was assumed to be due to an existing
immutable package. However, CCR uses a 409 code for other errors as
well. So if there was an issue with a package, a misleading message
may be shown.

## Testing
1. Get the package source for a package that you maintain on CCR
2. Get the apikey for your CCR account
3. Edit the package `.nuspec` to a version that exists and is immutable on CCR
4. Pack and try to push the package to CCR and validate that it shows the correct error
5. Edit the package `.nuspec` to a version that does not exist on CCR and the description to over 4000 characters. 
6. Pack and try to push the package to CCR and validate that it shows the full error message from CCR (without having to use --debug)

## Change Types Made

* [ ] Bug fix (non-breaking change)
* [x] Feature / Enhancement (non-breaking change)
* [ ] Breaking change (fix or feature that could cause existing functionality to change)

## Related Issue

Fixes #2007

## Change Checklist

* [ ] Requires a change to the documentation
* [ ] Documentation has been updated
* [ ] Tests to cover my changes, have been added (N/A)
* [x] All new and existing tests passed.
