### PR TITLE
(#1541) Fix package being added to results if none found

### DIFF
--- a/src/chocolatey.tests.integration/scenarios/InstallScenarios.cs
+++ b/src/chocolatey.tests.integration/scenarios/InstallScenarios.cs
@@ -3140,6 +3140,67 @@ namespace chocolatey.tests.integration.scenarios
         }
 
         [Concern(typeof(ChocolateyInstallCommand))]
+        public class when_installing_non_existing_package_from_priority_source : ScenariosBase
+        {
+            public override void Context()
+            {
+                base.Context();
+                Configuration.PackageNames = Configuration.Input = "non-existing";
+            }
+
+            public override void Because()
+            {
+                Results = Service.install_run(Configuration);
+            }
+
+            [Fact]
+            public void should_not_install_where_install_location_reports()
+            {
+                foreach (var packageResult in Results)
+                {
+                    packageResult.Value.Success.ShouldBeFalse();
+                }
+            }
+
+            [Fact]
+            public void should_not_install_a_package_in_the_lib_directory()
+            {
+                var packageDir = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames);
+
+                Directory.Exists(packageDir).ShouldBeFalse();
+            }
+
+            [Fact]
+            public void should_not_have_inconclusive_package_result()
+            {
+                foreach (var packageResult in Results)
+                {
+                    packageResult.Value.Inconclusive.ShouldBeFalse();
+                }
+            }
+
+            [Fact]
+            public void should_not_have_warning_package_result()
+            {
+                foreach (var packageResult in Results)
+                {
+                    packageResult.Value.Warning.ShouldBeFalse();
+                }
+            }
+
+            [Fact]
+            public void should_report_package_not_found()
+            {
+                foreach (var packageResult in Results)
+                {
+                    var message = packageResult.Value.Messages.First();
+                    message.MessageType.ShouldEqual(ResultType.Error);
+                    message.Message.ShouldStartWith("non-existing not installed. The package was not found with the source(s) listed.");
+                }
+            }
+        }
+
+        [Concern(typeof(ChocolateyInstallCommand))]
         public class when_installing_a_package_with_a_dependent_package_that_also_depends_on_a_less_constrained_but_still_valid_dependency_of_the_same_package : ScenariosBase
         {
             public override void Context()

--- a/src/chocolatey/infrastructure.app/nuget/NugetList.cs
+++ b/src/chocolatey/infrastructure.app/nuget/NugetList.cs
@@ -204,7 +204,12 @@ namespace chocolatey.infrastructure.app.nuget
                     var packageResults = new List<IPackage>();
                     foreach (var priorityAggregatedRepository in groupedRepositories.Item2)
                     {
-                        packageResults.Add(find_package(packageName, version, config, priorityAggregatedRepository));
+                        var foundPackage = find_package(packageName, version, config, priorityAggregatedRepository);
+
+                        if (foundPackage != null)
+                        {
+                            packageResults.Add(foundPackage);
+                        }
                     }
 
                     if (packageResults.Count > 0)


### PR DESCRIPTION
## Description Of Changes

This pull request updates the the acquiring of package from prioritized aggregate repository to not add a package to the result list we iterate through when a package could not be found.
This functionality was initially implemented in a previous pull request

## Motivation and Context

This change was necessary in case an invalid identifier was used, or the package exist but is only available on a disabled source.

## What Have I Done To Test This

Add multiple sources, with all sources having a non-zero specified priority.

1. Run `choco install invalid-id`
2. Disable the chocolatey source with `choco source disable -n chocolatey`
3. Run `choco install firefox` (or different package name only existing on disabled source)

Notice that there should not be any error mentioning a null reference exception.

## Change Types Made
<!-- Tick the boxes for the type of changes that have been made -->

* [x] Bug fix (non-breaking change)
* [ ] Feature / Enhancement (non-breaking change)
* [ ] Breaking change (fix or feature that could cause existing functionality to change)

## Related Issue
<!-- Make sure you have raised an issue for this merge request before
continuing. -->

## Change Checklist

* [ ] Requires a change to the documentation
* [ ] Documentation has been updated
* [ ] Tests to cover my changes, have been added
* [x] All new and existing tests passed.

<!-- PLEASE REMOVE ALL COMMENTS BEFORE SUBMITTING -->
