### PR TITLE
(#1541) Add priority ordering for repository optimizations

### DIFF
--- a/Scenarios.md
+++ b/Scenarios.md
@@ -1,6 +1,6 @@
 ## Chocolatey Usage Scenarios
 
-### ChocolateyInstallCommand [ 35 Scenario(s), 293 Observation(s) ]
+### ChocolateyInstallCommand [ 38 Scenario(s), 310 Observation(s) ]
 
 #### when force installing a package that depends on an unavailable newer version of an installed dependency forcing dependencies
 
@@ -351,6 +351,32 @@
  * should still have a package in the lib directory
  * should still have the expected version of the package installed
 
+#### when installing new package from priority source
+
+ * should have a successful package result
+ * should install a package in the lib directory
+ * should install lower version of package
+ * should install where install location reports
+ * should not have inconclusive package result
+ * should not have warning package result
+
+#### when installing new package from priority source with repository optimization
+
+ * should have a successful package result
+ * should install a package in the lib directory
+ * should install lower version of package
+ * should install where install location reports
+ * should not have inconclusive package result
+ * should not have warning package result
+
+#### when installing non existing package from priority source
+
+ * should not have inconclusive package result
+ * should not have warning package result
+ * should not install a package in the lib directory
+ * should not install where install location reports
+ * should report package not found
+
 #### when installing packages with packages config
 
  * should contain a message that upgradepackage with an expected specified version was installed
@@ -689,7 +715,7 @@
 
  * should throw an error that it is not allowed
 
-### ChocolateyUpgradeCommand [ 36 Scenario(s), 295 Observation(s) ]
+### ChocolateyUpgradeCommand [ 37 Scenario(s), 301 Observation(s) ]
 
 #### when force upgrading a package
 
@@ -1089,6 +1115,15 @@
  * should upgrade a package in the lib directory
  * should upgrade the package
  * should upgrade where install location reports
+
+#### when upgrading existing package from priority source
+
+ * should have a successful package result
+ * should install a package in the lib directory
+ * should install upgrade to expected version in priority repository
+ * should install where install location reports
+ * should not have inconclusive package result
+ * should not have warning package result
 
 #### when upgrading packages with packages config
 

--- a/src/chocolatey/chocolatey.csproj
+++ b/src/chocolatey/chocolatey.csproj
@@ -118,6 +118,7 @@
     <Compile Include="infrastructure.app\commands\ChocolateyExportCommand.cs" />
     <Compile Include="infrastructure.app\commands\ChocolateyInfoCommand.cs" />
     <Compile Include="infrastructure.app\commands\ChocolateyHelpCommand.cs" />
+    <Compile Include="infrastructure.app\nuget\ChocolateyPriorityRepository.cs" />
     <Compile Include="infrastructure\cryptography\DefaultEncryptionUtility.cs" />
     <Compile Include="infrastructure\adapters\IEncryptionUtility.cs" />
     <Compile Include="infrastructure.app\validations\GlobalConfigurationValidation.cs" />

--- a/src/chocolatey/infrastructure.app/nuget/ChocolateyPriorityRepository.cs
+++ b/src/chocolatey/infrastructure.app/nuget/ChocolateyPriorityRepository.cs
@@ -1,0 +1,18 @@
+﻿using NuGet;
+
+namespace chocolatey.infrastructure.app.nuget
+{
+    public class ChocolateyPriorityRepository : PriorityPackageRepository
+    {
+        public ChocolateyPriorityRepository(IPackageRepository primaryRepository, IPackageRepository secondaryRepository)
+            : base(primaryRepository, secondaryRepository)
+        {
+            PrimaryRepository = primaryRepository;
+            SecondaryRepository = secondaryRepository;
+        }
+
+        public IPackageRepository PrimaryRepository { get; set; }
+
+        public IPackageRepository SecondaryRepository { get; set; }
+    }
+}


### PR DESCRIPTION
## History

This PR is a combination of the work that was done in the following two PR's:

* https://github.com/chocolatey/choco/pull/2286
* https://github.com/chocolatey/choco/pull/2420

Originally, it was believed that these PR's solved the underlying problem, however, there were some performance related problems when trying to execute `choco outdated` as it would take much longer to run than normal.

These changes have been backed out of the `hotfix/0.11.3` and `develop` branches, and collected into this PR, for further investigation.

## Description Of Changes

This pull requests re-adds the ability to order sources by priority when installing and upgrading packages.

## Motivation and Context

Priority currently are not respected due to to sorting is done on prioritized sources.

## Testing

1. Manually set a higher priority on a source containing a package in a non-prioritized source with a lower version available.
2. Call Chocolatey installation command and see what package version would be installed.
3. Do the same test with both sources being unprioritiesed.
4. Do the same test with both sources being the same non-zero priority.

## Change Types Made

* [x] Bug fix (non-breaking change)
* [ ] Feature / Enhancement (non-breaking change)
* [ ] Breaking change (fix or feature that could cause existing functionality to change)

## Related Issue

Relates to #1541 

## Change Checklist

* [ ] Requires a change to the documentation
* [ ] Documentation has been updated
* [x] Tests to cover my changes, have been added
* [x] All new and existing tests passed.
