### PR TITLE
(#2424) Disable alternate sources on non-windows

### DIFF
--- a/src/chocolatey/infrastructure.app/services/CygwinService.cs
+++ b/src/chocolatey/infrastructure.app/services/CygwinService.cs
@@ -28,6 +28,7 @@ namespace chocolatey.infrastructure.app.services
     using infrastructure.commands;
     using logging;
     using results;
+    using platforms;
 
     /// <summary>
     ///   Alternative Source for Cygwin
@@ -126,6 +127,8 @@ namespace chocolatey.infrastructure.app.services
 
         public void ensure_source_app_installed(ChocolateyConfiguration config, Action<PackageResult> ensureAction)
         {
+            if (Platform.get_platform() != PlatformType.Windows) throw new NotImplementedException("This source is not supported on non-Windows systems");
+
             var runnerConfig = new ChocolateyConfiguration
                 {
                     Sources = ApplicationParameters.PackagesLocation,

--- a/src/chocolatey/infrastructure.app/services/PythonService.cs
+++ b/src/chocolatey/infrastructure.app/services/PythonService.cs
@@ -29,6 +29,7 @@ namespace chocolatey.infrastructure.app.services
     using infrastructure.commands;
     using logging;
     using results;
+    using platforms;
 
     /// <summary>
     ///   Alternative Source for Installing Python packages
@@ -173,6 +174,8 @@ namespace chocolatey.infrastructure.app.services
 
         public void ensure_source_app_installed(ChocolateyConfiguration config, Action<PackageResult> ensureAction)
         {
+            if (Platform.get_platform() != PlatformType.Windows) throw new NotImplementedException("This source is not supported on non-Windows systems");
+
             //ensure at least python 2.7.9 is installed
             var python = _fileSystem.get_executable_path("python");
             //python -V

--- a/src/chocolatey/infrastructure.app/services/RubyGemsService.cs
+++ b/src/chocolatey/infrastructure.app/services/RubyGemsService.cs
@@ -26,6 +26,7 @@ namespace chocolatey.infrastructure.app.services
     using infrastructure.commands;
     using logging;
     using results;
+    using platforms;
 
     public sealed class RubyGemsService : ISourceRunner
     {
@@ -113,6 +114,8 @@ namespace chocolatey.infrastructure.app.services
 
         public void ensure_source_app_installed(ChocolateyConfiguration config, Action<PackageResult> ensureAction)
         {
+            if (Platform.get_platform() != PlatformType.Windows) throw new NotImplementedException("This source is not supported on non-Windows systems");
+
             var runnerConfig = new ChocolateyConfiguration
                 {
                     PackageNames = RUBY_PORTABLE_PACKAGE,

--- a/src/chocolatey/infrastructure.app/services/WebPiService.cs
+++ b/src/chocolatey/infrastructure.app/services/WebPiService.cs
@@ -26,6 +26,7 @@ namespace chocolatey.infrastructure.app.services
     using infrastructure.commands;
     using logging;
     using results;
+    using platforms;
 
     public sealed class WebPiService : ISourceRunner
     {
@@ -94,6 +95,8 @@ namespace chocolatey.infrastructure.app.services
 
         public void ensure_source_app_installed(ChocolateyConfiguration config, Action<PackageResult> ensureAction)
         {
+            if (Platform.get_platform() != PlatformType.Windows) throw new NotImplementedException("This source is not supported on non-Windows systems");
+
             var runnerConfig = new ChocolateyConfiguration
                 {
                     PackageNames = WEB_PI_PACKAGE,

--- a/src/chocolatey/infrastructure.app/services/WindowsFeatureService.cs
+++ b/src/chocolatey/infrastructure.app/services/WindowsFeatureService.cs
@@ -27,6 +27,7 @@ namespace chocolatey.infrastructure.app.services
     using infrastructure.commands;
     using logging;
     using results;
+    using platforms;
 
     /// <summary>
     ///   Alternative Source for Enabling Windows Features
@@ -156,6 +157,8 @@ namespace chocolatey.infrastructure.app.services
 
         public void ensure_source_app_installed(ChocolateyConfiguration config, Action<PackageResult> ensureAction)
         {
+            if (Platform.get_platform() != PlatformType.Windows) throw new NotImplementedException("This source is not supported on non-Windows systems");
+
             set_executable_path_if_not_set();
         }
 


### PR DESCRIPTION
## Description Of Changes

This throws an exception if running on a non-windows system for all sources
except for nuget.

If there is a better place to add the checks, let me know, not a big deal to change.

## Motivation and Context

All of the alternates sources were broken on non-windows platforms, so this displays a
helpful error message instead of the misc error messages.

Later on, the python and ruby sources could theoretically be fixed to work on
non-windows.

## Testing

Built the code and ran these commands on a windows system to validate that each source gets past the added check:
```
choco install invalid-id -s python
choco install invalid-id -s windowsfeatures
choco install invalid-id -s cygwin
choco install invalid-id -s ruby
choco install invalid-id -s webpi
```
On a side note, it looks like the `ruby.portable` package is broken.

Built the code and ran these commands on a linux system to validate that the error message is shown:
```
mono choco install invalid-id -s python
mono choco install invalid-id -s windowsfeatures
mono choco install invalid-id -s cygwin
mono choco install invalid-id -s ruby
mono choco install invalid-id -s webpi
```

## Change Types Made

* [ ] Bug fix (non-breaking change)
* [x] Feature / Enhancement (non-breaking change)
* [ ] Breaking change (fix or feature that could cause existing functionality to change)

## Related Issue

Fixes #2424

## Change Checklist

* [ ] Requires a change to the documentation
* [ ] Documentation has been updated
* [ ] Tests to cover my changes, have been added
* [x] All new and existing tests passed.

