### PR TITLE
(#2089) Fixes package_is_a_dependency when install called with direct path to nupkg

### DIFF
--- a/src/chocolatey.tests/chocolatey.tests.csproj
+++ b/src/chocolatey.tests/chocolatey.tests.csproj
@@ -129,6 +129,7 @@
     <Compile Include="infrastructure\platforms\PlatformSpecs.cs" />
     <Compile Include="infrastructure\tokens\TokenReplacerSpecs.cs" />
     <Compile Include="infrastructure\tolerance\FaultToleranceSpecs.cs" />
+    <Compile Include="infrastructure.app\utility\PackageUtilitySpecs.cs" />
     <Compile Include="MockLogger.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="TinySpec.cs" />

--- a/src/chocolatey.tests/infrastructure.app/utility/PackageUtilitySpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/utility/PackageUtilitySpecs.cs
@@ -1,0 +1,74 @@
+﻿// Copyright © 2021 - 2021 Chocolatey Software, Inc
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// 
+// You may obtain a copy of the License at
+// 
+// 	http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace chocolatey.tests.infrastructure.app.utility
+{
+    using chocolatey.infrastructure.app.utility;
+    using chocolatey.infrastructure.app.configuration;
+    using chocolatey.infrastructure.platforms;
+    using NUnit.Framework;
+    using Should;
+
+    public class PackageUtilitySpecs
+    {
+        public abstract class PackageUtilitySpecsBase : TinySpec
+        {
+            public override void Context()
+            {
+            }
+        }
+
+
+        [TestFixture("bob", "", true)]
+        [TestFixture("", "bob", true)]
+        [TestFixture("bob", "bob", false)]
+        [TestFixture("bob", "bob;separatedPackage", false)]
+        [TestFixture("bob", "C:\\chocolatey-packages\\bob\\bob.1.0.0.nupkg", false)]
+        [TestFixture("dependency", "C:\\chocolatey-packages\\bob\\bob.1.0.0.nupkg", true)]
+        [TestFixture("bob", "C:\\chocolatey-packages\\bob\\bob.nuspec", false)]
+        [TestFixture("dependency", "C:\\chocolatey-packages\\bob\\bob.nuspec", true)]
+        [TestFixture("bob", "\\bob", false)]
+        [TestFixture("dependency", "\\bob", true)]
+        [TestFixture("dependency", "bob", true)]
+        [TestFixture("dependency", "bob;separatedPackage", true)]
+        public class when_PackageUtility_is_checking_if_package_is_dependency : PackageUtilitySpecsBase
+        {
+            private readonly ChocolateyConfiguration _config = new ChocolateyConfiguration();
+            private bool _result;
+            private bool _expectedResult;
+            private string _packageName;
+
+            public when_PackageUtility_is_checking_if_package_is_dependency(string packageName, string configNames, bool expectedResult)
+            {
+                if (Platform.get_platform() != PlatformType.Windows) configNames = configNames.Replace("\\", "/");
+                
+                _packageName = packageName;
+                _config.PackageNames = configNames;
+                _expectedResult = expectedResult;
+            }
+
+            public override void Because()
+            {
+                _result = PackageUtility.package_is_a_dependency(_config, _packageName);
+            }
+
+            [Fact]
+            public void should_return_expected_result()
+            {
+                _result.ShouldEqual(_expectedResult);
+            }
+        }
+    }
+}

--- a/src/chocolatey/infrastructure.app/utility/PackageUtility.cs
+++ b/src/chocolatey/infrastructure.app/utility/PackageUtility.cs
@@ -17,6 +17,7 @@ namespace chocolatey.infrastructure.app.utility
 {
     using System;
     using configuration;
+    using platforms;
 
     public class PackageUtility
     {
@@ -36,10 +37,10 @@ namespace chocolatey.infrastructure.app.utility
             {
                 if (packageName.is_equal_to(package)
                     || packageName.contains(package + ".")
-                    || (packageName.contains(package)
-                        && (packageName.contains(".nupkg")
-                            || packageName.contains(".nuspec")
-                            || packageName.contains("\\")
+                    || (package.contains(packageName)
+                        && (package.contains(".nupkg")
+                            || package.contains(".nuspec")
+                            || package.contains("{0}".format_with(Platform.get_platform() == PlatformType.Windows ? "\\" : "/"))
                         )
                     )
                 )


### PR DESCRIPTION
## Description Of Changes

Two variables appeared to have been swapped accidentally when this
check was created in e91f209. The "package" is the var from the config,
while the "packageName" is the var that is being checked if it is in
the config. This fixes that swap.

This also changes the check for a directory separator in the name to
work on non-windows as well.

Also, this adds tests for the package_is_a_dependency method to make sure that this issue does not regress.

## Motivation and Context

There is a bug when installing via a direct path to a nupkg that the package is incorrectly determined to be a dependency. These changes should fix that bug.

## Testing

1. Added unit tests
2. Installed a package via `choco install \\path\\to\\package.nupkg --verbose --debug --ia="shouldseeargs"` and validated that the `chocolateyInstall.ps1` was called with `-installArguments 'shouldseeargs'`

## Change Types Made

* [x] Bug fix (non-breaking change)
* [ ] Feature / Enhancement (non-breaking change)
* [ ] Breaking change (fix or feature that could cause existing functionality to change)

## Related Issue

Fixes #2089

## Change Checklist

* [ ] Requires a change to the documentation
* [ ] Documentation has been updated
* [x] Tests to cover my changes, have been added
* [x] All new and existing tests passed.
