### PR TITLE
(maint) Remove duplicate sensitive parameter check

### DIFF
--- a/src/chocolatey/infrastructure.app/utility/ArgumentsUtility.cs
+++ b/src/chocolatey/infrastructure.app/utility/ArgumentsUtility.cs
@@ -41,8 +41,6 @@ namespace chocolatey.infrastructure.app.utility
              || commandArguments.contains("-key=")
              || commandArguments.contains("-apikey")
              || commandArguments.contains("-api-key")
-             || commandArguments.contains("-apikey")
-             || commandArguments.contains("-api-key")
             ;
         }
     }


### PR DESCRIPTION
## Description Of Changes

Remove redundant checks for `-api-key` and `-apikey`.

## Motivation and Context

The check for potentially sensitive parameters was checking for both `-api-key` and `-apikey` twice. This PR removes the redundant check.

## Testing

I ensured both `test.bat` and `build.bat` still ran successfully.

## Change Types Made

* [x] Bug fix (non-breaking change)
* [ ] Feature / Enhancement (non-breaking change)
* [ ] Breaking change (fix or feature that could cause existing functionality to change)
* [ ] PowerShell code changes.

## Related Issue

Small maintenance change, didn't open an issue (can open one if we feel it's needed).

## Change Checklist

* [ ] Requires a change to the documentation
* [ ] Documentation has been updated
* [ ] Tests to cover my changes, have been added
* [x] All new and existing tests passed.
* [ ] PowerShell v2 compatibility checked.