### PR TITLE
(#62) Default push source config

### DIFF
--- a/src/chocolatey.tests/infrastructure.app/commands/ChocolateyPushCommandSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/commands/ChocolateyPushCommandSpecs.cs
@@ -26,6 +26,7 @@ namespace chocolatey.tests.infrastructure.app.commands
     using chocolatey.infrastructure.app.services;
     using chocolatey.infrastructure.commandline;
     using Moq;
+    using NUnit.Framework;
     using Should;
 
     public class ChocolateyPushCommandSpecs
@@ -215,6 +216,33 @@ namespace chocolatey.tests.infrastructure.app.commands
                 because();
 
                 configSettingsService.Verify(c => c.get_api_key(It.IsAny<ChocolateyConfiguration>(), It.IsAny<Action<ConfigFileApiKeySetting>>()), Times.Never);
+            }
+
+            [Fact]
+            public void should_throw_if_multiple_sources_are_passed()
+            {
+                reset();
+                configuration.Sources = "https://localhost/somewhere/out/there;https://localhost/somewhere/out/there";
+
+                Assert.Throws<ApplicationException>(() => because(), "Multiple sources are not support by push command.");
+            }
+
+            [Fact]
+            public void should_update_source_if_alias_is_passed()
+            {
+                reset();
+                configuration.Sources = "chocolatey";
+                configuration.MachineSources = new List<MachineSourceConfiguration>
+                {
+                    new MachineSourceConfiguration
+                    {
+                        Name = "chocolatey",
+                        Key = "https://localhost/somewhere/out/there"
+                    }
+                 };
+                because();
+
+                configuration.Sources.ShouldEqual("https://localhost/somewhere/out/there");
             }
         }
 

--- a/src/chocolatey/infrastructure.app/ApplicationParameters.cs
+++ b/src/chocolatey/infrastructure.app/ApplicationParameters.cs
@@ -194,6 +194,7 @@ namespace chocolatey.infrastructure.app
             public static readonly string WebRequestTimeoutSeconds = "webRequestTimeoutSeconds";
             public static readonly string UpgradeAllExceptions = "upgradeAllExceptions";
             public static readonly string DefaultTemplateName = "defaultTemplateName";
+            public static readonly string DefaultPushSource = "defaultPushSource";
         }
 
         public static class Features

--- a/src/chocolatey/infrastructure.app/builders/ConfigurationBuilder.cs
+++ b/src/chocolatey/infrastructure.app/builders/ConfigurationBuilder.cs
@@ -267,6 +267,7 @@ namespace chocolatey.infrastructure.app.builders
             config.Proxy.BypassOnLocal = set_config_item(ApplicationParameters.ConfigSettings.ProxyBypassOnLocal, configFileSettings, "true", "Bypass proxy for local connections. Available in 0.10.4+.").is_equal_to(bool.TrueString);
             config.UpgradeCommand.PackageNamesToSkip = set_config_item(ApplicationParameters.ConfigSettings.UpgradeAllExceptions, configFileSettings, string.Empty, "A comma-separated list of package names that should not be upgraded when running `choco upgrade all'. Defaults to empty. Available in 0.10.14+.");
             config.DefaultTemplateName = set_config_item(ApplicationParameters.ConfigSettings.DefaultTemplateName, configFileSettings, string.Empty, "Default template name used when running 'choco new' command. Available in 0.12.0+.");
+            config.PushCommand.DefaultSource = set_config_item(ApplicationParameters.ConfigSettings.DefaultPushSource, configFileSettings, string.Empty, "Default source to push packages to when running 'choco push' command. Available in 0.12.0 +.");
         }
 
         private static string set_config_item(string configName, ConfigFileSettings configFileSettings, string defaultValue, string description, bool forceSettingValue = false)

--- a/src/chocolatey/infrastructure.app/commands/ChocolateyPushCommand.cs
+++ b/src/chocolatey/infrastructure.app/commands/ChocolateyPushCommand.cs
@@ -63,6 +63,12 @@ namespace chocolatey.infrastructure.app.commands
             if (string.IsNullOrWhiteSpace(configuration.Sources) && !string.IsNullOrWhiteSpace(configuration.PushCommand.DefaultSource))
             {
                 configuration.Sources = configuration.PushCommand.DefaultSource;
+
+                // Can't put this in handle_validation, since "disabled" is not a URI, it would fail earlier
+                if (configuration.Sources.is_equal_to("disabled"))
+                {
+                    throw new ApplicationException("Default push source is disabled. Please pass a source to push to, such as --source={0}".format_with(ApplicationParameters.ChocolateyCommunityFeedPushSource));
+                }
             }
 
             if (string.IsNullOrWhiteSpace(configuration.Sources))

--- a/src/chocolatey/infrastructure.app/commands/ChocolateyPushCommand.cs
+++ b/src/chocolatey/infrastructure.app/commands/ChocolateyPushCommand.cs
@@ -18,6 +18,7 @@ namespace chocolatey.infrastructure.app.commands
 {
     using System;
     using System.Collections.Generic;
+    using System.Linq;
     using attributes;
     using commandline;
     using configuration;
@@ -66,6 +67,21 @@ namespace chocolatey.infrastructure.app.commands
 
             if (!string.IsNullOrWhiteSpace(configuration.Sources))
             {
+                IEnumerable<string> sources = configuration.Sources.Split(new[] { ";", "," }, StringSplitOptions.RemoveEmptyEntries);
+
+                if (sources.Count() > 1)
+                {
+                    throw new ApplicationException("Multiple sources are not support by push command.");
+                }
+
+                var machineSource = configuration.MachineSources.FirstOrDefault(m => m.Name.is_equal_to(configuration.Sources));
+                if (machineSource != null)
+                {
+                    "chocolatey".Log().Debug("Switching source name {0} to actual source value '{1}'.".format_with(configuration.Sources, machineSource.Key.to_string()));
+
+                    configuration.Sources = machineSource.Key;
+                }
+
                 var remoteSource = new Uri(configuration.Sources);
                 if (string.IsNullOrWhiteSpace(configuration.PushCommand.Key) && !remoteSource.IsUnc && !remoteSource.IsFile)
                 {

--- a/src/chocolatey/infrastructure.app/commands/ChocolateyPushCommand.cs
+++ b/src/chocolatey/infrastructure.app/commands/ChocolateyPushCommand.cs
@@ -60,6 +60,11 @@ namespace chocolatey.infrastructure.app.commands
         {
             configuration.Input = string.Join(" ", unparsedArguments); // path to .nupkg - assume relative
 
+            if (string.IsNullOrWhiteSpace(configuration.Sources) && !string.IsNullOrWhiteSpace(configuration.PushCommand.DefaultSource))
+            {
+                configuration.Sources = configuration.PushCommand.DefaultSource;
+            }
+
             if (string.IsNullOrWhiteSpace(configuration.Sources))
             {
                 configuration.Sources = ApplicationParameters.ChocolateyCommunityFeedPushSource;

--- a/src/chocolatey/infrastructure.app/configuration/ChocolateyConfiguration.cs
+++ b/src/chocolatey/infrastructure.app/configuration/ChocolateyConfiguration.cs
@@ -665,6 +665,7 @@ NOTE: Hiding sensitive configuration data! Please double and triple
     public sealed class PushCommandConfiguration
     {
         public string Key { get; set; }
+        public string DefaultSource { get; set; }
         //DisableBuffering?
     }
 


### PR DESCRIPTION
## Description Of Changes

Adds a new config value DefaultPushSource. This config value is used to set the default source used for
choco push. It goes into config.PushCommand.DefaultSource

If DefaultPushSource is set, it should set the source assuming that
a source is not passed in explicitly with --source. If a source is
passed in explicitly, then DefaultPushSource should not override it.

If --api-key is not passed and a api key has not been saved for the
DefaultPushSource, it will fail with the standard message about an api
key being required.

If DefaultPushSource is set to "disabled", it should throw an error if
there is not an explicit source passed in. But if an explicit source is
passed in, it should not error.

## Motivation and Context

The DefaultPushSource is useful for users that have an internal repository that they want to normally want to push to.

The behavior if DefaultPushSource is set to disabled is useful if a user wants has multiple repositories and wants to always have to explicitly specify a source so as to make sure to push package to the correct source.

## Testing

1. Build choco
1. Copy a nupkg next to choco.exe (so as to not have to specify it every time)
1. Run `choco push --allow-unofficial` to validate that it still defaults to `https://push.chocolatey.org` if `DefaultPushSource` is not set.
1. Run `choco config set DefaultPushSource --value=disabled  --allow-unofficial` to force passing an explicit source
1. Run `choco push --allow-unofficial` and it should fail, asking for you to pass an explicit `--source`
1. Run `choco push --source=https://push.chocolatey.org/ --allow-unofficial` to validate that it will not throw if an explicit source is passed
1. Run `choco config set DefaultPushSource --value=chocolatey  --allow-unofficial` 
1. Run `choco push --allow-unofficial` to validate that the name `chocolatey` will resolve to `https://community.chocolatey.org/api/v2/`
1. Run `choco config set DefaultPushSource --value=https://community.chocolatey.org/api/v2/ --allow-unofficial` 
1. Run `choco push --allow-unofficial` to validate that it will try to push to the `https://community.chocolatey.org/api/v2/`

## Change Types Made

* [ ] Bug fix (non-breaking change)
* [x] Feature / Enhancement (non-breaking change)
* [ ] Breaking change (fix or feature that could cause existing functionality to change)

## Related Issue

Fixes #62

Depends on #1511

## Change Checklist

* [x] Requires a change to the documentation
* [ ] Documentation has been updated
* [x] Tests to cover my changes, have been added
* [x] All new and existing tests passed.
