### PR TITLE
(#2432) Actions workflow run integration tests

### DIFF
--- a/.build/analyzers/nunit.test.step
+++ b/.build/analyzers/nunit.test.step
@@ -24,6 +24,8 @@
   <target name="go" depends="run_tasks" />
 
   <target name="run_all_tests" depends="prepare, set_nunit_failure_mode, get_test_dlls_all, run_tests, generate_report" description="Like go but runs all tests" />
+  
+  <target name="run_integration_tests" depends="prepare, set_nunit_failure_mode, get_test_dlls_integration, run_tests, generate_report" description="Like go but runs the integration tests" />
 
   <!-- run_normal_tasks is called from run_tasks unless replace extension exists -->
   <target name="run_normal_tasks"
@@ -96,6 +98,33 @@
 
     <property name="args.test_runner" value="${dlls.test} ${test.args}" />
   </target>
+
+  <target name="get_test_dlls_integration">
+    <echo level="Warning" message="Getting all test dlls (including integration tests) based on name in directory ${path::get-full-path(dirs.build.code)}." />
+    <property name="dll.names" value="" />
+    <foreach item="File" property="dll.filename">
+      <in>
+        <items>
+          <exclude name="${dirs.build.code}/lib/**" />
+          <exclude name="${dirs.build.code}/_PublishedApplications/**" />
+          <exclude name="${dirs.build.code}/**/TestFu.dll" />
+          <include name="${dirs.build.code}/**/*Test*.Integration*dll" />
+          <include name="${dirs.build.code}/**/*test*.integration*dll" />
+          <include name="${dirs.build.code}/**/*Spec*.Integration*dll" />
+          <include name="${dirs.build.code}/**/*spec*.integration*dll" />
+        </items>
+      </in>
+      <do>
+        <property name="dll.names" value="${dll.names + ' ' + string::replace(string::replace(dll.filename,path::get-full-path(dirs.build.code) + '\',''),'\',path.separator) + ''}" />
+      </do>
+    </foreach>
+
+    <property name="dlls.test" value="${dll.names}" />
+    <echo level="Warning" message="Running NUnit against these test dlls - ${dlls.test}." />
+
+    <property name="args.test_runner" value="${dlls.test} ${test.args} ${nunit.separator}exclude=&quot;NotWorking,Ignore,notworking,ignore&quot;" />
+  </target>
+
 
   <target name="run_tests" depends="prepare" description="Running Unit Tests">
     <if test="${dlls.test != ''}">

--- a/.build/analyzers/test.step
+++ b/.build/analyzers/test.step
@@ -35,6 +35,11 @@
     <call target="set_normal_failure_mode" />
   </target>
 
+  <target name="integration">
+    <nant buildfile="${dirs.current.file}${path.separator}nunit.test.step" target="run_integration_tests" inheritall="true" if="${test.framework == 'nunit'}" />
+    <call target="set_normal_failure_mode" />
+  </target>
+
   <target name="open_results">
     <nant buildfile="${dirs.current.file}${path.separator}mbunit2.test.step" target="open_results" inheritall="true" if="${test.framework == 'mbunit2'}" />
     <nant buildfile="${dirs.current.file}${path.separator}gallio.test.step" target="open_results" inheritall="true" if="${test.framework == 'gallio'}" />

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,15 +1,9 @@
 name: Chocolatey Builds
 
 on:
-  # Trigger on pushes to master and develop, or with pull requests
+  # Trigger on pushes and on pull requests
   push:
-    branches:
-    - master
-    - develop
   pull_request:
-    branches:
-    - master
-    - develop
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,6 +18,16 @@ jobs:
       run: |
         chmod +x build.sh
         $GITHUB_WORKSPACE//build.sh -v
+    - name: Upload Ubuntu build results
+      uses: actions/upload-artifact@v2
+      # Always upload build results
+      if: ${{ always() }}
+      with:
+        name: ubuntu-build-results
+        path: |
+          build_output/build_artifacts/tests/index.html
+          build_output/_BuildInfo.xml
+          build_output/build.log    
   # Build on Windows
   windows-build:
     runs-on: windows-latest
@@ -25,6 +35,24 @@ jobs:
     - uses: actions/checkout@v2
     - name: Build with .Net Framework
       run: .\build.bat -v
+    - name: Upload Windows build results
+      uses: actions/upload-artifact@v2
+      # Always upload build results
+      if: ${{ always() }}
+      with:
+        name: windows-build-results
+        path: |
+          build_output\build_artifacts\tests\index.html
+          build_output\build_artifacts\codecoverage\Html\index.htm
+          build_output\_BuildInfo.xml
+          build_output\build.log
+          code_drop\build_artifacts\ilmerge\ilmerge.log
+          code_drop\build_artifacts\ilmerge\ilmergedll.log
+    - name: Upload Windows build .nupkg
+      uses: actions/upload-artifact@v2
+      with:
+        name: windows-build-nupkg
+        path: code_drop\nuget\*.nupkg
   # Build using mono on MacOS
   macos-build:
     runs-on: macos-latest
@@ -34,6 +62,16 @@ jobs:
        run: |
           chmod +x build.sh
           $GITHUB_WORKSPACE//build.sh -v
+     - name: Upload MacOS build results
+       uses: actions/upload-artifact@v2
+       # Always upload build results
+       if: ${{ always() }}
+       with:
+         name: macos-build-results
+         path: |
+           build_output/build_artifacts/tests/index.html
+           build_output/_BuildInfo.xml
+           build_output/build.log
   # Build using Mono in Docker on Ubuntu
   docker-build:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,6 +20,16 @@ jobs:
         $GITHUB_WORKSPACE//build.sh -v
     - name: Test with Nunit on Mono
       run: $GITHUB_WORKSPACE//test.sh
+    - name: Upload Ubuntu build results
+      uses: actions/upload-artifact@v2
+      # Always upload build results
+      if: ${{ always() }}
+      with:
+        name: ubuntu-build-results
+        path: |
+          build_output/build_artifacts/tests/index.html
+          build_output/_BuildInfo.xml
+          build_output/build.log    
   # Build and test on Windows
   windows-build:
     runs-on: windows-latest
@@ -29,6 +39,24 @@ jobs:
       run: .\build.bat -v
     - name: Test with Nunit on .Net Framework
       run: .\test.bat integration
+    - name: Upload Windows build results
+      uses: actions/upload-artifact@v2
+      # Always upload build results
+      if: ${{ always() }}
+      with:
+        name: windows-build-results
+        path: |
+          build_output\build_artifacts\tests\index.html
+          build_output\build_artifacts\codecoverage\Html\index.htm
+          build_output\_BuildInfo.xml
+          build_output\build.log
+          code_drop\build_artifacts\ilmerge\ilmerge.log
+          code_drop\build_artifacts\ilmerge\ilmergedll.log
+    - name: Upload Windows build .nupkg
+      uses: actions/upload-artifact@v2
+      with:
+        name: windows-build-nupkg
+        path: code_drop\nuget\*.nupkg
   # Build and test using mono on MacOS
   macos-build:
     runs-on: macos-latest
@@ -40,6 +68,16 @@ jobs:
           $GITHUB_WORKSPACE//build.sh -v
      - name: Test with Nunit on Mono
        run: $GITHUB_WORKSPACE//test.sh
+     - name: Upload MacOS build results
+       uses: actions/upload-artifact@v2
+       # Always upload build results
+       if: ${{ always() }}
+       with:
+         name: macos-build-results
+         path: |
+           build_output/build_artifacts/tests/index.html
+           build_output/_BuildInfo.xml
+           build_output/build.log
   # Build using Mono in Docker on Ubuntu
   docker-build:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,63 @@
+name: Chocolatey Integration Tests
+
+on:
+  schedule:
+    # Run at 10:47pm, at a random  minute to reduce load on GH Actions
+    - cron:  '47 22 * * *'
+  
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  # Build and test using mono on Ubuntu
+  ubuntu-build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build with Mono
+      run: |
+        chmod +x build.sh
+        $GITHUB_WORKSPACE//build.sh -v
+    - name: Test with Nunit on Mono
+      run: $GITHUB_WORKSPACE//test.sh
+  # Build and test on Windows
+  windows-build:
+    runs-on: windows-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build with .Net Framework
+      run: .\build.bat -v
+    - name: Test with Nunit on .Net Framework
+      run: .\test.bat integration
+  # Build and test using mono on MacOS
+  macos-build:
+    runs-on: macos-latest
+    steps:
+     - uses: actions/checkout@v2
+     - name: Build with Mono
+       run: |
+          chmod +x build.sh
+          $GITHUB_WORKSPACE//build.sh -v
+     - name: Test with Nunit on Mono
+       run: $GITHUB_WORKSPACE//test.sh
+  # Build using Mono in Docker on Ubuntu
+  docker-build:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v2
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      -
+        name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: docker/Dockerfile.linux
+          push: false
+          tags: chocolatey/choco:latest

--- a/test.bat
+++ b/test.bat
@@ -27,7 +27,8 @@ goto finish
 
 :usage
 echo.
-echo Usage: test.bat
+echo Usage: test.bat - run unit tests
+echo Usage: test.bat integration - run integration tests
 echo Usage: test.bat all - to run all tests
 echo.
 goto finish

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# stty -echo
+
+# ::Project UppercuT - http://uppercut.googlecode.com
+# ::No edits to this file are required - http://uppercut.pbwiki.com
+
+function usage
+{
+	echo ""
+	echo "Usage: test.sh - to run unit tests"
+	echo "Usage: test.sh integration - run integration tests"   
+	echo "Usage: test.sh all - to run all tests"
+	exit
+}
+
+function displayUsage
+{
+	case $1 in
+		"/?"|"-?"|"?"|"/help") usage ;;
+	esac
+}
+
+displayUsage $1
+
+# http://www.michaelruck.de/2010/03/solving-pkg-config-and-mono-35-profile.html
+# http://cloudgen.wordpress.com/2013/03/06/configure-nant-to-run-under-mono-3-06-beta-for-mac-osx/
+export PKG_CONFIG_PATH=/opt/local/lib/pkgconfig:/Library/Frameworks/Mono.framework/Versions/Current/lib/pkgconfig:$PKG_CONFIG_PATH
+
+mono --runtime=v4.0.30319 ./lib/NAnt/NAnt.exe /logger:"NAnt.Core.DefaultLogger" /nologo /quiet /f:"$(cd $(dirname "$0"); pwd)/.build/compile.step" /D:build.config.settings="$(cd $(dirname "$0"); pwd)/.uppercut" /D:microsoft.framework="mono-4.5" /D:run.ilmerge="false" /D:run.nuget="false"
+
+mono --runtime=v4.0.30319 ./lib/NAnt/NAnt.exe /logger:"NAnt.Core.DefaultLogger" /nologo /f:"$(cd $(dirname "$0"); pwd)/.build/analyzers/test.step" $* /D:build.config.settings="$(cd $(dirname "$0"); pwd)/.uppercut" /D:microsoft.framework="mono-4.5" /D:run.ilmerge="false" /D:run.nuget="false" 


### PR DESCRIPTION
## Description Of Changes

- Adds a `full` target to the uppercut testing, which runs all tests but `NotWorking` and `Ignore` tests. It can be called with `test.bat full`
- Adds a `test.sh` script for non-Windows systems. 
- Adds a scheduled workflow to run `test.bat full` on the Windows, runs `test.sh` on non-Windows. 

## Motivation and Context

Running the integration tests on the Actions workflow is needed for feature parity with the Appveyor CI run.

## Testing

N/A, see github actions workflow

## Change Types Made

* [ ] Bug fix (non-breaking change)
* [x] Feature / Enhancement (non-breaking change)
* [ ] Breaking change (fix or feature that could cause existing functionality to change)

## Related Issue

Fixes #2432

## Change Checklist

* [ ] Requires a change to the documentation
* [ ] Documentation has been updated
* [x] Tests to cover my changes, have been added
* [x] All new and existing tests passed.
