### PR TITLE
(#2434) Integration tests run on non-windows platforms.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
         chmod +x build.sh
         $GITHUB_WORKSPACE//build.sh -v
     - name: Test with Nunit on Mono
-      run: $GITHUB_WORKSPACE//test.sh
+      run: $GITHUB_WORKSPACE//test.sh integration
     - name: Upload Ubuntu build results
       uses: actions/upload-artifact@v2
       # Always upload build results
@@ -67,7 +67,7 @@ jobs:
           chmod +x build.sh
           $GITHUB_WORKSPACE//build.sh -v
      - name: Test with Nunit on Mono
-       run: $GITHUB_WORKSPACE//test.sh
+       run: $GITHUB_WORKSPACE//test.sh integration
      - name: Upload MacOS build results
        uses: actions/upload-artifact@v2
        # Always upload build results

--- a/src/chocolatey.tests.integration/Scenario.cs
+++ b/src/chocolatey.tests.integration/Scenario.cs
@@ -121,7 +121,7 @@ namespace chocolatey.tests.integration
             // prior commands, so ensure that all items go back to the default values here
             var config = NUnitSetup.Container.GetInstance<ChocolateyConfiguration>();
 
-            config.Information.PlatformType = PlatformType.Windows;
+            config.Information.PlatformType = Platform.get_platform();
             config.Information.IsInteractive = false;
             config.Information.ChocolateyVersion = "1.2.3";
             config.Information.PlatformVersion = new Version(6, 1, 0, 0);

--- a/src/chocolatey.tests.integration/infrastructure.app/services/FilesServiceSpecs.cs
+++ b/src/chocolatey.tests.integration/infrastructure.app/services/FilesServiceSpecs.cs
@@ -28,6 +28,7 @@ namespace chocolatey.tests.integration.infrastructure.app.services
     using chocolatey.infrastructure.results;
     using chocolatey.infrastructure.services;
     using Moq;
+    using NUnit.Framework;
     using Should;
 
     public class FilesServiceSpecs
@@ -88,6 +89,8 @@ namespace chocolatey.tests.integration.infrastructure.app.services
             }
 
             [Fact]
+            [WindowsOnly]
+            [Platform(Exclude = "Mono")]
             public void should_log_a_warning_about_locked_files()
             {
                 bool lockedFiles = false;

--- a/src/chocolatey.tests.integration/infrastructure/commands/CommandExecutorSpecs.cs
+++ b/src/chocolatey.tests.integration/infrastructure/commands/CommandExecutorSpecs.cs
@@ -20,6 +20,7 @@ namespace chocolatey.tests.integration.infrastructure.commands
     using chocolatey.infrastructure.app;
     using chocolatey.infrastructure.commands;
     using chocolatey.infrastructure.filesystem;
+    using NUnit.Framework;
     using Should;
 
     public class CommandExecutorSpecs
@@ -35,6 +36,8 @@ namespace chocolatey.tests.integration.infrastructure.commands
             }
         }
 
+        [WindowsOnly]
+        [Platform(Exclude = "Mono")]
         public class when_CommandExecutor_errors : CommandExecutorSpecsBase
         {
             private int result;
@@ -77,6 +80,8 @@ namespace chocolatey.tests.integration.infrastructure.commands
             }
         }
 
+        [WindowsOnly]
+        [Platform(Exclude = "Mono")]
         public class when_CommandExecutor_is_given_a_nonexisting_process : CommandExecutorSpecsBase
         {
             private string result;

--- a/src/chocolatey.tests.integration/infrastructure/filesystem/DotNetFileSystemSpecs.cs
+++ b/src/chocolatey.tests.integration/infrastructure/filesystem/DotNetFileSystemSpecs.cs
@@ -74,7 +74,7 @@ namespace chocolatey.tests.integration.infrastructure.filesystem
                 FileSystem.get_executable_path("cmd.exe").ShouldEqual(
                     Platform.get_platform() == PlatformType.Windows
                         ? "c:\\windows\\system32\\cmd.exe"
-                        : "cmd",
+                        : "cmd.exe",
                     StringComparer.OrdinalIgnoreCase
                 );
             }
@@ -139,6 +139,8 @@ namespace chocolatey.tests.integration.infrastructure.filesystem
             }
 
             [Fact]
+            [WindowsOnly]
+            [Platform(Exclude = "Mono")]
             public void GetFiles_should_return_files_that_meet_the_pattern_regardless_of_case()
             {
                 string filePath = FileSystem.combine_paths(ContextPath, "chocolateyInstall.ps1");
@@ -189,6 +191,8 @@ namespace chocolatey.tests.integration.infrastructure.filesystem
         }
 
         [Category("Integration")]
+        [WindowsOnly]
+        [Platform(Exclude = "Mono")]
         public class when_setting_file_attributes_with_dotNetFileSystem : DotNetFileSystemSpecsBase
         {
             public override void Context()

--- a/src/chocolatey.tests.integration/scenarios/InstallScenarios.cs
+++ b/src/chocolatey.tests.integration/scenarios/InstallScenarios.cs
@@ -327,7 +327,7 @@ namespace chocolatey.tests.integration.scenarios
             public override void Context()
             {
                 base.Context();
-                var packagesConfig = "{0}\\context\\testing.packages.config".format_with(Scenario.get_top_level());
+                var packagesConfig = "{0}{1}context{1}testing.packages.config".format_with(Scenario.get_top_level(), Path.DirectorySeparatorChar);
                 Configuration.PackageNames = Configuration.Input = packagesConfig;
                 Scenario.add_packages_to_source_location(Configuration, "hasdependency.1.0.0*" + Constants.PackageExtension);
                 Scenario.add_packages_to_source_location(Configuration, "isdependency.1.0.0*" + Constants.PackageExtension);
@@ -3114,7 +3114,7 @@ namespace chocolatey.tests.integration.scenarios
             public override void Context()
             {
                 base.Context();
-                Configuration.PackageNames = Configuration.Input = "{0}\\installpackage.1.0.0.nupkg".format_with(Configuration.Sources);
+                Configuration.PackageNames = Configuration.Input = "{0}{1}installpackage.1.0.0.nupkg".format_with(Configuration.Sources, Path.DirectorySeparatorChar);
             }
 
             public override void Because()

--- a/src/chocolatey.tests.integration/scenarios/InstallScenarios.cs
+++ b/src/chocolatey.tests.integration/scenarios/InstallScenarios.cs
@@ -28,6 +28,7 @@ namespace chocolatey.tests.integration.scenarios
     using chocolatey.infrastructure.commands;
     using chocolatey.infrastructure.results;
     using NuGet;
+    using NUnit.Framework;
     using Should;
     using IFileSystem = chocolatey.infrastructure.filesystem.IFileSystem;
 
@@ -55,6 +56,8 @@ namespace chocolatey.tests.integration.scenarios
         }
 
         [Concern(typeof(ChocolateyInstallCommand))]
+        [WindowsOnly]
+        [Platform(Exclude = "Mono")]
         public class when_noop_installing_a_package : ScenariosBase
         {
             public override void Context()
@@ -150,6 +153,8 @@ namespace chocolatey.tests.integration.scenarios
         }
 
         [Concern(typeof(ChocolateyInstallCommand))]
+        [WindowsOnly]
+        [Platform(Exclude = "Mono")]
         public class when_installing_a_package_happy_path : ScenariosBase
         {
             private PackageResult packageResult;
@@ -539,6 +544,8 @@ namespace chocolatey.tests.integration.scenarios
         }
 
         [Concern(typeof(ChocolateyInstallCommand))]
+        [WindowsOnly]
+        [Platform(Exclude = "Mono")]
         public class when_force_installing_an_already_installed_package : ScenariosBase
         {
             private PackageResult packageResult;
@@ -641,6 +648,8 @@ namespace chocolatey.tests.integration.scenarios
         }
 
         [Concern(typeof(ChocolateyInstallCommand))]
+        [WindowsOnly]
+        [Platform(Exclude = "Mono")]
         public class when_force_installing_an_already_installed_package_that_errors : ScenariosBase
         {
             private PackageResult packageResult;
@@ -720,6 +729,8 @@ namespace chocolatey.tests.integration.scenarios
         }
 
         [Concern(typeof(ChocolateyInstallCommand))]
+        [WindowsOnly]
+        [Platform(Exclude = "Mono")]
         public class when_force_installing_an_already_installed_package_with_a_read_and_delete_share_locked_file : ScenariosBase
         {
             private PackageResult packageResult;
@@ -820,6 +831,8 @@ namespace chocolatey.tests.integration.scenarios
         }
 
         [Concern(typeof(ChocolateyInstallCommand))]
+        [WindowsOnly]
+        [Platform(Exclude = "Mono")]
         public class when_force_installing_an_already_installed_package_with_with_an_exclusively_locked_file : ScenariosBase
         {
             private PackageResult packageResult;
@@ -1083,6 +1096,8 @@ namespace chocolatey.tests.integration.scenarios
         }
 
         [Concern(typeof(ChocolateyInstallCommand))]
+        [WindowsOnly]
+        [Platform(Exclude = "Mono")]
         public class when_installing_a_package_that_errors : ScenariosBase
         {
             private PackageResult packageResult;
@@ -1262,6 +1277,8 @@ namespace chocolatey.tests.integration.scenarios
         }
 
         [Concern(typeof(ChocolateyInstallCommand))]
+        [WindowsOnly]
+        [Platform(Exclude = "Mono")]
         public class when_installing_a_package_that_has_nonterminating_errors_with_fail_on_stderr : ScenariosBase
         {
             private PackageResult packageResult;
@@ -3107,6 +3124,8 @@ namespace chocolatey.tests.integration.scenarios
         }
 
         [Concern(typeof(ChocolateyInstallCommand))]
+        [WindowsOnly]
+        [Platform(Exclude = "Mono")]
         public class when_installing_a_package_from_a_nupkg_file : ScenariosBase
         {
             private PackageResult packageResult;
@@ -3279,6 +3298,8 @@ namespace chocolatey.tests.integration.scenarios
         }
 
         [Concern(typeof(ChocolateyInstallCommand))]
+        [WindowsOnly]
+        [Platform(Exclude = "Mono")]
         public class when_installing_a_package_with_config_transforms : ScenariosBase
         {
             private PackageResult packageResult;

--- a/src/chocolatey.tests.integration/scenarios/ListScenarios.cs
+++ b/src/chocolatey.tests.integration/scenarios/ListScenarios.cs
@@ -25,6 +25,7 @@ namespace chocolatey.tests.integration.scenarios
     using chocolatey.infrastructure.app.services;
     using chocolatey.infrastructure.results;
     using NuGet;
+    using NUnit.Framework;
     using Should;
 
     public class ListScenarios
@@ -58,6 +59,8 @@ namespace chocolatey.tests.integration.scenarios
             }
 
             [Fact]
+            [WindowsOnly]
+            [Platform(Exclude = "Mono")]
             public void should_list_available_packages_only_once()
             {
                 MockLogger.contains_message_count("upgradepackage").ShouldEqual(1);

--- a/src/chocolatey.tests.integration/scenarios/UninstallScenarios.cs
+++ b/src/chocolatey.tests.integration/scenarios/UninstallScenarios.cs
@@ -60,6 +60,8 @@ namespace chocolatey.tests.integration.scenarios
         }
 
         [Concern(typeof(ChocolateyUninstallCommand))]
+        [WindowsOnly]
+        [Platform(Exclude = "Mono")]
         public class when_noop_uninstalling_a_package : ScenariosBase
         {
             public override void Context()
@@ -135,6 +137,8 @@ namespace chocolatey.tests.integration.scenarios
         }
 
         [Concern(typeof(ChocolateyUninstallCommand))]
+        [WindowsOnly]
+        [Platform(Exclude = "Mono")]
         public class when_uninstalling_a_package_happy_path : ScenariosBase
         {
             private PackageResult packageResult;
@@ -343,6 +347,8 @@ namespace chocolatey.tests.integration.scenarios
         }
 
         [Concern(typeof(ChocolateyUninstallCommand))]
+        [WindowsOnly]
+        [Platform(Exclude = "Mono")]
         public class when_uninstalling_a_package_with_readonly_files : ScenariosBase
         {
             private PackageResult _packageResult;
@@ -409,6 +415,8 @@ namespace chocolatey.tests.integration.scenarios
         }
 
         [Concern(typeof(ChocolateyUninstallCommand))]
+        [WindowsOnly]
+        [Platform(Exclude = "Mono")]
         public class when_uninstalling_a_package_with_a_read_and_delete_share_locked_file : ScenariosBase
         {
             private PackageResult _packageResult;
@@ -563,6 +571,8 @@ namespace chocolatey.tests.integration.scenarios
         }
 
         [Concern(typeof(ChocolateyUninstallCommand))]
+        [WindowsOnly]
+        [Platform(Exclude = "Mono")]
         public class when_uninstalling_a_package_with_added_files : ScenariosBase
         {
             private PackageResult packageResult;
@@ -661,6 +671,8 @@ namespace chocolatey.tests.integration.scenarios
         }
 
         [Concern(typeof(ChocolateyUninstallCommand))]
+        [WindowsOnly]
+        [Platform(Exclude = "Mono")]
         public class when_uninstalling_a_package_with_changed_files : ScenariosBase
         {
             private PackageResult packageResult;
@@ -759,6 +771,8 @@ namespace chocolatey.tests.integration.scenarios
         }
 
         [Concern(typeof(ChocolateyUninstallCommand))]
+        [WindowsOnly]
+        [Platform(Exclude = "Mono")]
         public class when_force_uninstalling_a_package_with_added_and_changed_files : ScenariosBase
         {
             private PackageResult packageResult;
@@ -940,6 +954,8 @@ namespace chocolatey.tests.integration.scenarios
         }
 
         [Concern(typeof(ChocolateyUninstallCommand))]
+        [WindowsOnly]
+        [Platform(Exclude = "Mono")]
         public class when_uninstalling_a_package_that_errors : ScenariosBase
         {
             private PackageResult packageResult;

--- a/src/chocolatey.tests.integration/scenarios/UninstallScenarios.cs
+++ b/src/chocolatey.tests.integration/scenarios/UninstallScenarios.cs
@@ -326,7 +326,7 @@ namespace chocolatey.tests.integration.scenarios
             public override void Context()
             {
                 base.Context();
-                var packagesConfig = "{0}\\context\\testing.packages.config".format_with(Scenario.get_top_level());
+                var packagesConfig = "{0}{1}context{1}testing.packages.config".format_with(Scenario.get_top_level(), Path.DirectorySeparatorChar);
                 Configuration.PackageNames = Configuration.Input = packagesConfig;
             }
 

--- a/src/chocolatey.tests.integration/scenarios/UpgradeScenarios.cs
+++ b/src/chocolatey.tests.integration/scenarios/UpgradeScenarios.cs
@@ -1202,7 +1202,7 @@ namespace chocolatey.tests.integration.scenarios
             public override void Context()
             {
                 base.Context();
-                var packagesConfig = "{0}\\context\\testing.packages.config".format_with(Scenario.get_top_level());
+                var packagesConfig = "{0}{1}context{1}testing.packages.config".format_with(Scenario.get_top_level(), Path.DirectorySeparatorChar);
                 Configuration.PackageNames = Configuration.Input = packagesConfig;
             }
 

--- a/src/chocolatey.tests.integration/scenarios/UpgradeScenarios.cs
+++ b/src/chocolatey.tests.integration/scenarios/UpgradeScenarios.cs
@@ -202,6 +202,8 @@ namespace chocolatey.tests.integration.scenarios
         }
 
         [Concern(typeof(ChocolateyUpgradeCommand))]
+        [WindowsOnly]
+        [Platform(Exclude = "Mono")]
         public class when_upgrading_an_existing_package_happy_path : ScenariosBase
         {
             private PackageResult _packageResult;
@@ -339,6 +341,8 @@ namespace chocolatey.tests.integration.scenarios
         }
 
         [Concern(typeof(ChocolateyUpgradeCommand))]
+        [WindowsOnly]
+        [Platform(Exclude = "Mono")]
         public class when_upgrading_an_existing_package_with_prerelease_available_without_prerelease_specified : ScenariosBase
         {
             private PackageResult _packageResult;
@@ -429,6 +433,8 @@ namespace chocolatey.tests.integration.scenarios
         }
 
         [Concern(typeof(ChocolateyUpgradeCommand))]
+        [WindowsOnly]
+        [Platform(Exclude = "Mono")]
         public class when_upgrading_an_existing_package_with_prerelease_available_and_prerelease_specified : ScenariosBase
         {
             private PackageResult _packageResult;
@@ -573,6 +579,8 @@ namespace chocolatey.tests.integration.scenarios
         }
 
         [Concern(typeof(ChocolateyUpgradeCommand))]
+        [WindowsOnly]
+        [Platform(Exclude = "Mono")]
         public class when_upgrading_an_existing_prerelease_package_without_prerelease_specified : ScenariosBase
         {
             private PackageResult _packageResult;
@@ -906,6 +914,8 @@ namespace chocolatey.tests.integration.scenarios
         }
 
         [Concern(typeof(ChocolateyUpgradeCommand))]
+        [WindowsOnly]
+        [Platform(Exclude = "Mono")]
         public class when_force_upgrading_a_package : ScenariosBase
         {
             private PackageResult _packageResult;
@@ -1106,6 +1116,8 @@ namespace chocolatey.tests.integration.scenarios
         }
 
         [Concern(typeof(ChocolateyUpgradeCommand))]
+        [WindowsOnly]
+        [Platform(Exclude = "Mono")]
         public class when_force_upgrading_a_package_that_does_not_have_available_upgrades : ScenariosBase
         {
             private PackageResult _packageResult;
@@ -1219,6 +1231,8 @@ namespace chocolatey.tests.integration.scenarios
         }
 
         [Concern(typeof(ChocolateyUpgradeCommand))]
+        [WindowsOnly]
+        [Platform(Exclude = "Mono")]
         public class when_upgrading_a_package_with_readonly_files : ScenariosBase
         {
             private PackageResult _packageResult;
@@ -1319,6 +1333,8 @@ namespace chocolatey.tests.integration.scenarios
         }
 
         [Concern(typeof(ChocolateyUpgradeCommand))]
+        [WindowsOnly]
+        [Platform(Exclude = "Mono")]
         public class when_upgrading_a_package_with_a_read_and_delete_share_locked_file : ScenariosBase
         {
             private PackageResult _packageResult;
@@ -1426,6 +1442,8 @@ namespace chocolatey.tests.integration.scenarios
         }
 
         [Concern(typeof(ChocolateyUpgradeCommand))]
+        [WindowsOnly]
+        [Platform(Exclude = "Mono")]
         public class when_upgrading_a_package_with_an_exclusively_locked_file : ScenariosBase
         {
             private PackageResult _packageResult;
@@ -1527,6 +1545,8 @@ namespace chocolatey.tests.integration.scenarios
         }
 
         [Concern(typeof(ChocolateyUpgradeCommand))]
+        [WindowsOnly]
+        [Platform(Exclude = "Mono")]
         public class when_upgrading_a_package_with_added_files : ScenariosBase
         {
             private PackageResult _packageResult;
@@ -1606,6 +1626,8 @@ namespace chocolatey.tests.integration.scenarios
         }
 
         [Concern(typeof(ChocolateyUpgradeCommand))]
+        [WindowsOnly]
+        [Platform(Exclude = "Mono")]
         public class when_upgrading_a_package_with_changed_files : ScenariosBase
         {
             private PackageResult _packageResult;
@@ -1783,6 +1805,8 @@ namespace chocolatey.tests.integration.scenarios
         }
 
         [Concern(typeof(ChocolateyUpgradeCommand))]
+        [WindowsOnly]
+        [Platform(Exclude = "Mono")]
         public class when_upgrading_a_package_that_is_not_installed : ScenariosBase
         {
             private PackageResult _packageResult;
@@ -1854,6 +1878,8 @@ namespace chocolatey.tests.integration.scenarios
         }
 
         [Concern(typeof(ChocolateyUpgradeCommand))]
+        [WindowsOnly]
+        [Platform(Exclude = "Mono")]
         public class when_upgrading_a_package_that_is_not_installed_and_failing_on_not_installed : ScenariosBase
         {
             private PackageResult _packageResult;
@@ -1942,6 +1968,8 @@ namespace chocolatey.tests.integration.scenarios
         }
 
         [Concern(typeof(ChocolateyUpgradeCommand))]
+        [WindowsOnly]
+        [Platform(Exclude = "Mono")]
         public class when_upgrading_a_package_that_errors : ScenariosBase
         {
             private PackageResult packageResult;
@@ -2790,6 +2818,8 @@ namespace chocolatey.tests.integration.scenarios
         }
 
         [Concern(typeof(ChocolateyUpgradeCommand))]
+        [WindowsOnly]
+        [Platform(Exclude = "Mono")]
         public class when_upgrading_a_package_with_config_transforms : ScenariosBase
         {
             private PackageResult _packageResult;
@@ -2886,6 +2916,8 @@ namespace chocolatey.tests.integration.scenarios
         }
 
         [Concern(typeof(ChocolateyUpgradeCommand))]
+        [WindowsOnly]
+        [Platform(Exclude = "Mono")]
         public class when_upgrading_a_package_with_config_transforms_when_config_was_edited : ScenariosBase
         {
             private PackageResult _packageResult;
@@ -3055,6 +3087,8 @@ namespace chocolatey.tests.integration.scenarios
         }
 
         [Concern(typeof(ChocolateyUpgradeCommand))]
+        [WindowsOnly]
+        [Platform(Exclude = "Mono")]
         public class when_upgrading_all_packages_with_prereleases_installed : ScenariosBase
         {
             public override void Context()


### PR DESCRIPTION
## Description Of Changes

Get integration tests working on non-windows platforms. 

Skips most of the tests that are not working.

Misc fixes (TODO, describe) to get some tests working. Path seperator, casing, typo in string, etc

## Motivation and Context

Currently, the integration tests can only be run on Windows platforms. It would be good to get as many as possible running on all platforms, both to find bugs in the first place, and prevent regressions.

## Testing

Ran `./test.sh integration` on both an Ubuntu system (wsl) and a Debian system to validate that the integration tests run, and all of the non-skipped tests pass.

Ran `.\test.bat integration` on a Windows system to validate that the integration tests still work correctly.

## Change Types Made

* [ ] Bug fix (non-breaking change)
* [x] Feature / Enhancement (non-breaking change)
* [ ] Breaking change (fix or feature that could cause existing functionality to change)

## Related Issue

Fixes #2434

Depends on #2433 (Merged)
Depends on #2437 (Merged)

## Change Checklist

* [ ] Requires a change to the documentation
* [ ] Documentation has been updated
* [ ] Tests to cover my changes, have been added
* [x] All new and existing tests passed.
