### PR TITLE
(#2437) Fall back to CurrentUser scope when permission denied

### DIFF
--- a/src/chocolatey/infrastructure/cryptography/DefaultEncryptionUtility.cs
+++ b/src/chocolatey/infrastructure/cryptography/DefaultEncryptionUtility.cs
@@ -1,13 +1,13 @@
 ﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
-// 
+//
 // You may obtain a copy of the License at
-// 
+//
 // 	http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -20,6 +20,7 @@ namespace chocolatey.infrastructure.cryptography
     using System.Security.Cryptography;
     using System.Text;
     using adapters;
+    using platforms;
 
     public class DefaultEncryptionUtility : IEncryptionUtility
     {
@@ -30,7 +31,26 @@ namespace chocolatey.infrastructure.cryptography
             if (string.IsNullOrWhiteSpace(cleartextValue)) return null;
 
             var decryptedByteArray = Encoding.UTF8.GetBytes(cleartextValue);
-            var encryptedByteArray = ProtectedData.Protect(decryptedByteArray, _entropyBytes, DataProtectionScope.LocalMachine);
+            byte[] encryptedByteArray;
+            try
+            {
+                encryptedByteArray = ProtectedData.Protect(decryptedByteArray, _entropyBytes, DataProtectionScope.LocalMachine);
+            }
+            catch (Exception ex)
+            {
+                if (Platform.get_platform() != PlatformType.Windows && ex is CryptographicException)
+                {
+                    this.Log().Warn(@"Could not encrypt with LocalMachine scope.
+Falling back to CurrentUser scope for encryption.
+This is can be because the machine keyfile cannot be written as a normal user.
+Anything encrypted as CurrentUser can only be decrypted by your current user.");
+                    encryptedByteArray = ProtectedData.Protect(decryptedByteArray, _entropyBytes, DataProtectionScope.CurrentUser);
+                }
+                else
+                {
+                    throw;
+                }
+            }
             var encryptedString = Convert.ToBase64String(encryptedByteArray);
 
             return encryptedString;
@@ -39,7 +59,26 @@ namespace chocolatey.infrastructure.cryptography
         public string decrypt_string(string encryptedString)
         {
             var encryptedByteArray = Convert.FromBase64String(encryptedString);
-            var decryptedByteArray = ProtectedData.Unprotect(encryptedByteArray, _entropyBytes, DataProtectionScope.LocalMachine);
+            byte[] decryptedByteArray;
+
+            try
+            {
+                decryptedByteArray = ProtectedData.Unprotect(encryptedByteArray, _entropyBytes, DataProtectionScope.LocalMachine);
+            }
+            catch (Exception ex)
+            {
+                if (Platform.get_platform() != PlatformType.Windows && ex is CryptographicException)
+                {
+                    this.Log().Warn(@"Could not decrypt with LocalMachine scope.
+Falling back to CurrentUser scope for decryption.
+Anything encrypted as CurrentUser can only be decrypted by your current user.");
+                    decryptedByteArray = ProtectedData.Unprotect(encryptedByteArray, _entropyBytes, DataProtectionScope.CurrentUser);
+                }
+                else
+                {
+                    throw;
+                }
+            }
 
             return Encoding.UTF8.GetString(decryptedByteArray);
         }


### PR DESCRIPTION
## Description, Motivation and Context Of Changes


When running on mono on a non-Windows system, the ProtectedData methods
use /usr/local/.mono/keypair as the folder to save keypairs. This
folder is not normally writable by non-root users, thus erroring when
used by a normal user.

This catches that error and falls back to using the CurrentUser scope.
Also, during data unprotection, it will try to fall back to CurrentUser
scope if the decryption fails for other reasons, so as to attempt to
decrypt data encrypted with CurrentUser if the LocalSystem scope starts
working.

I'm not convinced that this is the best way to fix this issue, if people have better ideas, I'm all ears.

## Testing

1. Built source on Linux machine
2. Removed all files under `/usr/share/.mono/keypair` (don't do this if you use mono for other things on that install)
3. Ran `mono choco.exe install --allow-unofficial curl`
4. Validated that it was able to fall back to CurrentUser scope

## Change Types Made

* [x] Bug fix (non-breaking change)
* [ ] Feature / Enhancement (non-breaking change)
* [ ] Breaking change (fix or feature that could cause existing functionality to change)

## Related Issue

Fixes #2437

## Change Checklist

* [x] Requires a change to the documentation
* [ ] Documentation has been updated, will update docs once this gets reviewed/approved.
* [x] Tests to cover my changes, have been added
* [x] All new and existing tests passed.


