### PR TITLE
(#2401) Replace bit.ly with ch0.co links

### DIFF
--- a/src/chocolatey/infrastructure.app/commands/ChocolateyApiKeyCommand.cs
+++ b/src/chocolatey/infrastructure.app/commands/ChocolateyApiKeyCommand.cs
@@ -109,7 +109,7 @@ For the key, this can be an apikey that is provided by your source repository.
 With some sources, like Nexus, this can be a NuGet API key or it could be a
 user name and password specified as 'user:password' for the API key. Please see
 your repository's documentation (for Nexus, please see
-https://bit.ly/nexus2apikey).
+https://ch0.co/nexus2apikey).
 
 NOTE: See scripting in the command reference (`choco -?`) for how to
  write proper scripts and integrations.

--- a/src/chocolatey/infrastructure.app/commands/ChocolateyInstallCommand.cs
+++ b/src/chocolatey/infrastructure.app/commands/ChocolateyInstallCommand.cs
@@ -257,7 +257,7 @@ NOTE: `all` is a special package keyword that will allow you to install
  feed. THIS IS NOT YET REIMPLEMENTED.
 
 NOTE: Any package name ending with .config is considered a
- 'packages.config' file. Please see https://bit.ly/packages_config
+ 'packages.config' file. Please see https://ch0.co/packages_config
 
 NOTE: Chocolatey Pro / Business builds on top of a great open source
  experience with quite a few features that enhance the your use of the


### PR DESCRIPTION
## Description Of Changes

Replaces outdated bit.ly links with updated ch0.co links.

https://ch0.co/nexus2apikey points to
https://help.sonatype.com/repomanager3/formats/nuget-repositories/deploying-packages-to-nuget-hosted-repositories

https://ch0.co/packages_config points to
https://docs.chocolatey.org/en-us/choco/commands/install#packages.config

## Motivation and Context

The apikey help link was updated to the latest nexus 3 documentation from the previous
bit.ly link to nexus 2 documentation

The install help link was updated to the docs site from the previous bit.ly link to the
now removed GitHub wiki.

## Testing

Ran `choco install -h` and `choco apikey -h` to validate that the links are updated correctly.

## Change Types Made

* [x] Bug fix (non-breaking change)
* [ ] Feature / Enhancement (non-breaking change)
* [ ] Breaking change (fix or feature that could cause existing functionality to change)

## Related Issue

Fixes #2401

## Change Checklist

* [x] Requires a change to the documentation
* [ ] Documentation has been updated - This will need to be updated in the docs site as well.
* [ ] Tests to cover my changes, have been added
* [x] All new and existing tests passed.

