### PR TITLE
(#1332) Add switch to disable logging for archive extraction

### DIFF
--- a/src/chocolatey.resources/helpers/functions/Get-ChocolateyUnzip.ps1
+++ b/src/chocolatey.resources/helpers/functions/Get-ChocolateyUnzip.ps1
@@ -75,6 +75,14 @@ folder and its contents will be extracted to the destination.
 OPTIONAL - This will facilitate logging unzip activity for subsequent
 uninstalls
 
+.PARAMETER DisableLogging
+OPTIONAL - This disables logging of the extracted items. It speeds up
+extraction of archives with many files. 
+
+Usage of this parameter will prevent Uninstall-ChocolateyZipPackage
+from working, extracted files will have to be cleaned up with
+Remove-Item or a similar command instead.
+
 .PARAMETER IgnoredArguments
 Allows splatting with arguments that do not apply. Do not use directly.
 
@@ -93,6 +101,7 @@ param(
   [parameter(Mandatory=$false, Position=2)][string] $specificFolder,
   [parameter(Mandatory=$false, Position=3)][string] $packageName,
   [alias("file64")][parameter(Mandatory=$false)][string] $fileFullPath64,
+  [parameter(Mandatory=$false)][switch] $disableLogging,
   [parameter(ValueFromRemainingArguments = $true)][Object[]] $ignoredArguments
 )
 
@@ -156,7 +165,12 @@ param(
   }
   $workingDirectory = $workingDirectory.ProviderPath
 
-  $params = "x -aoa -bd -bb1 -o`"$destinationNoRedirection`" -y `"$fileFullPathNoRedirection`""
+  $loggingParam = '-bb1'
+  if ($disableLogging) {
+      $loggingParam = '-bb0'
+  }
+
+  $params = "x -aoa -bd $loggingParam -o`"$destinationNoRedirection`" -y `"$fileFullPathNoRedirection`""
   if ($specificfolder) {
     $params += " `"$specificfolder`""
   }
@@ -219,7 +233,7 @@ param(
   Set-PowerShellExitCode $exitCode
   Write-Debug "Command ['$7zip' $params] exited with `'$exitCode`'."
 
-  if ($zipExtractLogFullPath) {
+  if ($zipExtractLogFullPath -and -not $disableLogging) {
     Set-Content $zipExtractLogFullPath $global:zipFileList.ToString() -Encoding UTF8 -Force
   }
 

--- a/src/chocolatey.resources/helpers/functions/Install-ChocolateyZipPackage.ps1
+++ b/src/chocolatey.resources/helpers/functions/Install-ChocolateyZipPackage.ps1
@@ -151,6 +151,14 @@ Will be used for Url64bit if Url64bit is empty. Available in 0.10.7+.
 This parameter provides compatibility, but should not be used directly
 and not with the community package repository until January 2018.
 
+.PARAMETER DisableLogging
+OPTIONAL - This disables logging of the extracted items. It speeds up
+extraction of archives with many files. 
+
+Usage of this parameter will prevent Uninstall-ChocolateyZipPackage
+from working, extracted files will have to be cleaned up with
+Remove-Item or a similar command instead.
+
 .PARAMETER IgnoredArguments
 Allows splatting with arguments that do not apply. Do not use directly.
 
@@ -191,6 +199,7 @@ param(
   [parameter(Mandatory=$false)][hashtable] $options = @{Headers=@{}},
   [alias("fileFullPath")][parameter(Mandatory=$false)][string] $file = '',
   [alias("fileFullPath64")][parameter(Mandatory=$false)][string] $file64 = '',
+  [parameter(Mandatory=$false)][switch] $disableLogging,
   [parameter(ValueFromRemainingArguments = $true)][Object[]] $ignoredArguments
 )
 
@@ -213,5 +222,5 @@ param(
   }
 
   $filePath = Get-ChocolateyWebFile $packageName $downloadFilePath $url $url64bit -checkSum $checkSum -checksumType $checksumType -checkSum64 $checkSum64 -checksumType64 $checksumType64 -options $options -getOriginalFileName
-  Get-ChocolateyUnzip "$filePath" $unzipLocation $specificFolder $packageName
+  Get-ChocolateyUnzip "$filePath" $unzipLocation $specificFolder $packageName -disableLogging:$disableLogging
 }


### PR DESCRIPTION
## Description Of Changes

Adds a switch "disableLogging" to Get-ChocolateyUnzip and
Install-ChocolateyZipPackage. This switch disable 7zip logging of
extracted filenames and does not write out the log of extracted
files. Install-ChocolateyZip passes the switch to Get-ChocolateyUnzip,
and the functionality is implemented into Get-ChocolateyUnzip.

## Motivation and Context


This is useful for large archives with a very large number of files as
logging the extracted files can significantly slow down the extraction
process.

## Testing

- Imported `chocolateyInstall.psm1` into a `powershell.exe -version 2` window, the module loads fine.
- Ran `.\choco.exe install filespy --verbose --debug` to validate that the files are still correctly logged into the debug output and to the file
- Downloaded the filespy package, edited the `chocolateyInstall.ps1` to add the `DisableLogging` parameter, and installed the edited package to validate that the switch is passed correctly from `Install-ChocolateyZipPackage` to `Get-ChocolateyUnzip` and to validate that the logging and output file are correctly disabled.

## Change Types Made

* [ ] Bug fix (non-breaking change)
* [x] Feature / Enhancement (non-breaking change)
* [ ] Breaking change (fix or feature that could cause existing functionality to change)

## Related Issue

Fixes #1332

## Change Checklist

* [x] Requires a change to the documentation
* [x] Documentation has been updated
* [ ] Tests to cover my changes, have been added
* [x] All new and existing tests passed.
* [x] PowerShell v2 compatibility checked.
