### PR TITLE
(#2450) Enable configTransform and FilesSnapshot on non-Windows 

### DIFF
--- a/src/chocolatey.tests.integration/scenarios/InstallScenarios.cs
+++ b/src/chocolatey.tests.integration/scenarios/InstallScenarios.cs
@@ -3298,8 +3298,6 @@ namespace chocolatey.tests.integration.scenarios
         }
 
         [Concern(typeof(ChocolateyInstallCommand))]
-        [WindowsOnly]
-        [Platform(Exclude = "Mono")]
         public class when_installing_a_package_with_config_transforms : ScenariosBase
         {
             private PackageResult packageResult;

--- a/src/chocolatey.tests.integration/scenarios/UpgradeScenarios.cs
+++ b/src/chocolatey.tests.integration/scenarios/UpgradeScenarios.cs
@@ -2818,8 +2818,6 @@ namespace chocolatey.tests.integration.scenarios
         }
 
         [Concern(typeof(ChocolateyUpgradeCommand))]
-        [WindowsOnly]
-        [Platform(Exclude = "Mono")]
         public class when_upgrading_a_package_with_config_transforms : ScenariosBase
         {
             private PackageResult _packageResult;
@@ -2916,8 +2914,6 @@ namespace chocolatey.tests.integration.scenarios
         }
 
         [Concern(typeof(ChocolateyUpgradeCommand))]
-        [WindowsOnly]
-        [Platform(Exclude = "Mono")]
         public class when_upgrading_a_package_with_config_transforms_when_config_was_edited : ScenariosBase
         {
             private PackageResult _packageResult;

--- a/src/chocolatey/infrastructure.app/services/ChocolateyPackageService.cs
+++ b/src/chocolatey/infrastructure.app/services/ChocolateyPackageService.cs
@@ -386,7 +386,6 @@ Did you know Pro / Business automatically syncs with Programs and
                 _filesService.ensure_compatible_file_attributes(packageResult, config);
                 _configTransformService.run(packageResult, config);
 
-                //review: is this a Windows only kind of thing?
                 pkgInfo.FilesSnapshot = _filesService.capture_package_files(packageResult, config);
 
                 var is32Bit = !config.Information.Is64BitProcess || config.ForceX86;
@@ -397,6 +396,11 @@ Did you know Pro / Business automatically syncs with Programs and
             else
             {
                 if (config.Information.PlatformType != PlatformType.Windows) this.Log().Info(ChocolateyLoggers.Important, () => " Skipping PowerShell and shimgen portions of the install due to non-Windows.");
+                if (packageResult.Success)
+                {
+                    _configTransformService.run(packageResult, config);
+                    pkgInfo.FilesSnapshot = _filesService.capture_package_files(packageResult, config);
+                }
             }
 
             if (packageResult.Success)


### PR DESCRIPTION
## Description Of Changes

This runs configTransformService and capture_package_files on
non-Windows platforms. Both appear to be fully functional, so there is
no reason not to run them. They were added to non-Windows side of the if/else instead of being
moved from the Windows side so as to not screw up the functionality of
create_ignore_files_for_executables.

Also re-enables the integration tests that validate the config transform
service on non-Windows platforms. These can be enabled now that the
config transform service runs on non-Windows platforms.

## Motivation and Context

It would be good to get these two features working on non-Windows, as they both should be working. 

It also lets more integration tests work on non-Windows

## Testing

1. Build choco on non-windows
2. Run `mono choco.exe install --allow-unofficial msi.template zip.template --verbose --debug`
3. Validate that file snapshots are created correctly under the appropriate subdirectories the `.chocolatey` directory.
4. Uninstall the packages, make sure that the uninstall works.

The `configTransform` is tested in the `when_installing_a_package_with_config_transforms` test which is now enabled, along with the upgrade tests which pass.

## Change Types Made

* [ ] Bug fix (non-breaking change)
* [x] Feature / Enhancement (non-breaking change)
* [ ] Breaking change (fix or feature that could cause existing functionality to change)

## Related Issue

Fixes #2450
Depends on #2511

## Change Checklist

* [ ] Requires a change to the documentation
* [ ] Documentation has been updated
* [x] Tests to cover my changes, have been added
* [ ] All new and existing tests passed.
