### PR TITLE
(#798) Add parameter to install and upgrade commands to pin after install

### DIFF
--- a/src/chocolatey.tests/infrastructure.app/commands/ChocolateyInstallCommandSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/commands/ChocolateyInstallCommandSpecs.cs
@@ -235,6 +235,24 @@ namespace chocolatey.tests.infrastructure.app.commands
             {
                 optionSet.Contains("p").ShouldBeTrue();
             }
+
+            [Fact]
+            public void should_add_pin_to_the_option_set()
+            {
+                optionSet.Contains("pinpackage").ShouldBeTrue();
+            }
+
+            [Fact]
+            public void should_add_long_version_of_pin_to_the_option_set()
+            {
+                optionSet.Contains("pin-package").ShouldBeTrue();
+            }
+
+            [Fact]
+            public void should_add_short_version_of_pin_to_the_option_set()
+            {
+                optionSet.Contains("pin").ShouldBeTrue();
+            }
         }
 
         public class when_handling_additional_argument_parsing : ChocolateyInstallCommandSpecsBase

--- a/src/chocolatey.tests/infrastructure.app/commands/ChocolateyUpgradeCommandSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/commands/ChocolateyUpgradeCommandSpecs.cs
@@ -217,6 +217,24 @@ namespace chocolatey.tests.infrastructure.app.commands
             {
                 optionSet.Contains("p").ShouldBeTrue();
             }
+
+            [Fact]
+            public void should_add_pin_to_the_option_set()
+            {
+                optionSet.Contains("pinpackage").ShouldBeTrue();
+            }
+
+            [Fact]
+            public void should_add_long_version_of_pin_to_the_option_set()
+            {
+                optionSet.Contains("pin-package").ShouldBeTrue();
+            }
+
+            [Fact]
+            public void should_add_short_version_of_pin_to_the_option_set()
+            {
+                optionSet.Contains("pin").ShouldBeTrue();
+            }
         }
 
         public class when_handling_additional_argument_parsing : ChocolateyUpgradeCommandSpecsBase

--- a/src/chocolatey/infrastructure.app/commands/ChocolateyInstallCommand.cs
+++ b/src/chocolatey/infrastructure.app/commands/ChocolateyInstallCommand.cs
@@ -179,6 +179,10 @@ namespace chocolatey.infrastructure.app.commands
                              configuration.Features.UsePackageRepositoryOptimizations = false;
                          }
                      })
+                .Add("pin|pinpackage|pin-package",
+                    "Pin Package - Add a pin to the package after install. Available in 1.2.0+",
+                    option => configuration.PinPackage = option != null
+                    )
                 ;
 
             //todo: #770 package name can be a url / installertype

--- a/src/chocolatey/infrastructure.app/commands/ChocolateyInstallCommand.cs
+++ b/src/chocolatey/infrastructure.app/commands/ChocolateyInstallCommand.cs
@@ -108,7 +108,7 @@ namespace chocolatey.infrastructure.app.commands
                       {
                           if (option != null) configuration.Features.AllowEmptyChecksums = true;
                       })
-                 .Add("allowemptychecksumsecure|allowemptychecksumssecure|allow-empty-checksums-secure",
+                .Add("allowemptychecksumsecure|allowemptychecksumssecure|allow-empty-checksums-secure",
                       "Allow Empty Checksums Secure - Allow packages to have empty checksums for downloaded resources from secure locations (HTTPS). Overrides the default feature '{0}' set to '{1}'. Available in 0.10.0+.".format_with(ApplicationParameters.Features.AllowEmptyChecksumsSecure, configuration.Features.AllowEmptyChecksumsSecure.to_string()),
                       option =>
                       {
@@ -146,20 +146,20 @@ namespace chocolatey.infrastructure.app.commands
                              configuration.Features.UsePackageExitCodes = false;
                          }
                      })
-                 .Add("usepackagecodes|usepackageexitcodes|use-package-codes|use-package-exit-codes",
+                .Add("usepackagecodes|usepackageexitcodes|use-package-codes|use-package-exit-codes",
                      "UsePackageExitCodes - Package scripts can provide exit codes. Use those for choco's exit code when non-zero (this value can come from a dependency package). Chocolatey defines valid exit codes as 0, 1605, 1614, 1641, 3010.  Overrides the default feature '{0}' set to '{1}'. Available in 0.9.10+.".format_with(ApplicationParameters.Features.UsePackageExitCodes, configuration.Features.UsePackageExitCodes.to_string()),
                      option => configuration.Features.UsePackageExitCodes = option != null
                      )
-                 .Add("stoponfirstfailure|stop-on-first-failure|stop-on-first-package-failure",
+                .Add("stoponfirstfailure|stop-on-first-failure|stop-on-first-package-failure",
                      "Stop On First Package Failure - stop running install, upgrade or uninstall on first package failure instead of continuing with others. Overrides the default feature '{0}' set to '{1}'. Available in 0.10.4+.".format_with(ApplicationParameters.Features.StopOnFirstPackageFailure, configuration.Features.StopOnFirstPackageFailure.to_string()),
                      option => configuration.Features.StopOnFirstPackageFailure = option != null
                      )
-                 .Add("exitwhenrebootdetected|exit-when-reboot-detected",
+                .Add("exitwhenrebootdetected|exit-when-reboot-detected",
                      "Exit When Reboot Detected - Stop running install, upgrade, or uninstall when a reboot request is detected. Requires '{0}' feature to be turned on. Will exit with either {1} or {2}. Overrides the default feature '{3}' set to '{4}'. Available in 0.10.12+.".format_with
                      (ApplicationParameters.Features.UsePackageExitCodes, ApplicationParameters.ExitCodes.ErrorFailNoActionReboot, ApplicationParameters.ExitCodes.ErrorInstallSuspend, ApplicationParameters.Features.ExitOnRebootDetected, configuration.Features.ExitOnRebootDetected.to_string()),
                      option => configuration.Features.ExitOnRebootDetected = option != null
                      )
-                 .Add("ignoredetectedreboot|ignore-detected-reboot",
+                .Add("ignoredetectedreboot|ignore-detected-reboot",
                      "Ignore Detected Reboot - Ignore any detected reboots if found. Overrides the default feature '{0}' set to '{1}'. Available in 0.10.12+.".format_with
                      (ApplicationParameters.Features.ExitOnRebootDetected, configuration.Features.ExitOnRebootDetected.to_string()),
                      option =>

--- a/src/chocolatey/infrastructure.app/commands/ChocolateyUpgradeCommand.cs
+++ b/src/chocolatey/infrastructure.app/commands/ChocolateyUpgradeCommand.cs
@@ -218,6 +218,10 @@ namespace chocolatey.infrastructure.app.commands
                              configuration.Features.UsePackageRepositoryOptimizations = false;
                          }
                      })
+                .Add("pin|pinpackage|pin-package",
+                    "Pin Package - Add a pin to the package after upgrade. Available in 1.2.0+",
+                    option => configuration.PinPackage = option != null
+                    )
                 ;
         }
 

--- a/src/chocolatey/infrastructure.app/commands/ChocolateyUpgradeCommand.cs
+++ b/src/chocolatey/infrastructure.app/commands/ChocolateyUpgradeCommand.cs
@@ -152,23 +152,23 @@ namespace chocolatey.infrastructure.app.commands
                              configuration.Features.UsePackageExitCodes = false;
                          }
                      })
-                 .Add("usepackagecodes|usepackageexitcodes|use-package-codes|use-package-exit-codes",
+                .Add("usepackagecodes|usepackageexitcodes|use-package-codes|use-package-exit-codes",
                      "UsePackageExitCodes - Package scripts can provide exit codes. Use those for choco's exit code when non-zero (this value can come from a dependency package). Chocolatey defines valid exit codes as 0, 1605, 1614, 1641, 3010. Overrides the default feature '{0}' set to '{1}'. Available in 0.9.10+.".format_with(ApplicationParameters.Features.UsePackageExitCodes, configuration.Features.UsePackageExitCodes.to_string()),
                      option => configuration.Features.UsePackageExitCodes = option != null
                      )
-                 .Add("except=",
+                .Add("except=",
                      "Except - a comma-separated list of package names that should not be upgraded when upgrading 'all'. Overrides the configuration setting '{0}' set to '{1}'. Available in 0.9.10+.".format_with(ApplicationParameters.ConfigSettings.UpgradeAllExceptions, configuration.UpgradeCommand.PackageNamesToSkip.to_string()),
                      option => configuration.UpgradeCommand.PackageNamesToSkip = option.remove_surrounding_quotes()
                      )
-                 .Add("stoponfirstfailure|stop-on-first-failure|stop-on-first-package-failure",
+                .Add("stoponfirstfailure|stop-on-first-failure|stop-on-first-package-failure",
                      "Stop On First Package Failure - stop running install, upgrade or uninstall on first package failure instead of continuing with others. Overrides the default feature '{0}' set to '{1}'. Available in 0.10.4+.".format_with(ApplicationParameters.Features.StopOnFirstPackageFailure, configuration.Features.StopOnFirstPackageFailure.to_string()),
                      option => configuration.Features.StopOnFirstPackageFailure = option != null
                      )
-                 .Add("skip-if-not-installed|only-upgrade-installed|skip-when-not-installed",
+                .Add("skip-if-not-installed|only-upgrade-installed|skip-when-not-installed",
                      "Skip Packages Not Installed - if a package is not installed, do not install it during the upgrade process. Overrides the default feature '{0}' set to '{1}'. Available in 0.10.12+.".format_with(ApplicationParameters.Features.SkipPackageUpgradesWhenNotInstalled, configuration.Features.SkipPackageUpgradesWhenNotInstalled.to_string()),
                      option => configuration.Features.SkipPackageUpgradesWhenNotInstalled = option != null
                      )
-                 .Add("install-if-not-installed",
+                .Add("install-if-not-installed",
                      "Install Missing Packages When Not Installed - if a package is not installed, install it as part of running upgrade (typically default behavior). Overrides the default feature '{0}' set to '{1}'. Available in 0.10.12+.".format_with(ApplicationParameters.Features.SkipPackageUpgradesWhenNotInstalled, configuration.Features.SkipPackageUpgradesWhenNotInstalled.to_string()),
                      option =>
                      {
@@ -177,28 +177,28 @@ namespace chocolatey.infrastructure.app.commands
                              configuration.Features.SkipPackageUpgradesWhenNotInstalled = false;
                          }
                      })
-                 .Add("exclude-pre|exclude-prerelease|exclude-prereleases",
+                .Add("exclude-pre|exclude-prerelease|exclude-prereleases",
                      "Exclude Prerelease - Should prerelease be ignored for upgrades? Will be ignored if you pass `--pre`. Available in 0.10.4+.",
                      option => configuration.UpgradeCommand.ExcludePrerelease = option != null
                      )
-                 .Add("userememberedargs|userememberedarguments|userememberedoptions|use-remembered-args|use-remembered-arguments|use-remembered-options",
+                .Add("userememberedargs|userememberedarguments|userememberedoptions|use-remembered-args|use-remembered-arguments|use-remembered-options",
                      "Use Remembered Options for Upgrade - use the arguments and options used during install for upgrade. Does not override arguments being passed at runtime. Overrides the default feature '{0}' set to '{1}'. Available in 0.10.4+.".format_with(ApplicationParameters.Features.UseRememberedArgumentsForUpgrades, configuration.Features.UseRememberedArgumentsForUpgrades.to_string()),
                      option =>
                      {
                          if (option != null) configuration.Features.UseRememberedArgumentsForUpgrades = true;
                      })
-                 .Add("ignorerememberedargs|ignorerememberedarguments|ignorerememberedoptions|ignore-remembered-args|ignore-remembered-arguments|ignore-remembered-options",
+                .Add("ignorerememberedargs|ignorerememberedarguments|ignorerememberedoptions|ignore-remembered-args|ignore-remembered-arguments|ignore-remembered-options",
                      "Ignore Remembered Options for Upgrade - ignore the arguments and options used during install for upgrade. Overrides the default feature '{0}' set to '{1}'. Available in 0.10.4+.".format_with(ApplicationParameters.Features.UseRememberedArgumentsForUpgrades, configuration.Features.UseRememberedArgumentsForUpgrades.to_string()),
                      option =>
                      {
                          if (option != null) configuration.Features.UseRememberedArgumentsForUpgrades = false;
                      })
-                 .Add("exitwhenrebootdetected|exit-when-reboot-detected",
+                .Add("exitwhenrebootdetected|exit-when-reboot-detected",
                      "Exit When Reboot Detected - Stop running install, upgrade, or uninstall when a reboot request is detected. Requires '{0}' feature to be turned on. Will exit with either {1} or {2}. Overrides the default feature '{3}' set to '{4}'. Available in 0.10.12+.".format_with
                          (ApplicationParameters.Features.UsePackageExitCodes, ApplicationParameters.ExitCodes.ErrorFailNoActionReboot, ApplicationParameters.ExitCodes.ErrorInstallSuspend, ApplicationParameters.Features.ExitOnRebootDetected, configuration.Features.ExitOnRebootDetected.to_string()),
                      option => configuration.Features.ExitOnRebootDetected = option != null
                      )
-                 .Add("ignoredetectedreboot|ignore-detected-reboot",
+                .Add("ignoredetectedreboot|ignore-detected-reboot",
                      "Ignore Detected Reboot - Ignore any detected reboots if found. Overrides the default feature '{0}' set to '{1}'. Available in 0.10.12+.".format_with
                          (ApplicationParameters.Features.ExitOnRebootDetected, configuration.Features.ExitOnRebootDetected.to_string()),
                      option =>
@@ -208,7 +208,7 @@ namespace chocolatey.infrastructure.app.commands
                              configuration.Features.ExitOnRebootDetected = false;
                          }
                      })
-                 .Add("disable-repository-optimizations|disable-package-repository-optimizations",
+                .Add("disable-repository-optimizations|disable-package-repository-optimizations",
                      "Disable Package Repository Optimizations - Do not use optimizations for reducing bandwidth with repository queries during package install/upgrade/outdated operations. Should not generally be used, unless a repository needs to support older methods of query. When disabled, this makes queries similar to the way they were done in Chocolatey v0.10.11 and before. Overrides the default feature '{0}' set to '{1}'. Available in 0.10.14+.".format_with
                          (ApplicationParameters.Features.UsePackageRepositoryOptimizations, configuration.Features.UsePackageRepositoryOptimizations.to_string()),
                      option =>

--- a/src/chocolatey/infrastructure.app/configuration/ChocolateyConfiguration.cs
+++ b/src/chocolatey/infrastructure.app/configuration/ChocolateyConfiguration.cs
@@ -235,6 +235,7 @@ NOTE: Hiding sensitive configuration data! Please double and triple
         public string DownloadChecksum64 { get; set; }
         public string DownloadChecksumType { get; set; }
         public string DownloadChecksumType64 { get; set; }
+        public bool PinPackage { get; set; }
 
         /// <summary>
         ///   Configuration values provided by choco.

--- a/src/chocolatey/infrastructure.app/configuration/PackagesConfigFilePackageSetting.cs
+++ b/src/chocolatey/infrastructure.app/configuration/PackagesConfigFilePackageSetting.cs
@@ -59,6 +59,9 @@ namespace chocolatey.infrastructure.app.configuration
         [XmlAttribute(AttributeName = "disabled")]
         public bool Disabled { get; set; }
 
+        [XmlAttribute(AttributeName = "pinPackage")]
+        public bool PinPackage { get; set; }
+        
         [System.ComponentModel.DefaultValue(-1)]
         [XmlAttribute(AttributeName = "executionTimeout")]
         public int ExecutionTimeout { get; set; }

--- a/src/chocolatey/infrastructure.app/services/ChocolateyPackageService.cs
+++ b/src/chocolatey/infrastructure.app/services/ChocolateyPackageService.cs
@@ -738,6 +738,7 @@ Would have determined packages that are out of date based on what is
                     if (pkgSettings.ApplyPackageParametersToDependencies) packageConfig.ApplyPackageParametersToDependencies = true;
                     SourceType sourceType;
                     if (Enum.TryParse(pkgSettings.Source, true, out sourceType)) packageConfig.SourceType = sourceType;
+                    if (pkgSettings.PinPackage) packageConfig.PinPackage = true;
                     if (pkgSettings.Force) packageConfig.Force = true;
                     packageConfig.CommandExecutionTimeoutSeconds = pkgSettings.ExecutionTimeout == -1 ? packageConfig.ExecutionTimeout : pkgSettings.CommandExecutionTimeoutSeconds;
                     if (pkgSettings.Prerelease) packageConfig.Prerelease = true;

--- a/src/chocolatey/infrastructure.app/services/ChocolateyPackageService.cs
+++ b/src/chocolatey/infrastructure.app/services/ChocolateyPackageService.cs
@@ -740,7 +740,7 @@ Would have determined packages that are out of date based on what is
                     if (Enum.TryParse(pkgSettings.Source, true, out sourceType)) packageConfig.SourceType = sourceType;
                     if (pkgSettings.PinPackage) packageConfig.PinPackage = true;
                     if (pkgSettings.Force) packageConfig.Force = true;
-                    packageConfig.CommandExecutionTimeoutSeconds = pkgSettings.ExecutionTimeout == -1 ? packageConfig.ExecutionTimeout : pkgSettings.CommandExecutionTimeoutSeconds;
+                    packageConfig.CommandExecutionTimeoutSeconds = pkgSettings.ExecutionTimeout == -1 ? packageConfig.CommandExecutionTimeoutSeconds : pkgSettings.ExecutionTimeout;
                     if (pkgSettings.Prerelease) packageConfig.Prerelease = true;
                     if (pkgSettings.OverrideArguments) packageConfig.OverrideArguments = true;
                     if (pkgSettings.NotSilent) packageConfig.NotSilent = true;

--- a/src/chocolatey/infrastructure.app/services/ChocolateyPackageService.cs
+++ b/src/chocolatey/infrastructure.app/services/ChocolateyPackageService.cs
@@ -408,6 +408,7 @@ Did you know Pro / Business automatically syncs with Programs and
                 handle_extension_packages(config, packageResult);
                 handle_template_packages(config, packageResult);
                 pkgInfo.Arguments = capture_arguments(config, packageResult);
+                pkgInfo.IsPinned = config.PinPackage;
             }
 
             var toolsLocation = Environment.GetEnvironmentVariable(ApplicationParameters.Environment.ChocolateyToolsLocation);


### PR DESCRIPTION
## Description Of Changes

This adds a parameter to pin packages after install or upgrade.
It re-uses the code in save_package_information to create the pin file.

## Motivation and Context

See #798

## Testing

- Installed `wget` with `--pin`, checked that it was pinned with `choco pin list`
- Unpinned and uninstalled
- Install `wget` without `--pin`, checked that it was not pinned with `choco pin list`
- Unpinned and uninstalled
- Upgraded `wget` with `--pin`, checked that it was pinned with `choco pin list`
- Unpinned and uninstalled
- Upgraded `wget` without `--pin`, checked that it was not pinned with `choco pin list`
- Unpinned and uninstalled

Create this `packages.config` file:
```
<?xml version="1.0" encoding="utf-8"?>
<packages>
    <package id="wget" pinPackage="true" />
</packages>
```

Install via that file and then check that wget is pinned with `choco pin list`

## Change Types Made

* [ ] Bug fix (non-breaking change)
* [x] Feature / Enhancement (non-breaking change)
* [ ] Breaking change (fix or feature that could cause existing functionality to change)

## Related Issue

Fixes #798

## Change Checklist

* [x] Requires a change to the documentation
* [x] Documentation has been updated
* [x] Tests to cover my changes, have been added
* [x] All new and existing tests passed.
* N/A PowerShell v2 compatibility checked.
