### PR TITLE
(#2481) Only allow installing template packages on non-Windows

### DIFF
--- a/src/chocolatey.tests.integration/NUnitSetup.cs
+++ b/src/chocolatey.tests.integration/NUnitSetup.cs
@@ -102,6 +102,9 @@ namespace chocolatey.tests.integration
             field = typeof(ApplicationParameters).GetField("LockTransactionalInstallFiles");
             field.SetValue(null, false);
 
+            field = typeof(ApplicationParameters).GetField("CheckPackageIdsNonWindows");
+            field.SetValue(null, false);
+
             // we need to speed up specs a bit, so only try filesystem locking operations twice
             field = fileSystem.GetType().GetField("TIMES_TO_TRY_OPERATION", BindingFlags.Instance | BindingFlags.NonPublic);
             if (field != null)

--- a/src/chocolatey/infrastructure.app/ApplicationParameters.cs
+++ b/src/chocolatey/infrastructure.app/ApplicationParameters.cs
@@ -150,6 +150,11 @@ namespace chocolatey.infrastructure.app
         /// </summary>
         public static readonly bool AllowPrompts = true;
 
+        /// <summary>
+        /// This is a readonly bool set to true. It is only shifted for specs.
+        /// </summary>
+        public static readonly bool CheckPackageIdsNonWindows = true;
+
         public static class ExitCodes
         {
             public static readonly int ErrorFailNoActionReboot = 350;

--- a/src/chocolatey/infrastructure.app/services/NugetService.cs
+++ b/src/chocolatey/infrastructure.app/services/NugetService.cs
@@ -447,7 +447,7 @@ folder.");
                 //todo: get smarter about realizing multiple versions have been installed before and allowing that
                 IPackage installedPackage = packageManager.LocalRepository.FindPackage(packageName);
 
-                if (Platform.get_platform() != PlatformType.Windows && !packageName.EndsWith(".template"))
+                if (ApplicationParameters.CheckPackageIdsNonWindows && Platform.get_platform() != PlatformType.Windows && !packageName.EndsWith(".template"))
                 {
                     if (config.Force)
                     {

--- a/src/chocolatey/infrastructure.app/services/NugetService.cs
+++ b/src/chocolatey/infrastructure.app/services/NugetService.cs
@@ -447,6 +447,23 @@ folder.");
                 //todo: get smarter about realizing multiple versions have been installed before and allowing that
                 IPackage installedPackage = packageManager.LocalRepository.FindPackage(packageName);
 
+                if (Platform.get_platform() != PlatformType.Windows && !packageName.EndsWith(".template"))
+                {
+                    if (config.Force)
+                    {
+                        string logMessage = "{0} is not a supported package on non-Windows systems.{1}Only template packages are currently supported.{1}Bypassing check and installing anyway as force is specified".format_with(packageName, Environment.NewLine);
+                        this.Log().Warn(ChocolateyLoggers.Important, logMessage);
+                    }
+                    else
+                    {
+                        string logMessage = "{0} is not a supported package on non-Windows systems.{1}Only template packages are currently supported.".format_with(packageName, Environment.NewLine);
+                        var noPkgResult = packageInstalls.GetOrAdd(packageName, new PackageResult(packageName, version.to_string(), null));
+                        noPkgResult.Messages.Add(new ResultMessage(ResultType.Error, logMessage));
+                        this.Log().Error(ChocolateyLoggers.Important, logMessage);
+                        continue;
+                    }
+                }
+
                 if (installedPackage != null && (version == null || version == installedPackage.Version) && !config.Force)
                 {
                     string logMessage = "{0} v{1} already installed.{2} Use --force to reinstall, specify a version to install, or try upgrade.".format_with(installedPackage.Id, installedPackage.Version, Environment.NewLine);


### PR DESCRIPTION
## Description Of Changes

This adds a check for non-Windows systems that only allows package ids
ending in .template to install. 

The check can be overridden if --force is specified. Because
upgrade_run calls install_run if the package is not already installed,
there is no need to duplicate this check in upgrade_run.

A bool in application parameters was also added which is used to disable the
check during install for supported package IDs. This bool is shifted
during testing so the integration tests will still run as normal,
without failing due to the package ID check.


## Motivation and Context

This check is added to help provide guidance to users, as templates are the only package type currently supported on non-Windows systems.

In the future, if the licensed extension becomes supported on
non-Windows systems, then the check will need to be amended to support
installing packages relating to licensed extension.

## Testing

- Ran `choco install wget` on Windows to validate that the check is bypassed on Windows systems
- Ran `choco install curl` on Linux to validate that it fails with the specified error message.
- Ran `choco install msi.template` on Linux to validate that it installs without the error.
- Ran `choco install curl -f` on Linux to validate that the check can be bypassed if force is specified.
- Ran integration tests on both Windows and a Linux system.

## Change Types Made

* [ ] Bug fix (non-breaking change)
* [ ] Feature / Enhancement (non-breaking change)
* [x] Breaking change (fix or feature that could cause existing functionality to change) (Breaks non-Windows systems only)

## Related Issue

Fixes #2481

## Change Checklist

* [x] Requires a change to the documentation
* [x] Documentation has been updated https://github.com/chocolatey/docs/pull/280
* [ ] Tests to cover my changes, have been added
* [x] All new and existing tests passed.
* N/A PowerShell v2 compatibility checked.
