### PR TITLE
(#886) Add support for more arguments in packages.config

### DIFF
--- a/src/chocolatey/infrastructure.app/configuration/PackagesConfigFilePackageSetting.cs
+++ b/src/chocolatey/infrastructure.app/configuration/PackagesConfigFilePackageSetting.cs
@@ -65,5 +65,98 @@ namespace chocolatey.infrastructure.app.configuration
 
         [XmlAttribute(AttributeName = "force")]
         public bool Force { get; set; }
+
+        [XmlAttribute(AttributeName = "prerelease")]
+        public bool Prerelease { get; set; }
+
+        [XmlAttribute(AttributeName = "overrideArguments")]
+        public bool OverrideArguments { get; set; }
+
+        [XmlAttribute(AttributeName = "notSilent")]
+        public bool NotSilent { get; set; }
+
+        [XmlAttribute(AttributeName = "allowDowngrade")]
+        public bool AllowDowngrade { get; set; }
+
+        [XmlAttribute(AttributeName = "forceDependencies")]
+        public bool ForceDependencies { get; set; }
+
+        [XmlAttribute(AttributeName = "skipAutomationScripts")]
+        public bool SkipAutomationScripts { get; set; }
+
+        [XmlAttribute(AttributeName = "user")]
+        public string User { get; set; }
+
+        [XmlAttribute(AttributeName = "password")]
+        public string Password { get; set; }
+
+        [XmlAttribute(AttributeName = "cert")]
+        public string Cert { get; set; }
+
+        [XmlAttribute(AttributeName = "certPassword")]
+        public string CertPassword { get; set; }
+
+        [XmlAttribute(AttributeName = "ignoreChecksums")]
+        public bool IgnoreChecksums { get; set; }
+
+        [XmlAttribute(AttributeName = "allowEmptyChecksums")]
+        public bool AllowEmptyChecksums { get; set; }
+
+        [XmlAttribute(AttributeName = "allowEmptyChecksumsSecure")]
+        public bool AllowEmptyChecksumsSecure { get; set; }
+
+        [XmlAttribute(AttributeName = "requireChecksums")]
+        public bool RequireChecksums { get; set; }
+
+        [XmlAttribute(AttributeName = "downloadChecksum")]
+        public string DownloadChecksum { get; set; }
+
+        [XmlAttribute(AttributeName = "downloadChecksum64")]
+        public string DownloadChecksum64 { get; set; }
+
+        [XmlAttribute(AttributeName = "downloadChecksumType")]
+        public string DownloadChecksumType { get; set; }
+
+        [XmlAttribute(AttributeName = "downloadChecksumType64")]
+        public string DownloadChecksumType64 { get; set; }
+
+        [XmlAttribute(AttributeName = "ignorePackageExitCodes")]
+        public bool IgnorePackageExitCodes { get; set; }
+
+        [XmlAttribute(AttributeName = "usePackageExitCodes")]
+        public bool UsePackageExitCodes { get; set; }
+
+        [XmlAttribute(AttributeName = "stopOnFirstFailure")]
+        public bool StopOnFirstFailure { get; set; }
+
+        [XmlAttribute(AttributeName = "exitWhenRebootDetected")]
+        public bool ExitWhenRebootDetected { get; set; }
+
+        [XmlAttribute(AttributeName = "ignoreDetectedReboot")]
+        public bool IgnoreDetectedReboot { get; set; }
+
+        [XmlAttribute(AttributeName = "disableRepositoryOptimizations")]
+        public bool DisableRepositoryOptimizations { get; set; }
+
+        [XmlAttribute(AttributeName = "acceptLicense")]
+        public bool AcceptLicense { get; set; }
+
+        [XmlAttribute(AttributeName = "confirm")]
+        public bool Confirm { get; set; }
+
+        [XmlAttribute(AttributeName = "limitOutput")]
+        public bool LimitOutput { get; set; }
+
+        [XmlAttribute(AttributeName = "cacheLocation")]
+        public string CacheLocation { get; set; }
+
+        [XmlAttribute(AttributeName = "failOnStderr")]
+        public bool FailOnStderr { get; set; }
+
+        [XmlAttribute(AttributeName = "useSystemPowershell")]
+        public bool UseSystemPowershell { get; set; }
+
+        [XmlAttribute(AttributeName = "noProgress")]
+        public bool NoProgress { get; set; }
     }
 }

--- a/src/chocolatey/infrastructure.app/services/ChocolateyPackageService.cs
+++ b/src/chocolatey/infrastructure.app/services/ChocolateyPackageService.cs
@@ -739,6 +739,45 @@ Would have determined packages that are out of date based on what is
                     if (Enum.TryParse(pkgSettings.Source, true, out sourceType)) packageConfig.SourceType = sourceType;
                     if (pkgSettings.Force) packageConfig.Force = true;
                     packageConfig.CommandExecutionTimeoutSeconds = pkgSettings.CommandExecutionTimeoutSeconds == -1 ? packageConfig.CommandExecutionTimeoutSeconds : pkgSettings.CommandExecutionTimeoutSeconds;
+                    if (pkgSettings.Prerelease) packageConfig.Prerelease = true;
+                    if (pkgSettings.OverrideArguments) packageConfig.OverrideArguments = true;
+                    if (pkgSettings.NotSilent) packageConfig.NotSilent = true;
+                    if (pkgSettings.AllowDowngrade) packageConfig.AllowDowngrade = true;
+                    if (pkgSettings.ForceDependencies) packageConfig.ForceDependencies = true;
+                    if (pkgSettings.SkipAutomationScripts) packageConfig.SkipPackageInstallProvider = true;
+                    packageConfig.SourceCommand.Username = string.IsNullOrWhiteSpace(pkgSettings.User) ? packageConfig.SourceCommand.Username : pkgSettings.User;
+                    packageConfig.SourceCommand.Password = string.IsNullOrWhiteSpace(pkgSettings.Password) ? packageConfig.SourceCommand.Password : pkgSettings.Password;
+                    packageConfig.SourceCommand.Certificate = string.IsNullOrWhiteSpace(pkgSettings.Cert) ? packageConfig.SourceCommand.Certificate : pkgSettings.Cert;
+                    packageConfig.SourceCommand.CertificatePassword = string.IsNullOrWhiteSpace(pkgSettings.CertPassword) ? packageConfig.SourceCommand.CertificatePassword : pkgSettings.CertPassword;
+                    if (pkgSettings.IgnoreChecksums) packageConfig.Features.ChecksumFiles = false;
+                    if (pkgSettings.AllowEmptyChecksums) packageConfig.Features.AllowEmptyChecksums = true;
+                    if (pkgSettings.AllowEmptyChecksumsSecure) packageConfig.Features.AllowEmptyChecksumsSecure = true;
+                    if (pkgSettings.RequireChecksums)
+                    {
+                        packageConfig.Features.AllowEmptyChecksums = false;
+                        packageConfig.Features.AllowEmptyChecksumsSecure = false;
+                    }
+                    packageConfig.DownloadChecksum = string.IsNullOrWhiteSpace(pkgSettings.DownloadChecksum) ? packageConfig.DownloadChecksum : pkgSettings.DownloadChecksum;
+                    packageConfig.DownloadChecksum64 = string.IsNullOrWhiteSpace(pkgSettings.DownloadChecksum64) ? packageConfig.DownloadChecksum64 : pkgSettings.DownloadChecksum64;
+                    packageConfig.DownloadChecksum = string.IsNullOrWhiteSpace(pkgSettings.DownloadChecksumType) ? packageConfig.DownloadChecksumType : pkgSettings.DownloadChecksumType;
+                    packageConfig.DownloadChecksumType64 = string.IsNullOrWhiteSpace(pkgSettings.DownloadChecksumType64) ? packageConfig.DownloadChecksumType : pkgSettings.DownloadChecksumType64;
+                    if (pkgSettings.IgnorePackageExitCodes) packageConfig.Features.UsePackageExitCodes = false;
+                    if (pkgSettings.UsePackageExitCodes) packageConfig.Features.UsePackageExitCodes = true;
+                    if (pkgSettings.StopOnFirstFailure) packageConfig.Features.StopOnFirstPackageFailure = true;
+                    if (pkgSettings.ExitWhenRebootDetected) packageConfig.Features.ExitOnRebootDetected = true;
+                    if (pkgSettings.IgnoreDetectedReboot) packageConfig.Features.ExitOnRebootDetected = false;
+                    if (pkgSettings.DisableRepositoryOptimizations) packageConfig.Features.UsePackageRepositoryOptimizations = false;
+                    if (pkgSettings.AcceptLicense) packageConfig.AcceptLicense = true;
+                    if (pkgSettings.Confirm)
+                    {
+                        packageConfig.PromptForConfirmation = false;
+                        packageConfig.AcceptLicense = true;
+                    }
+                    if (pkgSettings.LimitOutput) packageConfig.RegularOutput = false;
+                    packageConfig.CacheLocation = string.IsNullOrWhiteSpace(pkgSettings.CacheLocation) ? packageConfig.CacheLocation : pkgSettings.CacheLocation;
+                    if (pkgSettings.FailOnStderr) packageConfig.Features.FailOnStandardError = true;
+                    if (pkgSettings.UseSystemPowershell) packageConfig.Features.UsePowerShellHost = false;
+                    if (pkgSettings.NoProgress) packageConfig.Features.ShowDownloadProgress = false;
 
                     this.Log().Info(ChocolateyLoggers.Important, @"{0}".format_with(packageConfig.PackageNames));
                     packageConfigs.Add(packageConfig);


### PR DESCRIPTION
## Description Of Changes

This adds the remaining arguments in the install command's OptionSet and some more arguments in the global OptionSet as elements to the packages.config xml serialization schema. 

## Motivation and Context

This is useful for users wanting arguments that were previously not
available. It is also a pre-requisite for exporting remembered 
arguments, as some of the remembered arguments were not available
in the previous available schema.

Some of the global arguments were not added:
- debug
- verbose 
- trace
- nocolor
- noop
- allowunofficial
- proxy
- proxy-user
- proxy-password
- proxy-bypass-list
- proxy-bypass-on-local
- log-file

All of these appeared to either not be applicable to a single package (e.g. proxy related) or required earlier than the packages.config would get read (like log-file).

## Testing

Save this as a packages.config file:
```xml
<?xml version="1.0" encoding="utf-8"?>
<packages>
   <package id="iperf2" prerelease="true" overrideArguments="true"
     notSilent="true" allowDowngrade="true" forceDependencies="true"
     skipAutomationScripts="true" user="string" password="string" cert="string"
     certPassword="string" ignoreChecksums="true" allowEmptyChecksums="true" 
     allowEmptyChecksumsSecure="true" requireChecksums="true" 
     downloadChecksum="string" downloadChecksum64="string" 
     downloadChecksumType="sha512" downloadChecksumType64="sha512"
     ignorePackageExitCodes="true" usePackageExitCodes="true"
     stopOnFirstFailure="true" exitWhenRebootDetected="true"
     ignoreDetectedReboot="true" disableRepositoryOptimizations="true"
     acceptLicense="true" confirm="true" limitOutput="true" cacheLocation="Z:\"
     failOnStderr="true" useSystemPowershell="true" noProgress="true"
   />
</packages>
```

Set the debugging arguments as `install \path\to\packages.config`

Then set a breakpoint at `get_packages_from_config` in `ChocolateyPackageService`, and step through the method, ensuring that the settings in the `packageConfig` get updated correctly.

## Change Types Made

* [ ] Bug fix (non-breaking change)
* [x] Feature / Enhancement (non-breaking change)
* [ ] Breaking change (fix or feature that could cause existing functionality to change)

## Related Issue

Fixes #886
Depends on #2187

## Change Checklist

* [x] Requires a change to the documentation
* [ ] Documentation has been updated (Tracked in https://github.com/chocolatey/docs/issues/403)
* [ ] Tests to cover my changes, have been added
* [x] All new and existing tests passed.
* N/A PowerShell v2 compatibility checked
