### PR TITLE
(#2500) List parameters in templates

### DIFF
--- a/src/chocolatey.tests/infrastructure.app/services/TemplateServiceSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/services/TemplateServiceSpecs.cs
@@ -26,6 +26,7 @@ namespace chocolatey.tests.infrastructure.app.services
     using chocolatey.infrastructure.app.services;
     using chocolatey.infrastructure.app.templates;
     using chocolatey.infrastructure.filesystem;
+    using chocolatey.infrastructure.services;
     using Moq;
     using NUnit.Framework;
     using Should;
@@ -36,12 +37,14 @@ namespace chocolatey.tests.infrastructure.app.services
         {
             protected TemplateService service;
             protected Mock<IFileSystem> fileSystem = new Mock<IFileSystem>();
+            protected Mock<IXmlService> xmlService = new Mock<IXmlService>();
 
             public override void Context()
             {
                 fileSystem.ResetCalls();
+                xmlService.ResetCalls();
 
-                service = new TemplateService(fileSystem.Object);
+                service = new TemplateService(fileSystem.Object, xmlService.Object);
             }
         }
 

--- a/src/chocolatey/infrastructure/tokens/TokenReplacer.cs
+++ b/src/chocolatey/infrastructure/tokens/TokenReplacer.cs
@@ -61,5 +61,16 @@ namespace chocolatey.infrastructure.tokens
 
             return propertyDictionary;
         }
+
+        public static IEnumerable<string> get_tokens(string textWithTokens, string tokenPrefix = "[[", string tokenSuffix = "]]")
+        {
+            var regexMatches = Regex.Matches(textWithTokens, "{0}(?<key>\\w+){1}"
+                .format_with(Regex.Escape(tokenPrefix), Regex.Escape(tokenSuffix))
+            );
+            foreach (Match regexMatch in regexMatches)
+            {
+                yield return regexMatch.Groups["key"].to_string();
+            }
+        }
     }
 }


### PR DESCRIPTION
## Description Of Changes

This adds the ability for the template command to list the parameters
in templates. If the template is installed via a package, the
parameters get cached in a file called .parameters in the template's
directory. This file is ignored by calls to choco new, as it is
excluded from being copied.

There another method added to TokenReplacer to get the parameters via
regex. This keeps the regex in the TokenReplacer class.

## Motivation and Context

It it useful to be able to list the available parameters in a template. 

The parameters are cached to reduce the number of files that need to be read to get the parameters. Only templates installed via a `.template` package have the parameters cached. This is because those cache files would get deleted as a part of the package upgrade process, so any cache files from those templates would be up to date. However, for packages that are installed manually, there is not an efficient way to check that the cache is still valid, so that it why parameters from those templates are always read manually.

## Testing

Just like in #2385, unit tests cannot be added yet, due to #2501

Manual testing instructions:
1. Install `msi.template` and `zip.template`
2. Make a copy of the msi template folder and rename to "default"
3. Make a copy of the msi template folder and rename to "non-pkg"
4. Run `choco template --verbose`
5. Check that the parameters are listed correctly
6. Check that only the msi and zip template folders have the `.parameters` file

## Change Types Made

* [ ] Bug fix (non-breaking change)
* [x] Feature / Enhancement (non-breaking change)
* [ ] Breaking change (fix or feature that could cause existing functionality to change)

## Related Issue

Fixes #2500
Depends on #2385 (now merged)

## Change Checklist

* [ ] Requires a change to the documentation
* [ ] Documentation has been updated
* [ ] Tests to cover my changes, have been added
* [ ] All new and existing tests passed.
* N/A PowerShell v2 compatibility checked.