### PR TITLE
(#2434) Don't hardcode platform in NUnitSetup

### DIFF
--- a/src/chocolatey.tests.integration/NUnitSetup.cs
+++ b/src/chocolatey.tests.integration/NUnitSetup.cs
@@ -50,7 +50,7 @@ namespace chocolatey.tests.integration
             // deep copy so we don't have the same configuration and 
             // don't have to worry about issues using it
             var config = Container.GetInstance<ChocolateyConfiguration>().deep_copy();
-            config.Information.PlatformType = PlatformType.Windows;
+            config.Information.PlatformType = Platform.get_platform();
             config.Information.IsInteractive = false;
             config.PromptForConfirmation = false;
             config.Force = true;


### PR DESCRIPTION
## Description Of Changes

Don't hardcode the platform type in the config to windows in the
Nunit Setup.

## Motivation and Context

If the platform type is set to windows, it will try to
run powershell when the tests are run on Linux.

## Testing

Ran integration and unit tests on both windows and linux.

## Change Types Made

* [x] Bug fix (non-breaking change)
* [ ] Feature / Enhancement (non-breaking change)
* [ ] Breaking change (fix or feature that could cause existing functionality to change)

## Related Issue

Part of #2434

## Change Checklist

* [ ] Requires a change to the documentation
* [ ] Documentation has been updated
* [ ] Tests to cover my changes, have been added
* [x] All new and existing tests passed.
* N/A PowerShell v2 compatibility checked.
