### PR TITLE
(#2510) Stop Beforemodify scripts from running on non-windows

### DIFF
--- a/nuget/chocolatey/tools/init.ps1
+++ b/nuget/chocolatey/tools/init.ps1
@@ -20,7 +20,7 @@ After you have run Initialize-Chocolatey, you can safely uninstall the chocolate
 ----------
 Alternative NuGet -
 ----------
-If you are not using NuGet in Visual Studio, please navigate to the directory with the chocolateysetup.psm1 and run that in Powershell, followed by Initialize-Chocolatey.
+If you are not using NuGet in Visual Studio, please navigate to the directory with the chocolateysetup.psm1 and run that in PowerShell, followed by Initialize-Chocolatey.
 Upgrade is the same, just run Initialize-Chocolatey again.
 ----------
 Once you've run initialize or upgrade, you can uninstall this package from the local project without affecting your chocolatey repository.

--- a/src/chocolatey.resources/helpers/functions/Get-CheckSumValid.ps1
+++ b/src/chocolatey.resources/helpers/functions/Get-CheckSumValid.ps1
@@ -147,7 +147,7 @@ param(
     Write-Warning "Missing package checksums are not allowed (by default for HTTP/FTP, `n HTTPS when feature 'allowEmptyChecksumsSecure' is disabled) for `n safety and security reasons. Although we strongly advise against it, `n if you need this functionality, please set the feature `n 'allowEmptyChecksums' ('choco feature enable -n `n allowEmptyChecksums') `n or pass in the option '--allow-empty-checksums'. You can also pass `n checksums at runtime (recommended). See `choco install -?` for details."
     Write-Debug "If you are a maintainer attempting to determine the checksum for packaging purposes, please run `n 'choco install checksum' and run 'checksum -t sha256 -f $file' `n Ensure you do this for all remote resources."
     if ($PSVersionTable.PSVersion.Major -ge 4){
-      Write-Debug "Because you are running Powershell with a major version of v4 or greater, you could also opt to run `n '(Get-FileHash -Path $file -Algorithm SHA256).Hash' `n rather than install a separate tool."
+      Write-Debug "Because you are running PowerShell with a major version of v4 or greater, you could also opt to run `n '(Get-FileHash -Path $file -Algorithm SHA256).Hash' `n rather than install a separate tool."
     }
 
     if ($env:ChocolateyPowerShellHost -eq 'true') {

--- a/src/chocolatey.resources/helpers/functions/Get-ChocolateyWebFile.ps1
+++ b/src/chocolatey.resources/helpers/functions/Get-ChocolateyWebFile.ps1
@@ -306,7 +306,7 @@ param(
       $headers = Get-WebHeaders -Url $url -ErrorAction "Stop"
     } catch {
       if ($PSVersionTable.PSVersion -lt (New-Object 'Version' 3,0)) {
-        Write-Debug "Converting Security Protocol to SSL3 only for Powershell v2"
+        Write-Debug "Converting Security Protocol to SSL3 only for PowerShell v2"
         # this should last for the entire duration
         $originalProtocol = [System.Net.ServicePointManager]::SecurityProtocol
         [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]::Ssl3

--- a/src/chocolatey.tests.integration/scenarios/UninstallScenarios.cs
+++ b/src/chocolatey.tests.integration/scenarios/UninstallScenarios.cs
@@ -490,6 +490,8 @@ namespace chocolatey.tests.integration.scenarios
         }
 
         [Concern(typeof(ChocolateyUninstallCommand))]
+        [WindowsOnly]
+        [Platform(Exclude = "Mono")]
         public class when_uninstalling_a_package_with_an_exclusively_locked_file : ScenariosBase
         {
             private PackageResult _packageResult;

--- a/src/chocolatey/infrastructure.app/commands/ChocolateyInstallCommand.cs
+++ b/src/chocolatey/infrastructure.app/commands/ChocolateyInstallCommand.cs
@@ -83,7 +83,7 @@ namespace chocolatey.infrastructure.app.commands
                      "ForceDependencies - Force dependencies to be reinstalled when force installing package(s). Must be used in conjunction with --force. Defaults to false.",
                      option => configuration.ForceDependencies = option != null)
                 .Add("n|skippowershell|skip-powershell|skipscripts|skip-scripts|skip-automation-scripts",
-                     "Skip Powershell - Do not run chocolateyInstall.ps1. Defaults to false.",
+                     "Skip PowerShell - Do not run chocolateyInstall.ps1. Defaults to false.",
                      option => configuration.SkipPackageInstallProvider = option != null)
                 .Add("u=|user=",
                      "User - used with authenticated feeds. Defaults to empty.",

--- a/src/chocolatey/infrastructure.app/commands/ChocolateyUninstallCommand.cs
+++ b/src/chocolatey/infrastructure.app/commands/ChocolateyUninstallCommand.cs
@@ -73,7 +73,7 @@ namespace chocolatey.infrastructure.app.commands
                      "RemoveDependencies - Uninstall dependencies when uninstalling package(s). Defaults to false.",
                      option => configuration.ForceDependencies = option != null)
                 .Add("n|skippowershell|skip-powershell|skipscripts|skip-scripts|skip-automation-scripts",
-                     "Skip Powershell - Do not run chocolateyUninstall.ps1. Defaults to false.",
+                     "Skip PowerShell - Do not run chocolateyUninstall.ps1. Defaults to false.",
                      option => configuration.SkipPackageInstallProvider = option != null)
                 .Add("ignorepackagecodes|ignorepackageexitcodes|ignore-package-codes|ignore-package-exit-codes",
                      "IgnorePackageExitCodes - Exit with a 0 for success and 1 for non-success, no matter what package scripts provide for exit codes. Overrides the default feature '{0}' set to '{1}'. Available in 0.9.10+.".format_with(ApplicationParameters.Features.UsePackageExitCodes, configuration.Features.UsePackageExitCodes.to_string()),

--- a/src/chocolatey/infrastructure.app/commands/ChocolateyUpgradeCommand.cs
+++ b/src/chocolatey/infrastructure.app/commands/ChocolateyUpgradeCommand.cs
@@ -81,7 +81,7 @@ namespace chocolatey.infrastructure.app.commands
                      "IgnoreDependencies - Ignore dependencies when upgrading package(s). Defaults to false.",
                      option => configuration.IgnoreDependencies = option != null)
                 .Add("n|skippowershell|skip-powershell|skipscripts|skip-scripts|skip-automation-scripts",
-                     "Skip Powershell - Do not run chocolateyInstall.ps1. Defaults to false.",
+                     "Skip PowerShell - Do not run chocolateyInstall.ps1. Defaults to false.",
                      option => configuration.SkipPackageInstallProvider = option != null)
                 .Add("failonunfound|fail-on-unfound",
                      "Fail On Unfound Packages - If a package is not found in sources specified, fail instead of warn.",

--- a/src/chocolatey/infrastructure.app/services/ChocolateyPackageService.cs
+++ b/src/chocolatey/infrastructure.app/services/ChocolateyPackageService.cs
@@ -986,20 +986,28 @@ The recent package changes indicate a reboot is necessary.
                 packageResult.InstallLocation += ".{0}".format_with(packageResult.Package.Version.to_string());
             }
 
-            _shimgenService.uninstall(config, packageResult);
-
-            if (!config.SkipPackageInstallProvider)
+            //These items only apply to windows systems.
+            if (config.Information.PlatformType == PlatformType.Windows)
             {
-                _powershellService.uninstall(config, packageResult);
-            }
+                _shimgenService.uninstall(config, packageResult);
 
-            if (packageResult.Success)
+                if (!config.SkipPackageInstallProvider)
+                {
+                    _powershellService.uninstall(config, packageResult);
+                }
+
+                if (packageResult.Success)
+                {
+                    _autoUninstallerService.run(packageResult, config);
+                }
+
+                // we don't care about the exit code
+                CommandExecutor.execute_static(_shutdownExe, "/a", config.CommandExecutionTimeoutSeconds, _fileSystem.get_current_directory(), (s, e) => { }, (s, e) => { }, false, false);
+            }
+            else
             {
-                _autoUninstallerService.run(packageResult, config);
+                this.Log().Info(ChocolateyLoggers.Important, () => " Skipping Powershell, shimgen, and autoUninstaller portions of the uninstall due to non-Windows.");
             }
-
-            // we don't care about the exit code
-            if (config.Information.PlatformType == PlatformType.Windows) CommandExecutor.execute_static(_shutdownExe, "/a", config.CommandExecutionTimeoutSeconds, _fileSystem.get_current_directory(), (s, e) => { }, (s, e) => { }, false, false);
 
             if (packageResult.Success)
             {

--- a/src/chocolatey/infrastructure.app/services/ChocolateyPackageService.cs
+++ b/src/chocolatey/infrastructure.app/services/ChocolateyPackageService.cs
@@ -814,9 +814,13 @@ Would have determined packages that are out of date based on what is
 
         private void before_package_modify(PackageResult packageResult, ChocolateyConfiguration config)
         {
-            if (!config.SkipPackageInstallProvider)
+            if (!config.SkipPackageInstallProvider && config.Information.PlatformType == PlatformType.Windows)
             {
                 _powershellService.before_modify(config, packageResult);
+            }
+            else
+            {
+                if (config.Information.PlatformType != PlatformType.Windows) this.Log().Info(ChocolateyLoggers.Important, () => " Skipping beforemodify Powershell script due to non-Windows.");
             }
         }
 

--- a/src/chocolatey/infrastructure.app/services/ChocolateyPackageService.cs
+++ b/src/chocolatey/infrastructure.app/services/ChocolateyPackageService.cs
@@ -396,7 +396,7 @@ Did you know Pro / Business automatically syncs with Programs and
             }
             else
             {
-                if (config.Information.PlatformType != PlatformType.Windows) this.Log().Info(ChocolateyLoggers.Important, () => " Skipping Powershell and shimgen portions of the install due to non-Windows.");
+                if (config.Information.PlatformType != PlatformType.Windows) this.Log().Info(ChocolateyLoggers.Important, () => " Skipping PowerShell and shimgen portions of the install due to non-Windows.");
             }
 
             if (packageResult.Success)
@@ -820,7 +820,7 @@ Would have determined packages that are out of date based on what is
             }
             else
             {
-                if (config.Information.PlatformType != PlatformType.Windows) this.Log().Info(ChocolateyLoggers.Important, () => " Skipping beforemodify Powershell script due to non-Windows.");
+                if (config.Information.PlatformType != PlatformType.Windows) this.Log().Info(ChocolateyLoggers.Important, () => " Skipping beforemodify PowerShell script due to non-Windows.");
             }
         }
 
@@ -1006,7 +1006,7 @@ The recent package changes indicate a reboot is necessary.
             }
             else
             {
-                this.Log().Info(ChocolateyLoggers.Important, () => " Skipping Powershell, shimgen, and autoUninstaller portions of the uninstall due to non-Windows.");
+                this.Log().Info(ChocolateyLoggers.Important, () => " Skipping PowerShell, shimgen, and autoUninstaller portions of the uninstall due to non-Windows.");
             }
 
             if (packageResult.Success)


### PR DESCRIPTION
## Description Of Changes

This sets the beforemodify script to only run on windows platforms.
This put a check on the powershell uninstall script, shimgen uninstall,
autoUninstaller and shutdown /a calls during uninstall. They will now
only run on windows.

## Motivation and Context

None of these services work on non-windows, so
they should not be run.

See #2434 for more context

## Testing

- Build choco and run integration tests on non-windows
- Remove the upgradepackage install
- Run `choco install --version=1.0.0 -s ./context upgradepackage`
- Run `choco uninstall -s ./context upgradepackage`
- Ensure that the beforemodify and uninstall scripts do not try to run, ensure that the shimgen and automatic uninstall services do not try to run.

## Change Types Made

* [x] Bug fix (non-breaking change)
* [ ] Feature / Enhancement (non-breaking change)
* [ ] Breaking change (fix or feature that could cause existing functionality to change)

## Related Issue

Fixes #2510
Related to #2434
Based on #2509

## Change Checklist

* [ ] Requires a change to the documentation
* [ ] Documentation has been updated
* [ ] Tests to cover my changes, have been added
* [x] All new and existing tests passed.
* N/A PowerShell v2 compatibility checked.
