### PR TITLE
(#2434) Enable more integration tests on non-windows

### DIFF
--- a/src/chocolatey.tests.integration/scenarios/InstallScenarios.cs
+++ b/src/chocolatey.tests.integration/scenarios/InstallScenarios.cs
@@ -552,8 +552,6 @@ namespace chocolatey.tests.integration.scenarios
         }
 
         [Concern(typeof(ChocolateyInstallCommand))]
-        [WindowsOnly]
-        [Platform(Exclude = "Mono")]
         public class when_force_installing_an_already_installed_package : ScenariosBase
         {
             private PackageResult packageResult;
@@ -563,7 +561,7 @@ namespace chocolatey.tests.integration.scenarios
             {
                 base.Context();
                 Scenario.install_package(Configuration, "installpackage", "1.0.0");
-                var fileToModify = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, "tools", "chocolateyInstall.ps1");
+                var fileToModify = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, "tools", "chocolateyinstall.ps1");
                 File.WriteAllText(fileToModify, modifiedText);
 
                 Configuration.Force = true;
@@ -600,7 +598,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void should_remove_and_re_add_the_package_files_in_the_lib_directory()
             {
-                var modifiedFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, "tools", "chocolateyInstall.ps1");
+                var modifiedFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, "tools", "chocolateyinstall.ps1");
                 File.ReadAllText(modifiedFile).ShouldNotEqual(modifiedText);
             }
 

--- a/src/chocolatey.tests.integration/scenarios/InstallScenarios.cs
+++ b/src/chocolatey.tests.integration/scenarios/InstallScenarios.cs
@@ -56,8 +56,6 @@ namespace chocolatey.tests.integration.scenarios
         }
 
         [Concern(typeof(ChocolateyInstallCommand))]
-        [WindowsOnly]
-        [Platform(Exclude = "Mono")]
         public class when_noop_installing_a_package : ScenariosBase
         {
             public override void Context()
@@ -92,6 +90,8 @@ namespace chocolatey.tests.integration.scenarios
             }
 
             [Fact]
+            [WindowsOnly]
+            [Platform(Exclude = "Mono")]
             public void should_contain_a_message_that_it_would_have_run_a_powershell_script()
             {
                 MockLogger.contains_message("chocolateyinstall.ps1", LogLevel.Info).ShouldBeTrue();
@@ -153,8 +153,6 @@ namespace chocolatey.tests.integration.scenarios
         }
 
         [Concern(typeof(ChocolateyInstallCommand))]
-        [WindowsOnly]
-        [Platform(Exclude = "Mono")]
         public class when_installing_a_package_happy_path : ScenariosBase
         {
             private PackageResult packageResult;
@@ -188,6 +186,8 @@ namespace chocolatey.tests.integration.scenarios
             }
 
             [Fact]
+            [WindowsOnly]
+            [Platform(Exclude = "Mono")]
             public void should_create_a_shim_for_console_in_the_bin_directory()
             {
                 var shimfile = Path.Combine(Scenario.get_top_level(), "bin", "console.exe");
@@ -196,6 +196,8 @@ namespace chocolatey.tests.integration.scenarios
             }
 
             [Fact]
+            [WindowsOnly]
+            [Platform(Exclude = "Mono")]
             public void should_create_a_shim_for_graphical_in_the_bin_directory()
             {
                 var shimfile = Path.Combine(Scenario.get_top_level(), "bin", "graphical.exe");
@@ -228,6 +230,8 @@ namespace chocolatey.tests.integration.scenarios
             }
 
             [Fact]
+            [WindowsOnly]
+            [Platform(Exclude = "Mono")]
             public void should_have_a_console_shim_that_is_set_for_non_gui_access()
             {
                 var messages = new List<string>();
@@ -253,6 +257,8 @@ namespace chocolatey.tests.integration.scenarios
             }
 
             [Fact]
+            [WindowsOnly]
+            [Platform(Exclude = "Mono")]
             public void should_have_a_graphical_shim_that_is_set_for_gui_access()
             {
                 var messages = new List<string>();
@@ -320,6 +326,8 @@ namespace chocolatey.tests.integration.scenarios
             }
 
             [Fact]
+            [WindowsOnly]
+            [Platform(Exclude = "Mono")]
             public void should_have_executed_chocolateyInstall_script()
             {
                 MockLogger.contains_message("installpackage v1.0.0 has been installed", LogLevel.Info).ShouldBeTrue();
@@ -3124,8 +3132,6 @@ namespace chocolatey.tests.integration.scenarios
         }
 
         [Concern(typeof(ChocolateyInstallCommand))]
-        [WindowsOnly]
-        [Platform(Exclude = "Mono")]
         public class when_installing_a_package_from_a_nupkg_file : ScenariosBase
         {
             private PackageResult packageResult;
@@ -3165,6 +3171,8 @@ namespace chocolatey.tests.integration.scenarios
             }
 
             [Fact]
+            [WindowsOnly]
+            [Platform(Exclude = "Mono")]
             public void should_create_a_shim_for_console_in_the_bin_directory()
             {
                 var shimfile = Path.Combine(Scenario.get_top_level(), "bin", "console.exe");
@@ -3173,6 +3181,8 @@ namespace chocolatey.tests.integration.scenarios
             }
 
             [Fact]
+            [WindowsOnly]
+            [Platform(Exclude = "Mono")]
             public void should_create_a_shim_for_graphical_in_the_bin_directory()
             {
                 var shimfile = Path.Combine(Scenario.get_top_level(), "bin", "graphical.exe");
@@ -3205,6 +3215,8 @@ namespace chocolatey.tests.integration.scenarios
             }
 
             [Fact]
+            [WindowsOnly]
+            [Platform(Exclude = "Mono")]
             public void should_have_a_console_shim_that_is_set_for_non_gui_access()
             {
                 var messages = new List<string>();
@@ -3230,6 +3242,8 @@ namespace chocolatey.tests.integration.scenarios
             }
 
             [Fact]
+            [WindowsOnly]
+            [Platform(Exclude = "Mono")]
             public void should_have_a_graphical_shim_that_is_set_for_gui_access()
             {
                 var messages = new List<string>();

--- a/src/chocolatey.tests.integration/scenarios/UninstallScenarios.cs
+++ b/src/chocolatey.tests.integration/scenarios/UninstallScenarios.cs
@@ -683,8 +683,6 @@ namespace chocolatey.tests.integration.scenarios
         }
 
         [Concern(typeof(ChocolateyUninstallCommand))]
-        [WindowsOnly]
-        [Platform(Exclude = "Mono")]
         public class when_uninstalling_a_package_with_changed_files : ScenariosBase
         {
             private PackageResult packageResult;
@@ -692,7 +690,7 @@ namespace chocolatey.tests.integration.scenarios
             public override void Context()
             {
                 base.Context();
-                var fileChanged = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, "tools", "chocolateyInstall.ps1");
+                var fileChanged = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, "tools", "chocolateyinstall.ps1");
                 File.WriteAllText(fileChanged, "hellow");
             }
 
@@ -705,7 +703,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void should_keep_the_changed_file()
             {
-                var fileChanged = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, "tools", "chocolateyInstall.ps1");
+                var fileChanged = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, "tools", "chocolateyinstall.ps1");
 
                 File.Exists(fileChanged).ShouldBeTrue();
             }
@@ -787,8 +785,6 @@ namespace chocolatey.tests.integration.scenarios
         }
 
         [Concern(typeof(ChocolateyUninstallCommand))]
-        [WindowsOnly]
-        [Platform(Exclude = "Mono")]
         public class when_force_uninstalling_a_package_with_added_and_changed_files : ScenariosBase
         {
             private PackageResult packageResult;
@@ -796,7 +792,7 @@ namespace chocolatey.tests.integration.scenarios
             public override void Context()
             {
                 base.Context();
-                var fileChanged = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, "tools", "chocolateyInstall.ps1");
+                var fileChanged = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, "tools", "chocolateyinstall.ps1");
                 File.WriteAllText(fileChanged, "hellow");
                 var fileAdded = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, "dude.txt");
                 File.WriteAllText(fileAdded, "hellow");
@@ -828,7 +824,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void should_not_keep_the_changed_file()
             {
-                var fileChanged = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, "tools", "chocolateyInstall.ps1");
+                var fileChanged = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, "tools", "chocolateyinstall.ps1");
 
                 File.Exists(fileChanged).ShouldBeFalse();
             }

--- a/src/chocolatey.tests.integration/scenarios/UninstallScenarios.cs
+++ b/src/chocolatey.tests.integration/scenarios/UninstallScenarios.cs
@@ -60,8 +60,6 @@ namespace chocolatey.tests.integration.scenarios
         }
 
         [Concern(typeof(ChocolateyUninstallCommand))]
-        [WindowsOnly]
-        [Platform(Exclude = "Mono")]
         public class when_noop_uninstalling_a_package : ScenariosBase
         {
             public override void Context()
@@ -96,12 +94,16 @@ namespace chocolatey.tests.integration.scenarios
             }
 
             [Fact]
+            [WindowsOnly]
+            [Platform(Exclude = "Mono")]
             public void should_contain_a_message_that_it_would_have_run_a_powershell_script()
             {
                 MockLogger.contains_message("chocolateyuninstall.ps1").ShouldBeTrue();
             }
 
             [Fact]
+            [WindowsOnly]
+            [Platform(Exclude = "Mono")]
             public void should_contain_a_message_that_it_would_have_run_powershell_modification_script()
             {
                 MockLogger.contains_message("chocolateyBeforeModify.ps1").ShouldBeTrue();
@@ -137,8 +139,6 @@ namespace chocolatey.tests.integration.scenarios
         }
 
         [Concern(typeof(ChocolateyUninstallCommand))]
-        [WindowsOnly]
-        [Platform(Exclude = "Mono")]
         public class when_uninstalling_a_package_happy_path : ScenariosBase
         {
             private PackageResult packageResult;
@@ -166,6 +166,8 @@ namespace chocolatey.tests.integration.scenarios
             }
 
             [Fact]
+            [WindowsOnly]
+            [Platform(Exclude = "Mono")]
             public void should_delete_a_shim_for_console_in_the_bin_directory()
             {
                 var shimfile = Path.Combine(Scenario.get_top_level(), "bin", "console.exe");
@@ -174,6 +176,8 @@ namespace chocolatey.tests.integration.scenarios
             }
 
             [Fact]
+            [WindowsOnly]
+            [Platform(Exclude = "Mono")]
             public void should_delete_a_shim_for_graphical_in_the_bin_directory()
             {
                 var shimfile = Path.Combine(Scenario.get_top_level(), "bin", "graphical.exe");
@@ -226,12 +230,16 @@ namespace chocolatey.tests.integration.scenarios
             }
 
             [Fact]
+            [WindowsOnly]
+            [Platform(Exclude = "Mono")]
             public void should_have_executed_chocolateyBeforeModify_script()
             {
                 MockLogger.contains_message("installpackage 1.0.0 Before Modification", LogLevel.Info).ShouldBeTrue();
             }
 
             [Fact]
+            [WindowsOnly]
+            [Platform(Exclude = "Mono")]
             public void should_have_executed_chocolateyUninstall_script()
             {
                 MockLogger.contains_message("installpackage 1.0.0 Uninstalled", LogLevel.Info).ShouldBeTrue();
@@ -573,8 +581,6 @@ namespace chocolatey.tests.integration.scenarios
         }
 
         [Concern(typeof(ChocolateyUninstallCommand))]
-        [WindowsOnly]
-        [Platform(Exclude = "Mono")]
         public class when_uninstalling_a_package_with_added_files : ScenariosBase
         {
             private PackageResult packageResult;
@@ -620,6 +626,8 @@ namespace chocolatey.tests.integration.scenarios
             }
 
             [Fact]
+            [WindowsOnly]
+            [Platform(Exclude = "Mono")]
             public void should_delete_a_shim_for_console_in_the_bin_directory()
             {
                 var shimfile = Path.Combine(Scenario.get_top_level(), "bin", "console.exe");
@@ -628,6 +636,8 @@ namespace chocolatey.tests.integration.scenarios
             }
 
             [Fact]
+            [WindowsOnly]
+            [Platform(Exclude = "Mono")]
             public void should_delete_a_shim_for_graphical_in_the_bin_directory()
             {
                 var shimfile = Path.Combine(Scenario.get_top_level(), "bin", "graphical.exe");
@@ -720,6 +730,8 @@ namespace chocolatey.tests.integration.scenarios
             }
 
             [Fact]
+            [WindowsOnly]
+            [Platform(Exclude = "Mono")]
             public void should_delete_a_shim_for_console_in_the_bin_directory()
             {
                 var shimfile = Path.Combine(Scenario.get_top_level(), "bin", "console.exe");
@@ -728,6 +740,8 @@ namespace chocolatey.tests.integration.scenarios
             }
 
             [Fact]
+            [WindowsOnly]
+            [Platform(Exclude = "Mono")]
             public void should_delete_a_shim_for_graphical_in_the_bin_directory()
             {
                 var shimfile = Path.Combine(Scenario.get_top_level(), "bin", "graphical.exe");
@@ -828,6 +842,8 @@ namespace chocolatey.tests.integration.scenarios
             }
 
             [Fact]
+            [WindowsOnly]
+            [Platform(Exclude = "Mono")]
             public void should_delete_a_shim_for_console_in_the_bin_directory()
             {
                 var shimfile = Path.Combine(Scenario.get_top_level(), "bin", "console.exe");
@@ -836,6 +852,8 @@ namespace chocolatey.tests.integration.scenarios
             }
 
             [Fact]
+            [WindowsOnly]
+            [Platform(Exclude = "Mono")]
             public void should_delete_a_shim_for_graphical_in_the_bin_directory()
             {
                 var shimfile = Path.Combine(Scenario.get_top_level(), "bin", "graphical.exe");

--- a/src/chocolatey.tests.integration/scenarios/UpgradeScenarios.cs
+++ b/src/chocolatey.tests.integration/scenarios/UpgradeScenarios.cs
@@ -202,8 +202,6 @@ namespace chocolatey.tests.integration.scenarios
         }
 
         [Concern(typeof(ChocolateyUpgradeCommand))]
-        [WindowsOnly]
-        [Platform(Exclude = "Mono")]
         public class when_upgrading_an_existing_package_happy_path : ScenariosBase
         {
             private PackageResult _packageResult;
@@ -307,12 +305,16 @@ namespace chocolatey.tests.integration.scenarios
             }
 
             [Fact]
+            [WindowsOnly]
+            [Platform(Exclude = "Mono")]
             public void should_have_executed_chocolateyBeforeModify_script_for_original_package()
             {
                 MockLogger.contains_message("upgradepackage 1.0.0 Before Modification", LogLevel.Info).ShouldBeTrue();
             }
 
             [Fact]
+            [WindowsOnly]
+            [Platform(Exclude = "Mono")]
             public void should_have_executed_chocolateyBeforeModify_before_chocolateyInstall()
             {
                 MockLogger.MessagesFor(LogLevel.Info).or_empty_list_if_null()
@@ -334,6 +336,8 @@ namespace chocolatey.tests.integration.scenarios
             }
 
             [Fact]
+            [WindowsOnly]
+            [Platform(Exclude = "Mono")]
             public void should_have_executed_chocolateyInstall_script_for_new_package()
             {
                 MockLogger.contains_message("upgradepackage 1.1.0 Installed", LogLevel.Info).ShouldBeTrue();
@@ -341,8 +345,6 @@ namespace chocolatey.tests.integration.scenarios
         }
 
         [Concern(typeof(ChocolateyUpgradeCommand))]
-        [WindowsOnly]
-        [Platform(Exclude = "Mono")]
         public class when_upgrading_an_existing_package_with_prerelease_available_without_prerelease_specified : ScenariosBase
         {
             private PackageResult _packageResult;
@@ -433,8 +435,6 @@ namespace chocolatey.tests.integration.scenarios
         }
 
         [Concern(typeof(ChocolateyUpgradeCommand))]
-        [WindowsOnly]
-        [Platform(Exclude = "Mono")]
         public class when_upgrading_an_existing_package_with_prerelease_available_and_prerelease_specified : ScenariosBase
         {
             private PackageResult _packageResult;
@@ -545,12 +545,16 @@ namespace chocolatey.tests.integration.scenarios
             }
 
             [Fact]
+            [WindowsOnly]
+            [Platform(Exclude = "Mono")]
             public void should_have_executed_chocolateyBeforeModify_script_for_original_package()
             {
                 MockLogger.contains_message("upgradepackage 1.0.0 Before Modification", LogLevel.Info).ShouldBeTrue();
             }
 
             [Fact]
+            [WindowsOnly]
+            [Platform(Exclude = "Mono")]
             public void should_have_executed_chocolateyBeforeModify_before_chocolateyInstall()
             {
                 MockLogger.MessagesFor(LogLevel.Info).or_empty_list_if_null()
@@ -572,6 +576,8 @@ namespace chocolatey.tests.integration.scenarios
             }
 
             [Fact]
+            [WindowsOnly]
+            [Platform(Exclude = "Mono")]
             public void should_have_executed_chocolateyInstall_script_for_new_package()
             {
                 MockLogger.contains_message("upgradepackage 1.1.1-beta2 Installed", LogLevel.Info).ShouldBeTrue();
@@ -579,8 +585,6 @@ namespace chocolatey.tests.integration.scenarios
         }
 
         [Concern(typeof(ChocolateyUpgradeCommand))]
-        [WindowsOnly]
-        [Platform(Exclude = "Mono")]
         public class when_upgrading_an_existing_prerelease_package_without_prerelease_specified : ScenariosBase
         {
             private PackageResult _packageResult;
@@ -693,12 +697,16 @@ namespace chocolatey.tests.integration.scenarios
             }
 
             [Fact]
+            [WindowsOnly]
+            [Platform(Exclude = "Mono")]
             public void should_have_executed_chocolateyBeforeModify_script_for_original_package()
             {
                 MockLogger.contains_message("upgradepackage 1.1.1-beta Before Modification", LogLevel.Info).ShouldBeTrue();
             }
 
             [Fact]
+            [WindowsOnly]
+            [Platform(Exclude = "Mono")]
             public void should_have_executed_chocolateyBeforeModify_before_chocolateyInstall()
             {
                 MockLogger.MessagesFor(LogLevel.Info).or_empty_list_if_null()
@@ -720,6 +728,8 @@ namespace chocolatey.tests.integration.scenarios
             }
 
             [Fact]
+            [WindowsOnly]
+            [Platform(Exclude = "Mono")]
             public void should_have_executed_chocolateyInstall_script_for_new_package()
             {
                 MockLogger.contains_message("upgradepackage 1.1.1-beta2 Installed", LogLevel.Info).ShouldBeTrue();
@@ -914,8 +924,6 @@ namespace chocolatey.tests.integration.scenarios
         }
 
         [Concern(typeof(ChocolateyUpgradeCommand))]
-        [WindowsOnly]
-        [Platform(Exclude = "Mono")]
         public class when_force_upgrading_a_package : ScenariosBase
         {
             private PackageResult _packageResult;
@@ -1116,8 +1124,6 @@ namespace chocolatey.tests.integration.scenarios
         }
 
         [Concern(typeof(ChocolateyUpgradeCommand))]
-        [WindowsOnly]
-        [Platform(Exclude = "Mono")]
         public class when_force_upgrading_a_package_that_does_not_have_available_upgrades : ScenariosBase
         {
             private PackageResult _packageResult;
@@ -1545,8 +1551,6 @@ namespace chocolatey.tests.integration.scenarios
         }
 
         [Concern(typeof(ChocolateyUpgradeCommand))]
-        [WindowsOnly]
-        [Platform(Exclude = "Mono")]
         public class when_upgrading_a_package_with_added_files : ScenariosBase
         {
             private PackageResult _packageResult;
@@ -1805,8 +1809,6 @@ namespace chocolatey.tests.integration.scenarios
         }
 
         [Concern(typeof(ChocolateyUpgradeCommand))]
-        [WindowsOnly]
-        [Platform(Exclude = "Mono")]
         public class when_upgrading_a_package_that_is_not_installed : ScenariosBase
         {
             private PackageResult _packageResult;
@@ -3083,8 +3085,6 @@ namespace chocolatey.tests.integration.scenarios
         }
 
         [Concern(typeof(ChocolateyUpgradeCommand))]
-        [WindowsOnly]
-        [Platform(Exclude = "Mono")]
         public class when_upgrading_all_packages_with_prereleases_installed : ScenariosBase
         {
             public override void Context()

--- a/src/chocolatey.tests.integration/scenarios/UpgradeScenarios.cs
+++ b/src/chocolatey.tests.integration/scenarios/UpgradeScenarios.cs
@@ -1630,8 +1630,6 @@ namespace chocolatey.tests.integration.scenarios
         }
 
         [Concern(typeof(ChocolateyUpgradeCommand))]
-        [WindowsOnly]
-        [Platform(Exclude = "Mono")]
         public class when_upgrading_a_package_with_changed_files : ScenariosBase
         {
             private PackageResult _packageResult;
@@ -1639,7 +1637,7 @@ namespace chocolatey.tests.integration.scenarios
             public override void Context()
             {
                 base.Context();
-                var fileChanged = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, "tools", "chocolateyInstall.ps1");
+                var fileChanged = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, "tools", "chocolateyinstall.ps1");
                 File.WriteAllText(fileChanged, "hellow");
             }
 
@@ -1652,7 +1650,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void should_update_the_changed_file()
             {
-                var fileChanged = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, "tools", "chocolateyInstall.ps1");
+                var fileChanged = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, "tools", "chocolateyinstall.ps1");
 
                 File.ReadAllText(fileChanged).ShouldNotEqual("hellow");
             }


### PR DESCRIPTION
## Description Of Changes

This enables more scenarios on non-windows platforms where the only
issues were that the facts relating to validating shimgen or powershell
script behavior did not work. These failures were expected as neither
shimgen or powershell run on non-windows platforms. So the individual 
tests can be skipped, while enabling the rest of the scenario.

This corrects the casing of the "chocolateyInstall.ps1" to now be
"chocolateyinstall.ps1". This allows these tests to work on case 
sensitive filesystems. The associated scenarios are no longer skipped
on non-windows platforms.

## Motivation and Context

More integration tests running on non-windows = better

The changes in this PR (and the dependent PRs) takes the count of skipped tests for non-windows down from ~350 to under 200

## Testing

Integration tests ran on a Linux system, all tests passed.

## Change Types Made

* [x] Bug fix (non-breaking change)
* [ ] Feature / Enhancement (non-breaking change)
* [ ] Breaking change (fix or feature that could cause existing functionality to change)

## Related Issue

Part of #2434 
Depends on #2451

## Change Checklist

* [ ] Requires a change to the documentation
* [ ] Documentation has been updated
* N/A Tests to cover my changes, have been added
* [x] All new and existing tests passed.
* N/A PowerShell v2 compatibility checked.**
