### PR TITLE
(#2513) Add support for filtering install locations via softwareName

### DIFF
--- a/src/chocolatey.resources/helpers/functions/Install-ChocolateyInstallPackage.ps1
+++ b/src/chocolatey.resources/helpers/functions/Install-ChocolateyInstallPackage.ps1
@@ -121,6 +121,14 @@ only use the ones available with the package. Available in 0.9.10+.
 .PARAMETER IgnoredArguments
 Allows splatting with arguments that do not apply. Do not use directly.
 
+.PARAMETER SoftwareName
+Specifies the display name of the installed software as shown in 
+Programs & Features. Can be an exact string or contain wildcards ("*").
+Available in 0.12.0+
+
+Use this to filter any software installed during the package installation
+script to ensure the correct software install location is found.
+
 .EXAMPLE
 >
 $packageName= 'bob'
@@ -220,6 +228,7 @@ Start-ChocolateyProcessAsAdmin
     [parameter(Mandatory = $false)] $validExitCodes = @(0),
     [parameter(Mandatory = $false)]
     [alias("useOnlyPackageSilentArgs")][switch] $useOnlyPackageSilentArguments = $false,
+    [parameter(Mandatory=$false)][string] $softwareName = '',
     [parameter(ValueFromRemainingArguments = $true)][Object[]] $ignoredArguments
   )
   [string]$silentArgs = $silentArgs -join ' '
@@ -370,6 +379,8 @@ Pro / Business supports a single, ubiquitous install directory option.
     }
     $env:ChocolateyExitCode = Start-ChocolateyProcessAsAdmin "$msuArgs" "$($env:SystemRoot)\System32\wusa.exe" -validExitCodes $validExitCodes -workingDirectory $workingDirectory
   }
+
+  $env:ChocolateyInstalledSoftwareName = $softwareName
 
   Write-Host "$packageName has been installed."
 }

--- a/src/chocolatey.resources/helpers/functions/Install-ChocolateyPackage.ps1
+++ b/src/chocolatey.resources/helpers/functions/Install-ChocolateyPackage.ps1
@@ -227,6 +227,14 @@ Available in 0.11.0+.
 Use this for starting an auxilary process such as AutoHotkey, so that any timeouts are not 
 affected by the time to download.
 
+.PARAMETER SoftwareName
+Specifies the display name of the installed software as shown in 
+Programs & Features. Can be an exact string or contain wildcards ("*").
+Available in 0.12.0+
+
+Use this to filter any software installed during the package installation
+script to ensure the correct software install location is found.
+
 .EXAMPLE
 >
 $packageName= 'bob'
@@ -365,6 +373,7 @@ param(
   [alias("useOnlyPackageSilentArgs")][switch] $useOnlyPackageSilentArguments = $false,
   [parameter(Mandatory=$false)][switch]$useOriginalLocation,
   [parameter(Mandatory=$false)][scriptblock] $beforeInstall,
+  [parameter(Mandatory=$false)][string] $softwareName = '',
   [parameter(ValueFromRemainingArguments = $true)][Object[]] $ignoredArguments
 )
   [string]$silentArgs = $silentArgs -join ' '
@@ -420,5 +429,6 @@ param(
                                    -SilentArgs $silentArgs `
                                    -File $filePath `
                                    -ValidExitCodes $validExitCodes `
-                                   -UseOnlyPackageSilentArguments:$useOnlyPackageSilentArguments
+                                   -UseOnlyPackageSilentArguments:$useOnlyPackageSilentArguments `
+                                   -SoftwareName $softwareName
 }

--- a/src/chocolatey/StringExtensions.cs
+++ b/src/chocolatey/StringExtensions.cs
@@ -223,5 +223,14 @@ namespace chocolatey
             return Regex.IsMatch(input, pattern, options);
         }
 
+        /// <summary>
+        /// Escapes a string for use in a regular expression
+        /// </summary>
+        /// <param name="input">The input.</param>
+        /// <returns>The string with all regular expression special characters escaped</returns>
+        public static string regex_escape(this string input)
+        {
+            return Regex.Escape(input);
+        }
     }
 }

--- a/src/chocolatey/StringExtensions.cs
+++ b/src/chocolatey/StringExtensions.cs
@@ -210,5 +210,18 @@ namespace chocolatey
             return input;
         }
 
+
+        /// <summary>
+        /// Determines if a string matches a regular expression
+        /// </summary>
+        /// <param name="input">The input.</param>
+        /// <param name="pattern">The regular expression</param>
+        /// <param name="options">The options for the regular expression. Defaults to ignore case</param>
+        /// <returns>If the regular expressions matches the input</returns>
+        public static bool match(this string input, string pattern, RegexOptions options = RegexOptions.IgnoreCase)
+        {
+            return Regex.IsMatch(input, pattern, options);
+        }
+
     }
 }

--- a/src/chocolatey/infrastructure.app/ApplicationParameters.cs
+++ b/src/chocolatey/infrastructure.app/ApplicationParameters.cs
@@ -115,6 +115,7 @@ namespace chocolatey.infrastructure.app
 
             public static readonly string ChocolateyToolsLocation = "ChocolateyToolsLocation";
             public static readonly string ChocolateyPackageInstallLocation = "ChocolateyPackageInstallLocation";
+            public static readonly string ChocolateyInstalledSoftwareName = "ChocolateyInstalledSoftwareName";
             public static readonly string ChocolateyPackageInstallerType = "ChocolateyInstallerType";
             public static readonly string ChocolateyPackageExitCode = "ChocolateyExitCode";
             public static readonly string ChocolateyIgnoreChecksums = "ChocolateyIgnoreChecksums";

--- a/src/chocolatey/infrastructure.app/configuration/EnvironmentSettings.cs
+++ b/src/chocolatey/infrastructure.app/configuration/EnvironmentSettings.cs
@@ -48,6 +48,7 @@ namespace chocolatey.infrastructure.app.configuration
         public static void reset_environment_variables(ChocolateyConfiguration config)
         {
             Environment.SetEnvironmentVariable(ApplicationParameters.Environment.ChocolateyPackageInstallLocation, null);
+            Environment.SetEnvironmentVariable(ApplicationParameters.Environment.ChocolateyInstalledSoftwareName, null);
             Environment.SetEnvironmentVariable(ApplicationParameters.Environment.ChocolateyPackageInstallerType, null);
             Environment.SetEnvironmentVariable(ApplicationParameters.Environment.ChocolateyPackageExitCode, null);
 


### PR DESCRIPTION
## Description Of Changes

Implement softwareName filtering of registry keys

TODO list:
* [ ] check PS v2 compatibility
* [ ] make sure this actually works
* [ ] check if ChocolateyInstalledSoftwareName is an ok name for the env variable
* [ ] check if behavior (and warnings) for filtering is ok
* [ ] breaking change discussion (not *technically* a breaking change for packages with a correct `softwareName`, some maintainers still may be affected.)
* [ ] document manual tests
* [ ] automated tests?
* [ ] fix commit messages

## Motivation and Context

TODO

## Testing

TODO

## Change Types Made

* [ ] Bug fix (non-breaking change)
* [ ] Feature / Enhancement (non-breaking change)
* [x] Breaking change (fix or feature that could cause existing functionality to change)

## Related Issue

Fixes #2513

## Change Checklist

* [x] Requires a change to the documentation
* [ ] Documentation has been updated (issue open chocolatey/docs#308)
* [ ] Tests to cover my changes, have been added
* [ ] All new and existing tests passed.
* [ ] PowerShell v2 compatibility checked.