### PR TITLE
(#2481) Warn about unsupported packages on non-Windows

### DIFF
--- a/src/chocolatey/infrastructure.app/services/NugetService.cs
+++ b/src/chocolatey/infrastructure.app/services/NugetService.cs
@@ -447,6 +447,12 @@ folder.");
                 //todo: get smarter about realizing multiple versions have been installed before and allowing that
                 IPackage installedPackage = packageManager.LocalRepository.FindPackage(packageName);
 
+                if (Platform.get_platform() != PlatformType.Windows && !packageName.EndsWith(".template"))
+                {
+                    string logMessage = "{0} is not a supported package on non-Windows systems.{1}Only template packages are currently supported.".format_with(packageName, Environment.NewLine);
+                    this.Log().Warn(ChocolateyLoggers.Important, logMessage);
+                }
+
                 if (installedPackage != null && (version == null || version == installedPackage.Version) && !config.Force)
                 {
                     string logMessage = "{0} v{1} already installed.{2} Use --force to reinstall, specify a version to install, or try upgrade.".format_with(installedPackage.Id, installedPackage.Version, Environment.NewLine);


### PR DESCRIPTION
## Description Of Changes

This adds a check for non-Windows systems that warns if the package id
does not end in .template on install. 

## Motivation and Context

This check is added to help
provide guidance to users, as templates are the only package type
currently supported on non-Windows systems.

In the future, this check may be expanded to allow other packages
types, as needed.

## Testing

1. Build choco on linux
2. Run `mono choco.exe install curl --allow-unofficial` and confirm that the warning appears
3. Run `mono choco.exe install msi.tempalte --allow-unofficial` and confirm that the warning does not appear

## Change Types Made

* [ ] Bug fix (non-breaking change)
* [x] Feature / Enhancement (non-breaking change)
* [ ] Breaking change (fix or feature that could cause existing functionality to change)

## Related Issue

Fixes #2481

## Change Checklist

* [x] Requires a change to the documentation
* [ ] Documentation has been updated chocolatey/docs#280
* [ ] Tests to cover my changes, have been added
* [x] All new and existing tests passed.
* N/A PowerShell v2 compatibility checked.