### PR TITLE
(#2518) Add tab completion for template command

### DIFF
--- a/src/chocolatey.resources/helpers/ChocolateyTabExpansion.ps1
+++ b/src/chocolatey.resources/helpers/ChocolateyTabExpansion.ps1
@@ -33,7 +33,7 @@ function script:chocoCmdOperations($commands, $command, $filter, $currentArgumen
       where { $_ -like "$filter*" }
 }
 
-$script:someCommands = @('-?','search','list','info','install','outdated','upgrade','uninstall','new','download','optimize','pack','push','sync','-h','--help','pin','source','config','feature','apikey','export','help','--version')
+$script:someCommands = @('-?','search','list','info','install','outdated','upgrade','uninstall','new','download','optimize','pack','push','sync','-h','--help','pin','source','config','feature','apikey','export','help','template','--version')
 
 # ensure these all have a space to start, or they will cause issues
 $allcommands = " --debug --verbose --trace --noop --help --accept-license --confirm --limit-output --no-progress --log-file='' --execution-timeout='' --cache-location='' --proxy='' --proxy-user='' --proxy-password='' --proxy-bypass-list='' --proxy-bypass-on-local --force --no-color"
@@ -63,6 +63,7 @@ $commandOptions = @{
   sync = "--output-directory='' --id='' --package-id='' -?" + $allcommands
   optimize = "--deflate-nupkg-only --id='' -?" + $allcommands
   export = "--include-version-numbers --output-file-path='' -?" + $allcommands
+  template = "--name=''" + $allcommands
 }
 
 try {
@@ -162,6 +163,11 @@ function ChocolateyTabExpansion($lastBlock) {
     # Handles config first tab
     "^(config)\s+(?<subcommand>[^-\s]*)$" {
       @('list','get','set','unset','-?') | where { $_ -like "$($matches['subcommand'])*" }
+    }
+    
+    # Handles template first tab
+    "^(template)\s+(?<subcommand>[^-\s]*)$" {
+        @('list', 'info', '-?') | where { $_ -like "$($matches['subcommand'])*" }
     }
 
     # Handles more options after others


### PR DESCRIPTION
## Description Of Changes

This add support for tab completion of the template command.
It has two subcommands, list and info, and one option, --name.

## Motivation and Context

The template command has been added, it should be added to the tab completion as well

## Testing

- Dotsourced the tab completion into a powershell window
- Validate that tab completion on `choco ` brings up `choco template` after a couple of presses
- Validate that tab completion on `choco t` bring up `choco template` after one presses
- Validate that tab completion `choco template ` brings up `choco template info`, `choco template list`, `choco list --name`, and global options
- Validate that tab completion `choco template list ` brings up `choco template list --name` (and global options)
- Validate that tab completion `choco template info ` brings up `choco template info --name` (and global options)
- Opened in `powershell.exe -version 2` and validated that it dotsources ok and works

## Change Types Made

* [ ] Bug fix (non-breaking change)
* [x] Feature / Enhancement (non-breaking change)
* [ ] Breaking change (fix or feature that could cause existing functionality to change)

## Related Issue

Fixes #2518

## Change Checklist

* [ ] Requires a change to the documentation
* [ ] Documentation has been updated
* [ ] Tests to cover my changes, have been added
* [ ] All new and existing tests passed.
* [x] PowerShell v2 compatibility checked.