### PR TITLE
(#2525) Close config file before we try to put a new copy in it's place

### DIFF
--- a/src/chocolatey/infrastructure/services/XmlService.cs
+++ b/src/chocolatey/infrastructure/services/XmlService.cs
@@ -24,7 +24,6 @@ namespace chocolatey.infrastructure.services
     using System.Xml.Serialization;
     using cryptography;
     using filesystem;
-    using logging;
     using tolerance;
     using synchronization;
 

--- a/src/chocolatey/infrastructure/services/XmlService.cs
+++ b/src/chocolatey/infrastructure/services/XmlService.cs
@@ -90,6 +90,8 @@ namespace chocolatey.infrastructure.services
                                            // If there's no errors and it's valid, go ahead and replace the bad file with the backup.
                                            if (validConfig != null)
                                            {
+                                               // Close fileReader so that we can copy the file without it being locked.
+                                               fileReader.Close();
                                                _fileSystem.copy_file(xmlFilePath + ".backup", xmlFilePath, overwriteExisting: true);
                                            }
 


### PR DESCRIPTION
## Description Of Changes

Close the file reader for the config file so we can copy over top of it.

## Motivation and Context

The file is locked by us for reading when we try to copy over it. This results in an unintuitive error regarding being locked.

## What Have I Done To Test This

1. Opened file and added a `</config>` immediately following the opening `<config>` tag
2. Ran a Chocolatey command
3. Verified that no error was presented.

## Change Types Made

* [x] Bug fix (non-breaking change)
* [ ] Feature / Enhancement (non-breaking change)
* [ ] Breaking change (fix or feature that could cause existing functionality to change)

## Related Issue

Fixes #2525

## Change Checklist

* [ ] Requires a change to the documentation
* [ ] Documentation has been updated
* [ ] Tests to cover my changes, have been added
* [x] All new and existing tests passed.