### PR TITLE
(#2529) Reset configuration options before each test

### DIFF
--- a/src/chocolatey.tests/infrastructure.app/configuration/ConfigurationOptionsSpec.cs
+++ b/src/chocolatey.tests/infrastructure.app/configuration/ConfigurationOptionsSpec.cs
@@ -67,6 +67,7 @@ namespace chocolatey.tests.infrastructure.app.configuration
                 validateConfiguration = () => { };
                 helpMessage = () => { };
                 helpMessageContents.Clear();
+                ConfigurationOptions.reset_options();
             }
         }
 


### PR DESCRIPTION
## Description Of Changes with Context

Since there is a `new` ChocolateyConfiguration before each spec, it
invalidates the action that sets the configuration from the passed in
option because the old config is no longer used. Thus, the options set
should be reset so the help option can be re-added for each spec,
pointing to the new ChocolateyConfiguration object.

## Testing

Run configuration options tests from the test explorer in VS 2019

## Change Types Made

* [x] Bug fix (non-breaking change)
* [ ] Feature / Enhancement (non-breaking change)
* [ ] Breaking change (fix or feature that could cause existing functionality to change)

## Related Issue

Fixes #2529 

## Change Checklist

* [ ] Requires a change to the documentation
* [ ] Documentation has been updated
* N/A Tests to cover my changes, have been added
* [x] All new and existing tests passed.
* N/A PowerShell v2 compatibility checked.