### PR TITLE
(#1896) Outdated with ignore-pinned use correct enhanced exit code

### DIFF
--- a/src/chocolatey/infrastructure.app/services/ChocolateyPackageService.cs
+++ b/src/chocolatey/infrastructure.app/services/ChocolateyPackageService.cs
@@ -647,6 +647,7 @@ Would have determined packages that are out of date based on what is
             config.RegularOutput = false;
             var outdatedPackages = _nugetService.get_outdated(config);
             config.RegularOutput = output;
+            var outdatedPackageCount = outdatedPackages.Count(p => p.Value.Success && !p.Value.Inconclusive);
 
             if (config.RegularOutput)
             {
@@ -654,7 +655,7 @@ Would have determined packages that are out of date based on what is
                 this.Log().Warn(() => @"{0}{1} has determined {2} package(s) are outdated. {3}".format_with(
                     Environment.NewLine,
                     ApplicationParameters.Name,
-                    outdatedPackages.Count(p => p.Value.Success && !p.Value.Inconclusive),
+                    outdatedPackageCount,
                     upgradeWarnings == 0 ? string.Empty : "{0} {1} package(s) had warnings.".format_with(Environment.NewLine, upgradeWarnings)
                     ));
 
@@ -668,8 +669,8 @@ Would have determined packages that are out of date based on what is
                 }
             }
 
-            if (config.Features.UseEnhancedExitCodes && outdatedPackages.Count != 0 && Environment.ExitCode == 0)
             // outdated packages, return 2
+            if (config.Features.UseEnhancedExitCodes && outdatedPackageCount != 0 && Environment.ExitCode == 0)
             {
                 Environment.ExitCode = 2;
             }

--- a/src/chocolatey/infrastructure.app/services/ChocolateyPackageService.cs
+++ b/src/chocolatey/infrastructure.app/services/ChocolateyPackageService.cs
@@ -668,8 +668,8 @@ Would have determined packages that are out of date based on what is
                 }
             }
 
-            // oudated packages, return 2
             if (config.Features.UseEnhancedExitCodes && outdatedPackages.Count != 0 && Environment.ExitCode == 0)
+            // outdated packages, return 2
             {
                 Environment.ExitCode = 2;
             }


### PR DESCRIPTION
## Description Of Changes

This corrects the check for if exit code 2 should be used to only
include unpinned packages, like the log output does.

## Motivation and Context

If there are no outdated unpinned packages, but there are are outdated
pinned packages, then an enhanced exit code of 2 will be incorrectly
used, while it should be an exit code of 0. This assumes enhanced exit
codes are enabled.

## Testing

- Build choco
- Run these setup commands:
```
.\choco.exe feature disable -n showNonElevatedWarnings --allow-unofficial -y
.\choco.exe feature enable -n allowGlobalConfirmation --allow-unofficial -y
.\choco.exe feature enable -n useRememberedArgumentsForUpgrades
.\choco.exe feature enable -n useenhancedexitcodes --allow-unofficial
.\choco.exe install iperf2 --version=2.1.1 --allow-unofficial
.\choco.exe pin add -n iperf2  --allow-unofficial
```
- Run `.\choco.exe outdated --allow-unofficial` and validate that it shows iperf2 is outdated and that it exits with 2
- Run `.\choco.exe outdated --allow-unofficial --ignore-pinned` and validate it shows no packages outdated and that it exits with 0

## Change Types Made

* [x] Bug fix (non-breaking change)
* [ ] Feature / Enhancement (non-breaking change)
* [ ] Breaking change (fix or feature that could cause existing functionality to change)

## Related Issue

Fixes #1896

## Change Checklist

* [ ] Requires a change to the documentation
* [ ] Documentation has been updated
* [ ] Tests to cover my changes, have been added
* [x] All new and existing tests passed.
* N/A PowerShell v2 compatibility checked.