### PR TITLE
(#1759) Add enhanced exit codes for multiple commands

### DIFF
--- a/src/chocolatey.tests/TinySpec.cs
+++ b/src/chocolatey.tests/TinySpec.cs
@@ -67,6 +67,14 @@ namespace chocolatey.tests
             {
                 MockLogger.Reset();
             }
+
+            // Chocolatey CLI by default will exit with Code 0, when everything work as expected, even if it doesn't
+            // set this explicitly.
+            // However, in some tests, we are testing for the setting of an explicit exit code, and when we do this,
+            // it can have an impact on other tests, since it may not have been reset.  Let's explicitly set it to
+            // 0 before running each test, so that everything starts off at the right place.
+            Environment.ExitCode = default;
+
             //Log.InitializeWith(MockLogger);
             NugetCommon.ClearRepositoriesCache();
             Context();

--- a/src/chocolatey.tests/infrastructure.app/commands/ChocolateyPinCommandSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/commands/ChocolateyPinCommandSpecs.cs
@@ -33,6 +33,7 @@ using NuGet.Versioning;
 using NUnit.Framework;
 
 using FluentAssertions;
+using FluentAssertions.Execution;
 
 namespace chocolatey.tests.infrastructure.app.commands
 {
@@ -535,6 +536,140 @@ namespace chocolatey.tests.infrastructure.app.commands
                 PackageInfoService.Verify(s =>
                     s.Save(It.Is<ChocolateyPackageInformation>(n =>
                         n.Package.Id.Equals("mingw"))), Times.Once);
+            }
+        }
+
+        public class When_adding_a_pin_on_an_already_pinned_package : ChocolateyPinCommandSpecsBase
+        {
+            public override void Context()
+            {
+                base.Context();
+                Configuration.Sources = ApplicationParameters.PackagesLocation;
+                Configuration.ListCommand.LocalOnly = true;
+                Configuration.AllVersions = true;
+
+                var packageResults = new[]
+                {
+                    new PackageResult(PinnedPackage.Object, null)
+                };
+                NugetService.Setup(n => n.List(It.IsAny<ChocolateyConfiguration>())).Returns(packageResults);
+            }
+
+            public new void Reset()
+            {
+                Context();
+                base.Reset();
+            }
+
+            public override void AfterEachSpec()
+            {
+                base.AfterEachSpec();
+                MockLogger.Messages.Clear();
+            }
+
+            public override void Because()
+            {
+            }
+
+            [Fact]
+            public void Should_Return_0_ExitCode_When_Pinning_An_Already_Pinned_Package()
+            {
+                Reset();
+                Configuration.Features.UseEnhancedExitCodes = false;
+                Configuration.PinCommand.Name = "pinned";
+                Configuration.PinCommand.Command = PinCommandType.Add;
+
+                Command.SetPin(Configuration);
+
+                using (new AssertionScope())
+                {
+                    MockLogger.Messages.Should().ContainKey("Warn").WhoseValue.Should().ContainSingle().And.Contain("Nothing to change. Pin already set or removed.");
+                    Environment.ExitCode.Should().Be(0);
+                }
+            }
+
+            [Fact]
+            public void Should_Return_2_ExitCode_When_Pinning_An_Already_Pinned_Package_With_UseEnhancedExitCodes_Enabled()
+            {
+                Reset();
+                Configuration.Features.UseEnhancedExitCodes = true;
+                Configuration.PinCommand.Name = "pinned";
+                Configuration.PinCommand.Command = PinCommandType.Add;
+
+                Command.SetPin(Configuration);
+
+                using (new AssertionScope())
+                {
+                    MockLogger.Messages.Should().ContainKey("Warn").WhoseValue.Should().ContainSingle().And.Contain("Nothing to change. Pin already set or removed.");
+                    Environment.ExitCode.Should().Be(2);
+                }
+            }
+        }
+
+        public class When_removing_a_pin_on_a_package_with_no_pin : ChocolateyPinCommandSpecsBase
+        {
+            public override void Context()
+            {
+                base.Context();
+                Configuration.Sources = ApplicationParameters.PackagesLocation;
+                Configuration.ListCommand.LocalOnly = true;
+                Configuration.AllVersions = true;
+
+                var packageResults = new[]
+                {
+                    new PackageResult(Package.Object, null)
+                };
+                NugetService.Setup(n => n.List(It.IsAny<ChocolateyConfiguration>())).Returns(packageResults);
+            }
+
+            public new void Reset()
+            {
+                Context();
+                base.Reset();
+            }
+
+            public override void AfterEachSpec()
+            {
+                base.AfterEachSpec();
+                MockLogger.Messages.Clear();
+            }
+
+            public override void Because()
+            {
+            }
+
+            [Fact]
+            public void Should_Return_0_ExitCode_When_Pinning_An_Already_Pinned_Package()
+            {
+                Reset();
+                Configuration.Features.UseEnhancedExitCodes = false;
+                Configuration.PinCommand.Name = "regular";
+                Configuration.PinCommand.Command = PinCommandType.Remove;
+
+                Command.SetPin(Configuration);
+
+                using (new AssertionScope())
+                {
+                    MockLogger.Messages.Should().ContainKey("Warn").WhoseValue.Should().ContainSingle().And.Contain("Nothing to change. Pin already set or removed.");
+                    Environment.ExitCode.Should().Be(0);
+                }
+            }
+
+            [Fact]
+            public void Should_Return_2_ExitCode_When_Pinning_An_Already_Pinned_Package_With_UseEnhancedExitCodes_Enabled()
+            {
+                Reset();
+                Configuration.Features.UseEnhancedExitCodes = true;
+                Configuration.PinCommand.Name = "regular";
+                Configuration.PinCommand.Command = PinCommandType.Remove;
+
+                Command.SetPin(Configuration);
+
+                using (new AssertionScope())
+                {
+                    MockLogger.Messages.Should().ContainKey("Warn").WhoseValue.Should().ContainSingle().And.Contain("Nothing to change. Pin already set or removed.");
+                    Environment.ExitCode.Should().Be(2);
+                }
             }
         }
     }

--- a/src/chocolatey.tests/infrastructure.app/services/ChocolateyConfigSettingsServiceSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/services/ChocolateyConfigSettingsServiceSpecs.cs
@@ -3,10 +3,12 @@ using System.Collections.Generic;
 using System.Linq;
 using chocolatey.infrastructure.app;
 using chocolatey.infrastructure.app.configuration;
+using chocolatey.infrastructure.app.nuget;
 using chocolatey.infrastructure.app.services;
 using chocolatey.infrastructure.services;
-using Moq;
 using FluentAssertions;
+using FluentAssertions.Execution;
+using Moq;
 
 namespace chocolatey.tests.integration.infrastructure.app.services
 {
@@ -570,6 +572,906 @@ namespace chocolatey.tests.integration.infrastructure.app.services
                 var infoMessages = MockLogger.Messages["Info"];
                 infoMessages.Should().ContainSingle();
                 infoMessages[0].Should().Contain("Enabled");
+            }
+        }
+
+        public class When_ChocolateyConfigSettingsService_AddSource_When_Source_Already_Exists : ChocolateyConfigSettingsServiceSpecsBase
+        {
+            public override void Because()
+            {
+                var config = new ChocolateyConfiguration()
+                {
+                    RegularOutput = true,
+                    Sources = "https://test.org/api/v2",
+                    SourceCommand = new SourcesCommandConfiguration()
+                    {
+                        Name = "testSource",
+                        Command = chocolatey.infrastructure.app.domain.SourceCommandType.Add
+                    },
+                    Features = new FeaturesConfiguration()
+                    {
+                        UseEnhancedExitCodes = false
+                    }
+                };
+
+                Service.AddSource(config);
+            }
+
+            public override void Context()
+            {
+                base.Context();
+
+                XmlService.Setup(x => x.Deserialize<ConfigFileSettings>(ApplicationParameters.GlobalConfigFileLocation))
+                    .Returns(new ConfigFileSettings
+                    {
+                        Sources = new HashSet<ConfigFileSourceSetting>
+                        {
+                            new ConfigFileSourceSetting()
+                            {
+                                Id = "testSource",
+                                Value = "https://test.org/api/v2"
+                            }
+                        }
+                    });
+
+                Service = new ChocolateyConfigSettingsService(XmlService.Object);
+            }
+
+            [Fact]
+            public void Should_return_exit_code_0()
+            {
+                using (new AssertionScope())
+                {
+                    MockLogger.Messages.Should().ContainKey("Warn").WhoseValue.Should().ContainSingle().And.Contain("Nothing to change. Config already set.");
+                    Environment.ExitCode.Should().Be(0);
+                }
+            }
+        }
+
+        public class When_ChocolateyConfigSettingsService_AddSource_When_Source_Already_Exists_With_Enhanced_Exit_Codes : ChocolateyConfigSettingsServiceSpecsBase
+        {
+            public override void Because()
+            {
+                var config = new ChocolateyConfiguration()
+                {
+                    RegularOutput = true,
+                    Sources = "https://test.org/api/v2",
+                    SourceCommand = new SourcesCommandConfiguration()
+                    {
+                        Name = "testSource",
+                        Command = chocolatey.infrastructure.app.domain.SourceCommandType.Add
+                    },
+                    Features = new FeaturesConfiguration()
+                    {
+                        UseEnhancedExitCodes = true
+                    }
+                };
+
+                Service.AddSource(config);
+            }
+
+            public override void Context()
+            {
+                base.Context();
+
+                XmlService.Setup(x => x.Deserialize<ConfigFileSettings>(ApplicationParameters.GlobalConfigFileLocation))
+                    .Returns(new ConfigFileSettings
+                    {
+                        Sources = new HashSet<ConfigFileSourceSetting>
+                        {
+                            new ConfigFileSourceSetting()
+                            {
+                                Id = "testSource",
+                                Value = "https://test.org/api/v2"
+                            }
+                        }
+                    });
+
+                Service = new ChocolateyConfigSettingsService(XmlService.Object);
+            }
+
+            [Fact]
+            public void Should_return_exit_code_2()
+            {
+                using (new AssertionScope())
+                {
+                    MockLogger.Messages.Should().ContainKey("Warn").WhoseValue.Should().ContainSingle().And.Contain("Nothing to change. Config already set.");
+                    Environment.ExitCode.Should().Be(2);
+                }
+            }
+        }
+
+        public class When_ChocolateyConfigSettingsService_RemoveSource_When_Source_Doesnt_Exist : ChocolateyConfigSettingsServiceSpecsBase
+        {
+            public override void Because()
+            {
+                var config = new ChocolateyConfiguration()
+                {
+                    RegularOutput = true,
+                    Sources = "https://test.org/api/v2",
+                    SourceCommand = new SourcesCommandConfiguration()
+                    {
+                        Name = "testSource",
+                        Command = chocolatey.infrastructure.app.domain.SourceCommandType.Remove
+                    },
+                    Features = new FeaturesConfiguration()
+                    {
+                        UseEnhancedExitCodes = false
+                    }
+                };
+
+                Service.RemoveSource(config);
+            }
+
+            public override void Context()
+            {
+                base.Context();
+
+                XmlService.Setup(x => x.Deserialize<ConfigFileSettings>(ApplicationParameters.GlobalConfigFileLocation))
+                    .Returns(new ConfigFileSettings
+                    {
+                        Sources = new HashSet<ConfigFileSourceSetting>()
+                    });
+
+                Service = new ChocolateyConfigSettingsService(XmlService.Object);
+            }
+
+            [Fact]
+            public void Should_return_exit_code_0()
+            {
+                using (new AssertionScope())
+                {
+                    MockLogger.Messages.Should().ContainKey("Warn").WhoseValue.Should().ContainSingle().And.Contain("Nothing to change. Config already set.");
+                    Environment.ExitCode.Should().Be(0);
+                }
+            }
+        }
+
+        public class When_ChocolateyConfigSettingsService_RemoveSource_When_Source_Doesnt_Exist_With_Enhanced_Exit_Codes : ChocolateyConfigSettingsServiceSpecsBase
+        {
+            public override void Because()
+            {
+                var config = new ChocolateyConfiguration()
+                {
+                    RegularOutput = true,
+                    Sources = "https://test.org/api/v2",
+                    SourceCommand = new SourcesCommandConfiguration()
+                    {
+                        Name = "testSource",
+                        Command = chocolatey.infrastructure.app.domain.SourceCommandType.Remove
+                    },
+                    Features = new FeaturesConfiguration()
+                    {
+                        UseEnhancedExitCodes = true
+                    }
+                };
+
+                Service.RemoveSource(config);
+            }
+
+            public override void Context()
+            {
+                base.Context();
+
+                XmlService.Setup(x => x.Deserialize<ConfigFileSettings>(ApplicationParameters.GlobalConfigFileLocation))
+                    .Returns(new ConfigFileSettings
+                    {
+                        Sources = new HashSet<ConfigFileSourceSetting>()
+                    });
+
+                Service = new ChocolateyConfigSettingsService(XmlService.Object);
+            }
+
+            [Fact]
+            public void Should_return_exit_code_2()
+            {
+                using (new AssertionScope())
+                {
+                    MockLogger.Messages.Should().ContainKey("Warn").WhoseValue.Should().ContainSingle().And.Contain("Nothing to change. Config already set.");
+                    Environment.ExitCode.Should().Be(2);
+                }
+            }
+        }
+
+        public class When_ChocolateyConfigSettingsService_DisableSource_When_Source_Doesnt_Exist : ChocolateyConfigSettingsServiceSpecsBase
+        {
+            public override void Because()
+            {
+                var config = new ChocolateyConfiguration()
+                {
+                    RegularOutput = true,
+                    Sources = "https://test.org/api/v2",
+                    SourceCommand = new SourcesCommandConfiguration()
+                    {
+                        Name = "testSource",
+                        Command = chocolatey.infrastructure.app.domain.SourceCommandType.Disable
+                    },
+                    Features = new FeaturesConfiguration()
+                    {
+                        UseEnhancedExitCodes = false
+                    }
+                };
+
+                Service.DisableSource(config);
+            }
+
+            public override void Context()
+            {
+                base.Context();
+
+                XmlService.Setup(x => x.Deserialize<ConfigFileSettings>(ApplicationParameters.GlobalConfigFileLocation))
+                    .Returns(new ConfigFileSettings
+                    {
+                        Sources = new HashSet<ConfigFileSourceSetting>()
+                    });
+
+                Service = new ChocolateyConfigSettingsService(XmlService.Object);
+            }
+
+            [Fact]
+            public void Should_return_exit_code_0()
+            {
+                using (new AssertionScope())
+                {
+                    MockLogger.Messages.Should().ContainKey("Warn").WhoseValue.Should().ContainSingle().And.Contain("Nothing to change. Config already set.");
+                    Environment.ExitCode.Should().Be(0);
+                }
+            }
+        }
+
+        public class When_ChocolateyConfigSettingsService_DisableSource_When_Source_Doesnt_Exist_With_Enhanced_Exit_Codes : ChocolateyConfigSettingsServiceSpecsBase
+        {
+            public override void Because()
+            {
+                var config = new ChocolateyConfiguration()
+                {
+                    RegularOutput = true,
+                    Sources = "https://test.org/api/v2",
+                    SourceCommand = new SourcesCommandConfiguration()
+                    {
+                        Name = "testSource",
+                        Command = chocolatey.infrastructure.app.domain.SourceCommandType.Disable
+                    },
+                    Features = new FeaturesConfiguration()
+                    {
+                        UseEnhancedExitCodes = true
+                    }
+                };
+
+                Service.DisableSource(config);
+            }
+
+            public override void Context()
+            {
+                base.Context();
+
+                XmlService.Setup(x => x.Deserialize<ConfigFileSettings>(ApplicationParameters.GlobalConfigFileLocation))
+                    .Returns(new ConfigFileSettings
+                    {
+                        Sources = new HashSet<ConfigFileSourceSetting>()
+                    });
+
+                Service = new ChocolateyConfigSettingsService(XmlService.Object);
+            }
+
+            [Fact]
+            public void Should_return_exit_code_2()
+            {
+                using (new AssertionScope())
+                {
+                    MockLogger.Messages.Should().ContainKey("Warn").WhoseValue.Should().ContainSingle().And.Contain("Nothing to change. Config already set.");
+                    Environment.ExitCode.Should().Be(2);
+                }
+            }
+        }
+
+        public class When_ChocolateyConfigSettingsService_EnableSource_When_Source_Doesnt_Exist : ChocolateyConfigSettingsServiceSpecsBase
+        {
+            public override void Because()
+            {
+                var config = new ChocolateyConfiguration()
+                {
+                    RegularOutput = true,
+                    Sources = "https://test.org/api/v2",
+                    SourceCommand = new SourcesCommandConfiguration()
+                    {
+                        Name = "testSource",
+                        Command = chocolatey.infrastructure.app.domain.SourceCommandType.Enable
+                    },
+                    Features = new FeaturesConfiguration()
+                    {
+                        UseEnhancedExitCodes = false
+                    }
+                };
+
+                Service.EnableSource(config);
+            }
+
+            public override void Context()
+            {
+                base.Context();
+
+                XmlService.Setup(x => x.Deserialize<ConfigFileSettings>(ApplicationParameters.GlobalConfigFileLocation))
+                    .Returns(new ConfigFileSettings
+                    {
+                        Sources = new HashSet<ConfigFileSourceSetting>()
+                    });
+
+                Service = new ChocolateyConfigSettingsService(XmlService.Object);
+            }
+
+            [Fact]
+            public void Should_return_exit_code_0()
+            {
+                using (new AssertionScope())
+                {
+                    MockLogger.Messages.Should().ContainKey("Warn").WhoseValue.Should().ContainSingle().And.Contain("Nothing to change. Config already set.");
+                    Environment.ExitCode.Should().Be(0);
+                }
+            }
+        }
+
+        public class When_ChocolateyConfigSettingsService_EnableSource_When_Source_Doesnt_Exist_With_Enhanced_Exit_Codes : ChocolateyConfigSettingsServiceSpecsBase
+        {
+            public override void Because()
+            {
+                var config = new ChocolateyConfiguration()
+                {
+                    RegularOutput = true,
+                    Sources = "https://test.org/api/v2",
+                    SourceCommand = new SourcesCommandConfiguration()
+                    {
+                        Name = "testSource",
+                        Command = chocolatey.infrastructure.app.domain.SourceCommandType.Enable
+                    },
+                    Features = new FeaturesConfiguration()
+                    {
+                        UseEnhancedExitCodes = true
+                    }
+                };
+
+                Service.EnableSource(config);
+            }
+
+            public override void Context()
+            {
+                base.Context();
+
+                XmlService.Setup(x => x.Deserialize<ConfigFileSettings>(ApplicationParameters.GlobalConfigFileLocation))
+                    .Returns(new ConfigFileSettings
+                    {
+                        Sources = new HashSet<ConfigFileSourceSetting>()
+                    });
+
+                Service = new ChocolateyConfigSettingsService(XmlService.Object);
+            }
+
+            [Fact]
+            public void Should_return_exit_code_2()
+            {
+                using (new AssertionScope())
+                {
+                    MockLogger.Messages.Should().ContainKey("Warn").WhoseValue.Should().ContainSingle().And.Contain("Nothing to change. Config already set.");
+                    Environment.ExitCode.Should().Be(2);
+                }
+            }
+        }
+
+        public class When_ChocolateyConfigSettingsService_DisableFeature_When_Feature_Already_Disabled : ChocolateyConfigSettingsServiceSpecsBase
+        {
+            public override void Because()
+            {
+                var config = new ChocolateyConfiguration()
+                {
+                    RegularOutput = true,
+                    FeatureCommand = new FeatureCommandConfiguration()
+                    {
+                        Name = ApplicationParameters.Features.ChecksumFiles,
+                        Command = chocolatey.infrastructure.app.domain.FeatureCommandType.Disable
+                    },
+                    Features = new FeaturesConfiguration()
+                    {
+                        UseEnhancedExitCodes = false
+                    }
+                };
+
+                Service.DisableFeature(config);
+            }
+
+            public override void Context()
+            {
+                base.Context();
+
+                XmlService.Setup(x => x.Deserialize<ConfigFileSettings>(ApplicationParameters.GlobalConfigFileLocation))
+                    .Returns(new ConfigFileSettings
+                    {
+                        Features = new HashSet<ConfigFileFeatureSetting>
+                        {
+                            new ConfigFileFeatureSetting
+                            {
+                                Name = ApplicationParameters.Features.ChecksumFiles,
+                                Enabled = false,
+                                SetExplicitly = true
+                            }
+                        }
+                    });
+
+                Service = new ChocolateyConfigSettingsService(XmlService.Object);
+            }
+
+            [Fact]
+            public void Should_return_exit_code_0()
+            {
+                using (new AssertionScope())
+                {
+                    MockLogger.Messages.Should().ContainKey("Warn").WhoseValue.Should().ContainSingle().And.Contain("Nothing to change. Config already set.");
+                    Environment.ExitCode.Should().Be(0);
+                }
+            }
+        }
+
+        public class When_ChocolateyConfigSettingsService_DisableFeature_When_Feature_Already_Disabled_With_Enhanced_Exit_Codes : ChocolateyConfigSettingsServiceSpecsBase
+        {
+            public override void Because()
+            {
+                var config = new ChocolateyConfiguration()
+                {
+                    RegularOutput = true,
+                    FeatureCommand = new FeatureCommandConfiguration()
+                    {
+                        Name = ApplicationParameters.Features.ChecksumFiles,
+                        Command = chocolatey.infrastructure.app.domain.FeatureCommandType.Disable
+                    },
+                    Features = new FeaturesConfiguration()
+                    {
+                        UseEnhancedExitCodes = true
+                    }
+                };
+
+                Service.DisableFeature(config);
+            }
+
+            public override void Context()
+            {
+                base.Context();
+
+                XmlService.Setup(x => x.Deserialize<ConfigFileSettings>(ApplicationParameters.GlobalConfigFileLocation))
+                    .Returns(new ConfigFileSettings
+                    {
+                        Features = new HashSet<ConfigFileFeatureSetting>
+                        {
+                            new ConfigFileFeatureSetting
+                            {
+                                Name = ApplicationParameters.Features.ChecksumFiles,
+                                Enabled = false,
+                                SetExplicitly = true
+                            }
+                        }
+                    });
+
+                Service = new ChocolateyConfigSettingsService(XmlService.Object);
+            }
+
+            [Fact]
+            public void Should_return_exit_code_2()
+            {
+                using (new AssertionScope())
+                {
+                    MockLogger.Messages.Should().ContainKey("Warn").WhoseValue.Should().ContainSingle().And.Contain("Nothing to change. Config already set.");
+                    Environment.ExitCode.Should().Be(2);
+                }
+            }
+        }
+
+        public class When_ChocolateyConfigSettingsService_EnableFeature_When_Feature_Already_Enabled: ChocolateyConfigSettingsServiceSpecsBase
+        {
+            public override void Because()
+            {
+                var config = new ChocolateyConfiguration()
+                {
+                    RegularOutput = true,
+                    FeatureCommand = new FeatureCommandConfiguration()
+                    {
+                        Name = ApplicationParameters.Features.ChecksumFiles,
+                        Command = chocolatey.infrastructure.app.domain.FeatureCommandType.Enable
+                    },
+                    Features = new FeaturesConfiguration()
+                    {
+                        UseEnhancedExitCodes = false
+                    }
+                };
+
+                Service.EnableFeature(config);
+            }
+
+            public override void Context()
+            {
+                base.Context();
+
+                XmlService.Setup(x => x.Deserialize<ConfigFileSettings>(ApplicationParameters.GlobalConfigFileLocation))
+                    .Returns(new ConfigFileSettings
+                    {
+                        Features = new HashSet<ConfigFileFeatureSetting>
+                        {
+                            new ConfigFileFeatureSetting
+                            {
+                                Name = ApplicationParameters.Features.ChecksumFiles,
+                                Enabled = true,
+                                SetExplicitly = true
+                            }
+                        }
+                    });
+
+                Service = new ChocolateyConfigSettingsService(XmlService.Object);
+            }
+
+            [Fact]
+            public void Should_return_exit_code_0()
+            {
+                using (new AssertionScope())
+                {
+                    MockLogger.Messages.Should().ContainKey("Warn").WhoseValue.Should().ContainSingle().And.Contain("Nothing to change. Config already set.");
+                    Environment.ExitCode.Should().Be(0);
+                }
+            }
+        }
+
+        public class When_ChocolateyConfigSettingsService_EnableFeature_When_Feature_Already_Enabled_With_Enhanced_Exit_Codes : ChocolateyConfigSettingsServiceSpecsBase
+        {
+            public override void Because()
+            {
+                var config = new ChocolateyConfiguration()
+                {
+                    RegularOutput = true,
+                    FeatureCommand = new FeatureCommandConfiguration()
+                    {
+                        Name = ApplicationParameters.Features.ChecksumFiles,
+                        Command = chocolatey.infrastructure.app.domain.FeatureCommandType.Enable
+                    },
+                    Features = new FeaturesConfiguration()
+                    {
+                        UseEnhancedExitCodes = true
+                    }
+                };
+
+                Service.EnableFeature(config);
+            }
+
+            public override void Context()
+            {
+                base.Context();
+
+                XmlService.Setup(x => x.Deserialize<ConfigFileSettings>(ApplicationParameters.GlobalConfigFileLocation))
+                    .Returns(new ConfigFileSettings
+                    {
+                        Features = new HashSet<ConfigFileFeatureSetting>
+                        {
+                            new ConfigFileFeatureSetting
+                            {
+                                Name = ApplicationParameters.Features.ChecksumFiles,
+                                Enabled = true,
+                                SetExplicitly = true
+                            }
+                        }
+                    });
+
+                Service = new ChocolateyConfigSettingsService(XmlService.Object);
+            }
+
+            [Fact]
+            public void Should_return_exit_code_2()
+            {
+                using (new AssertionScope())
+                {
+                    MockLogger.Messages.Should().ContainKey("Warn").WhoseValue.Should().ContainSingle().And.Contain("Nothing to change. Config already set.");
+                    Environment.ExitCode.Should().Be(2);
+                }
+            }
+        }
+
+        [WindowsOnly]
+        public class When_ChocolateyConfigSettingsService_SetApiKey_When_ApiKey_Already_Exists : ChocolateyConfigSettingsServiceSpecsBase
+        {
+            public override void Because()
+            {
+                var config = new ChocolateyConfiguration()
+                {
+                    RegularOutput = true,
+                    Sources = "https://test.org/api/v2",
+                    ApiKeyCommand = new ApiKeyCommandConfiguration()
+                    {
+                        Key = "bob",
+                        Command = chocolatey.infrastructure.app.domain.ApiKeyCommandType.Add
+                    },
+                    Features = new FeaturesConfiguration()
+                    {
+                        UseEnhancedExitCodes = false
+                    }
+                };
+
+                Service.SetApiKey(config);
+            }
+
+            public override void Context()
+            {
+                base.Context();
+
+                XmlService.Setup(x => x.Deserialize<ConfigFileSettings>(ApplicationParameters.GlobalConfigFileLocation))
+                    .Returns(new ConfigFileSettings
+                    {
+                        ApiKeys = new HashSet<ConfigFileApiKeySetting>
+                        {
+                            new ConfigFileApiKeySetting
+                            {
+                                Key = NugetEncryptionUtility.EncryptString("bob"),
+                                Source = "https://test.org/api/v2"
+                            }
+                        }
+                    });
+
+                Service = new ChocolateyConfigSettingsService(XmlService.Object);
+            }
+
+            [Fact]
+            public void Should_return_exit_code_0()
+            {
+                using (new AssertionScope())
+                {
+                    MockLogger.Messages.Should().ContainKey("Warn").WhoseValue.Should().ContainSingle().And.Contain("Nothing to change. Config already set.");
+                    Environment.ExitCode.Should().Be(0);
+                }
+            }
+        }
+
+        [WindowsOnly]
+        public class When_ChocolateyConfigSettingsService_SetApiKey_When_ApiKey_Already_Exists_With_Enhanced_Exit_Codes : ChocolateyConfigSettingsServiceSpecsBase
+        {
+            public override void Because()
+            {
+                var config = new ChocolateyConfiguration()
+                {
+                    RegularOutput = true,
+                    Sources = "https://test.org/api/v2",
+                    ApiKeyCommand = new ApiKeyCommandConfiguration()
+                    {
+                        Key = "bob",
+                        Command = chocolatey.infrastructure.app.domain.ApiKeyCommandType.Add
+                    },
+                    Features = new FeaturesConfiguration()
+                    {
+                        UseEnhancedExitCodes = true
+                    }
+                };
+
+                Service.SetApiKey(config);
+            }
+
+            public override void Context()
+            {
+                base.Context();
+
+                XmlService.Setup(x => x.Deserialize<ConfigFileSettings>(ApplicationParameters.GlobalConfigFileLocation))
+                    .Returns(new ConfigFileSettings
+                    {
+                        ApiKeys = new HashSet<ConfigFileApiKeySetting>
+                        {
+                            new ConfigFileApiKeySetting
+                            {
+                                Key = NugetEncryptionUtility.EncryptString("bob"),
+                                Source = "https://test.org/api/v2"
+                            }
+                        }
+                    });
+
+                Service = new ChocolateyConfigSettingsService(XmlService.Object);
+            }
+
+            [Fact]
+            public void Should_return_exit_code_2()
+            {
+                using (new AssertionScope())
+                {
+                    MockLogger.Messages.Should().ContainKey("Warn").WhoseValue.Should().ContainSingle().And.Contain("Nothing to change. Config already set.");
+                    Environment.ExitCode.Should().Be(2);
+                }
+            }
+        }
+
+        public class When_ChocolateyConfigSettingsService_SetConfig_When_Config_Already_Set : ChocolateyConfigSettingsServiceSpecsBase
+        {
+            public override void Because()
+            {
+                var config = new ChocolateyConfiguration()
+                {
+                    RegularOutput = true,
+                    ConfigCommand = new ConfigCommandConfiguration()
+                    {
+                        Name = ApplicationParameters.ConfigSettings.CacheLocation,
+                        Command = chocolatey.infrastructure.app.domain.ConfigCommandType.Set,
+                        ConfigValue = @"C:\temp"
+                    },
+                    Features = new FeaturesConfiguration()
+                    {
+                        UseEnhancedExitCodes = false
+                    }
+                };
+
+                Service.SetConfig(config);
+            }
+
+            public override void Context()
+            {
+                base.Context();
+
+                XmlService.Setup(x => x.Deserialize<ConfigFileSettings>(ApplicationParameters.GlobalConfigFileLocation))
+                    .Returns(new ConfigFileSettings
+                    {
+                        ConfigSettings = new HashSet<ConfigFileConfigSetting>()
+                        {
+                            new ConfigFileConfigSetting()
+                            {
+                                Key = ApplicationParameters.ConfigSettings.CacheLocation,
+                                Value = @"C:\temp"
+                            }
+                        }
+                    });
+
+                Service = new ChocolateyConfigSettingsService(XmlService.Object);
+            }
+
+            [Fact]
+            public void Should_return_exit_code_0()
+            {
+                using (new AssertionScope())
+                {
+                    MockLogger.Messages.Should().ContainKey("Warn").WhoseValue.Should().ContainSingle().And.Contain("Nothing to change. Config already set.");
+                    Environment.ExitCode.Should().Be(0);
+                }
+            }
+        }
+
+        public class When_ChocolateyConfigSettingsService_SetConfig_When_Config_Already_Set_Enhanced_Exit_Codes : ChocolateyConfigSettingsServiceSpecsBase
+        {
+            public override void Because()
+            {
+                var config = new ChocolateyConfiguration()
+                {
+                    RegularOutput = true,
+                    ConfigCommand = new ConfigCommandConfiguration()
+                    {
+                        Name = ApplicationParameters.ConfigSettings.CacheLocation,
+                        Command = chocolatey.infrastructure.app.domain.ConfigCommandType.Set,
+                        ConfigValue = @"C:\temp"
+
+                    },
+                    Features = new FeaturesConfiguration()
+                    {
+                        UseEnhancedExitCodes = true
+                    }
+                };
+
+                Service.SetConfig(config);
+            }
+
+            public override void Context()
+            {
+                base.Context();
+
+                XmlService.Setup(x => x.Deserialize<ConfigFileSettings>(ApplicationParameters.GlobalConfigFileLocation))
+                    .Returns(new ConfigFileSettings
+                    {
+                        ConfigSettings = new HashSet<ConfigFileConfigSetting>()
+                        {
+                            new ConfigFileConfigSetting()
+                            {
+                                Key = ApplicationParameters.ConfigSettings.CacheLocation,
+                                Value = @"C:\temp"
+                            }
+                        }
+                    });
+
+                Service = new ChocolateyConfigSettingsService(XmlService.Object);
+            }
+
+            [Fact]
+            public void Should_return_exit_code_2()
+            {
+                using (new AssertionScope())
+                {
+                    MockLogger.Messages.Should().ContainKey("Warn").WhoseValue.Should().ContainSingle().And.Contain("Nothing to change. Config already set.");
+                    Environment.ExitCode.Should().Be(2);
+                }
+            }
+        }
+
+        public class When_ChocolateyConfigSettingsService_UnSetConfig_When_Config_Already_UnSet : ChocolateyConfigSettingsServiceSpecsBase
+        {
+            public override void Because()
+            {
+                var config = new ChocolateyConfiguration()
+                {
+                    RegularOutput = true,
+                    ConfigCommand = new ConfigCommandConfiguration()
+                    {
+                        Name = ApplicationParameters.ConfigSettings.CacheLocation,
+                        Command = chocolatey.infrastructure.app.domain.ConfigCommandType.Unset
+                    },
+                    Features = new FeaturesConfiguration()
+                    {
+                        UseEnhancedExitCodes = false
+                    }
+                };
+
+                Service.UnsetConfig(config);
+            }
+
+            public override void Context()
+            {
+                base.Context();
+
+                XmlService.Setup(x => x.Deserialize<ConfigFileSettings>(ApplicationParameters.GlobalConfigFileLocation))
+                    .Returns(new ConfigFileSettings
+                    {
+                        ConfigSettings = new HashSet<ConfigFileConfigSetting>()
+                    });
+
+                Service = new ChocolateyConfigSettingsService(XmlService.Object);
+            }
+
+            [Fact]
+            public void Should_return_exit_code_0()
+            {
+                using (new AssertionScope())
+                {
+                    MockLogger.Messages.Should().ContainKey("Warn").WhoseValue.Should().ContainSingle().And.Contain("Nothing to change. Config already set.");
+                    Environment.ExitCode.Should().Be(0);
+                }
+            }
+        }
+
+        public class When_ChocolateyConfigSettingsService_UnSetConfig_When_Config_Already_UnSet_Enhanced_Exit_Codes : ChocolateyConfigSettingsServiceSpecsBase
+        {
+            public override void Because()
+            {
+                var config = new ChocolateyConfiguration()
+                {
+                    RegularOutput = true,
+                    ConfigCommand = new ConfigCommandConfiguration()
+                    {
+                        Name = ApplicationParameters.ConfigSettings.CacheLocation,
+                        Command = chocolatey.infrastructure.app.domain.ConfigCommandType.Unset
+
+                    },
+                    Features = new FeaturesConfiguration()
+                    {
+                        UseEnhancedExitCodes = true
+                    }
+                };
+
+                Service.UnsetConfig(config);
+            }
+
+            public override void Context()
+            {
+                base.Context();
+
+                XmlService.Setup(x => x.Deserialize<ConfigFileSettings>(ApplicationParameters.GlobalConfigFileLocation))
+                    .Returns(new ConfigFileSettings
+                    {
+                        ConfigSettings = new HashSet<ConfigFileConfigSetting>()
+                    });
+
+                Service = new ChocolateyConfigSettingsService(XmlService.Object);
+            }
+
+            [Fact]
+            public void Should_return_exit_code_2()
+            {
+                using (new AssertionScope())
+                {
+                    MockLogger.Messages.Should().ContainKey("Warn").WhoseValue.Should().ContainSingle().And.Contain("Nothing to change. Config already set.");
+                    Environment.ExitCode.Should().Be(2);
+                }
             }
         }
     }

--- a/src/chocolatey.tests/infrastructure.app/services/ChocolateyPackageServiceSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/services/ChocolateyPackageServiceSpecs.cs
@@ -17,10 +17,12 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Text;
 using chocolatey.infrastructure.app.configuration;
 using chocolatey.infrastructure.app.domain;
+using chocolatey.infrastructure.app.registration;
 using chocolatey.infrastructure.app.services;
 using chocolatey.infrastructure.filesystem;
 using chocolatey.infrastructure.results;
@@ -28,9 +30,8 @@ using chocolatey.infrastructure.services;
 using Moq;
 using NUnit.Framework;
 using FluentAssertions;
+using FluentAssertions.Execution;
 using IFileSystem = chocolatey.infrastructure.filesystem.IFileSystem;
-using System.IO;
-using chocolatey.infrastructure.app.registration;
 using NuGet.Packaging;
 
 namespace chocolatey.tests.infrastructure.app.services
@@ -395,7 +396,7 @@ namespace chocolatey.tests.infrastructure.app.services
                 Action = () => Service.Upgrade(Configuration);
                 Configuration.CommandName = "upgrade";
             }
-        }
+        }   
 
         public class When_ChocolateyPackageService_tries_to_upgrade_noop_nupkg_file : When_ChocolateyPackageService_tries_to_install_nupkg_file
         {
@@ -404,6 +405,82 @@ namespace chocolatey.tests.infrastructure.app.services
                 base.Context();
                 Action = () => Service.UpgradeDryRun(Configuration);
                 Configuration.CommandName = "upgrade";
+            }
+        }
+
+        public class When_ChocolateyPackageService_tries_to_upgrade_a_package_that_doesnt_need_upgraded : ChocolateyPackageServiceSpecsBase
+        {
+            private ConcurrentDictionary<string, PackageResult> _result;
+
+            public override void Context()
+            {
+                base.Context();
+                Configuration.PackageNames = "alreadyupgraded";
+                Configuration.Sources = @"c:\packages";
+                Configuration.Features.UseEnhancedExitCodes = false;
+
+                var package = new Mock<IPackageMetadata>();
+                var expectedResult = new ConcurrentDictionary<string, PackageResult>();
+                var packageResult = new PackageResult(package.Object, @"c:\programdata\chocolatey\lib\alreadyupgraded", null);
+                var logMessage = "alreadyupgraded v1.2.3 is the latest version available based on your source(s).";
+                packageResult.Messages.Add(new ResultMessage(ResultType.Inconclusive, logMessage));
+                expectedResult.TryAdd("alreadyupgraded", packageResult);
+
+                NugetService.Setup(n => n.Upgrade(It.IsAny<ChocolateyConfiguration>(), It.IsAny<Action<PackageResult, ChocolateyConfiguration>>(), It.IsAny<Action<PackageResult, ChocolateyConfiguration>>()))
+                    .Returns(expectedResult);
+            }
+
+            public override void Because()
+            {
+                _result = Service.Upgrade(Configuration);
+            }
+
+            [Fact]
+            public void Should_Return_0_Exit_Code()
+            {
+                using(new AssertionScope())
+                {
+                    MockLogger.Messages.Should().ContainKey("Warn").WhoseValue.Should().Contain(m => m.Contains("Chocolatey upgraded 0/1 packages."));
+                    Environment.ExitCode.Should().Be(0);
+                }
+            }
+        }
+
+        public class When_ChocolateyPackageService_tries_to_upgrade_a_package_that_doesnt_need_upgraded_using_enhanced_exitcodes : ChocolateyPackageServiceSpecsBase
+        {
+            private ConcurrentDictionary<string, PackageResult> _result;
+
+            public override void Context()
+            {
+                base.Context();
+                Configuration.PackageNames = "alreadyupgraded";
+                Configuration.Sources = @"c:\packages";
+                Configuration.Features.UseEnhancedExitCodes = true;
+
+                var package = new Mock<IPackageMetadata>();
+                var expectedResult = new ConcurrentDictionary<string, PackageResult>();
+                var packageResult = new PackageResult(package.Object, @"c:\programdata\chocolatey\lib\alreadyupgraded", null);
+                var logMessage = "alreadyupgraded v1.2.3 is the latest version available based on your source(s).";
+                packageResult.Messages.Add(new ResultMessage(ResultType.Inconclusive, logMessage));
+                expectedResult.TryAdd("alreadyupgraded", packageResult);
+
+                NugetService.Setup(n => n.Upgrade(It.IsAny<ChocolateyConfiguration>(), It.IsAny<Action<PackageResult, ChocolateyConfiguration>>(), It.IsAny<Action<PackageResult, ChocolateyConfiguration>>()))
+                    .Returns(expectedResult);
+            }
+
+            public override void Because()
+            {
+                _result = Service.Upgrade(Configuration);
+            }
+
+            [Fact]
+            public void Should_Return_0_Exit_Code()
+            {
+                using (new AssertionScope())
+                {
+                    MockLogger.Messages.Should().ContainKey("Warn").WhoseValue.Should().Contain(m => m.Contains("Chocolatey upgraded 0/1 packages."));
+                    Environment.ExitCode.Should().Be(2);
+                }
             }
         }
     }

--- a/src/chocolatey/infrastructure.app/commands/ChocolateyApiKeyCommand.cs
+++ b/src/chocolatey/infrastructure.app/commands/ChocolateyApiKeyCommand.cs
@@ -167,12 +167,17 @@ Exit codes that normally result from running this command.
 Normal:
  - 0: operation was successful, no issues detected
  - -1 or 1: an error has occurred
+ - 2: nothing to do, apikey already set (enhanced)
+
+NOTE: Starting in v2.3.0, if you have the feature '{0}'
+ turned on, then choco will provide enhanced exit codes that allow
+ better integration and scripting.
 
 If you find other exit codes that we have not yet documented, please
  file a ticket so we can document it at
  https://github.com/chocolatey/choco/issues/new/choose.
 
-");
+".FormatWith(ApplicationParameters.Features.UseEnhancedExitCodes));
             "chocolatey".Log().Info(ChocolateyLoggers.Important, "Options and Switches");
         }
 

--- a/src/chocolatey/infrastructure.app/commands/ChocolateyConfigCommand.cs
+++ b/src/chocolatey/infrastructure.app/commands/ChocolateyConfigCommand.cs
@@ -138,12 +138,17 @@ Exit codes that normally result from running this command.
 Normal:
  - 0: operation was successful, no issues detected
  - -1 or 1: an error has occurred
+ - 2: nothing to do, config already set/unset (enhanced)
+
+NOTE: Starting in v2.3.0, if you have the feature '{0}'
+ turned on, then choco will provide enhanced exit codes that allow
+ better integration and scripting.
 
 If you find other exit codes that we have not yet documented, please
  file a ticket so we can document it at
  https://github.com/chocolatey/choco/issues/new/choose.
 
-");
+".FormatWith(ApplicationParameters.Features.UseEnhancedExitCodes));
 
             "chocolatey".Log().Info(ChocolateyLoggers.Important, "See It In Action");
             "chocolatey".Log().Info(@"

--- a/src/chocolatey/infrastructure.app/commands/ChocolateyFeatureCommand.cs
+++ b/src/chocolatey/infrastructure.app/commands/ChocolateyFeatureCommand.cs
@@ -124,12 +124,17 @@ Exit codes that normally result from running this command.
 Normal:
  - 0: operation was successful, no issues detected
  - -1 or 1: an error has occurred
+ - 2: nothing to do, feature already set (enhanced)
+
+NOTE: Starting in v2.3.0, if you have the feature '{0}'
+ turned on, then choco will provide enhanced exit codes that allow
+ better integration and scripting.
 
 If you find other exit codes that we have not yet documented, please
  file a ticket so we can document it at
  https://github.com/chocolatey/choco/issues/new/choose.
 
-");
+".FormatWith(ApplicationParameters.Features.UseEnhancedExitCodes));
 
             "chocolatey".Log().Info(ChocolateyLoggers.Important, "Options and Switches");
         }

--- a/src/chocolatey/infrastructure.app/commands/ChocolateyOutdatedCommand.cs
+++ b/src/chocolatey/infrastructure.app/commands/ChocolateyOutdatedCommand.cs
@@ -130,7 +130,7 @@ Normal:
 Enhanced:
  - 0: no outdated packages
  - -1 or 1: an error has occurred
- - 2: outdated packages have been found
+ - 2: outdated packages have been found (enhanced)
 
 NOTE: If you have the feature '{0}' turned on,
  then choco will provide enhanced exit codes that allow

--- a/src/chocolatey/infrastructure.app/commands/ChocolateyPinCommand.cs
+++ b/src/chocolatey/infrastructure.app/commands/ChocolateyPinCommand.cs
@@ -134,12 +134,17 @@ Exit codes that normally result from running this command.
 Normal:
  - 0: operation was successful, no issues detected
  - -1 or 1: an error has occurred
+ - 2: nothing to do (enhanced)
+
+NOTE: Starting in v2.3.0, if you have the feature '{0}'
+ turned on, then choco will provide enhanced exit codes that allow
+ better integration and scripting.
 
 If you find other exit codes that we have not yet documented, please
  file a ticket so we can document it at
  https://github.com/chocolatey/choco/issues/new/choose.
 
-");
+".FormatWith(ApplicationParameters.Features.UseEnhancedExitCodes));
 
             "chocolatey".Log().Info(ChocolateyLoggers.Important, "Options and Switches");
         }
@@ -222,6 +227,11 @@ If you find other exit codes that we have not yet documented, please
             else
             {
                 this.Log().Warn(NoChangeMessage);
+
+                if (config.Features.UseEnhancedExitCodes && Environment.ExitCode == 0)
+                {
+                    Environment.ExitCode = 2;
+                }
             }
         }
 

--- a/src/chocolatey/infrastructure.app/commands/ChocolateySourceCommand.cs
+++ b/src/chocolatey/infrastructure.app/commands/ChocolateySourceCommand.cs
@@ -164,12 +164,17 @@ Exit codes that normally result from running this command.
 Normal:
  - 0: operation was successful, no issues detected
  - -1 or 1: an error has occurred
+ - 2: nothing to do (enhanced)
+
+NOTE: Starting in v2.3.0, if you have the feature '{0}'
+ turned on, then choco will provide enhanced exit codes that allow
+ better integration and scripting.
 
 If you find other exit codes that we have not yet documented, please
  file a ticket so we can document it at
  https://github.com/chocolatey/choco/issues/new/choose.
 
-");
+".FormatWith(ApplicationParameters.Features.UseEnhancedExitCodes));
 
             "chocolatey".Log().Info(ChocolateyLoggers.Important, "Options and Switches");
         }

--- a/src/chocolatey/infrastructure.app/commands/ChocolateyUpgradeCommand.cs
+++ b/src/chocolatey/infrastructure.app/commands/ChocolateyUpgradeCommand.cs
@@ -351,6 +351,11 @@ Exit codes that normally result from running this command.
 Normal:
  - 0: operation was successful, no issues detected
  - -1 or 1: an error has occurred
+ - 2: nothing to do, no packages outdated (enhanced)
+
+NOTE: Starting in v2.3.0, if you have the feature '{2}'
+ turned on, then choco will provide enhanced exit codes that allow
+ better integration and scripting.
 
 Package Exit Codes:
  - 1641: success, reboot initiated
@@ -368,7 +373,7 @@ Reboot Exit Codes:
 In addition to the above exit codes, you may also see reboot exit codes
  when the feature '{1}' is turned on. It typically requires
  the feature '{0}' to also be turned on to work properly.
-".FormatWith(ApplicationParameters.Features.UsePackageExitCodes, ApplicationParameters.Features.ExitOnRebootDetected));
+".FormatWith(ApplicationParameters.Features.UsePackageExitCodes, ApplicationParameters.Features.ExitOnRebootDetected, ApplicationParameters.Features.UseEnhancedExitCodes));
 
             "chocolatey".Log().Info(ChocolateyLoggers.Important, "See It In Action");
             "chocolatey".Log().Info(@"

--- a/src/chocolatey/infrastructure.app/services/ChocolateyConfigSettingsService.cs
+++ b/src/chocolatey/infrastructure.app/services/ChocolateyConfigSettingsService.cs
@@ -396,6 +396,11 @@ namespace chocolatey.infrastructure.app.services
                 else
                 {
                     this.Log().Warn(NoChangeMessage);
+
+                    if (configuration.Features.UseEnhancedExitCodes && Environment.ExitCode == 0)
+                    {
+                        Environment.ExitCode = 2;
+                    }
                 }
             }
         }

--- a/src/chocolatey/infrastructure.app/services/ChocolateyConfigSettingsService.cs
+++ b/src/chocolatey/infrastructure.app/services/ChocolateyConfigSettingsService.cs
@@ -492,6 +492,11 @@ namespace chocolatey.infrastructure.app.services
                 if (configuration.ConfigCommand.ConfigValue.IsEqualTo(currentValue.ToStringSafe()))
                 {
                     this.Log().Warn(NoChangeMessage);
+                    
+                    if (configuration.Features.UseEnhancedExitCodes && Environment.ExitCode == 0)
+                    {
+                        Environment.ExitCode = 2;
+                    }
                 }
                 else
                 {
@@ -509,6 +514,11 @@ namespace chocolatey.infrastructure.app.services
             if (config == null || string.IsNullOrEmpty(config.Value))
             {
                 this.Log().Warn(NoChangeMessage);
+
+                if (configuration.Features.UseEnhancedExitCodes && Environment.ExitCode == 0)
+                {
+                    Environment.ExitCode = 2;
+                }
             }
             else
             {

--- a/src/chocolatey/infrastructure.app/services/ChocolateyConfigSettingsService.cs
+++ b/src/chocolatey/infrastructure.app/services/ChocolateyConfigSettingsService.cs
@@ -307,6 +307,11 @@ namespace chocolatey.infrastructure.app.services
             else
             {
                 this.Log().Warn(NoChangeMessage);
+
+                if (configuration.Features.UseEnhancedExitCodes && Environment.ExitCode == 0)
+                {
+                    Environment.ExitCode = 2;
+                }
             }
         }
 
@@ -335,6 +340,11 @@ namespace chocolatey.infrastructure.app.services
             else
             {
                 this.Log().Warn(NoChangeMessage);
+
+                if (configuration.Features.UseEnhancedExitCodes && Environment.ExitCode == 0)
+                {
+                    Environment.ExitCode = 2;
+                }
             }
         }
 

--- a/src/chocolatey/infrastructure.app/services/ChocolateyConfigSettingsService.cs
+++ b/src/chocolatey/infrastructure.app/services/ChocolateyConfigSettingsService.cs
@@ -160,6 +160,11 @@ namespace chocolatey.infrastructure.app.services
                     {
                         this.Log().Warn(NoChangeMessage);
                     }
+                    
+                    if (configuration.Features.UseEnhancedExitCodes && Environment.ExitCode == 0)
+                    {
+                        Environment.ExitCode = 2;
+                    }
                 }
                 else
                 {
@@ -201,6 +206,11 @@ namespace chocolatey.infrastructure.app.services
                 {
                     this.Log().Warn(NoChangeMessage);
                 }
+
+                if (configuration.Features.UseEnhancedExitCodes && Environment.ExitCode == 0)
+                {
+                    Environment.ExitCode = 2;
+                }
             }
         }
 
@@ -222,6 +232,11 @@ namespace chocolatey.infrastructure.app.services
                 {
                     this.Log().Warn(NoChangeMessage);
                 }
+
+                if (configuration.Features.UseEnhancedExitCodes && Environment.ExitCode == 0)
+                {
+                    Environment.ExitCode = 2;
+                }
             }
         }
 
@@ -242,6 +257,11 @@ namespace chocolatey.infrastructure.app.services
                 if (!configuration.QuietOutput)
                 {
                     this.Log().Warn(NoChangeMessage);
+                }
+
+                if (configuration.Features.UseEnhancedExitCodes && Environment.ExitCode == 0)
+                {
+                    Environment.ExitCode = 2;
                 }
             }
         }


### PR DESCRIPTION
## Description Of Changes

This adds enhanced exit codes to the `apikey`, `config`, `feature`, `pin`, `source` and `upgrade` commands. Specifically, it adds exit code 2 for when there is nothing to do. All of these commands except `upgrade` have a `NOCHANGEMESSAGE` that is output, this sets exit code 2 if the conditions are met for that message to be logged, enhanced exit codes are enabled, and there is not another preexisting exit code set other than zero.

The upgrade command required returning more information from a method to allow checking if no packages were outdated. The check is done by checking that there are no successes or failures.

## Motivation and Context

Adding support for enhanced exit codes in more commands is useful for users that script choco, as it gives more information in a easily usable format of an exit code.

I did not try adding enhanced exit codes to push (#1763) as I don't think there is a way yet to check if the package already exists on the remote source. It would probably should be a separate PR, and perhaps a series of PRs even. (Edit, #494 would have to be completed first)

## Testing

```powershell
.\choco.exe feature disable -n useEnhancedExitCodes
.\choco.exe apikey add --source="https://does.not.exist" --key="1234abcd"
.\choco.exe apikey add --source="https://does.not.exist" --key="1234abcd" # Should return zero
WIP - COMPLETE

.\choco.exe feature enable -n useEnhancedExitCodes
.\choco.exe apikey add --source="https://does.not.exist" --key="1234abcd" # Should return two
```

## Change Types Made

* [ ] Bug fix (non-breaking change)
* [x] Feature / Enhancement (non-breaking change)
* [ ] Breaking change (fix or feature that could cause existing functionality to change)

## Related Issue

Fixes #1759 (apikey)
Fixes #1760 (config)
Fixes #1761 (feature)
Fixes #1762 (pin)
Fixes #1764 (source)
Fixes #2200 (upgrade)

## Change Checklist

* [x] Requires a change to the documentation
* [x] Documentation has been updated
* [ ] Tests to cover my changes, have been added
* [ ] All new and existing tests passed.
* N/A PowerShell v2 compatibility checked.





