### PR TITLE
(#23) Handle all keyword for install

### DIFF
--- a/src/chocolatey.tests.integration/scenarios/InstallScenarios.cs
+++ b/src/chocolatey.tests.integration/scenarios/InstallScenarios.cs
@@ -22,6 +22,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Xml.XPath;
+using chocolatey.infrastructure.app;
 using chocolatey.infrastructure.app.commands;
 using chocolatey.infrastructure.app.configuration;
 using chocolatey.infrastructure.app.services;
@@ -4593,6 +4594,53 @@ namespace chocolatey.tests.integration.scenarios
             public void Should_not_have_warning_package_result()
             {
                 Results.Should().AllSatisfy(r => r.Value.Warning.Should().BeFalse());
+            }
+        }
+
+        public class When_installing_all_packages_from_ccr : ScenariosBase
+        {
+            public override void Context()
+            {
+                base.Context();
+                Configuration.PackageNames = Configuration.Input = "all";
+                Configuration.Sources = ApplicationParameters.ChocolateyCommunityFeedSource;
+            }
+
+            public override void Because()
+            {
+            }
+
+            [Fact]
+            public void Should_throw_an_error_that_it_is_not_allowed()
+            {
+                Action m = () => Service.Install(Configuration); ;
+
+                m.Should().Throw<ApplicationException>();
+            }
+        }
+
+        public class When_installing_all_packages_from_local_source : ScenariosBase
+        {
+            public override void Context()
+            {
+                base.Context();
+                Configuration.PackageNames = Configuration.Input = "all";
+
+                Scenario.AddPackagesToSourceLocation(Configuration, "hasdependency.1.0.0*" + NuGetConstants.PackageExtension);
+                Scenario.AddPackagesToSourceLocation(Configuration, "isdependency.1.0.0*" + NuGetConstants.PackageExtension);
+                Scenario.AddPackagesToSourceLocation(Configuration, "isexactversiondependency*" + NuGetConstants.PackageExtension);
+                Scenario.AddPackagesToSourceLocation(Configuration, "upgradepackage*" + NuGetConstants.PackageExtension);
+            }
+
+            public override void Because()
+            {
+                Results = Service.Install(Configuration);
+            }
+
+            [Fact]
+            public void Should_install_all_packages()
+            {
+                Results.Should().HaveCount(6);
             }
         }
     }

--- a/src/chocolatey/infrastructure.app/ApplicationParameters.cs
+++ b/src/chocolatey/infrastructure.app/ApplicationParameters.cs
@@ -15,6 +15,7 @@
 // limitations under the License.
 
 using System;
+using System.Collections.Generic;
 using System.Security.Principal;
 using chocolatey.infrastructure.adapters;
 using chocolatey.infrastructure.filesystem;
@@ -101,6 +102,8 @@ namespace chocolatey.infrastructure.app
         public static readonly string ChocolateyCommunityFeedPushSource = "https://push.chocolatey.org/";
         public static readonly string ChocolateyCommunityGalleryUrl = "https://community.chocolatey.org/";
         public static readonly string ChocolateyCommunityFeedSource = "https://community.chocolatey.org/api/v2/";
+        public static readonly string NuGetPublicFeedSourceV2 = "https://www.nuget.org/api/v2/";
+        public static readonly string NuGetPublicFeedSourceV3 = "https://api.nuget.org/v3/index.json";
         public static readonly string ChocolateyLicensedFeedSource = "https://licensedpackages.chocolatey.org/api/v2/";
         public static readonly string ChocolateyLicensedFeedSourceName = "chocolatey.licensed";
         public static readonly string UserAgent = "Chocolatey Command Line";
@@ -110,6 +113,15 @@ namespace chocolatey.infrastructure.app
         public static readonly string PowerShellModulePathProcessDocuments = _fileSystem.CombinePaths(System.Environment.GetFolderPath(System.Environment.SpecialFolder.MyDocuments), "WindowsPowerShell\\Modules");
         public static readonly string LocalSystemSidString = "S-1-5-18";
         public static readonly SecurityIdentifier LocalSystemSid = new SecurityIdentifier(LocalSystemSidString);
+        public static readonly List<string> PublicNuGetSources = new List<string>()
+        {
+            ChocolateyCommunityFeedSource,
+            ChocolateyCommunityFeedPushSource,
+            ChocolateyCommunityFeedPushSourceOld,
+            NuGetPublicFeedSourceV2,
+            NuGetPublicFeedSourceV3,
+            ChocolateyLicensedFeedSource,
+        };
 
         private static string GetHttpCacheLocation()
         {

--- a/src/chocolatey/infrastructure.app/commands/ChocolateyInstallCommand.cs
+++ b/src/chocolatey/infrastructure.app/commands/ChocolateyInstallCommand.cs
@@ -314,6 +314,11 @@ NOTE: Chocolatey Pro / Business builds on top of a great open source
     choco install <path/to/nuspec>
     choco install <path/to/nupkg>
 
+NOTE: `all` is a special package keyword that will allow you to install
+ all packages available on a source. This keyword is not available for
+ public repositories like the Chocolatey Community Repository, and is
+ intended to  be used with internal package sources only.
+
 NOTE: See scripting in the command reference (`choco -?`) for how to
  write proper scripts and integrations.
 

--- a/src/chocolatey/infrastructure.app/services/CygwinService.cs
+++ b/src/chocolatey/infrastructure.app/services/CygwinService.cs
@@ -218,6 +218,11 @@ namespace chocolatey.infrastructure.app.services
 
         public ConcurrentDictionary<string, PackageResult> Install(ChocolateyConfiguration config, Action<PackageResult, ChocolateyConfiguration> continueAction, Action<PackageResult, ChocolateyConfiguration> beforeModifyAction)
         {
+            if (config.PackageNames.IsEqualTo(ApplicationParameters.AllPackages))
+            {
+                throw new NotImplementedException("Alternative sources do not allow the use of the 'all' package name/keyword.");
+            }
+
             var args = BuildArgs(config, _installArguments);
             var packageResults = new ConcurrentDictionary<string, PackageResult>(StringComparer.InvariantCultureIgnoreCase);
 

--- a/src/chocolatey/infrastructure.app/services/NugetService.cs
+++ b/src/chocolatey/infrastructure.app/services/NugetService.cs
@@ -1021,7 +1021,7 @@ Please see https://docs.chocolatey.org/en-us/troubleshooting for more
             var projectContext = new ChocolateyNuGetProjectContext(config, _nugetLogger);
 
             var configIgnoreDependencies = config.IgnoreDependencies;
-            var allLocalPackages = SetPackageNamesIfAllSpecified(config, () => { config.IgnoreDependencies = true; }).ToList();
+            var allLocalPackages = SetLocalPackageNamesIfAllSpecified(config, () => { config.IgnoreDependencies = true; }).ToList();
             config.IgnoreDependencies = configIgnoreDependencies;
             var localPackageListValid = true;
 
@@ -1679,7 +1679,7 @@ Please see https://docs.chocolatey.org/en-us/troubleshooting for more
 
             var outdatedPackages = new ConcurrentDictionary<string, PackageResult>();
 
-            var allPackages = SetPackageNamesIfAllSpecified(config, () => { config.IgnoreDependencies = true; });
+            var allPackages = SetLocalPackageNamesIfAllSpecified(config, () => { config.IgnoreDependencies = true; });
             var packageNames = config.PackageNames.Split(new[] { ApplicationParameters.PackageNamesSeparator }, StringSplitOptions.RemoveEmptyEntries).OrEmpty().ToList();
 
             config.CreateBackup();
@@ -2271,7 +2271,7 @@ Please see https://docs.chocolatey.org/en-us/troubleshooting for more
                 }
             }
 
-            SetPackageNamesIfAllSpecified(config, () =>
+            SetLocalPackageNamesIfAllSpecified(config, () =>
                 {
                     // force remove the item, ignore the dependencies
                     // as those are going to be picked up anyway
@@ -2862,7 +2862,7 @@ Please see https://docs.chocolatey.org/en-us/troubleshooting for more
             return installedPackages;
         }
 
-        private IEnumerable<PackageResult> SetPackageNamesIfAllSpecified(ChocolateyConfiguration config, Action customAction)
+        private IEnumerable<PackageResult> SetLocalPackageNamesIfAllSpecified(ChocolateyConfiguration config, Action customAction)
         {
             var allPackages = GetInstalledPackages(config);
             if (config.PackageNames.IsEqualTo(ApplicationParameters.AllPackages))

--- a/src/chocolatey/infrastructure.app/services/PythonService.cs
+++ b/src/chocolatey/infrastructure.app/services/PythonService.cs
@@ -358,6 +358,11 @@ namespace chocolatey.infrastructure.app.services
 
         public ConcurrentDictionary<string, PackageResult> Install(ChocolateyConfiguration config, Action<PackageResult, ChocolateyConfiguration> continueAction, Action<PackageResult, ChocolateyConfiguration> beforeModifyAction)
         {
+            if (config.PackageNames.IsEqualTo(ApplicationParameters.AllPackages))
+            {
+                throw new NotImplementedException("Alternative sources do not allow the use of the 'all' package name/keyword.");
+            }
+
             EnsureExecutablePathSet();
             var args = BuildArguments(config, _installArguments);
             var packageResults = new ConcurrentDictionary<string, PackageResult>(StringComparer.InvariantCultureIgnoreCase);
@@ -441,7 +446,7 @@ namespace chocolatey.infrastructure.app.services
         {
             if (config.PackageNames.IsEqualTo(ApplicationParameters.AllPackages))
             {
-                throw new NotImplementedException("The all keyword is not available for alternate sources");
+                throw new NotImplementedException("Alternative sources do not allow the use of the 'all' package name/keyword.");
             }
 
             EnsureExecutablePathSet();

--- a/src/chocolatey/infrastructure.app/services/RubyGemsService.cs
+++ b/src/chocolatey/infrastructure.app/services/RubyGemsService.cs
@@ -211,6 +211,11 @@ namespace chocolatey.infrastructure.app.services
 
         public ConcurrentDictionary<string, PackageResult> Install(ChocolateyConfiguration config, Action<PackageResult, ChocolateyConfiguration> continueAction, Action<PackageResult, ChocolateyConfiguration> beforeModifyAction)
         {
+            if (config.PackageNames.IsEqualTo(ApplicationParameters.AllPackages))
+            {
+                throw new NotImplementedException("Alternative sources do not allow the use of the 'all' package name/keyword.");
+            }
+
             var packageResults = new ConcurrentDictionary<string, PackageResult>(StringComparer.InvariantCultureIgnoreCase);
             var args = ExternalCommandArgsBuilder.BuildArguments(config, _installArguments);
 

--- a/src/chocolatey/infrastructure.app/services/WindowsFeatureService.cs
+++ b/src/chocolatey/infrastructure.app/services/WindowsFeatureService.cs
@@ -287,6 +287,11 @@ namespace chocolatey.infrastructure.app.services
 
         public ConcurrentDictionary<string, PackageResult> Install(ChocolateyConfiguration config, Action<PackageResult, ChocolateyConfiguration> continueAction, Action<PackageResult, ChocolateyConfiguration> beforeModifyAction)
         {
+            if (config.PackageNames.IsEqualTo(ApplicationParameters.AllPackages))
+            {
+                throw new NotImplementedException("Alternative sources do not allow the use of the 'all' package name/keyword.");
+            }
+
             EnsureExecutablePathSet();
             var args = BuildArguments(config, _installArguments);
             var packageResults = new ConcurrentDictionary<string, PackageResult>(StringComparer.InvariantCultureIgnoreCase);

--- a/tests/pester-tests/features/PythonSource.Tests.ps1
+++ b/tests/pester-tests/features/PythonSource.Tests.ps1
@@ -31,7 +31,7 @@ Describe "Python Source" -Tag Chocolatey, UpgradeCommand, PythonSource, ProxySki
         }
 
         It 'Outputs properly' {
-            $Output.Lines | Should -Not:($ExitCode -eq 0) -Contain 'The all keyword is not available for alternate sources'
+            $Output.Lines | Should -Not:($ExitCode -eq 0) -Contain "Alternative sources do not allow the use of the 'all' package name/keyword."
             $Output.Lines | Should  -Contain "Chocolatey upgraded $Count/$Count packages."
         }
     }


### PR DESCRIPTION
## Description Of Changes

This adds the ability to install all packages from a source via the all
keyword. It runs a list against the current sources, and sets the
package names from that list of packages. 

This functionality is only intended to be used with internal
repositories. Therefore a list of public repositories has been added,
and the current sources are checked against it to ensure only internal
sources are specified.

Renames the `set_package_names_if_all_is_specified function` to
`set_local_package_names_if_all_is_specified`. This is to increase
clarity with the `set_remote_package_names_if_all_is_specified` now being added.

Also this throws a not implemented exception if the all keyword is used with
non-nuget alternate sources. This is because the all keyword only has
handling built in for normal sources, and it is better to throw an
error than to have the source try to install a package called "all"

## Motivation and Context

Adding the all keyword for install will bring C# choco up to feature parity with PowerShell choco. Or, at least all of the feature parity issues will be closed.

## Testing

Run these to validate that choco will throw an error because public repositories are one of the sources:
```
choco install all --allow-unofficial
choco install all --allow-unofficial --source=https://community.chocolatey.org/api/v2/
choco install all --allow-unofficial --source=https://chocolatey.org/api/v2/
choco install all --allow-unofficial --source=https://www.nuget.org/api/v2/
choco install all --allow-unofficial --source=https://licensedpackages.chocolatey.org/api/v2/
choco install all --allow-unofficial --source=https://push.chocolatey.org/api/v2
choco install all --allow-unofficial --source="'https://community.chocolatey.org/api/v2/;"C:\packages"'"
```

Run these to validate that alternate sources fail with a notimplemented exception:
```
choco install all --allow-unofficial --source=WindowsFeatures
choco install all --allow-unofficial --source=ruby
choco install all --allow-unofficial --source=python
choco install all --allow-unofficial --source=webpi
choco install all --allow-unofficial --source=cygwin
```

Download these packages to a local folder:
- `curl` `7.81.0`
- `wget` `1.21.2`
- `iperf2` `2.0.13`
- `iperf2` `2.0.14`
- `iperf2` `2.0.14.1001-alpha20201022`

Run these commands pointing to that local folder to test the behavior of the all keyword:

Ensure that iperf 2.0.14 (i.e. not the prerelease version), wget and curl are installed:
`choco install all --allow-unofficial --source=c:\packages` 

Ensure that the prerelease iperf is installed when prerelease is specified:
`choco install all --allow-unofficial --source=c:\packages --pre` 
 
## Change Types Made

* [ ] Bug fix (non-breaking change)
* [x] Feature / Enhancement (non-breaking change)
* [ ] Breaking change (fix or feature that could cause existing functionality to change)

## Related Issue

Fixes #23

## Change Checklist

* [x] Requires a change to the documentation
* [x] Documentation has been updated
* [x] Tests to cover my changes, have been added
* [x] All new and existing tests passed.
* N/A PowerShell v2 compatibility checked.