### PR TITLE
(#2542) Adds TeamCity Build Definition

### DIFF
--- a/.teamcity/pom.xml
+++ b/.teamcity/pom.xml
@@ -1,0 +1,104 @@
+<?xml version="1.0"?>
+<project>
+  <modelVersion>4.0.0</modelVersion>
+  <name>Chocolatey Config DSL Script</name>
+  <groupId>Chocolatey</groupId>
+  <artifactId>Chocolatey_dsl</artifactId>
+  <version>1.0-SNAPSHOT</version>
+
+  <parent>
+    <groupId>org.jetbrains.teamcity</groupId>
+    <artifactId>configs-dsl-kotlin-parent</artifactId>
+    <version>1.0-SNAPSHOT</version>
+  </parent>
+
+  <repositories>
+    <repository>
+      <id>jetbrains-all</id>
+      <url>https://download.jetbrains.com/teamcity-repository</url>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+    </repository>
+    <repository>
+      <id>teamcity-server</id>
+      <url>https://teamcityserver/app/dsl-plugins-repository</url>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+    </repository>
+  </repositories>
+
+  <pluginRepositories>
+    <pluginRepository>
+      <id>JetBrains</id>
+      <url>https://download.jetbrains.com/teamcity-repository</url>
+    </pluginRepository>
+  </pluginRepositories>
+
+  <build>
+    <sourceDirectory>${basedir}</sourceDirectory>
+    <plugins>
+      <plugin>
+        <artifactId>kotlin-maven-plugin</artifactId>
+        <groupId>org.jetbrains.kotlin</groupId>
+        <version>${kotlin.version}</version>
+
+        <configuration/>
+        <executions>
+          <execution>
+            <id>compile</id>
+            <phase>process-sources</phase>
+            <goals>
+              <goal>compile</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>test-compile</id>
+            <phase>process-test-sources</phase>
+            <goals>
+              <goal>test-compile</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.jetbrains.teamcity</groupId>
+        <artifactId>teamcity-configs-maven-plugin</artifactId>
+        <version>${teamcity.dsl.version}</version>
+        <configuration>
+          <format>kotlin</format>
+          <dstDir>target/generated-configs</dstDir>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.jetbrains.teamcity</groupId>
+      <artifactId>configs-dsl-kotlin</artifactId>
+      <version>${teamcity.dsl.version}</version>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jetbrains.teamcity</groupId>
+      <artifactId>configs-dsl-kotlin-plugins</artifactId>
+      <version>1.0-SNAPSHOT</version>
+      <type>pom</type>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jetbrains.kotlin</groupId>
+      <artifactId>kotlin-stdlib-jdk8</artifactId>
+      <version>${kotlin.version}</version>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jetbrains.kotlin</groupId>
+      <artifactId>kotlin-script-runtime</artifactId>
+      <version>${kotlin.version}</version>
+      <scope>compile</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -1,0 +1,101 @@
+import jetbrains.buildServer.configs.kotlin.v2019_2.*
+import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.powerShell
+import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.xmlReport
+import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.XmlReport
+import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.commitStatusPublisher
+import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.nuGetPublish
+import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.vcs
+import jetbrains.buildServer.configs.kotlin.v2019_2.vcs.GitVcsRoot
+
+/*
+The settings script is an entry point for defining a TeamCity
+project hierarchy. The script should contain a single call to the
+project() function with a Project instance or an init function as
+an argument.
+VcsRoots, BuildTypes, Templates, and subprojects can be
+registered inside the project using the vcsRoot(), buildType(),
+template(), and subProject() methods respectively.
+To debug settings scripts in command-line, run the
+    mvnDebug org.jetbrains.teamcity:teamcity-configs-maven-plugin:generate
+command and attach your debugger to the port 8000.
+To debug in IntelliJ Idea, open the 'Maven Projects' tool window (View
+-> Tool Windows -> Maven Projects), find the generate task node
+(Plugins -> teamcity-configs -> teamcity-configs:generate), the
+'Debug' option is available in the context menu for the task.
+*/
+
+version = "2021.2"
+
+project {
+    buildType(Chocolatey)
+}
+
+object Chocolatey : BuildType({
+    name = "Build"
+
+    artifactRules = "code_drop/nuget/*.nupkg"
+
+    params {
+        text("env.CHOCOLATEY_SOURCE", "https://hermes.chocolatey.org:8443/repository/choco-internal-testing/", readOnly = true, allowEmpty = false)
+        password("env.CHOCOLATEY_API_KEY", "credentialsJSON:c0c84719-2f46-595e-b40b-e545c83c8e9b", display = ParameterDisplay.HIDDEN, readOnly = true)
+    }
+
+    vcs {
+        root(DslContext.settingsRoot)
+    }
+
+    steps {
+        powerShell {
+            name = "Prerequisites"
+            scriptMode = script {
+                content = """
+                    if ((Get-WindowsFeature -Name NET-Framework-Features).InstallState -ne 'Installed') {
+                        Install-WindowsFeature -Name NET-Framework-Features
+                    }
+
+                    choco install windows-sdk-7.1 --confirm --no-progress
+                    choco install netfx-4.0.3-devpack --confirm --no-progress
+                """.trimIndent()
+            }
+        }
+
+        step {
+            name = "Include Signing Keys"
+            type = "PrepareSigningEnvironment"
+        }
+
+        powerShell {
+            name = "Build"
+            scriptMode = script {
+                content = """
+                    .\\build.official.bat -D:version.fix=%build.counter%
+                """.trimIndent()
+            }
+        }
+
+        nuGetPublish {
+            name = "Publish Packages"
+
+            conditions {
+                matches("teamcity.build.branch", "^(develop|release/.*|hotfix/.*)${'$'}")
+            }
+
+            toolPath = "%teamcity.tool.NuGet.CommandLine.DEFAULT%"
+            packages = "code_drop/nuget/*.nupkg"
+            serverUrl = "%env.CHOCOLATEY_SOURCE%"
+            apiKey = "%env.CHOCOLATEY_API_KEY%"
+        }
+    }
+
+    triggers {
+        vcs {
+        }
+    }
+
+    features {
+        xmlReport {
+            reportType = XmlReport.XmlReportType.NUNIT
+            rules = "code_drop/build_artifacts/tests/test-results.xml"
+        }
+    }
+})


### PR DESCRIPTION
# Description of Changes

This commit adds a the build definition to be used by the Chocolatey internal TeamCity servers.

It matches the current build (though using the official.bat), with the addition of optionally loading the official signing keys.

# Motivation and Context

This PR will help us transition to importing and maintaining our builds as code, and ensuring they are maintained along with the code appropriately.

# Testing

We've tested this on our internal TeamCity servers deployed via Ansible.  
To test it elsewhere, import the repository/branch containing the `.teamcity\*` files into any TeamCity instance:

1.  Go to `Create project` and select `From a repository URL`
    ![image](https://user-images.githubusercontent.com/1975761/150360589-a7e6568b-ab4a-46ed-a5e5-3f7ae12226d6.png)
1. Fill in a link to the appropriate repository URL, e.g. `https://github.com/jpruskin/choco.git`
1. Import using a branch containing the `.teamcity` files, e.g. `refs/heads/enhance/add-teamcity-build`.
1. Verify that it imports the build as expected.

NB: Without importing using Ansible, secrets will not be created so there will be 1 error present after import.

# Change Types Made

- [ ] Bug fix (non-breaking change)
- [x] Feature / Enhancement (non-breaking change)
- [ ] Breaking change (fix or feature that could cause existing functionality to change)

# Related Issue

Closes #2542