### PR TITLE
(#2546) Fix template help usage statement

### DIFF
--- a/src/chocolatey/infrastructure.app/commands/ChocolateyTemplateCommand.cs
+++ b/src/chocolatey/infrastructure.app/commands/ChocolateyTemplateCommand.cs
@@ -92,7 +92,7 @@ NOTE: Available with 0.12.0+."
 
             "chocolatey".Log().Info(ChocolateyLoggers.Important, "Usage");
             "chocolatey".Log().Info(@"
-    choco pin [list]|info [<options/switches>]");
+    choco template [list]|info [<options/switches>]");
 
             "chocolatey".Log().Info(ChocolateyLoggers.Important, "Examples");
             "chocolatey".Log().Info(@"


### PR DESCRIPTION
This fixes #2546 and adds the correct command to the usage statement.
