### PR TITLE
(maint) Fixes TeamCity Signing in UppercuT

### DIFF
--- a/.build.custom/codeSign.step
+++ b/.build.custom/codeSign.step
@@ -26,7 +26,7 @@
   </target>
 
   <target name="get_password" if="${property::exists('path.code.cert.password')}">
-    <loadfile file="${path.code.cert.password}" property="code.cert.password" if="${file::exists(path.code.cert.password)}" />
+    <loadfile file="${path.code.cert.password}" property="code.cert.password" if="${not run.teamcity and file::exists(path.code.cert.password)}" />
     <property name="code.cert.password" value="${string::trim(code.cert.password)}" />
   </target>
 
@@ -34,40 +34,41 @@
 C:\Program Files (x86)\Microsoft SDKs\Windows\v7.0A\Bin\signtool.exe sign /t http://timestamp.digicert.com /fd SHA1 /f %CHOCOLATEY_OFFICIAL_CERT% /p [INSERT] /a "code_drop\chocolatey\console\choco.exe"
 -->
 
-  <target name="sign_assemblies" description="Signs the final assembly prior to packaging it up." if="${file::exists(app.signtool) and property::exists('path.code.cert')}">
+  <target name="sign_assemblies" description="Signs the final assembly prior to packaging it up." if="${file::exists(app.signtool) and msbuild.configuration == 'ReleaseOfficial'}">
+    <property name="app.choco.nuget" value="${dirs.drop.nuget}${path.separator}chocolatey${path.separator}tools${path.separator}chocolateyInstall${path.separator}choco.exe" />
+    <property name="lib.choco.nuget" value="${dirs.drop.nuget}${path.separator}chocolatey.lib${path.separator}lib${path.separator}chocolatey.dll" />
+    <property name="code.signing.args" value='/f "${path.code.cert}" /p "${code.cert.password}"' if="${property::exists('path.code.cert') and property::exists('code.cert.password')}" />
+    <property name="code.signing.args" value='/sm /n "${code.cert.subjectname}"' if="${run.teamcity}" />
+
     <echo level="Warning" message="Signing the assemblies using ${app.signtool}." />
     <property name="app.choco" value="${dirs.drop}${path.separator}chocolatey${path.separator}console${path.separator}choco.exe" />
     <property name="lib.choco" value="${dirs.drop}${path.separator}chocolatey${path.separator}lib${path.separator}chocolatey.dll" />
 
-    <echo message='"${app.signtool}" sign /t "${code.cert.timestampserver}" /fd ${code.cert.algorithm} /f ${path.code.cert} /p [REDACTED] /a "${app.choco}"' />
     <exec
       program="${app.signtool}"
-      commandline='sign /t "${code.cert.timestampserver}" /fd ${code.cert.algorithm} /f ${path.code.cert} /p ${code.cert.password} /a "${app.choco}"'
-      if="${file::exists(app.signtool) and file::exists(path.code.cert)}"
+      commandline='sign /t "${code.cert.timestampserver}" /fd ${code.cert.algorithm} ${code.signing.args} /a "${app.choco}"'
+      if="${file::exists(app.signtool) and property::exists('code.signing.args')}"
       failonerror="true"
     />
 
     <exec
       program="${app.signtool}"
-      commandline='sign /t "${code.cert.timestampserver}" /fd ${code.cert.algorithm} /f ${path.code.cert} /p ${code.cert.password} /a "${lib.choco}"'
-      if="${file::exists(app.signtool) and file::exists(path.code.cert)}"
-      failonerror="true"
-    />
-
-    <property name="app.choco.nuget" value="${dirs.drop.nuget}${path.separator}chocolatey${path.separator}tools${path.separator}chocolateyInstall${path.separator}choco.exe" />
-    <property name="lib.choco.nuget" value="${dirs.drop.nuget}${path.separator}chocolatey.lib${path.separator}lib${path.separator}chocolatey.dll" />
-
-    <exec
-      program="${app.signtool}"
-      commandline='sign /t "${code.cert.timestampserver}" /fd ${code.cert.algorithm} /f ${path.code.cert} /p ${code.cert.password} /a "${app.choco.nuget}"'
-      if="${file::exists(app.signtool) and file::exists(path.code.cert) and run.nuget}"
+      commandline='sign /t "${code.cert.timestampserver}" /fd ${code.cert.algorithm} ${code.signing.args} /a "${lib.choco}"'
+      if="${file::exists(app.signtool) and property::exists('code.signing.args')}"
       failonerror="true"
     />
 
     <exec
       program="${app.signtool}"
-      commandline='sign /t "${code.cert.timestampserver}" /fd ${code.cert.algorithm} /f ${path.code.cert} /p ${code.cert.password} /a "${lib.choco.nuget}"'
-      if="${file::exists(app.signtool) and file::exists(path.code.cert) and run.nuget}"
+      commandline='sign /t "${code.cert.timestampserver}" /fd ${code.cert.algorithm} ${code.signing.args} /a "${app.choco.nuget}"'
+      if="${file::exists(app.signtool) and property::exists('code.signing.args') and run.nuget}"
+      failonerror="true"
+    />
+
+    <exec
+      program="${app.signtool}"
+      commandline='sign /t "${code.cert.timestampserver}" /fd ${code.cert.algorithm} ${code.signing.args} /a "${lib.choco.nuget}"'
+      if="${file::exists(app.signtool) and property::exists('code.signing.args') and run.nuget}"
       failonerror="true"
     />
 
@@ -80,8 +81,8 @@ C:\Program Files (x86)\Microsoft SDKs\Windows\v7.0A\Bin\signtool.exe sign /t htt
       <do>
         <exec
           program="${app.signtool}"
-          commandline='sign /t "${code.cert.timestampserver}" /fd ${code.cert.algorithm} /f ${path.code.cert} /p ${code.cert.password} /a "${shim.filename}"'
-          if="${file::exists(app.signtool) and file::exists(path.code.cert) and run.nuget}"
+          commandline='sign /t "${code.cert.timestampserver}" /fd ${code.cert.algorithm} ${code.signing.args} /a "${shim.filename}"'
+          if="${file::exists(app.signtool) and property::exists('code.signing.args') and run.nuget}"
           failonerror="true"
         />
       </do>
@@ -98,8 +99,8 @@ C:\Program Files (x86)\Microsoft SDKs\Windows\v7.0A\Bin\signtool.exe sign /t htt
       <do>
         <exec
           program="${app.signtool}"
-          commandline='sign /t "${code.cert.timestampserver}" /fd ${code.cert.algorithm} /f ${path.code.cert} /p ${code.cert.password} /a "${tools.filename}"'
-          if="${file::exists(app.signtool) and file::exists(path.code.cert) and run.nuget}"
+          commandline='sign /t "${code.cert.timestampserver}" /fd ${code.cert.algorithm} ${code.signing.args} /a "${tools.filename}"'
+          if="${file::exists(app.signtool) and property::exists('code.signing.args') and run.nuget}"
           failonerror="true"
         />
       </do>
@@ -113,7 +114,7 @@ $cert = New-Object System.Security.Cryptography.X509Certificates.X509Certificate
 Set-AuthenticodeSignature -Filepath @("C:\ProgramData\chocolatey\helpers\chocolateyInstaller.psm1","C:\ProgramData\chocolatey\helpers\chocolateyProfile.psm1") -Cert $cert -TimeStampServer "http://timestamp.digicert.com" -IncludeChain NotRoot -HashAlgorithm SHA256
 -->
 
-  <target name="sign_powershell_files" description="Signs the final PowerShell files prior to packaging them up." if="${file::exists(app.powershell) and property::exists('path.code.cert')}">
+  <target name="sign_powershell_files" description="Signs the final PowerShell files prior to packaging them up." if="${file::exists(app.powershell) and msbuild.configuration == 'ReleaseOfficial'}">
     <echo level="Warning" message="Signing the PowerShell files." />
     <property name="apostrophe" value="'" />
     <property name="powershell.filenames" value="remove" />
@@ -133,11 +134,22 @@ Set-AuthenticodeSignature -Filepath @("C:\ProgramData\chocolatey\helpers\chocola
 
     <echo message="Signing PowerShell files - @(${powershell.filenames})" />
 
-    <exec
-      program="${app.powershell}"
-      commandline="$cert = New-Object System.Security.Cryptography.X509Certificates.X509Certificate2('${path.code.cert}', '${code.cert.password}'); Set-AuthenticodeSignature -Filepath @(${powershell.filenames}) -Cert $cert -TimeStampServer '${code.cert.timestampserver}' -IncludeChain NotRoot -HashAlgorithm SHA256"
-      if="${file::exists(app.powershell) and string::contains(powershell.filenames,',') and file::exists(path.code.cert) and run.nuget}"
-      failonerror="true"
-    />
+    <if test="${property::exists('path.code.cert')}">
+      <exec
+        program="${app.powershell}"
+        commandline="$cert = New-Object System.Security.Cryptography.X509Certificates.X509Certificate2('${path.code.cert}', '${code.cert.password}'); Set-AuthenticodeSignature -Filepath @(${powershell.filenames}) -Cert $cert -TimeStampServer '${code.cert.timestampserver}' -IncludeChain NotRoot -HashAlgorithm SHA256"
+        if="${file::exists(app.powershell) and string::contains(powershell.filenames,',') and file::exists(path.code.cert) and run.nuget}"
+        failonerror="true"
+      />
+    </if>
+
+    <if test="${run.teamcity}">
+      <exec
+        program="${app.powershell}"
+        commandline="$cert = Get-ChildItem Cert:\LocalMachine\My | Where-Object Subject -like '*${code.cert.subjectname}*' ; Set-AuthenticodeSignature -Filepath @(${powershell.filenames}) -Cert $cert -TimeStampServer '${code.cert.timestampserver}' -IncludeChain NotRoot -HashAlgorithm SHA256"
+        if="${file::exists(app.powershell) and string::contains(powershell.filenames,',') and run.nuget}"
+        failonerror="true"
+      />
+    </if>
   </target>
 </project>

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -1,4 +1,5 @@
 import jetbrains.buildServer.configs.kotlin.v2019_2.*
+import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.script
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.powerShell
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.xmlReport
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.XmlReport
@@ -53,8 +54,8 @@ object Chocolatey : BuildType({
                         Install-WindowsFeature -Name NET-Framework-Features
                     }
 
-                    choco install windows-sdk-7.1 --confirm --no-progress
-                    choco install netfx-4.0.3-devpack --confirm --no-progress
+                    choco install windows-sdk-7.1 netfx-4.0.3-devpack --confirm --no-progress
+                    exit ${'$'}LastExitCode
                 """.trimIndent()
             }
         }
@@ -64,13 +65,9 @@ object Chocolatey : BuildType({
             type = "PrepareSigningEnvironment"
         }
 
-        powerShell {
-            name = "Build"
-            scriptMode = script {
-                content = """
-                    .\\build.official.bat -D:version.fix=%build.counter%
-                """.trimIndent()
-            }
+        script {
+            name = "Call UppercuT"
+            scriptContent = "call build.official.bat -D:version.fix=%build.counter%"
         }
 
         nuGetPublish {

--- a/.uppercut
+++ b/.uppercut
@@ -58,9 +58,12 @@
 
   <property name="app.signtool" value="C:${path.separator}Program Files${path.separator}Microsoft SDKs${path.separator}Windows${path.separator}v7.0A${path.separator}Bin${path.separator}signtool.exe" />
   <property name="app.signtool" value="C:${path.separator}Program Files (x86)${path.separator}Microsoft SDKs${path.separator}Windows${path.separator}v7.0A${path.separator}Bin${path.separator}signtool.exe" if="${not file::exists(app.signtool)}" />
+  <property name="app.signtool" value="C:${path.separator}Program Files${path.separator}Microsoft SDKs${path.separator}Windows${path.separator}v7.1${path.separator}Bin${path.separator}signtool.exe" if="${not file::exists(app.signtool)}" />
   <property name="path.code.cert" value="${environment::get-variable('CHOCOLATEY_OFFICIAL_CERT')}" if="${environment::variable-exists('CHOCOLATEY_OFFICIAL_CERT')}" />
   <property name="path.code.cert.password" value="${environment::get-variable('CHOCOLATEY_OFFICIAL_CERT_PASSWORD')}" if="${environment::variable-exists('CHOCOLATEY_OFFICIAL_CERT_PASSWORD')}" />
   <property name="code.cert.timestampserver" value="http://timestamp.digicert.com" />
+  <property name="code.cert.subjectname" value="Chocolatey Software, Inc." />
+  <property name="run.teamcity" value="${environment::variable-exists('TEAMCITY_VERSION') and msbuild.configuration == 'ReleaseOfficial'}" overwrite="false" />
   <!-- When Windows 2003 is no longer supported, switch to SHA256 -->
   <property name="code.cert.algorithm" value="SHA1" />
 


### PR DESCRIPTION
There was an issue with using `signtool.exe` during the TeamCity build

This PR fixes the UppercuT build to work with signing in our environment by:

- Adding a property to be able to pass in the certificate subject name
- Adding a property to track if the build is running in TeamCity or not
- Adding a third potential path to signtool.exe, in the Windows SDK 7.1 folder
- Adding logic to use a certificate stored in the local machine store if running in TeamCity

It also adds better handling for failure during the build.
