### PR TITLE
(maint) Add NUnitTestAdapter nuget package

### DIFF
--- a/src/chocolatey.tests.integration/packages.config
+++ b/src/chocolatey.tests.integration/packages.config
@@ -5,6 +5,7 @@
   <package id="Microsoft.Web.Xdt" version="2.1.1" targetFramework="net40" />
   <package id="Moq" version="4.2.1402.2112" targetFramework="net40" />
   <package id="NUnit" version="2.6.4" targetFramework="net40" />
+  <package id="NUnitTestAdapter" version="2.3.0" targetFramework="net40" />
   <package id="Rx-Core" version="2.1.30214.0" targetFramework="net40" />
   <package id="Rx-Interfaces" version="2.1.30214.0" targetFramework="net40" />
   <package id="Rx-Linq" version="2.1.30214.0" targetFramework="net40" />

--- a/src/chocolatey.tests/infrastructure.app/configuration/ConfigurationOptionsSpec.cs
+++ b/src/chocolatey.tests/infrastructure.app/configuration/ConfigurationOptionsSpec.cs
@@ -67,6 +67,7 @@ namespace chocolatey.tests.infrastructure.app.configuration
                 validateConfiguration = () => { };
                 helpMessage = () => { };
                 helpMessageContents.Clear();
+                ConfigurationOptions.reset_options();
             }
         }
 

--- a/src/chocolatey.tests/packages.config
+++ b/src/chocolatey.tests/packages.config
@@ -4,6 +4,7 @@
   <package id="Microsoft.Web.Xdt" version="2.1.1" targetFramework="net40" />
   <package id="Moq" version="4.2.1402.2112" targetFramework="net40" />
   <package id="NUnit" version="2.6.4" targetFramework="net40" />
+  <package id="NUnitTestAdapter" version="2.3.0" targetFramework="net40" />
   <package id="Should" version="1.1.12.0" />
   <package id="SimpleInjector" version="2.5.0" targetFramework="net40" />
   <package id="TinySpec.NUnit" version="0.9.5" />


### PR DESCRIPTION
## Description Of Changes

Adds the NUnitTestAdapter nuget package to the chocolatey.tests and chocolatey.tests.integration projects.

## Motivation and Context

The NUnit test adapter extension does not work with VisualStudio 2022
and will not be updated to work it. The recommended alternative is to
use the nuget package instead of the extension. This PR adds the nuget
package to the packages.config for the test projects, so the tests can
be run directly in VisualStudio 2022.

## Testing

- Open up this PR in Visual Studio 2022
- Attempt to run the choco unit and integration tests from the test explorer
- They should run

## Change Types Made

* [ ] Bug fix (non-breaking change)
* [x] Feature / Enhancement (non-breaking change)
* [ ] Breaking change (fix or feature that could cause existing functionality to change)

## Related Issue

Depends on #2530

## Change Checklist

* [ ] Requires a change to the documentation
* [ ] Documentation has been updated
N/A Tests to cover my changes, have been added
* [x] All new and existing tests passed.
N/A PowerShell v2 compatibility checked.