### PR TITLE
(build) Updates TeamCity BuildNumber

### DIFF
--- a/.build/nugetBuild.step
+++ b/.build/nugetBuild.step
@@ -45,6 +45,7 @@
     <property name="nuget.version" value="${nuget.version + '-' + version.fix}" if="${version.fix != '0' and version.use.build_date}" />
     <!-- version.use.build_date -->
     <echo level="Warning" message="Using ${nuget.version} as the version for the nuget package(s)." />
+    <echo level="Warning" message="##teamcity[buildNumber '${nuget.version}']" if="${run.teamcity}" />
   </target>
 
   <target name="build_nugget">


### PR DESCRIPTION
A very minor update to the UppercuT steps to use the artifact version as the build number, which allows us to have a far more user-friendly experience when finding linked builds / artifacts in our systems.

Please note that though this shows as `level="Warning"` it doesn't appear in the build logs - but needs to be at that level, otherwise TeamCity won't consume it.

This has been shown to work on the dev and local build server(s), and in the Licensed builds.