### PR TITLE
(#2540) Python source disable all keyword on upgrade

### DIFF
--- a/src/chocolatey/infrastructure.app/services/PythonService.cs
+++ b/src/chocolatey/infrastructure.app/services/PythonService.cs
@@ -1,13 +1,13 @@
 ﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
-// 
+//
 // You may obtain a copy of the License at
-// 
+//
 // 	http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -233,7 +233,7 @@ namespace chocolatey.infrastructure.app.services
                     return;
                 }
             }
-            
+
             var topLevelPath = string.Empty;
             var python34PathKey = _registryService.get_key(RegistryHive.LocalMachine, "SOFTWARE\\Python\\PythonCore\\3.4\\InstallPath");
             if (python34PathKey != null)
@@ -248,7 +248,7 @@ namespace chocolatey.infrastructure.app.services
                     topLevelPath = python27PathKey.GetValue("", string.Empty).to_string();
                 }
             }
-            
+
             if (string.IsNullOrWhiteSpace(topLevelPath))
             {
                 var binRoot = Environment.GetEnvironmentVariable("ChocolateyBinRoot");
@@ -262,7 +262,7 @@ namespace chocolatey.infrastructure.app.services
             {
                 _exePath = pipPath;
             }
-            
+
             if (string.IsNullOrWhiteSpace(_exePath)) throw new FileNotFoundException("Unable to find pip");
         }
 

--- a/src/chocolatey/infrastructure.app/services/PythonService.cs
+++ b/src/chocolatey/infrastructure.app/services/PythonService.cs
@@ -413,6 +413,11 @@ namespace chocolatey.infrastructure.app.services
 
         public ConcurrentDictionary<string, PackageResult> upgrade_run(ChocolateyConfiguration config, Action<PackageResult> continueAction, Action<PackageResult> beforeUpgradeAction = null)
         {
+            if (config.PackageNames.is_equal_to(ApplicationParameters.AllPackages))
+            {
+                throw new NotImplementedException("The all keyword is not available for alternate sources");
+            }
+
             set_executable_path_if_not_set();
             var args = build_args(config, _upgradeArguments);
             var packageResults = new ConcurrentDictionary<string, PackageResult>(StringComparer.InvariantCultureIgnoreCase);


### PR DESCRIPTION
## Description Of Changes

This throws an exception if the all keyword is used on the python
alternate source for the upgrade command.

## Motivation and Context

On normal nuget sources, the
all keyword will upgrade all installed packages. However, on the python
source, it will try to upgrade a package named "all", which provides a
confusing error message for a user expecting all installed python
packages to be upgraded. This provides an explicit error message
explaining that the all keyword is not supported.

The other alternate sources do not require this, as they do not
implement upgrade at all.

## Testing

Run `choco upgrade all --source=python` and ensure that it throws the exception
Run `choco upgrade wheel --source=python` and ensure that it does not throw the exception

## Change Types Made

* [ ] Bug fix (non-breaking change)
* [x] Feature / Enhancement (non-breaking change)
* [ ] Breaking change (fix or feature that could cause existing functionality to change)

## Related Issue

Fixes #2540

## Change Checklist

* [ ] Requires a change to the documentation
* [ ] Documentation has been updated
* [ ] Tests to cover my changes, have been added
* [ ] All new and existing tests passed.
* [ ] PowerShell v2 compatibility checked.
