### PR TITLE
(#2407) Update licensed assembly not found warning

### DIFF
--- a/src/chocolatey/infrastructure/licensing/License.cs
+++ b/src/chocolatey/infrastructure/licensing/License.cs
@@ -50,22 +50,15 @@ namespace chocolatey.infrastructure.licensing
                 catch (Exception ex)
                 {
                     "chocolatey".Log().Error(
-@"Error when attempting to load chocolatey licensed assembly. Ensure
- that chocolatey.licensed.dll exists at
- '{0}'.
- The error message itself may be helpful:{1} {2}".format_with(
-                    ApplicationParameters.LicensedAssemblyLocation,
-                    Environment.NewLine,
-                    ex.Message
-                    ));
-                    "chocolatey".Log().Warn(ChocolateyLoggers.Important,@" Install the Chocolatey Licensed Extension package with
- `choco install chocolatey.extension` to remove this license warning.
- TRIALS: If you have a trial license, you cannot use the above command
- as is and be successful. You need to download nupkgs from the links in
- the trial email as your license will not be registered on the licensed
- repository. Please reference
- https://docs.chocolatey.org/en-us/licensed-extension/setup#how-do-i-install-the-trial-edition
- for specific instructions.");
+                        @"A valid Chocolatey license was found, but the chocolatey.licensed.dll assembly could not be loaded:
+  {0}
+Ensure that the chocolatey.licensed.dll exists at the following path:
+ '{1}'".format_with(ex.Message, ApplicationParameters.LicensedAssemblyLocation));
+
+                    "chocolatey".Log().Warn(
+                        ChocolateyLoggers.Important,
+                        @"To resolve this, install the Chocolatey Licensed Extension package with
+ `choco install chocolatey.extension`");
                 }
             }
 


### PR DESCRIPTION
## Description Of Changes

Removed mention of trials not being able to install the extension in the normal way (this is no longer the case), and clarified the error and warning a little more succinctly.

## Motivation and Context

The error message is outdated and gives trial customers the wrong information, as well as linking to docs that now contradict the error message.

## Testing

1. Build and run/install the `choco` from the repo
2. Add a valid `chocolatey.license.xml` without installing `chocolatey.extension`
3. Run `choco list -lo` (or any other `choco` command)
4. Note the error message and warning emitted when the chocolatey.licensed.dll cannot be found

## Change Types Made
<!-- Tick the boxes for the type of changes that have been made -->

* [x] Bug fix (non-breaking change)
* [ ] Feature / Enhancement (non-breaking change)
* [ ] Breaking change (fix or feature that could cause existing functionality to change)
* [ ] PowerShell code changes.

## Related Issue

Fixes #2407

## Change Checklist

* [ ] Requires a change to the documentation
* [x] Documentation has been updated
* [ ] Tests to cover my changes, have been added
* [ ] All new and existing tests passed.
* [ ] PowerShell v2 compatibility checked.

<!-- PLEASE REMOVE ALL COMMENTS BEFORE SUBMITTING -->
