### PR TITLE
(#2545) Adds Clarity to List Command Help

### DIFF
--- a/src/chocolatey/infrastructure.app/commands/ChocolateyListCommand.cs
+++ b/src/chocolatey/infrastructure.app/commands/ChocolateyListCommand.cs
@@ -46,7 +46,8 @@ namespace chocolatey.infrastructure.app.commands
                      "Source - Source location for install. Can use special 'webpi' or 'windowsfeatures' sources. Defaults to sources.",
                      option => configuration.Sources = option.remove_surrounding_quotes())
                 .Add("l|lo|local|localonly|local-only",
-                     "LocalOnly - Only search against local machine items.",
+                     "LocalOnly - Only search against local machine items. Ignores --source if provided.",
+
                      option => configuration.ListCommand.LocalOnly = option != null)
                 .Add("idonly|id-only",
                      "Id Only - Only return Package Ids in the list results. Available in 0.10.6+.",


### PR DESCRIPTION
## Description of Changes

This PR adds some clarity to the `choco list` command help.

## Motivation and Context

There was confusion around `choco list --local-only` and if it supported `--source` (see issue #2545). This addition to the help line for `--local-only` makes it clearer that searching your local machine won't filter further by source. Given that this is the line after the help output for `--source` it seemed like it didn't need to be clarified there.

## Related Issue

Fixes #2545

## Notes

I worry that it's a little terse, but any further words seemed to add potential confusion. Happy to modify it as folk prefer.

Please note that this won't show up in docs until the docs are regenerated and pushed.

