### PR TITLE
(maint) Remove todo comment about resealing commands

### DIFF
--- a/src/chocolatey/infrastructure.app/commands/ChocolateyUpgradeCommand.cs
+++ b/src/chocolatey/infrastructure.app/commands/ChocolateyUpgradeCommand.cs
@@ -29,8 +29,6 @@ namespace chocolatey.infrastructure.app.commands
     [CommandFor("upgrade", "upgrades packages from various sources")]
     public class ChocolateyUpgradeCommand : ICommand
     {
-        //todo v1 Deprecation reseal this class and remove virtuals
-
         private readonly IChocolateyPackageService _packageService;
 
         public ChocolateyUpgradeCommand(IChocolateyPackageService packageService)


### PR DESCRIPTION
This pull request removes the todo comment about resealing the upgrade
command.
This is removed due to our usage in Chocolatey Licensed Extension
means that we can not reseal the command without breaking
the Licensed Extension, or doing major rework of the Extension
to allow it to happen.
