### PR TITLE
(#1310) List remembered arguments

### DIFF
--- a/src/chocolatey.tests.integration/scenarios/ListScenarios.cs
+++ b/src/chocolatey.tests.integration/scenarios/ListScenarios.cs
@@ -21,6 +21,7 @@ using chocolatey.infrastructure.results;
 using NuGet.Configuration;
 using FluentAssertions;
 using FluentAssertions.Execution;
+using NUnit.Framework;
 
 namespace chocolatey.tests.integration.scenarios
 {
@@ -140,7 +141,10 @@ namespace chocolatey.tests.integration.scenarios
                 MockLogger.ContainsMessage("upgradepackage|1.0.0").Should().BeTrue();
             }
 
+            // Windows only because decryption fallback on Mac/Linux logs a message
             [Fact]
+            [WindowsOnly]
+            [Platform(Exclude = "Mono")]
             public void Should_only_have_messages_related_to_package_information()
             {
                 MockLogger.Messages.Should()

--- a/src/chocolatey/infrastructure.app/services/NugetService.cs
+++ b/src/chocolatey/infrastructure.app/services/NugetService.cs
@@ -192,6 +192,7 @@ that uses these options.");
             foreach (var pkg in NugetList.GetPackages(config, _nugetLogger, _fileSystem))
             {
                 var package = pkg; // for lamda access
+                string packageArgumentsUnencrypted = null;
 
                 ChocolateyPackageMetadata packageLocalMetadata;
                 string packageInstallLocation = null;
@@ -218,6 +219,10 @@ that uses these options.");
                     }
 
                     deploymentLocation = packageInfo.DeploymentLocation;
+                    if (!string.IsNullOrWhiteSpace(packageInfo.Arguments))
+                    {
+                        packageArgumentsUnencrypted = "\n Remembered Package Arguments: " + (packageInfo.Arguments.ContainsSafe(" --") && packageInfo.Arguments.ToStringSafe().Length > 4 ? packageInfo.Arguments : NugetEncryptionUtility.DecryptString(packageInfo.Arguments));
+                    }
                 }
 
                 if (!config.QuietOutput)
@@ -244,7 +249,7 @@ that uses these options.");
  Tags: {9}
  Software Site: {10}
  Software License: {11}{12}{13}{14}{15}{16}
- Description: {17}{18}{19}
+ Description: {17}{18}{19}{20}
 ".FormatWith(
                                 package.Title.EscapeCurlyBraces(),
                                 package.Published.GetValueOrDefault().UtcDateTime.ToShortDateString(),
@@ -279,7 +284,8 @@ that uses these options.");
                                 package.Summary != null && !string.IsNullOrWhiteSpace(package.Summary.ToStringSafe()) ? "\r\n Summary: {0}".FormatWith(package.Summary.EscapeCurlyBraces().ToStringSafe()) : string.Empty,
                                 package.Description.EscapeCurlyBraces().Replace("\n    ", "\n").Replace("\n", "\n  "),
                                 !string.IsNullOrWhiteSpace(package.ReleaseNotes.ToStringSafe()) ? "{0} Release Notes: {1}".FormatWith(Environment.NewLine, package.ReleaseNotes.EscapeCurlyBraces().Replace("\n    ", "\n").Replace("\n", "\n  ")) : string.Empty,
-                                !string.IsNullOrWhiteSpace(deploymentLocation) ? "{0} Deployed to: '{1}'".FormatWith(Environment.NewLine, deploymentLocation) : string.Empty
+                                !string.IsNullOrWhiteSpace(deploymentLocation) ? "{0} Deployed to: '{1}'".FormatWith(Environment.NewLine, deploymentLocation) : string.Empty,
+                                packageArgumentsUnencrypted != null ? packageArgumentsUnencrypted : string.Empty
                             ));
                         }
                     }

--- a/src/chocolatey/infrastructure.app/services/NugetService.cs
+++ b/src/chocolatey/infrastructure.app/services/NugetService.cs
@@ -221,7 +221,9 @@ that uses these options.");
                     deploymentLocation = packageInfo.DeploymentLocation;
                     if (!string.IsNullOrWhiteSpace(packageInfo.Arguments))
                     {
-                        packageArgumentsUnencrypted = "\n Remembered Package Arguments: " + (packageInfo.Arguments.ContainsSafe(" --") && packageInfo.Arguments.ToStringSafe().Length > 4 ? packageInfo.Arguments : NugetEncryptionUtility.DecryptString(packageInfo.Arguments));
+                        var decryptedArguments = ArgumentsUtility.DecryptPackageArgumentsFile(_fileSystem, packageInfo.Package.Id, packageInfo.Package.Version.ToNormalizedStringChecked());
+
+                        packageArgumentsUnencrypted = "\n Remembered Package Arguments: \n  {0}".FormatWith(string.Join(Environment.NewLine + "  ", decryptedArguments));
                     }
                 }
 


### PR DESCRIPTION
## Description Of Changes

This adds the listing of remembered arguments to the list/info commands
It only grabs the arguments when --local-only is specified, then
decrypts and outputs them. Requires --verbose to be listed on the
command line.

## Motivation and Context

If `useRememberedArgumentsForUpgrades` is enabled, it is useful to know what argument are remembered.

## Testing

1. Install some packages, like `.\choco install iperf2 --pre --ia="argument" --params="/param"` and `.\choco install wget --params="/param"`
1. Run `.\choco.exe list --verbose` and check that the remembered arguments are listed.
1. Run `.\choco.exe info iperf2 --local-only` and check that the remembered arguments are listed.
1. Run `.\choco.exe info iperf2` and check that the remembered argument are NOT listed.

## Change Types Made

* [ ] Bug fix (non-breaking change)
* [x] Feature / Enhancement (non-breaking change)
* [ ] Breaking change (fix or feature that could cause existing functionality to change)

## Related Issue

Fixes #1310

## Change Checklist

* [ ] Requires a change to the documentation
* [ ] Documentation has been updated
* [ ] Tests to cover my changes, have been added
* [ ] All new and existing tests passed.
* N/A PowerShell v2 compatibility checked.