### PR TITLE
(#2538) Store a list of supported features

### DIFF
--- a/src/chocolatey.tests/chocolatey.tests.csproj
+++ b/src/chocolatey.tests/chocolatey.tests.csproj
@@ -109,6 +109,7 @@
     <Compile Include="infrastructure.app\configuration\ConfigurationOptionsSpec.cs" />
     <Compile Include="infrastructure.app\nuget\NugetCommonSpecs.cs" />
     <Compile Include="infrastructure.app\services\AutomaticUninstallerServiceSpecs.cs" />
+    <Compile Include="infrastructure.app\services\ChocolateyConfigSettingsServiceSpecs.cs" />
     <Compile Include="infrastructure.app\services\ChocolateyPackageServiceSpecs.cs" />
     <Compile Include="infrastructure.app\services\FilesServiceSpecs.cs" />
     <Compile Include="infrastructure.app\services\NugetServiceSpecs.cs" />

--- a/src/chocolatey.tests/infrastructure.app/services/ChocolateyConfigSettingsServiceSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/services/ChocolateyConfigSettingsServiceSpecs.cs
@@ -1,0 +1,321 @@
+﻿namespace chocolatey.tests.integration.infrastructure.app.services
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using chocolatey.infrastructure.app;
+    using chocolatey.infrastructure.app.configuration;
+    using chocolatey.infrastructure.app.services;
+    using chocolatey.infrastructure.services;
+    using Moq;
+    using Should;
+    using Assert = Should.Core.Assertions.Assert;
+
+    public class ChocolateyConfigSettingsServiceSpecs
+    {
+        public abstract class ChocolateyConfigSettingsServiceSpecsBase : TinySpec
+        {
+            protected ChocolateyConfigSettingsService Service;
+            protected readonly Mock<IXmlService> XmlService = new Mock<IXmlService>();
+
+            public override void Context()
+            {
+                XmlService.ResetCalls();
+            }
+        }
+
+        public class when_ChocolateyConfigSettingsService_disables_available_feature : ChocolateyConfigSettingsServiceSpecsBase
+        {
+            public override void Because()
+            {
+                var config = new ChocolateyConfiguration()
+                {
+                    FeatureCommand = new FeatureCommandConfiguration()
+                    {
+                        Name = ApplicationParameters.Features.ChecksumFiles
+                    }
+                };
+
+                Service.feature_disable(config);
+            }
+
+            public override void Context()
+            {
+                base.Context();
+
+                XmlService.Setup(x => x.deserialize<ConfigFileSettings>(ApplicationParameters.GlobalConfigFileLocation))
+                    .Returns(new ConfigFileSettings
+                    {
+                        Features = new HashSet<ConfigFileFeatureSetting>()
+                        {
+                            new ConfigFileFeatureSetting()
+                            {
+                                Name = ApplicationParameters.Features.ChecksumFiles
+                            }
+                        }
+                    });
+
+                Service = new ChocolateyConfigSettingsService(XmlService.Object);
+            }
+
+            [Fact]
+            public void should_not_report_feature_being_unsupported()
+            {
+                MockLogger.Messages["Warn"].ShouldNotContain("Feature '{0}' is not supported. Any change have no effect on running Chocolatey.".format_with(ApplicationParameters.Features.ChecksumFiles));
+            }
+
+            [Fact]
+            public void should_report_feature_being_disabled()
+            {
+                MockLogger.Messages.Keys.ShouldContain("Warn");
+                MockLogger.Messages["Warn"].ShouldContain("Disabled {0}".format_with(ApplicationParameters.Features.ChecksumFiles));
+            }
+
+            [Fact]
+            public void should_serialize_feature_correctly()
+            {
+                XmlService.Verify(x => x.serialize(It.Is<ConfigFileSettings>(config =>
+                    config.Features.Any(f =>
+                        f.Name == ApplicationParameters.Features.ChecksumFiles && f.SetExplicitly && !f.Enabled)), ApplicationParameters.GlobalConfigFileLocation), Times.Once);
+            }
+        }
+
+        public class when_ChocolateyConfigSettingsService_disables_unknown_feature : ChocolateyConfigSettingsServiceSpecsBase
+        {
+            public override void Because()
+            {
+            }
+
+            public override void Context()
+            {
+                base.Context();
+
+                XmlService.Setup(x => x.deserialize<ConfigFileSettings>(ApplicationParameters.GlobalConfigFileLocation))
+                    .Returns(new ConfigFileSettings
+                    {
+                        Features = new HashSet<ConfigFileFeatureSetting>()
+                    });
+
+                Service = new ChocolateyConfigSettingsService(XmlService.Object);
+            }
+
+            [Fact]
+            public void should_not_contain_any_warnings()
+            {
+                MockLogger.Messages.Keys.ShouldNotContain("Warn");
+            }
+
+            [Fact]
+            public void should_throw_exception_on_unknown_feature()
+            {
+                Assert.ThrowsDelegate action = () =>
+                {
+                    var config = new ChocolateyConfiguration()
+                    {
+                        FeatureCommand = new FeatureCommandConfiguration()
+                        {
+                            Name = "unknown"
+                        }
+                    };
+
+                    Service.feature_disable(config);
+                };
+
+                Assert.Throws<ApplicationException>(action)
+                    .Message.ShouldEqual("Feature 'unknown' not found");
+            }
+        }
+
+        public class when_ChocolateyConfigSettingsService_disables_unsupported_feature : ChocolateyConfigSettingsServiceSpecsBase
+        {
+            private const string FEATURE_NAME = "scriptsCheckLastExitCode";
+
+            public override void Because()
+            {
+            }
+
+            public override void Context()
+            {
+                base.Context();
+
+                XmlService.Setup(x => x.deserialize<ConfigFileSettings>(ApplicationParameters.GlobalConfigFileLocation))
+                    .Returns(new ConfigFileSettings
+                    {
+                        Features = new HashSet<ConfigFileFeatureSetting>()
+                        {
+                            new ConfigFileFeatureSetting()
+                            {
+                                Name = FEATURE_NAME
+                            }
+                        }
+                    });
+
+                Service = new ChocolateyConfigSettingsService(XmlService.Object);
+            }
+
+            [Fact]
+            public void should_throw_exception_on_unsupported_feature()
+            {
+                Assert.Throws<ApplicationException>(() =>
+                {
+                    var config = new ChocolateyConfiguration()
+                    {
+                        FeatureCommand = new FeatureCommandConfiguration()
+                        {
+                            Name = FEATURE_NAME
+                        }
+                    };
+
+                    Service.feature_disable(config);
+                }).Message.ShouldEqual("Feature '{0}' is not supported.".format_with(FEATURE_NAME));
+            }
+        }
+
+        public class when_ChocolateyConfigSettingsService_enables_available_feature : ChocolateyConfigSettingsServiceSpecsBase
+        {
+            public override void Because()
+            {
+                var config = new ChocolateyConfiguration()
+                {
+                    FeatureCommand = new FeatureCommandConfiguration()
+                    {
+                        Name = ApplicationParameters.Features.ChecksumFiles
+                    }
+                };
+
+                Service.feature_enable(config);
+            }
+
+            public override void Context()
+            {
+                base.Context();
+
+                XmlService.Setup(x => x.deserialize<ConfigFileSettings>(ApplicationParameters.GlobalConfigFileLocation))
+                    .Returns(new ConfigFileSettings
+                    {
+                        Features = new HashSet<ConfigFileFeatureSetting>()
+                        {
+                            new ConfigFileFeatureSetting()
+                            {
+                                Name = ApplicationParameters.Features.ChecksumFiles
+                            }
+                        }
+                    });
+
+                Service = new ChocolateyConfigSettingsService(XmlService.Object);
+            }
+
+            [Fact]
+            public void should_not_report_feature_being_unsupported()
+            {
+                MockLogger.Messages["Warn"].ShouldNotContain("Feature '{0}' is not supported. Any change have no effect on running Chocolatey.".format_with(ApplicationParameters.Features.ChecksumFiles));
+            }
+
+            [Fact]
+            public void should_report_feature_being_enabled()
+            {
+                MockLogger.Messages.Keys.ShouldContain("Warn");
+                MockLogger.Messages["Warn"].ShouldContain("Enabled {0}".format_with(ApplicationParameters.Features.ChecksumFiles));
+            }
+
+            [Fact]
+            public void should_serialize_feature_correctly()
+            {
+                XmlService.Verify(x => x.serialize(It.Is<ConfigFileSettings>(config =>
+                    config.Features.Any(f =>
+                        f.Name == ApplicationParameters.Features.ChecksumFiles && f.SetExplicitly && f.Enabled)), ApplicationParameters.GlobalConfigFileLocation), Times.Once);
+            }
+        }
+
+        public class when_ChocolateyConfigSettingsService_enables_unknown_feature : ChocolateyConfigSettingsServiceSpecsBase
+        {
+            public override void Because()
+            {
+            }
+
+            public override void Context()
+            {
+                base.Context();
+
+                XmlService.Setup(x => x.deserialize<ConfigFileSettings>(ApplicationParameters.GlobalConfigFileLocation))
+                    .Returns(new ConfigFileSettings
+                    {
+                        Features = new HashSet<ConfigFileFeatureSetting>()
+                    });
+
+                Service = new ChocolateyConfigSettingsService(XmlService.Object);
+            }
+
+            [Fact]
+            public void should_not_contain_any_warnings()
+            {
+                MockLogger.Messages.Keys.ShouldNotContain("Warn");
+            }
+
+            [Fact]
+            public void should_throw_exception_on_unknown_feature()
+            {
+                Assert.ThrowsDelegate action = () =>
+                {
+                    var config = new ChocolateyConfiguration()
+                    {
+                        FeatureCommand = new FeatureCommandConfiguration()
+                        {
+                            Name = "unknown"
+                        }
+                    };
+
+                    Service.feature_enable(config);
+                };
+
+                Assert.Throws<ApplicationException>(action)
+                    .Message.ShouldEqual("Feature 'unknown' not found");
+            }
+        }
+
+        public class when_ChocolateyConfigSettingsService_enables_unsupported_feature : ChocolateyConfigSettingsServiceSpecsBase
+        {
+            private const string FEATURE_NAME = "scriptsCheckLastExitCode";
+
+            public override void Because()
+            {
+            }
+
+            public override void Context()
+            {
+                base.Context();
+
+                XmlService.Setup(x => x.deserialize<ConfigFileSettings>(ApplicationParameters.GlobalConfigFileLocation))
+                    .Returns(new ConfigFileSettings
+                    {
+                        Features = new HashSet<ConfigFileFeatureSetting>()
+                        {
+                            new ConfigFileFeatureSetting()
+                            {
+                                Name = FEATURE_NAME
+                            }
+                        }
+                    });
+
+                Service = new ChocolateyConfigSettingsService(XmlService.Object);
+            }
+
+            [Fact]
+            public void should_throw_exception_on_unsupported_feature()
+            {
+                Assert.Throws<ApplicationException>(() =>
+                {
+                    var config = new ChocolateyConfiguration()
+                    {
+                        FeatureCommand = new FeatureCommandConfiguration()
+                        {
+                            Name = FEATURE_NAME
+                        }
+                    };
+
+                    Service.feature_enable(config);
+                }).Message.ShouldEqual("Feature '{0}' is not supported.".format_with(FEATURE_NAME));
+            }
+        }
+    }
+}

--- a/src/chocolatey/infrastructure.app/services/ChocolateyConfigSettingsService.cs
+++ b/src/chocolatey/infrastructure.app/services/ChocolateyConfigSettingsService.cs
@@ -58,7 +58,8 @@ namespace chocolatey.infrastructure.app.services
             {
                 if (skip_source(source, configuration)) continue;
 
-                if (!configuration.QuietOutput) {
+                if (!configuration.QuietOutput)
+                {
                     if (configuration.RegularOutput)
                     {
                         this.Log().Info(() => "{0}{1} - {2} {3}| Priority {4}|Bypass Proxy - {5}|Self-Service - {6}|Admin Only - {7}.".format_with(
@@ -87,7 +88,8 @@ namespace chocolatey.infrastructure.app.services
                         ));
                     }
                 }
-                list.Add(new ChocolateySource {
+                list.Add(new ChocolateySource
+                {
                     Id = source.Id,
                     Value = source.Value,
                     Disabled = source.Disabled,
@@ -134,9 +136,9 @@ namespace chocolatey.infrastructure.app.services
                     configuration.SourceCommand.Password.is_equal_to(currentPassword) &&
                     configuration.SourceCommand.CertificatePassword.is_equal_to(currentCertificatePassword) &&
                     configuration.SourceCommand.Certificate.is_equal_to(source.Certificate) &&
-                    configuration.SourceCommand.BypassProxy == source.BypassProxy && 
+                    configuration.SourceCommand.BypassProxy == source.BypassProxy &&
                     configuration.SourceCommand.AllowSelfService == source.AllowSelfService &&
-                    configuration.SourceCommand.VisibleToAdminsOnly == source.VisibleToAdminsOnly 
+                    configuration.SourceCommand.VisibleToAdminsOnly == source.VisibleToAdminsOnly
                     )
                 {
                     if (!configuration.QuietOutput) this.Log().Warn(NO_CHANGE_MESSAGE);
@@ -284,7 +286,7 @@ namespace chocolatey.infrastructure.app.services
 
                     if (keyAction != null)
                     {
-                        keyAction.Invoke(new ConfigFileApiKeySetting {Key = apiKeyValue, Source = apiKey.Source});
+                        keyAction.Invoke(new ConfigFileApiKeySetting { Key = apiKeyValue, Source = apiKey.Source });
                     }
                 }
             }
@@ -295,7 +297,7 @@ namespace chocolatey.infrastructure.app.services
                     var keyValue = NugetEncryptionUtility.DecryptString(apiKey.Key).to_string();
                     if (keyAction != null)
                     {
-                        keyAction.Invoke(new ConfigFileApiKeySetting {Key = keyValue, Source = apiKey.Source});
+                        keyAction.Invoke(new ConfigFileApiKeySetting { Key = keyValue, Source = apiKey.Source });
                     }
                 }
             }
@@ -309,10 +311,10 @@ namespace chocolatey.infrastructure.app.services
             if (apiKey == null)
             {
                 configFileSettings.ApiKeys.Add(new ConfigFileApiKeySetting
-                    {
-                        Source = configuration.Sources,
-                        Key = NugetEncryptionUtility.EncryptString(configuration.ApiKeyCommand.Key),
-                    });
+                {
+                    Source = configuration.Sources,
+                    Key = NugetEncryptionUtility.EncryptString(configuration.ApiKeyCommand.Key),
+                });
 
                 _xmlService.serialize(configFileSettings, ApplicationParameters.GlobalConfigFileLocation);
 


### PR DESCRIPTION
## Description Of Changes

This pull request updates the config settings service to
store a list of supported features. This is done so we
know which features we should handle without reporting
to the user that the feature is not supported, and will have
no effect when running Chocolatey.

## Motivation and Context

To handle features that we support and don't support, and to notify the user if it isn't supported.

## Testing

1. Run build.bat to ensure that the build and unit tests has not been broken
2. run `choco feature disable -n checksumFiles` and make sure there is no mention it is unsupported
3. Run `choco feature enable -n checksumFiles` and make sure there is no mention it is unsupported
4. Ensure that the feature `scriptsCheckLastExitCode` is set in the configuration file, with a disabled value
5. Run `choco feature enable -n scriptsCheckLastExitCode` and make sure the user is notified that the feature is not supported
6. Run `choco feature disable -n scriptsCheckLastExitCode` and make sure the user is notified that the feature is not supported 

## Change Types Made
<!-- Tick the boxes for the type of changes that have been made -->

* [ ] Bug fix (non-breaking change)
* [x] Feature / Enhancement (non-breaking change)
* [ ] Breaking change (fix or feature that could cause existing functionality to change)
* [ ] PowerShell code changes.

## Related Issue
<!-- Make sure you have raised an issue for this pull request before
continuing. -->

Fixes #2538

## Change Checklist

* [ ] Requires a change to the documentation
* [ ] Documentation has been updated
* [x] Tests to cover my changes, have been added
* [x] All new and existing tests passed.
* [x] PowerShell v2 compatibility checked.

<!-- PLEASE REMOVE ALL COMMENTS BEFORE SUBMITTING -->