### PR TITLE
(#2627) Remove deprecated `-t` argument for the push command

### DIFF
--- a/src/chocolatey.tests/infrastructure.app/commands/ChocolateyPushCommandSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/commands/ChocolateyPushCommandSpecs.cs
@@ -107,9 +107,9 @@ namespace chocolatey.tests.infrastructure.app.commands
             }
 
             [Fact]
-            public void should_add_short_version_of_timeout_to_the_option_set()
+            public void should_not_add_short_version_of_timeout_to_the_option_set()
             {
-                optionSet.Contains("t").ShouldBeTrue();
+                optionSet.Contains("t").ShouldBeFalse();
             }
         }
 

--- a/src/chocolatey/infrastructure.app/ApplicationParameters.cs
+++ b/src/chocolatey/infrastructure.app/ApplicationParameters.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -90,6 +90,7 @@ namespace chocolatey.infrastructure.app
         public static readonly string TemplatesLocation = _fileSystem.combine_paths(InstallLocation, "templates");
         public static readonly string ChocolateyCommunityFeedPushSourceOld = "https://chocolatey.org/";
         public static readonly string ChocolateyCommunityFeedPushSource = "https://push.chocolatey.org/";
+        public static readonly string ChocolateyCommunityGalleryUrl = "https://community.chocolatey.org/";
         public static readonly string ChocolateyCommunityFeedSource = "https://community.chocolatey.org/api/v2/";
         public static readonly string ChocolateyLicensedFeedSource = "https://licensedpackages.chocolatey.org/api/v2/";
         public static readonly string ChocolateyLicensedFeedSourceName = "chocolatey.licensed";

--- a/src/chocolatey/infrastructure.app/commands/ChocolateyPushCommand.cs
+++ b/src/chocolatey/infrastructure.app/commands/ChocolateyPushCommand.cs
@@ -167,14 +167,14 @@ NOTE: If there is more than one nupkg file in the folder, the command
 
             "chocolatey".Log().Info(ChocolateyLoggers.Important, "Examples");
             "chocolatey".Log().Info(@"
-    choco push --source https://chocolatey.org/
-    choco push --source ""'https://chocolatey.org/'"" --execution-timeout 500
-    choco push --source ""'https://chocolatey.org/'"" -k=""'123-123123-123'""
+    choco push --source {0}
+    choco push --source ""'{0}'"" --execution-timeout 500
+    choco push --source ""'{0}'"" -k=""'123-123123-123'""
 
 NOTE: See scripting in the command reference (`choco -?`) for how to
  write proper scripts and integrations.
 
-");
+".format_with(ApplicationParameters.ChocolateyCommunityFeedPushSource));
 
             "chocolatey".Log().Info(ChocolateyLoggers.Important, "Troubleshooting");
             "chocolatey".Log().Info(() => @"
@@ -192,7 +192,7 @@ A common error is `Failed to process request. 'The specified API key
  You can verify by going to {0}packages/packageName.
  Please contact the administrators of {0} if you see this
  and you don't see a good reason for it.
-".format_with(ApplicationParameters.ChocolateyCommunityFeedPushSource));
+".format_with(ApplicationParameters.ChocolateyCommunityGalleryUrl));
 
             "chocolatey".Log().Info(ChocolateyLoggers.Important, "Exit Codes");
             "chocolatey".Log().Info(@"

--- a/src/chocolatey/infrastructure.app/commands/ChocolateyPushCommand.cs
+++ b/src/chocolatey/infrastructure.app/commands/ChocolateyPushCommand.cs
@@ -48,18 +48,6 @@ namespace chocolatey.infrastructure.app.commands
                 .Add("k=|key=|apikey=|api-key=",
                      "ApiKey - The api key for the source. If not specified (and not local file source), does a lookup. If not specified and one is not found for an https source, push will fail.",
                      option => configuration.PushCommand.Key = option.remove_surrounding_quotes())
-                .Add("t=",
-                     "Timeout (in seconds) - The time to allow a package push to occur before timing out. Defaults to execution timeout {0}.".format_with(configuration.CommandExecutionTimeoutSeconds),
-                     option =>
-                         {
-                             this.Log().Warn("Using -t for timeout has been deprecated and will be removed in v1. Please update to use --timeout or --execution-timeout instead.");
-                             int timeout = 0;
-                             int.TryParse(option, out timeout);
-                             if (timeout > 0)
-                             {
-                                 configuration.CommandExecutionTimeoutSeconds = timeout;
-                             }
-                         })
                 //.Add("b|disablebuffering|disable-buffering",
                 //    "DisableBuffering -  Disable buffering when pushing to an HTTP(S) server to decrease memory usage. Note that when this option is enabled, integrated windows authentication might not work.",
                 //    option => configuration.PushCommand.DisableBuffering = option)
@@ -180,7 +168,7 @@ NOTE: If there is more than one nupkg file in the folder, the command
             "chocolatey".Log().Info(ChocolateyLoggers.Important, "Examples");
             "chocolatey".Log().Info(@"
     choco push --source https://chocolatey.org/
-    choco push --source ""'https://chocolatey.org/'"" -t 500
+    choco push --source ""'https://chocolatey.org/'"" --execution-timeout 500
     choco push --source ""'https://chocolatey.org/'"" -k=""'123-123123-123'""
 
 NOTE: See scripting in the command reference (`choco -?`) for how to 

--- a/src/chocolatey/infrastructure.app/commands/ChocolateyPushCommand.cs
+++ b/src/chocolatey/infrastructure.app/commands/ChocolateyPushCommand.cs
@@ -1,13 +1,13 @@
 // Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
-// 
+//
 // You may obtain a copy of the License at
-// 
+//
 // 	http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -75,12 +75,12 @@ namespace chocolatey.infrastructure.app.commands
                     }
                     else
                     {
-                        this.Log().Warn(ChocolateyLoggers.Important, @"ACTION: Please update your apikey to use 
-  '{0}' 
- instead of 
-  '{1}'. 
- The latter source url is now considered deprecated and will not be 
- checked as the default source in Chocolatey v1.0. For details, run 
+                        this.Log().Warn(ChocolateyLoggers.Important, @"ACTION: Please update your apikey to use
+  '{0}'
+ instead of
+  '{1}'.
+ The latter source url is now considered deprecated and will not be
+ checked as the default source in Chocolatey v1.0. For details, run
  `choco apikey -?`".format_with(ApplicationParameters.ChocolateyCommunityFeedPushSource, ApplicationParameters.ChocolateyCommunityFeedPushSourceOld));
                     }
                 }
@@ -118,13 +118,13 @@ namespace chocolatey.infrastructure.app.commands
                 {
                     string errorMessage =
                         @"WARNING! The specified source '{0}' is not secure.
- Sending apikey over insecure channels leaves your data susceptible to 
+ Sending apikey over insecure channels leaves your data susceptible to
  hackers. Please update your source to a more secure source and try again.
- 
- Use --force if you understand the implications of this warning or are 
- accessing an internal feed. If you are however doing this against an 
+
+ Use --force if you understand the implications of this warning or are
+ accessing an internal feed. If you are however doing this against an
  internet feed, then the choco gods think you are crazy. ;-)
- 
+
 NOTE: For chocolatey.org, you must update the source to be secure.".format_with(configuration.Sources);
                     throw new ApplicationException(errorMessage);
                 }
@@ -135,15 +135,15 @@ NOTE: For chocolatey.org, you must update the source to be secure.".format_with(
         {
             this.Log().Info(ChocolateyLoggers.Important, "Push Command");
             this.Log().Info(@"
-Chocolatey will attempt to push a compiled nupkg to a package feed. 
+Chocolatey will attempt to push a compiled nupkg to a package feed.
  Some may prefer to use `cpush` as a shortcut for `choco push`.
 
 NOTE: 100% compatible with older chocolatey client (0.9.8.32 and below)
  with options and switches. In most cases you can still pass options and 
- switches with one dash (`-`). For more details, see 
+ switches with one dash (`-`). For more details, see
  the command reference (`choco -?`).
 
-A feed can be a local folder, a file share, the community feed 
+A feed can be a local folder, a file share, the community feed
  ({0}), or a custom/private feed. For web
  feeds, it has a requirement that it implements the proper OData
  endpoints required for NuGet packages.
@@ -161,7 +161,7 @@ using the `--source` argument.
     choco push [<path to nupkg>] [<options/switches>]
     cpush [<path to nupkg>] [<options/switches>]
 
-NOTE: If there is more than one nupkg file in the folder, the command 
+NOTE: If there is more than one nupkg file in the folder, the command
  will require specifying the path to the file.
 ");
 
@@ -171,26 +171,26 @@ NOTE: If there is more than one nupkg file in the folder, the command
     choco push --source ""'https://chocolatey.org/'"" --execution-timeout 500
     choco push --source ""'https://chocolatey.org/'"" -k=""'123-123123-123'""
 
-NOTE: See scripting in the command reference (`choco -?`) for how to 
+NOTE: See scripting in the command reference (`choco -?`) for how to
  write proper scripts and integrations.
 
 ");
 
             "chocolatey".Log().Info(ChocolateyLoggers.Important, "Troubleshooting");
-            "chocolatey".Log().Info(()=> @"
+            "chocolatey".Log().Info(() => @"
 To use this command, you must have your API key saved for the community
- feed (chocolatey.org) or the source you want to push to. Or you can 
- explicitly pass the apikey to the command. See `apikey` command help 
+ feed (chocolatey.org) or the source you want to push to. Or you can
+ explicitly pass the apikey to the command. See `apikey` command help
  for instructions on saving your key:
 
     choco apikey -?
 
-A common error is `Failed to process request. 'The specified API key 
- does not provide the authority to push packages.' The remote server 
- returned an error: (403) Forbidden..` This means the package already 
- exists with a different user (API key). The package could be unlisted. 
- You can verify by going to {0}packages/packageName. 
- Please contact the administrators of {0} if you see this 
+A common error is `Failed to process request. 'The specified API key
+ does not provide the authority to push packages.' The remote server
+ returned an error: (403) Forbidden..` This means the package already
+ exists with a different user (API key). The package could be unlisted.
+ You can verify by going to {0}packages/packageName.
+ Please contact the administrators of {0} if you see this
  and you don't see a good reason for it.
 ".format_with(ApplicationParameters.ChocolateyCommunityFeedPushSource));
 
@@ -202,8 +202,8 @@ Normal:
  - 0: operation was successful, no issues detected
  - -1 or 1: an error has occurred
 
-If you find other exit codes that we have not yet documented, please 
- file a ticket so we can document it at 
+If you find other exit codes that we have not yet documented, please
+ file a ticket so we can document it at
  https://github.com/chocolatey/choco/issues/new/choose.
 
 ");


### PR DESCRIPTION
## Description Of Changes

This pull request removes the deprecated argument `-t` as a valid argument when pushing packages.

Additionally some maintenance is done for the formatting, and the documentation to use the correct URL's in the documentation help page for push.

## Motivation and Context

The `-t` argument has been deprecated for some time, and instead it was recommended to use `--execution-timeout` instead.
There are no functional differences in these two.

## Testing

1. Run `choco push --help` to ensure that `-t` is not showing up

## Change Types Made
<!-- Tick the boxes for the type of changes that have been made -->

* [ ] Bug fix (non-breaking change)
* [ ] Feature / Enhancement (non-breaking change)
* [x] Breaking change (fix or feature that could cause existing functionality to change)
* [ ] PowerShell code changes.

## Related Issue
<!-- Make sure you have raised an issue for this pull request before
continuing. -->

Fixes #2627

## Change Checklist

* [x] Requires a change to the documentation
* [ ] Documentation has been updated
* [ ] Tests to cover my changes, have been added
* [x] All new and existing tests passed.
* [x] PowerShell v2 compatibility checked.

<!-- PLEASE REMOVE ALL COMMENTS BEFORE SUBMITTING -->