### PR TITLE
(#2628) Remove deprecated fallback to old community push URL

### DIFF
--- a/src/chocolatey.tests/infrastructure.app/commands/ChocolateyPushCommandSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/commands/ChocolateyPushCommandSpecs.cs
@@ -151,6 +151,25 @@ namespace chocolatey.tests.infrastructure.app.commands
             }
 
             [Fact]
+            public void should_check_for_fallback_community_url()
+            {
+                reset();
+                configuration.Sources = "";
+                configSettingsService.Setup(c => c.get_api_key(
+                    It.Is<ChocolateyConfiguration>(config => config.Sources.is_equal_to(ApplicationParameters.ChocolateyCommunityFeedPushSourceOld)),
+                    null))
+                    .Returns(apiKey);
+                because();
+
+                configuration.Sources.ShouldEqual(ApplicationParameters.ChocolateyCommunityFeedPushSourceOld);
+                configSettingsService.Verify(c => c.get_api_key(
+                    It.Is<ChocolateyConfiguration>(config => config.Sources.is_equal_to(ApplicationParameters.ChocolateyCommunityFeedPushSourceOld)),
+                    null),
+                    Times.Once);
+                configuration.PushCommand.Key.ShouldEqual(apiKey);
+            }
+
+            [Fact]
             public void should_not_set_the_apiKey_if_source_is_not_found()
             {
                 reset();

--- a/src/chocolatey.tests/infrastructure.app/commands/ChocolateyPushCommandSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/commands/ChocolateyPushCommandSpecs.cs
@@ -151,7 +151,7 @@ namespace chocolatey.tests.infrastructure.app.commands
             }
 
             [Fact]
-            public void should_check_for_fallback_community_url()
+            public void should_not_check_for_fallback_community_url()
             {
                 reset();
                 configuration.Sources = "";
@@ -161,12 +161,12 @@ namespace chocolatey.tests.infrastructure.app.commands
                     .Returns(apiKey);
                 because();
 
-                configuration.Sources.ShouldEqual(ApplicationParameters.ChocolateyCommunityFeedPushSourceOld);
+                configuration.Sources.ShouldEqual(ApplicationParameters.ChocolateyCommunityFeedPushSource);
                 configSettingsService.Verify(c => c.get_api_key(
                     It.Is<ChocolateyConfiguration>(config => config.Sources.is_equal_to(ApplicationParameters.ChocolateyCommunityFeedPushSourceOld)),
                     null),
-                    Times.Once);
-                configuration.PushCommand.Key.ShouldEqual(apiKey);
+                    Times.Never);
+                configuration.PushCommand.Key.ShouldNotEqual(apiKey);
             }
 
             [Fact]

--- a/src/chocolatey/infrastructure.app/commands/ChocolateyPushCommand.cs
+++ b/src/chocolatey/infrastructure.app/commands/ChocolateyPushCommand.cs
@@ -62,28 +62,6 @@ namespace chocolatey.infrastructure.app.commands
             if (string.IsNullOrWhiteSpace(configuration.Sources))
             {
                 configuration.Sources = ApplicationParameters.ChocolateyCommunityFeedPushSource;
-                var newSourceKey = _configSettingsService.get_api_key(configuration, null);
-
-                if (string.IsNullOrWhiteSpace(newSourceKey))
-                {
-                    configuration.Sources = ApplicationParameters.ChocolateyCommunityFeedPushSourceOld;
-                    var oldSourceKey = _configSettingsService.get_api_key(configuration, null);
-
-                    if (string.IsNullOrWhiteSpace(oldSourceKey))
-                    {
-                        configuration.Sources = ApplicationParameters.ChocolateyCommunityFeedPushSource;
-                    }
-                    else
-                    {
-                        this.Log().Warn(ChocolateyLoggers.Important, @"ACTION: Please update your apikey to use
-  '{0}'
- instead of
-  '{1}'.
- The latter source url is now considered deprecated and will not be
- checked as the default source in Chocolatey v1.0. For details, run
- `choco apikey -?`".format_with(ApplicationParameters.ChocolateyCommunityFeedPushSource, ApplicationParameters.ChocolateyCommunityFeedPushSourceOld));
-                    }
-                }
             }
 
             if (!string.IsNullOrWhiteSpace(configuration.Sources))


### PR DESCRIPTION
## Description Of Changes

This pull request removes the deprecated ability to fallback to an older URL for pushing packages to the community repository when no sources is configured, but an API Key is present for the old URL.
Additionally, another commit is added that ensured that the fallback was working previous to this change (added for historic purposes and for testing).

## Motivation and Context

To get rid of deprecated functionality when we can.

## Testing

1. Run `choco push` with an API key only configured for `https://chocolatey.org/`
2. Make sure there is a message that no api key is configured (this is expected, as we use `https://push.chocolatey.org/`).
3. Run `build.bat` to ensure the new tests work

## Change Types Made
<!-- Tick the boxes for the type of changes that have been made -->

* [ ] Bug fix (non-breaking change)
* [ ] Feature / Enhancement (non-breaking change)
* [x] Breaking change (fix or feature that could cause existing functionality to change)
* [ ] PowerShell code changes.

## Related Issue
<!-- Make sure you have raised an issue for this pull request before
continuing. -->

Fixes #2628

## Change Checklist

* [ ] Requires a change to the documentation (unsure)
* [ ] Documentation has been updated
* [x] Tests to cover my changes, have been added
* [x] All new and existing tests passed.
* [x] PowerShell v2 compatibility checked.