### PR TITLE
(#2634) Update push command default source deprecation

### DIFF
--- a/src/chocolatey/infrastructure.app/commands/ChocolateyPushCommand.cs
+++ b/src/chocolatey/infrastructure.app/commands/ChocolateyPushCommand.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -151,8 +151,7 @@ Chocolatey will attempt to push a compiled nupkg to a package feed.
  Some may prefer to use `cpush` as a shortcut for `choco push`.
 
 NOTE: 100% compatible with older chocolatey client (0.9.8.32 and below)
- with options and switches. Default push location is deprecated and 
- will be removed by v1. In most cases you can still pass options and 
+ with options and switches. In most cases you can still pass options and 
  switches with one dash (`-`). For more details, see 
  the command reference (`choco -?`).
 
@@ -161,6 +160,13 @@ A feed can be a local folder, a file share, the community feed
  feeds, it has a requirement that it implements the proper OData
  endpoints required for NuGet packages.
 ".format_with(ApplicationParameters.ChocolateyCommunityFeedPushSource));
+
+            "chocolatey".Log().Warn(ChocolateyLoggers.Important, "DEPRECATION NOTICE");
+            "chocolatey".Log().Warn(@"
+Default push location is deprecated and will be removed by v2.0.0.
+It is recommended to always specify the source you want to push to
+using the `--source` argument.
+");
 
             "chocolatey".Log().Info(ChocolateyLoggers.Important, "Usage");
             "chocolatey".Log().Info(@"


### PR DESCRIPTION
## Description Of Changes

This commit updates the note about using a default source
being deprecated and removed in v1 to instead be removed
in v2.0.0.

Additionally, its own section called `DEPRECATION NOTICE`
was added to make it more visible that the functionality
will be going away.

## Motivation and Context

The removal of using the default source has been pushed back to instead be removed in v2, as such the help page should mention this.

## Testing

N/A (other than running `--help`)

## Screenshot

![image](https://user-images.githubusercontent.com/1474648/157434417-356914f3-a35a-469e-8fb3-a124613fe5e0.png)

## Change Types Made

* [ ] Bug fix (non-breaking change)
* [ ] Feature / Enhancement (non-breaking change)
* [ ] Breaking change (fix or feature that could cause existing functionality to change)
* [x] Documentation

## Related Issue

fixes #2634 

## Change Checklist

* [ ] Requires a change to the documentation
* [x] Documentation has been updated
* [ ] Tests to cover my changes, have been added
* [ ] All new and existing tests passed