### PR TITLE
(#2615/#2549) Reference CREDITS file for other licenses

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -12,3 +12,7 @@
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
+
+   Additional legal information and licenses used by Chocolatey CLI can be
+   found in the CREDITS file or at
+   https://github.com/chocolatey/choco/blob/develop/docs/legal/CREDITS.md


### PR DESCRIPTION
In response to [this issue](https://github.com/chocolatey/choco/issues/2549) the CREDITS.md file has been updated with the latest Shimgen license (see #2644) and this PR will reference the updated CREDITS file in the NOTICE file.

Open to changes in the wording.

Closes #2615  #2549 