### PR TITLE
(maint) Update deprecation notice for config settings

### DIFF
--- a/src/chocolatey/infrastructure.app/configuration/ConfigFileSettings.cs
+++ b/src/chocolatey/infrastructure.app/configuration/ConfigFileSettings.cs
@@ -27,11 +27,11 @@ namespace chocolatey.infrastructure.app.configuration
     [XmlRoot("chocolatey")]
     public class ConfigFileSettings
     {
-        [Obsolete("This will be removed in v1 of Chocolatey")]
+        [Obsolete("This will be removed once CCM v0.7.0 is no longer supported. Possibly in Chocolatey CLI v2.0.0.")]
         [XmlElement(ElementName = "cacheLocation")]
         public string CacheLocation { get; set; }
 
-        [Obsolete("This will be removed in v1 of Chocolatey")]
+        [Obsolete("This will be removed once CCM v0.7.0 is no longer supported. Possibly in Chocolatey CLI v2.0.0.")]
         [XmlElement(ElementName = "commandExecutionTimeoutSeconds")]
         public int CommandExecutionTimeoutSeconds { get; set; }
 


### PR DESCRIPTION
This pull request updates the deprecation notice mentioned for
obsolete settings values which had initially been slated to
be removed in Chocolatey CLI v1.0.0. However, these are
required by CCM 0.7.0 and needs to be available until we
stop supporting this version.

As such, the deprecation notice is updated to reflect the
status, and the possibility of it being removed in v2.