### PR TITLE
(docs) Update committers documentation with correct/fixed links

### DIFF
--- a/COMMITTERS.md
+++ b/COMMITTERS.md
@@ -115,7 +115,7 @@ Please be VERY familiar with [CONTRIBUTING](https://github.com/chocolatey/choco/
  * Did the user create a branch with these changes? If it is on their default branch (i.e. develop), please ask them to review [CONTRIBUTING](https://github.com/chocolatey/choco/blob/develop/CONTRIBUTING.md).
  * Did the user reformat files and they should not have? Was is just white-space? You can try adding [?w=1](https://github.com/blog/967-github-secrets) to the URL on GitHub.
  * Are there tests? We really want any new contributions to contain tests so unless the committer believes this code really needs to be in the code base and is willing to write the tests, then we need to ask the contributor to make a good faith effort in adding test cases. Ask them to review the [contributing document](https://github.com/chocolatey/choco/blob/develop/CONTRIBUTING.md) and provide tests. **Note:** Some commits may be refactoring which wouldn't necessarily add additional test sets.
- * Is the code documented properly? Does this additional set of changes require changes to the [wiki](https://github.com/chocolatey/choco/wiki)?
+ * Is the code documented properly? Does this additional set of changes require changes to the [documentation](https://docs.chocolatey.org)?
  * Was this code warranted? Did the contributor follow the process of gaining approval for big change sets? If not please have them review the [contributing document](https://github.com/chocolatey/choco/blob/develop/CONTRIBUTING.md) and ask that they follow up with a case for putting the code into the code base on the mailing list.
 
 #### Review the Code
@@ -131,7 +131,7 @@ Unless there is something wrong with the code, we don't ask contributors to reba
 ## Merging
 Once you have reviewed the change set and determined it is ready for merge, the next steps are to bring it local and evaluate the code further by actually working with it, running the tests locally and adding any additional commits or fix-ups that are necessary in a local branch.
 
-When merging the user's contribution, it should be done with `git merge --log --no-ff` to create a merge commit so that in case there is an issue it becomes easier to revert later, and so that we can see where the code came from should we ever need to go find it later (more information on this can be found [here](https://www.kernel.org/pub/software/scm/git/docs/git-merge.html) and also a discussion on why this is a good idea [here](https://differential.com/insights/best-way-to-merge-a-github-pull-request/)).
+When merging the user's contribution, it should be done with `git merge --log --no-ff` to create a merge commit so that in case there is an issue it becomes easier to revert later, and so that we can see where the code came from should we ever need to go find it later (more information on this can be found [here](https://www.kernel.org/pub/software/scm/git/docs/git-merge.html) and also a discussion on why this is a good idea [here](https://web.archive.org/web/20190529002804/https://differential.com/insights/best-way-to-merge-a-github-pull-request/)).
 
 ### Pull Request Retargeting
 Because we ask contributors to target develop, sometimes a fix/enhancement may need to be retargeted to a hotfix, or release, branch. This process is somewhat easy thanks to git. In most cases you won't even need to ask the user to do this for you.
@@ -150,5 +150,5 @@ Because we ask contributors to target develop, sometimes a fix/enhancement may n
 
 References
 
- * http://pivotallabs.com/git-rebase-onto/
+ * [http://pivotallabs.com/git-rebase-onto/ (Archive)](https://web.archive.org/web/20150709101404/http://pivotallabs.com:80/git-rebase-onto/)
  * http://git-scm.com/book/ch3-6.html


### PR DESCRIPTION
This commit updates the COMMITTERS.md file to use the
correct links to the documentation, as well as updating the
links that are pointing to pages that no longer exist to use
an archived version of the page.

The archive links should be updated to later posts that
are more up to date and still exists without having to rely
on the web archive, however in the interest of time and to
have valid links that users can use I opted to only point
to the web archive now.

## Description Of Changes

This PR updates the COMMITTERS.md file use to valid/correct links to the documentation page which previously was only available on the wiki page.
Additionally this PR also updates the links that pointed to pages that no longer exist to instead point to their web archive equivalent instead.
While the best would be to link these links to an up to date and existing page, in the interest of time and to have valid links for users to use
the web archive was chosen.

## Motivation and Context

To have the documentation point to the correct location, and update invalid links to at least have a location that contributers/committers can use.

## Testing

N/A

## Change Types Made
<!-- Tick the boxes for the type of changes that have been made -->

* [ ] Bug fix (non-breaking change)
* [ ] Feature / Enhancement (non-breaking change)
* [ ] Breaking change (fix or feature that could cause existing functionality to change)
* [ ] PowerShell code changes.
* [x] Documentation

## Related Issue

Invalid links was mentioned in: https://github.com/chocolatey/choco/issues/2549#issuecomment-1065203315

## Change Checklist

* [ ] Requires a change to the documentation
* [x] Documentation has been updated
* [ ] Tests to cover my changes, have been added
* [ ] All new and existing tests passed.
* [ ] PowerShell v2 compatibility checked.