### PR TITLE
(#2443) Fix misspellings for profile text

### DIFF
--- a/nuget/chocolatey/tools/chocolateysetup.psm1
+++ b/nuget/chocolatey/tools/chocolateysetup.psm1
@@ -687,8 +687,8 @@ function Add-ChocolateyProfile {
 
 # Import the Chocolatey Profile that contains the necessary code to enable
 # tab-completions to function for `choco`.
-# Be aware that if you are missing these lines from you profile, tab completion
-# for `choco` wil not function.
+# Be aware that if you are missing these lines from your profile, tab completion
+# for `choco` will not function.
 # See https://ch0.co/tab-completion for details.
 $ChocolateyProfile = "$env:ChocolateyInstall\helpers\chocolateyProfile.psm1"
 if (Test-Path($ChocolateyProfile)) {


### PR DESCRIPTION
## Description Of Changes

Fixed a couple minor misspellings in the comments we're adding to folks' profiles in the Chocolatey install.

## Motivation and Context

Noticed it in the testing, figured we may as well fix it.

## Testing

N/A, only code comments edited.

## Change Types Made

* [x] Doc/comments updated
* [ ] Bug fix (non-breaking change)
* [ ] Feature / Enhancement (non-breaking change)
* [ ] Breaking change (fix or feature that could cause existing functionality to change)
* [ ] PowerShell code changes.

## Related Issue

#2443

## Change Checklist

* [ ] Requires a change to the documentation
* [x] Documentation has been updated
* [ ] Tests to cover my changes, have been added
* [x] All new and existing tests passed.
* [ ] PowerShell v2 compatibility checked.