### PR TITLE
(#2660) Check for valid license before checking for compatibility

### DIFF
--- a/src/chocolatey.console/Program.cs
+++ b/src/chocolatey.console/Program.cs
@@ -78,7 +78,7 @@ namespace chocolatey.console
                      warning => { warnings.Add(warning); }
                      );
 
-                if (!license.IsCompatible && !config.DisableCompatibilityChecks)
+                if (license.is_licensed_version() && !license.IsCompatible && !config.DisableCompatibilityChecks)
                 {
                     write_warning_for_incompatible_versions();
                 }
@@ -171,7 +171,7 @@ namespace chocolatey.console
             }
             finally
             {
-                if (license != null && !license.IsCompatible && config != null && !config.DisableCompatibilityChecks)
+                if (license != null && license.is_licensed_version() && !license.IsCompatible && config != null && !config.DisableCompatibilityChecks)
                 {
                     write_warning_for_incompatible_versions();
                 }

--- a/src/chocolatey/infrastructure/licensing/LicenseValidation.cs
+++ b/src/chocolatey/infrastructure/licensing/LicenseValidation.cs
@@ -31,7 +31,8 @@ namespace chocolatey.infrastructure.licensing
         {
             var chocolateyLicense = new ChocolateyLicense
             {
-                LicenseType = ChocolateyLicenseType.Unknown
+                LicenseType = ChocolateyLicenseType.Unknown,
+                IsCompatible = true
             };
 
             var regularLogOutput = determine_if_regular_output_for_logging();

--- a/src/chocolatey/infrastructure/licensing/LicenseValidation.cs
+++ b/src/chocolatey/infrastructure/licensing/LicenseValidation.cs
@@ -1,13 +1,13 @@
 ﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
-// 
+//
 // You may obtain a copy of the License at
-// 
+//
 // 	http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -53,7 +53,7 @@ namespace chocolatey.infrastructure.licensing
                 {
                     if (Directory.GetFiles(licenseDirectory).Length != 0)
                     {
-                        "chocolatey".Log().Error(regularLogOutput ? ChocolateyLoggers.Normal : ChocolateyLoggers.LogFileOnly, @"Files found in directory '{0}' but not a 
+                        "chocolatey".Log().Error(regularLogOutput ? ChocolateyLoggers.Normal : ChocolateyLoggers.LogFileOnly, @"Files found in directory '{0}' but not a
  valid license file. License should be named '{1}'.".format_with(licenseDirectory, licenseFileName));
                         "chocolatey".Log().Warn(ChocolateyLoggers.Important,@" Rename license file to '{0}' to allow commercial features.".format_with(licenseFileName));
                     }
@@ -63,12 +63,12 @@ namespace chocolatey.infrastructure.licensing
                 // - user put the license file in the top level location and/or forgot to rename it
                 if (File.Exists(Path.Combine(ApplicationParameters.InstallLocation, licenseFileName)) || File.Exists(Path.Combine(ApplicationParameters.InstallLocation, licenseFileName + ".txt")))
                 {
-                    "chocolatey".Log().Error(regularLogOutput ? ChocolateyLoggers.Normal : ChocolateyLoggers.LogFileOnly, @"Chocolatey license found in the wrong location. File must be located at 
+                    "chocolatey".Log().Error(regularLogOutput ? ChocolateyLoggers.Normal : ChocolateyLoggers.LogFileOnly, @"Chocolatey license found in the wrong location. File must be located at
  '{0}'.".format_with(ApplicationParameters.LicenseFileLocation));
                     "chocolatey".Log().Warn(regularLogOutput ? ChocolateyLoggers.Important : ChocolateyLoggers.LogFileOnly, @" Move license file to '{0}' to allow commercial features.".format_with(ApplicationParameters.LicenseFileLocation));
                 }
             }
-            
+
             // no IFileSystem at this point
             if (File.Exists(licenseFile))
             {


### PR DESCRIPTION
## Description Of Changes

When running choco.exe with no Chocolatey Licensed Extension in play the
compatibility warnings were still showing when they shouldn't. Make sure
to initialize the ChocolateyLicense with IsCompatible defaulting to true
until found to be anything else, as well as to only show the warnings
when it is known that a licensed version is being used.

## Motivation and Context

This was missed in the original PR for this issue, but was caught during testing.

## Testing

1. Get a system that has Chocolatey 0.12.1 installed
1. Run choco list -lo and ensure that it outputs as expected - i.e. no warnings
1. Install the built alpha package from this PR
1. Run choco list -lo and ensure that it outputs as expected - i.e. no warnings
1. Install Chocolatey Licensed Extension v3.2.0 installed
1. Run choco list -lo and see that there is a new warning before and after the command has executed
1. Run choco list -lo --skip-compatibility-checks and see that the warnings are not shown
1. Run choco feature enable --name="'disableCompatibilityChecks'"
1. Run choco list -lo and see that the warnings are not shown
1. Upgrade to the latest Chocolatey Licensed Extension
1. Run choco list -lo and see that the warnings are not shown
1. Run choco feature enable --name="'disableCompatibilityChecks'"
1. Run choco list -lo and see that the warnings are not shown

## Change Types Made

* [ ] Bug fix (non-breaking change)
* [x] Feature / Enhancement (non-breaking change)
* [ ] Breaking change (fix or feature that could cause existing functionality to change)

## Related Issue

Fixes #2660 

## Change Checklist

* [x] Requires a change to the documentation
* [ ] Documentation has been updated
* [ ] Tests to cover my changes, have been added
* [x] All new and existing tests passed.