### PR TITLE
(#2659) Handle scenario where install has no buffer

### DIFF
--- a/nuget/chocolatey/tools/chocolateyInstall.ps1
+++ b/nuget/chocolatey/tools/chocolateyInstall.ps1
@@ -11,12 +11,19 @@ if ($null -ne $licensedAssembly) {
     # The licensed assembly is installed, check its supported Chocolatey versions and/or the assembly
     # version so we can attempt to determine whether it's compatible with this version of Chocolatey.
     $attributeData = $licensedAssembly.GetCustomAttributes($true)
-    
+
     $minVersion = $attributeData |
         Where-Object { $_.TypeId -like '*MinimumChocolateyVersion*' } |
         Select-Object -ExpandProperty Version -First 1
 
-    $messageBorder = '=' * ([System.Console]::BufferWidth - 10)
+    $borderWidth = 70
+    try {
+        $borderWidth = [System.Console]::BufferWidth - 10
+    } catch {
+        # Do nothing. This means we're in a non-interactive environment without a console attached.
+    }
+
+    $messageBorder = '=' * $borderWidth
     $extensionVersionWarning = @"
 $messageBorder
 


### PR DESCRIPTION
## Description Of Changes

Ensure that we catch the exception if there is no buffer (PSRemoting, Background Agent, etc) and thus no buffer width.

An example of what happens when trying to upgrade (or reinstall) Chocolatey when run as Background agent: 
![image](https://user-images.githubusercontent.com/30301021/160730817-a3efef31-f3e2-4d4a-bdfb-c848faeb2437.png)


## Motivation and Context

Test Kitchen tests were failing on reinstalling the Chocolatey package but only in Test Kitchen runs, not when run manually.

## Testing

I'm starting with getting a PR up so I can get a build for my local test kitchen, then I will run it through the tests, in particular the ones that have been troublesome. The testing will also mirror #2664 

So my testing (on Windows 7 and Test Kitchen through PSRemoting):

1. Capture package from Team City server (`1.1.0-alpha-20220330-118`)
2. Push this package to internal repository (Test Kitchen needs it here to do it's reinstall)
3. Install v1.0.1 of Chocolatey from the community repository.
4. Install a version 3.x.x of `chocolatey.extension`
5. Install the newly built version of Chocolatey from the internal repository
6. You should see a yellow warning message emitted during the installation stating that the extension version is not known to be compatible with the version of Chocolatey being installed.
7. The installation should succeed.
8. Install version 4.0.0 of the `chocolatey.extension` package.
9. Reinstall the prerelease version of Chocolatey from the internal repository with `--force` to force the reinstall.
10. No warnings should be emitted.
11. Test with a prerelease version of the extension that includes a MinimumChocolateyVersion attribute set to higher than 1.0.x and ensure that attempting to install Chocolatey in this scenario correctly also emits a warning.
12. Check the installation still works on PowerShell v2.

And for completeness sake:

1. Install this build of Chocolatey, chocolatey.extension, and chocolatey-agent.
2. Enable Background agent: `choco feature enable -n useBackgroundService`
3. Force reinstall of Chocolatey: `choco install chocolatey --version 1.1.0-alpha-20220330-118 --force`
4. Verify that it installed successfully.

## Change Types Made

* [x] Bug fix (non-breaking change)
* [ ] Feature / Enhancement (non-breaking change)
* [ ] Breaking change (fix or feature that could cause existing functionality to change)
* [x] PowerShell code changes.

## Related Issue

Fixes #2659

## Change Checklist

* [ ] Requires a change to the documentation
* [ ] Documentation has been updated
* [x] Tests to cover my changes, have been added
* [x] All new and existing tests passed.
* [x] PowerShell v2 compatibility checked.
