### PR TITLE
(#2584) Remove license leeway comments

### DIFF
--- a/src/chocolatey/infrastructure/licensing/LicenseValidation.cs
+++ b/src/chocolatey/infrastructure/licensing/LicenseValidation.cs
@@ -125,9 +125,6 @@ namespace chocolatey.infrastructure.licensing
                 chocolateyLicense.ExpirationDate = license.ExpirationDate;
                 chocolateyLicense.Name = license.Name;
                 chocolateyLicense.Id = license.UserId.to_string();
-
-                //todo: #2584 if it is expired, provide a warning.
-                // one month after it should stop working
             }
             else
             {


### PR DESCRIPTION
Removes comments that suggest there is a warning provided when a license expires.

Closes #2584