### PR TITLE
(#2690) Use Windows 2019 for Vagrant VM

### DIFF
--- a/tests/Vagrantfile
+++ b/tests/Vagrantfile
@@ -2,7 +2,7 @@
 # vi: set ft=ruby :
 
 Vagrant.configure("2") do |config|
-  config.vm.box = "StefanScherer/windows_2022"
+  config.vm.box = "StefanScherer/windows_2019"
   config.vm.boot_timeout = 600
 
   # windows


### PR DESCRIPTION
## Summary

Updated the Vagrantfile provided for the test environment to use Windows 2019 instead of 2022.

## Context

As described in #2690, using 2022 for this test environment is likely to cause test failures.
We can revisit when #2690 has been more fully investigated, but for now this is a known working environment for the purposes of our tests.

Thanks to @corbob for noticing this mistake had snuck in under our noses!

## Testing

Run the test script under the Vagrant environment and verify all tests pass.

## Related Issue

#2690

## Checklist

- [ ] Requires a change to the documentation
- [ ] Documentation has been updated
- [ ] Tests to cover my changes, have been added
- [x] All new and existing tests passed.
- N/A PowerShell v2 compatibility checked.

