### PR TITLE
(#2728) Update failing tests running together with other projects

### DIFF
--- a/tests/chocolatey-tests/choco-feature.Tests.ps1
+++ b/tests/chocolatey-tests/choco-feature.Tests.ps1
@@ -63,8 +63,10 @@ Describe "choco <_>" -ForEach $Command -Tag Chocolatey, FeatureCommand {
 
     Context "Adjusting Feature Settings" {
         BeforeDiscovery {
-            # Get the features this way so we're working with the entire list, and not just what was in the config file initially
-            $FeaturesToTest = (Invoke-Choco feature list -r).Lines | ConvertFrom-ChocolateyOutput -Command Feature
+            # Get the features this way so we're working with the entire list, and not just what was in the config file initially.
+            # We additionally want to ignore any presence of removed features
+            # as these are not intended to work as expected, even when present.
+            $FeaturesToTest = (Invoke-Choco feature list -r).Lines | ConvertFrom-ChocolateyOutput -Command Feature | Where-Object Name -ne 'scriptsCheckLastExitCode'
         }
 
         BeforeAll {

--- a/tests/chocolatey-tests/choco-list.Tests.ps1
+++ b/tests/chocolatey-tests/choco-list.Tests.ps1
@@ -26,6 +26,8 @@ Describe "choco <_>" -ForEach $Command -Tag Chocolatey, ListCommand {
         Invoke-Choco install installpackage --version 1.0.0 --confirm
         Invoke-Choco install upgradepackage --version 1.0.0 --confirm
         $VersionRegex = "[^v]\d+\.\d+\.\d+"
+        # Ensure that we remove any compatibility package before running the tests
+        $null = Invoke-Choco uninstall chocolatey-compatibility.extension -y --force
     }
 
     AfterAll {

--- a/tests/chocolatey-tests/choco-removed.Tests.ps1
+++ b/tests/chocolatey-tests/choco-removed.Tests.ps1
@@ -3,6 +3,8 @@
 Describe "Ensuring removed things are removed" -Tag Removed, Chocolatey {
     BeforeAll {
         Initialize-ChocolateyTestInstall
+        # Ensure that we do not have any compatibility layer package installed
+        $null = Invoke-Choco uninstall chocolatey-compatibility.extension -y --force
         New-ChocolateyInstallSnapshot
     }
 

--- a/tests/chocolatey-tests/choco-removed.Tests.ps1
+++ b/tests/chocolatey-tests/choco-removed.Tests.ps1
@@ -96,6 +96,6 @@ exit $command.Count
         @{ Name = 'cver' }
         @{ Name = 'cpack' }
     ) {
-        Get-Command "$Name.exe" -ErrorAction SilentlyContinue | Should -HaveCount 0
+        Get-ChildItem -Path $env:ChocolateyInstall -Name "$Name.exe" -Recurse -ErrorAction SilentlyContinue | Should -HaveCount 0
     }
 }

--- a/tests/chocolatey-tests/chocolatey.Tests.ps1
+++ b/tests/chocolatey-tests/chocolatey.Tests.ps1
@@ -16,7 +16,9 @@ Describe "Ensuring Chocolatey is correctly installed" -Tag Environment, Chocolat
             "\bin\cver.exe"
         )
         $PowerShellFiles = Get-ChildItem -Path $ChocolateyDirectoriesToCheck -Include "*.ps1", "*.psm1" -Recurse -ErrorAction Ignore
-        $ExecutableFiles = Get-ChildItem -Path $ChocolateyDirectoriesToCheck -Include "*.exe", "*.dll" -Recurse -ErrorAction Ignore
+        # For certain test scenarious we run, there are additional files available in the bin directory.
+        # These files should not be tested as part of the signing check.
+        $ExecutableFiles = Get-ChildItem -Path $ChocolateyDirectoriesToCheck -Include "*.exe", "*.dll" -Recurse -ErrorAction Ignore | Where-Object Name -NotMatch 'driver\.exe$'
         $StrongNamingKeyFiles = Get-ChildItem -Path $StrongNamingKeyFilesToCheck -ErrorAction Ignore
     }
 


### PR DESCRIPTION
## Description Of Changes

There are times we run these tests together we other projects that we provide, as the tests do not consider that that may happen some tests are failing due to changes having been made to the basic installation of Chocolatey before these tests has run.
As such, updating the tests to ignore such scenarios where there are polluted files and/or features being available is needed.

## Motivation and Context

To only test what we want to test, and fix failing tests.

## Testing

1. Run all changed tests through test kitchen, together with CCM builds

## Change Types Made
<!-- Tick the boxes for the type of changes that have been made -->

* [ ] Bug fix (non-breaking change)
* [ ] Feature / Enhancement (non-breaking change)
* [ ] Breaking change (fix or feature that could cause existing functionality to change)
* [ ] PowerShell code changes.
* [x] E2E Tests

## Related Issue

#2728

## Change Checklist

* [ ] Requires a change to the documentation
* [ ] Documentation has been updated
* [ ] Tests to cover my changes, have been added
* [ ] All new and existing tests passed.
* [ ] PowerShell v2 compatibility checked.
