### PR TITLE
#2206 Add security protocols to config. Add TLS 1.3 protocol.

### DIFF
--- a/src/chocolatey/infrastructure.app/ApplicationParameters.cs
+++ b/src/chocolatey/infrastructure.app/ApplicationParameters.cs
@@ -175,6 +175,7 @@ namespace chocolatey.infrastructure.app
             public static readonly string WebRequestTimeoutSeconds = "webRequestTimeoutSeconds";
             public static readonly string UpgradeAllExceptions = "upgradeAllExceptions";
             public static readonly string DefaultTemplateName = "defaultTemplateName";
+            public static readonly string AllowedSecurityProtocols = "allowedSecurityProtocols";
         }
 
         public static class Features

--- a/src/chocolatey/infrastructure.app/builders/ConfigurationBuilder.cs
+++ b/src/chocolatey/infrastructure.app/builders/ConfigurationBuilder.cs
@@ -255,6 +255,7 @@ namespace chocolatey.infrastructure.app.builders
             config.Proxy.BypassOnLocal = set_config_item(ApplicationParameters.ConfigSettings.ProxyBypassOnLocal, configFileSettings, "true", "Bypass proxy for local connections. Available in 0.10.4+.").is_equal_to(bool.TrueString);
             config.UpgradeCommand.PackageNamesToSkip = set_config_item(ApplicationParameters.ConfigSettings.UpgradeAllExceptions, configFileSettings, string.Empty, "A comma-separated list of package names that should not be upgraded when running `choco upgrade all'. Defaults to empty. Available in 0.10.14+.");
             config.DefaultTemplateName = set_config_item(ApplicationParameters.ConfigSettings.DefaultTemplateName, configFileSettings, string.Empty, "Default template name used when running 'choco new' command. Available in 0.12.0+.");
+            config.SecurityProtocols.AllowedSecurityProtocol = set_config_item(ApplicationParameters.ConfigSettings.AllowedSecurityProtocols, configFileSettings, "ssl3,tls,tls11,tls12,tls13", "Allowed security protocols. Available in 1.1.1+.");
         }
 
         private static string set_config_item(string configName, ConfigFileSettings configFileSettings, string defaultValue, string description, bool forceSettingValue = false)

--- a/src/chocolatey/infrastructure.app/configuration/ChocolateyConfiguration.cs
+++ b/src/chocolatey/infrastructure.app/configuration/ChocolateyConfiguration.cs
@@ -20,6 +20,7 @@ namespace chocolatey.infrastructure.app.configuration
     using System.Collections.Generic;
     using System.Reflection;
     using System.Text;
+using chocolatey.infrastructure.registration;
     using domain;
     using logging;
     using platforms;
@@ -53,6 +54,7 @@ namespace chocolatey.infrastructure.app.configuration
             Proxy = new ProxyConfiguration();
             ExportCommand = new ExportCommandConfiguration();
             TemplateCommand = new TemplateCommandConfiguration();
+            SecurityProtocols = new SecurityProtocolsConfiguration();
 #if DEBUG
             AllowUnofficialBuild = true;
 #endif
@@ -365,6 +367,12 @@ NOTE: Hiding sensitive configuration data! Please double and triple
         ///   On .NET 4.0, get error CS0200 when private set - see http://stackoverflow.com/a/23809226/18475
         /// </remarks>
         public TemplateCommandConfiguration TemplateCommand { get;  set; }
+
+        /// <summary>
+        /// Security protocol configuration to allow the
+        /// specific list of communication protocol
+        /// </summary>
+        public SecurityProtocolsConfiguration SecurityProtocols { get; set; }
     }
 
     [Serializable]
@@ -580,5 +588,11 @@ NOTE: Hiding sensitive configuration data! Please double and triple
     {
         public TemplateCommandType Command { get; set; }
         public string Name { get; set; }
+    }
+
+    [Serializable]
+    public sealed class SecurityProtocolsConfiguration
+    {
+        public string AllowedSecurityProtocol { get; set; }
     }
 }


### PR DESCRIPTION
 ## Description Of Changes
The previous configuration allowed the use of SSL3, TLS 1.0, TLS 1.1, TLS 1.2 by default. An entry has been added to the configuration that allows you to specify which protocols are allowed. TLS 1.3 has also been added.
 
 ## Motivation and Context
Ability to decide which protocol should be used when using choco.
 
 ## Testing
`---`
 
 ## Change Types Made
 * [ ]  Bug fix (non-breaking change)
 * [x]  Feature / Enhancement (non-breaking change)
 * [ ]  Breaking change (fix or feature that could cause existing functionality to change)
 
 ## Related Issue
 Fixes #2206  
 
 ## Change Checklist
 * [x]  Requires a change to the documentation
 * [ ]  Documentation has been updated - added to tracking issue here:
 * [ ]  Tests to cover my changes, have been added
 * [x]  All new and existing tests passed.

