### PR TITLE
#2676 Throw correctly error when url is not given

### DIFF
--- a/src/chocolatey.resources/helpers/functions/Get-ChocolateyWebFile.ps1
+++ b/src/chocolatey.resources/helpers/functions/Get-ChocolateyWebFile.ps1
@@ -261,8 +261,18 @@ param(
 
   # If we're on 32 bit or attempting to force 32 bit and there is no
   # 32 bit url, we need to throw an error.
-  if ($url -eq $null -or $url -eq '') {
-    throw "This package does not support $bitPackage architecture."
+  if (Get-OSArchitectureWidth 32) {
+      if ($url -eq $null -or $url -eq '') {
+        throw "$url was not given."
+  }
+  }
+
+  # If we're on 64 bit or attempting to force 64 bit and there is no
+  # 64 bit url, we need to throw an error.
+  if (Get-ProcessorBits 64) {
+      if ($url64bit -eq $null -or $url64bit -eq '') {
+        throw "$url64bit was not given."
+  }
   }
 
   # determine if the url can be SSL/TLS

--- a/src/chocolatey.resources/helpers/functions/Get-ChocolateyWebFile.ps1
+++ b/src/chocolatey.resources/helpers/functions/Get-ChocolateyWebFile.ps1
@@ -269,7 +269,7 @@ param(
 
   # If we're on 64 bit or attempting to force 64 bit and there is no
   # 64 bit url, we need to throw an error.
-  if (Get-ProcessorBits 64) {
+  if (Get-OSArchitectureWidth 64) {
       if ($url64bit -eq $null -or $url64bit -eq '') {
         throw "$url64bit was not given."
   }

--- a/src/chocolatey.resources/helpers/functions/Get-ChocolateyWebFile.ps1
+++ b/src/chocolatey.resources/helpers/functions/Get-ChocolateyWebFile.ps1
@@ -267,11 +267,17 @@ param(
   }
   }
 
+  if (Get-OSArchitectureWidth 32){
+      if (($url -eq $null -or $url -eq '') -and ($url64bit -ne $null -or $url64bit -ne '')){
+          throw "This package does not support $bitPackage architecture."
+      }
+  }
+
   # If we're on 64 bit or attempting to force 64 bit and there is no
   # 64 bit url, we need to throw an error.
   if (Get-OSArchitectureWidth 64) {
-      if ($url64bit -eq $null -or $url64bit -eq '') {
-        throw "$url64bit was not given."
+      if (($url64bit -eq $null -or $url64bit -eq '') -or ($url -eq $null -or $url -eq '')) {
+        throw "$url64bit or $url was not given."
   }
   }
 


### PR DESCRIPTION
 ## Description Of Changes
Change error message when url was not given. In addition, the `-url` and `-url64bit` flags were distinguished by checking whether you have a 32 or 64 bit system.
 
 ## Motivation and Context
Error message was misleading.
 
 ## Testing
 The following things have been done to test this:
Just run `Get-ChocolateyWebFile -packageName libreoffice-fresh -fileFullPath c:\file.exe -url "https://www.google.pl" -url64bit "https://www.google.pl"`
If you have 32 OS you must pass -url but -url64bit is not required.
If you have 64 OS you must pass -url64bit but -url is not required.

When you do not provide the parameter, you will recieve a error message
32 bit : `"$url was not given."`
64 bit : `"$url64bit was not given."` 
 
 ## Change Types Made
 * [x]  Bug fix (non-breaking change)
 * [ ]  Feature / Enhancement (non-breaking change)
 * [ ]  Breaking change (fix or feature that could cause existing functionality to change)
 
 ## Related Issue
 Fixes #2676 
 
 ## Change Checklist
 * [ ]  Requires a change to the documentation
 * [ ]  Documentation has been updated - added to tracking issue here:
 * [ ]  Tests to cover my changes, have been added
 * [x]  All new and existing tests passed.

