### PR TITLE
(#2743 #2742) Enhance the build and test environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,7 +41,9 @@ chocolatey.official.snk
 
 docs/generated
 
+# Testing related
 .vagrant
+buildOutput.txt
 
 # Build related
 tools/**

--- a/build.bat
+++ b/build.bat
@@ -1,12 +1,11 @@
 @echo off
-setlocal enableextensions enabledelayedexpansion
-set psscript="%~dp0/build.ps1"
+set psscript="%~dp0build.ps1"
 echo ==================================================
 echo ============= WRAP POWERSHELL SCRIPT =============
 echo ==================================================
 
 echo calling %psscript% with args %*
 PowerShell -NoProfile -ExecutionPolicy Bypass -Command "& '%psscript%' %*"
-
+set buildstatus=%ERRORLEVEL%
 echo ==================================================
-endlocal
+exit /b %buildstatus%

--- a/build.debug.bat
+++ b/build.debug.bat
@@ -1,12 +1,11 @@
 @echo off
-setlocal enableextensions enabledelayedexpansion
-set psscript="%~dp0/build.ps1"
+set psscript="%~dp0build.ps1"
 echo ==================================================
 echo ============= WRAP POWERSHELL SCRIPT =============
 echo ==================================================
 
 echo calling %psscript% with args %*
 PowerShell -NoProfile -ExecutionPolicy Bypass -Command "& '%psscript%' -Configuration Debug %*"
-
+set buildstatus=%ERRORLEVEL%
 echo ==================================================
-endlocal
+exit /b %buildstatus%

--- a/build.official.bat
+++ b/build.official.bat
@@ -1,12 +1,11 @@
 @echo off
-setlocal enableextensions enabledelayedexpansion
-set psscript="%~dp0/build.ps1"
+set psscript="%~dp0build.ps1"
 echo ==================================================
 echo ============= WRAP POWERSHELL SCRIPT =============
 echo ==================================================
 
 echo calling %psscript% with args %*
 PowerShell -NoProfile -ExecutionPolicy Bypass -Command "& '%psscript%' -Configuration ReleaseOfficial %*"
-
+set buildstatus=%ERRORLEVEL%
 echo ==================================================
-endlocal
+exit /b %buildstatus%

--- a/recipe.cake
+++ b/recipe.cake
@@ -109,7 +109,7 @@ Task("Prepare-Chocolatey-Packages")
     // Run Chocolatey Unpackself
     CopyFile(BuildParameters.Paths.Directories.PublishedApplications + "/choco_merged/choco.exe", BuildParameters.Paths.Directories.ChocolateyNuspecDirectory + "/tools/chocolateyInstall/choco.exe");
 
-    StartProcess(BuildParameters.Paths.Directories.ChocolateyNuspecDirectory + "/tools/chocolateyInstall/choco.exe", new ProcessSettings{ Arguments = "unpackself -f --allow-unofficial-build" });
+    StartProcess(BuildParameters.Paths.Directories.ChocolateyNuspecDirectory + "/tools/chocolateyInstall/choco.exe", new ProcessSettings{ Arguments = "unpackself -f -y --allow-unofficial-build" });
 
     // Tidy up logs and config folder which are not required
     var logsDirectory = BuildParameters.Paths.Directories.ChocolateyNuspecDirectory + "/tools/chocolateyInstall/logs";

--- a/tests/Vagrantfile
+++ b/tests/Vagrantfile
@@ -38,7 +38,7 @@ Vagrant.configure("2") do |config|
   config.vm.synced_folder '../', '/chocoRoot'
 
   config.vm.provision "shell", inline: <<-SHELL
-    cscript c:/windows/system32/slmgr.vbs /rearm
+    cscript c:/windows/system32/slmgr.vbs /rearm | Out-Null
     Set-ExecutionPolicy Bypass -Scope Process -Force
     [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072
     iex ((New-Object System.Net.WebClient).DownloadString('https://community.chocolatey.org/install.ps1'))
@@ -53,6 +53,8 @@ Vagrant.configure("2") do |config|
     Write-Host "Files have been copied, beginning build process. You may see some red warning text regarding VsVersionToYearString, this can be safely ignored"
     $CakeOutput = ./build.bat
     if ($LastExitCode -ne 0) {
+      Set-Content c:/chocoRoot/buildOutput.txt -Value $CakeOutput
+      Write-Host "The build has failed. Please see the buildOutput.txt file at the root of the repository for details"
       exit $LastExitCode
     }
 


### PR DESCRIPTION
## Description Of Changes

* Enhance the build process to work without input when not an administrator.
* Enhance build batch files to exit with proper exit code if build fails.
* Update testing vagrantfile to take advantage of the proper exit code and provide build output in a file if the build fails.

## Motivation and Context

* The build process runs `choco unpackself` which by default requires administrator permissions. In this scenario they're not needed, so we can at least get around the prompt by passing `-y`.
* Currently the build exits 0 regardless of the results. Exiting with non-zero when fail allows CI/CD automations to keep using the build.bat file.
* If the build fails for the test environment, it would be helpful to have the output somewhere to reference.

## Testing

1. From a non-administrator prompt run `./build.bat`
2. Confirm that at the `Prepare-Chocolatey-Packages` stage Chocolatey prompts for admin, then continues after a 20 second wait
3. Remove a source file from somewhere
4. Run `./build.bat`
5. Check `%ERRORLEVEL%` or `$LastExitCode` if in cmd or PowerShell
6. Change into the `tests` directory
7. Run `vagrant up`
8. Verify that it tells you that the build failed
9. Verify that the `buildOutput.txt` file is in the root of the repository.
10. Run `git restore ..` to restore the files in the repository
11. run `vagrant provision` (this will rerun the provision script which does the test running, this allows you to forego all of the prerequisite installations as they can take a while)
12. Verify that the tests all run successfully (this is expected to take 15 or more minutes)

## Change Types Made

* [ ] Bug fix (non-breaking change)
* [ ] Feature / Enhancement (non-breaking change)
* [ ] Breaking change (fix or feature that could cause existing functionality to change)
* [ ] PowerShell code changes.
* [x] Build enhancement

## Related Issue

Fixes #2743 
Fixes #2742 

## Change Checklist

* [ ] Requires a change to the documentation
* [ ] Documentation has been updated
* [ ] Tests to cover my changes, have been added
* [x] All new and existing tests passed.
* [ ] PowerShell v2 compatibility checked.