### PR TITLE
(#2754) Add support for detecting newer Windows versions

### DIFF
--- a/src/chocolatey/infrastructure/platforms/Platform.cs
+++ b/src/chocolatey/infrastructure/platforms/Platform.cs
@@ -126,7 +126,15 @@ namespace chocolatey.infrastructure.platforms
             switch (majorMinor)
             {
                 case "10.0":
-                    name = isServer ? "Windows Server 2016" : "Windows 10";
+                    if (isServer)
+                    {
+                        name = (version.Build < 20348) ? (version.Build < 17763) ?
+                            "Windows Server 2016" : "Windows Server 2019" : "Windows Server 2022";
+                    }
+                    else
+                    {
+                        name = (version.Build < 22000) ? "Windows 10" : "Windows 11";
+                    }
                     break;
                 case "6.4":
                     name = isServer ? "Windows Server 2016" : "Windows 10";


### PR DESCRIPTION
## Description Of Changes

This allows Chocolatey CLI to detect Windows 11, Server 2019 and Server 2022.
Which will allow the OS_NAME environment variable to be set correctly on those
operating systems.

## Motivation and Context

See #2754

## Testing

N/A

## Change Types Made

* [ ] Bug fix (non-breaking change)
* [x] Feature / Enhancement (non-breaking change)
* [ ] Breaking change (fix or feature that could cause existing functionality to change)
* [ ] PowerShell code changes.

## Related Issue

Fixes #2754

## Change Checklist

* [ ] Requires a change to the documentation
* [ ] Documentation has been updated
* [ ] Tests to cover my changes, have been added
* [x] All new and existing tests passed.
* [x] PowerShell v2 compatibility checked.
