### PR TITLE
(#2801) Pin Chocolatey packages for outdated tests

### DIFF
--- a/tests/chocolatey-tests/commands/choco-outdated.Tests.ps1
+++ b/tests/chocolatey-tests/commands/choco-outdated.Tests.ps1
@@ -3,7 +3,6 @@
 Describe "choco outdated" -Tag Chocolatey, OutdatedCommand {
     BeforeAll {
         Initialize-ChocolateyTestInstall
-        New-ChocolateyInstallSnapshot
         # Pin all of the Chocolatey packages
         @(
             'chocolatey'
@@ -16,6 +15,7 @@ Describe "choco outdated" -Tag Chocolatey, OutdatedCommand {
             $null = Invoke-Choco pin add -n $_
         }
         Invoke-Choco install upgradepackage --version 1.0.0 --confirm
+        New-ChocolateyInstallSnapshot
     }
 
     AfterAll {

--- a/tests/chocolatey-tests/commands/choco-outdated.Tests.ps1
+++ b/tests/chocolatey-tests/commands/choco-outdated.Tests.ps1
@@ -4,6 +4,17 @@ Describe "choco outdated" -Tag Chocolatey, OutdatedCommand {
     BeforeAll {
         Initialize-ChocolateyTestInstall
         New-ChocolateyInstallSnapshot
+        # Pin all of the Chocolatey packages
+        @(
+            'chocolatey'
+            'chocolatey.extension'
+            'chocolatey-agent'
+            'chocolatey-management-database'
+            'chocolatey-management-service'
+            'chocolatey-management-web'
+        ) | ForEach-Object {
+            $null = Invoke-Choco pin add -n $_
+        }
         Invoke-Choco install upgradepackage --version 1.0.0 --confirm
     }
 


### PR DESCRIPTION
## Description Of Changes

Update the pester tests for the `outdated` command to pin all of the Chocolatey packages to prevent inadvertent test failures when CI/CD builds new versions automatically.

## Motivation and Context

Occasionally CI will build a new version while Test Kitchen is running. This results in a failure as there's an outdated Chocolatey package that wasn't expected.

## Testing

1. Ran in Team City indicating to pull from `https://github.com/corbob/choco.git` for the repository, `outdated-tests` for the branch, `1.2.0-alpha-20220813-368` for the Chocolatey CLI version (latest on internal repository at this time is: `1.2.0-alpha-20220822-371`), and `OutdatedCommand` for the Tags to test: https://sra-soteria-web.ch0.co/buildConfiguration/TestKitchen_AdHoc/3721?buildTab=tests which resulted in 0 failed tests.
2. Ran in Team City indicating to pull from `https://github.com/chocolatey/choco.git` for the repository, `develop` for the branch, `1.2.0-alpha-20220813-368` for the Chocolatey CLI version (latest on internal repository at this time is: `1.2.0-alpha-20220822-371`), and `OutdatedCommand` for the Tags to test: https://sra-soteria-web.ch0.co/buildConfiguration/TestKitchen_AdHoc/3723?buildTab=tests which resulted in 2 failed tests (as expected).

## Change Types Made

* [x] Bug fix (non-breaking change)
* [ ] Feature / Enhancement (non-breaking change)
* [ ] Breaking change (fix or feature that could cause existing functionality to change)
* [x] PowerShell code changes.

## Related Issue

Fixes #2801

## Change Checklist

* [ ] Requires a change to the documentation
* [ ] Documentation has been updated
* [x] Tests to cover my changes, have been added
* [x] All new and existing tests passed.
* [ ] PowerShell v2 compatibility checked.