### PR TITLE
(#2410) Update to escape single quote as well as double quotes.

### DIFF
--- a/src/chocolatey/infrastructure.app/services/PowershellService.cs
+++ b/src/chocolatey/infrastructure.app/services/PowershellService.cs
@@ -165,7 +165,7 @@ namespace chocolatey.infrastructure.app.services
 
         private string prepare_powershell_arguments(string argument)
         {
-            return argument.to_string().Replace("\"", "\\\"");
+            return argument.to_string().Replace("\"", "\\\"").Replace("'", "\\'");
         }
 
         public bool run_action(ChocolateyConfiguration configuration, PackageResult packageResult, CommandNameType command)


### PR DESCRIPTION
## Description Of Changes

Update to escape single quote as well as double quotes.

## Motivation and Context

When a saved parameter has a single quote in it the quoted string passed is incorrectly formatted

## Testing
<!-- How has this change been tested? If multiple different tests have been done please list them.
1. Tested this way
1. Tested that way
-->

## Change Types Made

* [x] Bug fix (non-breaking change)
* [ ] Feature / Enhancement (non-breaking change)
* [ ] Breaking change (fix or feature that could cause existing functionality to change)
* [ ] PowerShell code changes.

## Related Issue

Fixes #2410

## Change Checklist

* [ ] Requires a change to the documentation
* [ ] Documentation has been updated
* [ ] Tests to cover my changes, have been added
* [ ] All new and existing tests passed.
* [ ] PowerShell v2 compatibility checked.
