### PR TITLE
(doc) Remove Get-WebHeaders notes

### DIFF
--- a/src/chocolatey.resources/helpers/functions/Get-WebHeaders.ps1
+++ b/src/chocolatey.resources/helpers/functions/Get-WebHeaders.ps1
@@ -24,9 +24,6 @@ This is a low-level function that is used by Chocolatey to get the
 headers for a request/response to better help when getting and
 validating internet resources.
 
-.NOTES
-Not recommended for use in package scripts.
-
 .INPUTS
 None
 


### PR DESCRIPTION
## Description Of Changes
Removed the notes section of the function comment based help.

## Motivation and Context
The notes suggested the function was not recommended for use in the package scripts. With changes to the [Package Validator rules](https://blog.chocolatey.org/2022/08/upcoming-changes-validator/) we want to avoid suggesting this cannot be used in lieu of `Invoke-WebRequest`, for example.

## Testing
N/A

## Change Types Made
<!-- Tick the boxes for the type of changes that have been made -->

* [ ] Bug fix (non-breaking change)
* [ ] Feature / Enhancement (non-breaking change)
* [ ] Breaking change (fix or feature that could cause existing functionality to change)
* [ ] PowerShell code changes.

## Related Issue
N/A

## Change Checklist

* [x] Requires a change to the documentation
* [x] Documentation has been updated
* [ ] Tests to cover my changes, have been added
* [ ] All new and existing tests passed.
* [ ] PowerShell v2 compatibility checked.