### PR TITLE
(#2807) Removed trailing semicolon for PowerShell code

### DIFF
--- a/src/chocolatey/infrastructure.app/templates/ChocolateyInstallTemplate.cs
+++ b/src/chocolatey/infrastructure.app/templates/ChocolateyInstallTemplate.cs
@@ -26,7 +26,7 @@ namespace chocolatey.infrastructure.app.templates
 # 1. See the _TODO.md that is generated top level and read through that
 # 2. Follow the documentation below to learn how to create a package for the package type you are creating.
 # 3. In Chocolatey scripts, ALWAYS use absolute paths - $toolsDir gets you to the package's tools directory.
-$ErrorActionPreference = 'Stop'; # stop on all errors[[AutomaticPackageNotesInstaller]]
+$ErrorActionPreference = 'Stop' # stop on all errors[[AutomaticPackageNotesInstaller]]
 $toolsDir   = ""$(Split-Path -parent $MyInvocation.MyCommand.Definition)""
 # Internal packages (organizations) or software that has redistribution rights (community repo)
 # - Use `Install-ChocolateyInstallPackage` instead of `Install-ChocolateyPackage`

--- a/src/chocolatey/infrastructure.app/templates/ChocolateyUninstallTemplate.cs
+++ b/src/chocolatey/infrastructure.app/templates/ChocolateyUninstallTemplate.cs
@@ -31,7 +31,7 @@ namespace chocolatey.infrastructure.app.templates
 ## If this is an MSI, ensure 'softwareName' is appropriate, then clean up comments and you are done.
 ## If this is an exe, change fileType, silentArgs, and validExitCodes
 
-$ErrorActionPreference = 'Stop'; # stop on all errors
+$ErrorActionPreference = 'Stop' # stop on all errors
 $packageArgs = @{
   packageName   = $env:ChocolateyPackageName
   softwareName  = '[[PackageName]]*'  #part or all of the Display Name as you see it in Programs and Features. It should be enough to be unique

--- a/tests/packages/business-only-license/tools/chocolateyinstall.ps1
+++ b/tests/packages/business-only-license/tools/chocolateyinstall.ps1
@@ -1,4 +1,4 @@
-﻿$ErrorActionPreference = 'Stop';
+﻿$ErrorActionPreference = 'Stop'
 
 $LicensedCommandsRegistered = Get-Command "Invoke-ValidateChocolateyLicense" -EA SilentlyContinue
 if (!$LicensedCommandsRegistered) {

--- a/tests/packages/business-only-license/tools/chocolateyuninstall.ps1
+++ b/tests/packages/business-only-license/tools/chocolateyuninstall.ps1
@@ -1,4 +1,4 @@
-﻿$ErrorActionPreference = 'Stop';
+﻿$ErrorActionPreference = 'Stop'
 
 $packageArgs = @{
   packageName   = $env:ChocolateyPackageName

--- a/tests/packages/get-chocolateyunzip-licensed/tools/chocolateyinstall.ps1
+++ b/tests/packages/get-chocolateyunzip-licensed/tools/chocolateyinstall.ps1
@@ -1,4 +1,4 @@
-﻿$ErrorActionPreference = 'Stop';
+﻿$ErrorActionPreference = 'Stop'
 
 $toolsDir     = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
 $fileLocation = Join-Path $toolsDir 'cmake-3.21.2-windows-i386.zip'

--- a/tests/packages/hasbeforeinstallblock/1.0.0/tools/chocolateyinstall.ps1
+++ b/tests/packages/hasbeforeinstallblock/1.0.0/tools/chocolateyinstall.ps1
@@ -1,4 +1,4 @@
-﻿$ErrorActionPreference = 'Stop'; # stop on all errors
+﻿$ErrorActionPreference = 'Stop' # stop on all errors
 
 $packageArgs = @{
   packageName   = $env:ChocolateyPackageName

--- a/tests/packages/msi.template/templates/tools/chocolateyinstall.ps1
+++ b/tests/packages/msi.template/templates/tools/chocolateyinstall.ps1
@@ -1,4 +1,4 @@
-﻿$ErrorActionPreference = 'Stop';
+﻿$ErrorActionPreference = 'Stop'
 
 [[AutomaticPackageNotesInstaller]]
 $packageName= '[[PackageName]]'

--- a/tests/packages/msi.template/templates/tools/chocolateyuninstall.ps1
+++ b/tests/packages/msi.template/templates/tools/chocolateyuninstall.ps1
@@ -1,4 +1,4 @@
-﻿$ErrorActionPreference = 'Stop'; # stop on all errors
+﻿$ErrorActionPreference = 'Stop' # stop on all errors
 
 $packageName = '[[PackageName]]'
 $softwareName = '[[PackageName]]*' #part or all of the Display Name as you see it in Programs and Features. It should be enough to be unique

--- a/tests/packages/zip.template/templates/tools/chocolateyinstall.ps1
+++ b/tests/packages/zip.template/templates/tools/chocolateyinstall.ps1
@@ -1,4 +1,4 @@
-﻿$ErrorActionPreference = 'Stop';
+﻿$ErrorActionPreference = 'Stop'
 
 [[AutomaticPackageNotesInstaller]]
 $packageName= '[[PackageName]]'


### PR DESCRIPTION
## Description Of Changes
Removed the trailing semicolon from PowerShell Code.

## Motivation and Context
PowerShell does not need a trailing semicolon on code so it should be removed to be PowerShell like.

## Testing
N/A

## Change Types Made

* [x] Bug fix (non-breaking change)
* [ ] Feature / Enhancement (non-breaking change)
* [ ] Breaking change (fix or feature that could cause existing functionality to change)
* [ ] PowerShell code changes.

## Related Issue
<!-- Make sure you have raised an issue for this pull request before
continuing. -->

Fixes #2807

## Change Checklist

* [ ] Requires a change to the documentation
* [ ] Documentation has been updated
* [ ] Tests to cover my changes, have been added
* [ ] All new and existing tests passed.
* [ ] PowerShell v2 compatibility checked.