### PR TITLE
(#2789) Use PowerShell to get and set ACLs (CU-ENGTASKS-1480)

### DIFF
--- a/nuspec/chocolatey/chocolatey/tools/chocolateysetup.psm1
+++ b/nuspec/chocolatey/chocolatey/tools/chocolateysetup.psm1
@@ -288,7 +288,7 @@ param(
   $ErrorActionPreference = 'Stop'
   try {
     # get current acl
-    $acl = (Get-Item $folder).GetAccessControl('Access,Owner')
+    $acl = Get-Acl $folder
 
     Write-Debug "Removing existing permissions."
     $acl.Access | ForEach-Object { $acl.RemoveAccessRuleAll($_) }
@@ -334,17 +334,17 @@ param(
     $acl.SetAccessRuleProtection($true, $false)
 
     # enact the changes against the actual
-    (Get-Item $folder).SetAccessControl($acl)
+    Set-Acl -Path $folder -AclObject $acl
 
     # set an explicit append permission on the logs folder
     Write-Debug "Allow users to append to log files."
     $logsFolder = "$folder\logs"
     Create-DirectoryIfNotExists $logsFolder
-    $logsAcl = (Get-Item $logsFolder).GetAccessControl('Access')
+    $logsAcl = Get-Acl $logsFolder
     $usersAppendAccessRule = New-Object System.Security.AccessControl.FileSystemAccessRule($builtinUsers, $rightsWrite, [Security.AccessControl.InheritanceFlags]::ObjectInherit, [Security.AccessControl.PropagationFlags]::InheritOnly, "Allow")
     $logsAcl.SetAccessRule($usersAppendAccessRule)
     $logsAcl.SetAccessRuleProtection($false, $true)
-    (Get-Item $logsFolder).SetAccessControl($logsAcl)
+    Set-Acl -Path $logsFolder -AclObject $logsAcl
   } catch {
     Write-ChocolateyWarning "Not able to set permissions for $folder."
   }


### PR DESCRIPTION
## Description Of Changes

Get and Set ACLs using PowerShell cmdlets instead of .Net calls.

## Motivation and Context

The methods we were using to get and set ACLs were removed sometime after PowerShell 5.1 (I would guess in .Net core), and so installation of Chocolatey did not work under PowerShell Core or newer.

## Testing

On a Windows 7 PowerShell 2 system, and on a Windows 10 PowerShell 7.2.6 system performed the following steps:

1. Download `https://community.chocolatey.org/install.ps1` to the local system (This is mostly because the Windows 7 system can't access much due to TLS versions).
2. Copy Chocolatey nupkg to system
3. Run `install.ps1 -ChocolateyDownloadUrl <Path to Chocolatey.nupkg>` (Note: I made a slight change to the 7za.exe download for Windows 7 due to TLS)
4. Confirmed that Chocolatey installed and did not encounter the error described.

<img width="1484" alt="image" src="https://user-images.githubusercontent.com/30301021/190016382-13726a50-c5c9-46c4-975a-402b3971aeb1.png">

I'm not sure this is something we can reliably test with Pester/Test Kitchen. I have expanded the Manual testing document to explicitly call out the warning and ensure it doesn't appear.

## Change Types Made

* [x] Bug fix (non-breaking change)
* [ ] Feature / Enhancement (non-breaking change)
* [ ] Breaking change (fix or feature that could cause existing functionality to change)
* [x] PowerShell code changes.

## Related Issue

Fixes #2789 

## Change Checklist

* [ ] Requires a change to the documentation
* [ ] Documentation has been updated
* [ ] Tests to cover my changes, have been added
* [x] All new and existing tests passed.
* [x] PowerShell v2 compatibility checked.
