### PR TITLE
(#2787) Deprecate side by side installations

### DIFF
--- a/src/chocolatey.tests.integration/scenarios/InstallScenarios.cs
+++ b/src/chocolatey.tests.integration/scenarios/InstallScenarios.cs
@@ -1409,6 +1409,22 @@ namespace chocolatey.tests.integration.scenarios
             }
 
             [Fact]
+            public void should_contain_a_warning_message_that_installing_package_with_multiple_versions_being_deprecated()
+            {
+                const string expected = "Installing the same package with multiple versions is deprecated and will be removed in v2.0.0.";
+
+                foreach (var message in MockLogger.MessagesFor(LogLevel.Warn).or_empty_list_if_null())
+                {
+                    if (message.Contains(expected))
+                    {
+                        return;
+                    }
+                }
+
+                Assert.Fail("No warning message about side by side deprecation outputted");
+            }
+
+            [Fact]
             public void should_have_a_successful_package_result()
             {
                 packageResult.Success.ShouldBeTrue();

--- a/src/chocolatey/infrastructure.app/commands/ChocolateyInstallCommand.cs
+++ b/src/chocolatey/infrastructure.app/commands/ChocolateyInstallCommand.cs
@@ -73,7 +73,7 @@ namespace chocolatey.infrastructure.app.commands
                      "AllowDowngrade - Should an attempt at downgrading be allowed? Defaults to false.",
                      option => configuration.AllowDowngrade = option != null)
                 .Add("m|sxs|sidebyside|side-by-side|allowmultiple|allow-multiple|allowmultipleversions|allow-multiple-versions",
-                     "AllowMultipleVersions - Should multiple versions of a package be installed? Defaults to false.",
+                     "AllowMultipleVersions - Should multiple versions of a package be installed? Defaults to false. (DEPRECATED)",
                      option => configuration.AllowMultipleVersions = option != null)
                 .Add("i|ignoredependencies|ignore-dependencies",
                      "IgnoreDependencies - Ignore dependencies when installing package(s). Defaults to false.",
@@ -254,6 +254,10 @@ NOTE: 100% compatible with older chocolatey client (0.9.8.32 and below)
 Starting in v2.0.0 the shortcut `cinst` will be removed and can not be used
 to install packages anymore. We recommend you make sure that you always
 use the full command going forward (`choco install`).
+
+Side by side installations has been deprecated and will be removed in v2.0.0.
+Instead of using side by side installations, distinct packages should be created
+if similar functionality is needed going forward.
 ");
 
             "chocolatey".Log().Info(ChocolateyLoggers.Important, "Usage");

--- a/src/chocolatey/infrastructure.app/commands/ChocolateyUninstallCommand.cs
+++ b/src/chocolatey/infrastructure.app/commands/ChocolateyUninstallCommand.cs
@@ -67,7 +67,7 @@ namespace chocolatey.infrastructure.app.commands
                      "Apply Package Parameters To Dependencies  - Should package parameters be applied to dependent packages? Defaults to false.",
                      option => configuration.ApplyPackageParametersToDependencies = option != null)
                 .Add("m|sxs|sidebyside|side-by-side|allowmultiple|allow-multiple|allowmultipleversions|allow-multiple-versions",
-                     "AllowMultipleVersions - Should multiple versions of a package be installed? Defaults to false.",
+                     "AllowMultipleVersions - Should multiple versions of a package be installed? Defaults to false. (DEPRECATED)",
                      option => configuration.AllowMultipleVersions = option != null)
                 .Add("x|forcedependencies|force-dependencies|removedependencies|remove-dependencies",
                      "RemoveDependencies - Uninstall dependencies when uninstalling package(s). Defaults to false.",
@@ -208,6 +208,10 @@ NOTE: Synchronizer and AutoUninstaller enhancements in licensed
 Starting in v2.0.0 the shortcut `cuninst` will be removed and can not be used
 to uninstall packages anymore. We recommend you make sure that you always
 use the full command going forward (`choco uninstall`).
+
+Side by side installations has been deprecated and support for uninstalling such packages will be removed in v2.0.0.
+Instead of using side by side installations, distinct packages should be created
+if similar functionality is needed going forward.
 ");
 
             "chocolatey".Log().Info(ChocolateyLoggers.Important, "Usage");

--- a/src/chocolatey/infrastructure.app/commands/ChocolateyUpgradeCommand.cs
+++ b/src/chocolatey/infrastructure.app/commands/ChocolateyUpgradeCommand.cs
@@ -73,7 +73,7 @@ namespace chocolatey.infrastructure.app.commands
                      "AllowDowngrade - Should an attempt at downgrading be allowed? Defaults to false.",
                      option => configuration.AllowDowngrade = option != null)
                 .Add("m|sxs|sidebyside|side-by-side|allowmultiple|allow-multiple|allowmultipleversions|allow-multiple-versions",
-                     "AllowMultipleVersions - Should multiple versions of a package be installed? Defaults to false.",
+                     "AllowMultipleVersions - Should multiple versions of a package be installed? Defaults to false. (DEPRECATED)",
                      option => configuration.AllowMultipleVersions = option != null)
                 .Add("i|ignoredependencies|ignore-dependencies",
                      "IgnoreDependencies - Ignore dependencies when upgrading package(s). Defaults to false.",
@@ -285,6 +285,10 @@ NOTE: 100% compatible with older Chocolatey client (0.9.8.x and below)
 Starting in v2.0.0 the shortcut `cup` will be removed and can not be used
 to upgrade or install packages anymore. We recommend you make sure that you always
 use the full command going forward (`choco upgrade`).
+
+Side by side installations has been deprecated and will be removed in v2.0.0.
+Instead of using side by side installations, distinct packages should be created
+if similar functionality is needed going forward.
 ");
 
             "chocolatey".Log().Info(ChocolateyLoggers.Important, "Usage");

--- a/src/chocolatey/infrastructure.app/configuration/ChocolateyConfiguration.cs
+++ b/src/chocolatey/infrastructure.app/configuration/ChocolateyConfiguration.cs
@@ -233,6 +233,8 @@ NOTE: Hiding sensitive configuration data! Please double and triple
         public bool ApplyPackageParametersToDependencies { get; set; }
         public bool ApplyInstallArgumentsToDependencies { get; set; }
         public bool IgnoreDependencies { get; set; }
+
+        [Obsolete("Side by Side installation is deprecated, and is pending removal in v2.0.0")]
         public bool AllowMultipleVersions { get; set; }
         public bool AllowDowngrade { get; set; }
         public bool ForceDependencies { get; set; }

--- a/src/chocolatey/infrastructure.app/domain/ChocolateyPackageInformation.cs
+++ b/src/chocolatey/infrastructure.app/domain/ChocolateyPackageInformation.cs
@@ -16,6 +16,7 @@
 
 namespace chocolatey.infrastructure.app.domain
 {
+    using System;
     using NuGet;
 
     public sealed class ChocolateyPackageInformation
@@ -31,6 +32,8 @@ namespace chocolatey.infrastructure.app.domain
         public string Arguments { get; set; }
         public SemanticVersion VersionOverride { get; set; }
         public bool HasSilentUninstall { get; set; }
+
+        [Obsolete("Side by side installations are deprecated, with removal pending in v2.0.0")]
         public bool IsSideBySide { get; set; }
         public bool IsPinned { get; set; }
         public string ExtraInformation { get; set; }

--- a/src/chocolatey/infrastructure.app/nuget/ChocolateyPackagePathResolver.cs
+++ b/src/chocolatey/infrastructure.app/nuget/ChocolateyPackagePathResolver.cs
@@ -16,6 +16,7 @@
 
 namespace chocolatey.infrastructure.app.nuget
 {
+    using System;
     using System.IO;
     using NuGet;
 
@@ -24,8 +25,16 @@ namespace chocolatey.infrastructure.app.nuget
     public sealed class ChocolateyPackagePathResolver : DefaultPackagePathResolver
     {
         private readonly IFileSystem _nugetFileSystem;
+
+        [Obsolete("Side by Side installations are deprecated, and is pending removal in v2.0.0")]
         public bool UseSideBySidePaths { get; set; }
 
+        public ChocolateyPackagePathResolver(IFileSystem nugetFileSystem)
+            : this(nugetFileSystem, useSideBySidePaths: false)
+        {
+        }
+
+        [Obsolete("Initializing using side by side installation enabled is deprecated. Use overload without useSideBySidePaths instead.")]
         public ChocolateyPackagePathResolver(IFileSystem nugetFileSystem, bool useSideBySidePaths)
             : base(nugetFileSystem, useSideBySidePaths)
         {
@@ -47,6 +56,7 @@ namespace chocolatey.infrastructure.app.nuget
             return GetPackageDirectory(packageId, version, UseSideBySidePaths);
         }
 
+        [Obsolete("Side by Side installations are deprecated, and is pending removal in v2.0.0")]
         public string GetPackageDirectory(string packageId, SemanticVersion version, bool useVersionInPath)
         {
             string directory = packageId;

--- a/src/chocolatey/infrastructure.app/services/ChocolateyPackageService.cs
+++ b/src/chocolatey/infrastructure.app/services/ChocolateyPackageService.cs
@@ -573,6 +573,11 @@ package '{0}' - stopping further execution".format_with(packageResult.Name));
 
         public virtual ConcurrentDictionary<string, PackageResult> install_run(ChocolateyConfiguration config)
         {
+            if (config.AllowMultipleVersions)
+            {
+                this.Log().Warn(ChocolateyLoggers.Important, "Installing the same package with multiple versions is deprecated and will be removed in v2.0.0.");
+            }
+
             this.Log().Info(is_packages_config_file(config.PackageNames) ? @"Installing from config file:" : @"Installing the following packages:");
             this.Log().Info(ChocolateyLoggers.Important, @"{0}".format_with(config.PackageNames));
 
@@ -812,6 +817,11 @@ Would have determined packages that are out of date based on what is
 
         public virtual ConcurrentDictionary<string, PackageResult> upgrade_run(ChocolateyConfiguration config)
         {
+            if (config.AllowMultipleVersions)
+            {
+                this.Log().Warn(ChocolateyLoggers.Important, "Upgrading the same package with multiple versions is deprecated and will be removed in v2.0.0.");
+            }
+
             this.Log().Info(@"Upgrading the following packages:");
             this.Log().Info(ChocolateyLoggers.Important, @"{0}".format_with(config.PackageNames));
 

--- a/src/chocolatey/infrastructure.app/services/NugetService.cs
+++ b/src/chocolatey/infrastructure.app/services/NugetService.cs
@@ -950,6 +950,15 @@ Please see https://docs.chocolatey.org/en-us/troubleshooting for more
                 packageResult.Messages.Add(new ResultMessage(ResultType.Note, logMessage));
 
                 this.Log().Info("{0}|{1}|{2}|{3}".format_with(installedPackage.Id, installedPackage.Version, latestPackage.Version, isPinned.to_string().to_lower()));
+
+                if (pkgInfo.IsSideBySide)
+                {
+                    var deprecationMessage = @"
+{0} v{1} has been installed as a side by side installation.
+Side by side installations are deprecated and is pending removal in v2.0.0".format_with(installedPackage.Id, installedPackage.Version);
+
+                    packageResult.Messages.Add(new ResultMessage(ResultType.Warn, deprecationMessage));
+                }
             }
 
             return outdatedPackages;
@@ -1264,6 +1273,8 @@ Please see https://docs.chocolatey.org/en-us/troubleshooting for more
             packageManager.PackageUninstalling += (s, e) =>
                 {
                     var pkg = e.Package;
+
+                    // TODO: Removal special handling for SxS packages once we hit v2.0.0
 
                     // this section fires twice sometimes, like for older packages in a sxs install...
                     var packageResult = packageUninstalls.GetOrAdd(pkg.Id.to_lower() + "." + pkg.Version.to_string(), new PackageResult(pkg, e.InstallPath));

--- a/tests/chocolatey-tests/choco-info.Tests.ps1
+++ b/tests/chocolatey-tests/choco-info.Tests.ps1
@@ -142,4 +142,21 @@ Describe "choco info" -Tag Chocolatey, InfoCommand {
             $Output.Lines | Should -Contain "${Title}: $Value"
         }
     }
+
+    Context "Listing package information about local side by side installed package" {
+        BeforeAll {
+            $null = Invoke-Choco install 'isdependency' --confirm --sxs
+
+            $Output = Invoke-Choco info 'isdependency' --local-only
+        }
+
+        It "Exits with Success (0)" {
+            $Output.ExitCode | Should -Be 0
+        }
+
+        It "Outputs a warning message that installed side by side package is deprecated" {
+            $Output.Lines | Should -Contain "isdependency has been installed as a side by side installation." -Because $Output.String
+            $Output.Lines | Should -Contain "Side by side installations are deprecated and is pending removal in v2.0.0." -Because $Output.String
+        }
+    }
 }

--- a/tests/chocolatey-tests/choco-install.Tests.ps1
+++ b/tests/chocolatey-tests/choco-install.Tests.ps1
@@ -565,6 +565,10 @@ Describe "choco install" -Tag Chocolatey, InstallCommand {
             $XML.package.metadata.version | Should -Be "1.0.0"
         }
 
+        It "Outputs a warning message about side by side installs are deprecated" {
+            $Output.Lines | Should -Contain "Installing the same package with multiple versions is deprecated and will be removed in v2.0.0." -Because $Output.String
+        }
+
         It "Outputs a message indicating that it installed the package successfully" {
             $Output.Lines | Should -Contain "Chocolatey installed 1/1 packages."
         }
@@ -599,6 +603,10 @@ Describe "choco install" -Tag Chocolatey, InstallCommand {
             $XML.package.metadata.version | Should -Be "1.0.0"
         }
 
+        It "Outputs a warning message about side by side installs are deprecated" {
+            $Output.Lines | Should -Contain "Installing the same package with multiple versions is deprecated and will be removed in v2.0.0." -Because $Output.String
+        }
+
         It "Outputs a message indicating that it installed the package successfully" {
             $Output.Lines | Should -Contain "Chocolatey installed 1/1 packages."
         }
@@ -627,6 +635,15 @@ Describe "choco install" -Tag Chocolatey, InstallCommand {
             "$env:ChocolateyInstall\lib\$($PackageUnderTest)\$($PackageUnderTest).nuspec" | Should -Exist
             [xml]$XML = Get-Content "$env:ChocolateyInstall\lib\$($PackageUnderTest)\$($PackageUnderTest).nuspec"
             $XML.package.metadata.version | Should -Be "1.0.0"
+        }
+
+        It "Does not output a warning message about side by side installs are deprecated" {
+            $Output.Lines | Should -Not -Contain "Installing the same package with multiple versions is deprecated and will be removed in v2.0.0." -Because $Output.String
+        }
+
+        It "Does not output a warning message that installed side by side package is deprecated" {
+            $Output.Lines | Should -Not -Contain "installpackage has been installed as a side by side installation." -Because $Output.String
+            $Output.Lines | Should -Not -Contain "Side by side installations are deprecated and is pending removal in v2.0.0." -Because $Output.String
         }
 
         It "Outputs a message indicating that it installed the package successfully" {

--- a/tests/chocolatey-tests/choco-list.Tests.ps1
+++ b/tests/chocolatey-tests/choco-list.Tests.ps1
@@ -169,6 +169,11 @@ Describe "choco <_>" -ForEach $Command -Tag Chocolatey, ListCommand, SearchComma
         It "Shows version <_> of local package" -ForEach @("2.0.0"; "1.1.0") {
             $Output.Lines | Should -Contain "isdependency $_"
         }
+
+        It "Outputs a warning message that installed side by side package is deprecated" {
+            $Output.Lines | Should -Contain "isdependency has been installed as a side by side installation."
+            $Output.Lines | Should -Contain "Side by side installations are deprecated and is pending removal in v2.0.0."
+        }
     }
 
     Context "Searching packages with Verbose" {

--- a/tests/chocolatey-tests/choco-uninstall.Tests.ps1
+++ b/tests/chocolatey-tests/choco-uninstall.Tests.ps1
@@ -1,0 +1,43 @@
+Import-Module helpers/common-helpers
+
+Describe "choco uninstall" -Tag Chocolatey, UninstallCommand {
+    BeforeAll {
+        Initialize-ChocolateyTestInstall
+
+        New-ChocolateyInstallSnapshot
+    }
+
+    AfterAll {
+        Remove-ChocolateyTestInstall
+    }
+
+    Context "Uninstalling a side-by-side Package" {
+        BeforeAll {
+            Restore-ChocolateyInstallSnapshot
+
+            $PackageUnderTest = "installpackage"
+
+            $null = Invoke-Choco upgrade $PackageUnderTest --confirm --allowmultipleversions
+
+            $Output = Invoke-Choco uninstall $PackageUnderTest --confirm
+        }
+
+        It "Exits with Success (0)" {
+            $Output.ExitCode | Should -Be 0
+        }
+
+        It "Removed a package to the lib directory" {
+            "$env:ChocolateyInstall\lib\$($PackageUnderTest).1.0.0" | Should -Not -Exist
+            "$env:ChocolateyInstall\lib-bad\$($PackageUnderTest).1.0.0" | Should -Not -Exist
+        }
+
+        It "Outputs a warning message that installed side by side package is deprecated" {
+            $Output.Lines | Should -Contain "$PackageUnderTest has been installed as a side by side installation." -Because $Output.String
+            $Output.Lines | Should -Contain "Side by side installations are deprecated and is pending removal in v2.0.0." -Because $Output.String
+        }
+
+        It "Outputs a message indicating that it uninstalled the package successfully" {
+            $Output.Lines | Should -Contain "Chocolatey uninstalled 1/1 packages." -Because $Output.String
+        }
+    }
+}

--- a/tests/chocolatey-tests/choco-upgrade.Tests.ps1
+++ b/tests/chocolatey-tests/choco-upgrade.Tests.ps1
@@ -1,0 +1,122 @@
+Import-Module helpers/common-helpers
+
+Describe "choco upgrade" -Tag Chocolatey, UpgradeCommand {
+    BeforeAll {
+        Initialize-ChocolateyTestInstall
+
+        New-ChocolateyInstallSnapshot
+    }
+
+    AfterAll {
+        Remove-ChocolateyTestInstall
+    }
+
+    Context "Upgrading a side-by-side Package (non-existing)" {
+        BeforeAll {
+            Restore-ChocolateyInstallSnapshot
+
+            $PackageUnderTest = "installpackage"
+
+            $Output = Invoke-Choco upgrade $PackageUnderTest --confirm --allowmultipleversions
+        }
+
+        It "Exits with Success (0)" {
+            $Output.ExitCode | Should -Be 0
+        }
+
+        It "Installed a package to the lib directory" {
+            "$env:ChocolateyInstall\lib\$($PackageUnderTest).1.0.0" | Should -Exist
+        }
+
+        It "Installs the expected version of the package" {
+            "$env:ChocolateyInstall\lib\$($PackageUnderTest).1.0.0\$($PackageUnderTest).1.0.0.nuspec" | Should -Exist
+            [xml]$XML = Get-Content "$env:ChocolateyInstall\lib\$($PackageUnderTest).1.0.0\$($PackageUnderTest).1.0.0.nuspec"
+            $XML.package.metadata.version | Should -Be "1.0.0"
+        }
+
+        It "Outputs a warning message about side by side installs are deprecated" {
+            $Output.Lines | Should -Contain "Upgrading the same package with multiple versions is deprecated and will be removed in v2.0.0." -Because $Output.String
+        }
+
+        It "Outputs a message indicating that it upgraded the package successfully" {
+            $Output.Lines | Should -Contain "Chocolatey upgraded 1/1 packages." -Because $Output.String
+        }
+    }
+
+    Context "Switching a normal Package to a side-by-side Package" {
+        BeforeAll {
+            Restore-ChocolateyInstallSnapshot
+
+            $PackageUnderTest = "installpackage"
+
+            $null = Invoke-Choco install $PackageUnderTest --confirm
+
+            $Output = Invoke-Choco upgrade $PackageUnderTest --confirm --force --allowmultipleversions
+        }
+
+        It "Exits with Success (0)" {
+            $Output.ExitCode | Should -Be 0
+        }
+
+        It "Installed the package to the lib directory" {
+            "$env:ChocolateyInstall\lib\$($PackageUnderTest).1.0.0" | Should -Exist
+        }
+
+        It "Removed the previous version of the package from the lib directory" {
+            "$env:ChocolateyInstall\lib\$($PackageUnderTest)" | Should -Not -Exist
+        }
+
+        It "Installs the expected version of the package" {
+            "$env:ChocolateyInstall\lib\$($PackageUnderTest).1.0.0\$($PackageUnderTest).1.0.0.nuspec" | Should -Exist
+            [xml]$XML = Get-Content "$env:ChocolateyInstall\lib\$($PackageUnderTest).1.0.0\$($PackageUnderTest).1.0.0.nuspec"
+            $XML.package.metadata.version | Should -Be "1.0.0"
+        }
+
+        It "Outputs a warning message about side by side installs are deprecated" {
+            $Output.Lines | Should -Contain "Upgrading the same package with multiple versions is deprecated and will be removed in v2.0.0." -Because $Output.String
+        }
+
+        It "Outputs a message indicating that it upgraded the package successfully" {
+            $Output.Lines | Should -Contain "Chocolatey upgraded 1/1 packages." -Because $Output.String
+        }
+    }
+
+    Context "Switching a side-by-side Package to a normal Package" {
+        BeforeAll {
+            Restore-ChocolateyInstallSnapshot
+
+            $PackageUnderTest = "installpackage"
+
+            $null = Invoke-Choco install $PackageUnderTest --confirm --allowmultipleversion
+
+            $Output = Invoke-Choco upgrade $PackageUnderTest --confirm --force
+        }
+
+        It "Exits with Success (0)" {
+            $Output.ExitCode | Should -Be 0
+        }
+
+        It "Installed the package to the lib directory" {
+            "$env:ChocolateyInstall\lib\$($PackageUnderTest)" | Should -Exist
+        }
+
+        It "Installs the expected version of the package" {
+            "$env:ChocolateyInstall\lib\$($PackageUnderTest)\$($PackageUnderTest).nuspec" | Should -Exist
+            [xml]$XML = Get-Content "$env:ChocolateyInstall\lib\$($PackageUnderTest)\$($PackageUnderTest).nuspec"
+            $XML.package.metadata.version | Should -Be "1.0.0"
+        }
+
+        It "Does not output a warning message about side by side installs are deprecated" {
+            $Output.Lines | Should -Not -Contain "Upgrading the same package with multiple versions is deprecated and will be removed in v2.0.0." -Because $Output.String
+        }
+
+        It "Does not output a warning message that installed side by side package is deprecated" {
+            $Output.Lines | Should -Not -Contain "installpackage has been installed as a side by side installation." -Because $Output.String
+            $Output.Lines | Should -Not -Contain "Side by side installations are deprecated and is pending removal in v2.0.0." -Because $Output.String
+        }
+
+        It "Outputs a message indicating that it upgraded the package successfully" {
+            $Output.Lines | Should -Contain "Chocolatey upgraded 1/1 packages." -Because $Output.String
+        }
+    }
+}


### PR DESCRIPTION
## Description Of Changes

This pull request makes the necessary changes in the codebase to deprecate the ability to do side by side installations, as well as informing the user about side by side installation deprecation as best as we can.

## Motivation and Context

There have been too many problems with side by side installations, and it do not work as was originally intended.
As such removing this functionality is appropriate, and something else will need to be implemented if we plan to support similar scenarios in the future.

## Testing

1. Run `choco install --help`.
2. Verify the side by side argument is labeled as deprecated.
3. Verify the deprecation notice contains information about side by side being deprecated and will be removed.
4. Run `choco upgrade --help` and do the same checks as step 2 and 3.
5. Run `choco uninstall --help` and do the same checks as step 2 and 3.
3. Run `choco install 7zip.portable --sxs --version 22.0`
4. Verify there is a mention about side by side installations is deprecated is shown to the user.
5. Verify an additional deprecation message is shown that side by side installed packages is available. (_This may not show up during install and upgrade_)
6. Run `choco list -lo`
7. Verify a message about 7zip.portable is installed as a side-by-side package, and support for this will be removed in v2.0.0
8. Run `choco list -lo -r`
9. Verify no message about deprecation is shown
10. Run `choco info 7zip.portable -lo` and verify the same as in step 7.
11. Run `choco info 7zip.portable -lo`
12. Verify no message about deprecation is shown
13. Run `choco outdated`
14. Verify the result mentions that `7zip.portable` has a warning.
15. Verify the log file contain a message that 7zip.portable is installed as a side-by-side package, and support for this will be removed in v2.0.0
16. Run `choco upgrade 7zip.portable --sxs`
17. Verify there is a mention about side by side upgrading is deprecated is shown to the user.
18. Do the same verification as in step 7.
19. Run `choco uninstall 7zip.portable`
20. Verify again the message as in step 7.

Test kitchen builds has not been ran, all unofficial builds seems to fail for me in test kitchen.

## Change Types Made

* [ ] Bug fix (non-breaking change)
* [x] Feature / Enhancement (non-breaking change)
* [ ] Breaking change (fix or feature that could cause existing functionality to change)
* [ ] PowerShell code changes.

## Related Issue

Fixes #2787
https://app.clickup.com/t/20540031/ENGTASKS-1480

## Change Checklist

* [ ] Requires a change to the documentation
* [ ] Documentation has been updated
* [x] Tests to cover my changes, have been added
* [ ] All new and existing tests passed. (Not been able to run against test kitchen, most likely problem in existing tests causing problems for unofficial builds).
* [ ] PowerShell v2 compatibility checked.
