### PR TITLE
(#1185) Add original powershell host run as deprecated method

### DIFF
--- a/src/chocolatey/infrastructure.app/services/IPowershellService.cs
+++ b/src/chocolatey/infrastructure.app/services/IPowershellService.cs
@@ -1,4 +1,4 @@
-// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2022 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/services/IPowershellService.cs
+++ b/src/chocolatey/infrastructure.app/services/IPowershellService.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -68,6 +68,10 @@ namespace chocolatey.infrastructure.app.services
         bool before_modify(ChocolateyConfiguration configuration, PackageResult packageResult);
 
         void prepare_powershell_environment(IPackage package, ChocolateyConfiguration configuration, string packageDirectory);
+
+        [Obsolete("This version of running the powershell host do not support running additional hooks. Use the appropriate overload instead")]
+        PowerShellExecutionResults run_host(ChocolateyConfiguration config, string chocoPowerShellScript, Action<Pipeline> additionalActionsBeforeScript);
+
         PowerShellExecutionResults run_host(ChocolateyConfiguration config, string chocoPowerShellScript, Action<Pipeline> additionalActionsBeforeScript, IEnumerable<string> hookPreScriptPathList, IEnumerable<string> hookPostScriptPathList);
     }
 }

--- a/src/chocolatey/infrastructure.app/services/PowershellService.cs
+++ b/src/chocolatey/infrastructure.app/services/PowershellService.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -591,6 +591,12 @@ namespace chocolatey.infrastructure.app.services
             {
                 AppDomain.CurrentDomain.AssemblyResolve -= _handler;
             }
+        }
+
+        [Obsolete("This version of running the powershell host do not support running additional hooks. Use the appropriate overload instead")]
+        public PowerShellExecutionResults run_host(ChocolateyConfiguration config, string chocoPowershellScript, Action<Pipeline> additionalActionsBeforeScript)
+        {
+            return run_host(config, chocoPowershellScript, additionalActionsBeforeScript, Enumerable.Empty<string>(), Enumerable.Empty<string>());
         }
 
         public PowerShellExecutionResults run_host(ChocolateyConfiguration config, string chocoPowerShellScript, Action<Pipeline> additionalActionsBeforeScript, IEnumerable<string> hookPreScriptPathList, IEnumerable<string> hookPostScriptPathList)

--- a/src/chocolatey/infrastructure.app/services/PowershellService.cs
+++ b/src/chocolatey/infrastructure.app/services/PowershellService.cs
@@ -1,4 +1,4 @@
-// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2022 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -23,10 +23,7 @@ namespace chocolatey.infrastructure.app.services
     using System.Management.Automation;
     using System.Management.Automation.Runspaces;
     using System.Reflection;
-    using System.Security.Cryptography;
-    using System.Text;
     using adapters;
-    using builders;
     using commandline;
     using configuration;
     using cryptography;
@@ -38,8 +35,6 @@ namespace chocolatey.infrastructure.app.services
     using powershell;
     using results;
     using utility;
-    using Assembly = adapters.Assembly;
-    using Console = System.Console;
     using CryptoHashProvider = cryptography.CryptoHashProvider;
     using Environment = System.Environment;
     using IFileSystem = filesystem.IFileSystem;
@@ -112,12 +107,15 @@ namespace chocolatey.infrastructure.app.services
                 case CommandNameType.install:
                     filenameBase += "install-";
                     break;
+
                 case CommandNameType.uninstall:
                     filenameBase += "uninstall-";
                     break;
+
                 case CommandNameType.upgrade:
                     filenameBase += "beforemodify-";
                     break;
+
                 default:
                     throw new ApplicationException("Could not find CommandNameType '{0}' to get hook scripts".format_with(command));
             }
@@ -353,7 +351,6 @@ namespace chocolatey.infrastructure.app.services
  `choco -h` for details.");
                     }
 
-
                     if (result.ExitCode != 0)
                     {
                         Environment.ExitCode = result.ExitCode;
@@ -534,7 +531,7 @@ namespace chocolatey.infrastructure.app.services
                 }
             }
 
-            SecurityProtocol.set_protocol(configuration, provideWarning:false);
+            SecurityProtocol.set_protocol(configuration, provideWarning: false);
         }
 
         private ResolveEventHandler _handler = null;
@@ -738,11 +735,11 @@ try {
                                 if (host.ExitCode == 0) host.SetShouldExit(1);
                                 host.HostException = pipeline.PipelineStateInfo.Reason;
                                 break;
+
                             case PipelineState.Completed:
                                 if (host.ExitCode == -1) host.SetShouldExit(0);
                                 break;
                         }
-
                     }
                 }
             }


### PR DESCRIPTION
## Description Of Changes

This pull request updates the PowershellService class and interface to re-add the original `run_host` method to prevent the need to do a breaking release.

## Motivation and Context

We need to keep the old method contract around until we create a new breaking major release of Chocolatey CLI so it will be backwards compatible with other projects we own, or projects that make use of the Chocolatey.Lib API library.

## Testing

1. Built Chocolatey Licensed Extension together with this change.

## Change Types Made

* [x] Bug fix (non-breaking change)
* [ ] Feature / Enhancement (non-breaking change)
* [ ] Breaking change (fix or feature that could cause existing functionality to change)
* [ ] PowerShell code changes.

## Related Issue
<!-- Make sure you have raised an issue for this pull request before
continuing. -->

#1185  
https://app.clickup.com/t/20540031/ENGTASKS-1480

## Change Checklist

* [ ] Requires a change to the documentation
* [ ] Documentation has been updated
* [ ] Tests to cover my changes, have been added
* [x] All new and existing tests passed.
* [ ] PowerShell v2 compatibility checked.
