### PR TITLE
(#1185) Always pass in hook scripts event if empty

### DIFF
--- a/src/chocolatey/infrastructure.app/services/PowershellService.cs
+++ b/src/chocolatey/infrastructure.app/services/PowershellService.cs
@@ -194,14 +194,14 @@ namespace chocolatey.infrastructure.app.services
 
         private string get_script_arguments(string script, IEnumerable<string> hookPreScriptPathList, IEnumerable<string> hookPostScriptPathList, ChocolateyConfiguration config)
         {
-            return "-packageScript '{0}' -installArguments '{1}' -packageParameters '{2}'{3}{4}{5}{6}".format_with(
+            return "-packageScript '{0}' -installArguments '{1}' -packageParameters '{2}'{3}{4} -preRunHookScripts {5} -postRunHookScripts {6}".format_with(
                 script,
                 prepare_powershell_arguments(config.InstallArguments),
                 prepare_powershell_arguments(config.PackageParameters),
                 config.ForceX86 ? " -forceX86" : string.Empty,
                 config.OverrideArguments ? " -overrideArgs" : string.Empty,
-                hookPreScriptPathList.Any() ? " -preRunHookScripts {0}".format_with(string.Join(",", hookPreScriptPathList)) : string.Empty,
-                hookPostScriptPathList.Any() ? " -postRunHookScripts {0}".format_with(string.Join(",", hookPostScriptPathList)) : string.Empty
+                hookPreScriptPathList.Any() ? "{0}".format_with(string.Join(",", hookPreScriptPathList)) : "$null",
+                hookPostScriptPathList.Any() ? "{0}".format_with(string.Join(",", hookPostScriptPathList)) : "$null"
              );
         }
 


### PR DESCRIPTION
## Description Of Changes

Always pass the hook parameters to `chocolateyScriptRunner` even if we're just passing them `$null`

## Motivation and Context

There is a manual test that we have where we try to install a package thusly: `choco install test-params --package-parameters="/NoDesktop 'Not Displayed' /InstallDir:'C:\tools\package destination'"` this was resulting in the following in the log: `2022-09-26 16:08:41,822 7016 [DEBUG] - Running 'ChocolateyScriptRunner' for test-params v0.0.0 with packageScript 'C:\ProgramData\chocolatey\lib\test-params\tools\chocolateyinstall.ps1', packageFolder:'C:\ProgramData\chocolatey\lib\test-params', installArguments: '', packageParameters: '/NoDesktop ', preRunHookScripts: 'Not', postRunHookScripts: 'Displayed /InstallDir:C:\tools\package',` which is clearly not correct.

## Testing

1. I have run this through the debugger with the parameters `install test-params --package-parameters="/NoDesktop 'Not Displayed' /InstallDir:'C:\tools\package destination'"`
2. Confirmed that it installed as I expected it to.

## Change Types Made

* [x] Bug fix (non-breaking change)
* [ ] Feature / Enhancement (non-breaking change)
* [ ] Breaking change (fix or feature that could cause existing functionality to change)
* [ ] PowerShell code changes.

## Related Issue

Fixes #1185 

## Change Checklist

* [ ] Requires a change to the documentation
* [ ] Documentation has been updated
* [ ] Tests to cover my changes, have been added
* [ ] All new and existing tests passed.
* [ ] PowerShell v2 compatibility checked.
