### PR TITLE
(#886, 2693) Update packages.config install logging and add back resolve or load method for Assembly Resolution

### DIFF
--- a/src/chocolatey/infrastructure.app/services/ChocolateyPackageService.cs
+++ b/src/chocolatey/infrastructure.app/services/ChocolateyPackageService.cs
@@ -793,7 +793,7 @@ Would have determined packages that are out of date based on what is
 
                     this.Log().Info(ChocolateyLoggers.Important, @"{0}".format_with(packageConfig.PackageNames));
                     packageConfigs.Add(packageConfig);
-                    this.Log().Debug(() => "Package Configuration: {0}".format_with(packageConfig.ToString()));
+                    this.Log().Debug(() => "Package Configuration Start:{0}{1}{0}Package Configuration End".format_with(System.Environment.NewLine, packageConfig.ToString()));
                 }
             }
 

--- a/src/chocolatey/infrastructure/registration/AssemblyResolution.cs
+++ b/src/chocolatey/infrastructure/registration/AssemblyResolution.cs
@@ -37,6 +37,18 @@ namespace chocolatey.infrastructure.registration
         /// <param name="assemblySimpleName">Simple Name of the assembly, such as "chocolatey"</param>
         /// <param name="publicKeyToken">The public key token.</param>
         /// <param name="assemblyFileLocation">The assembly file location. Typically the path to the DLL on disk.</param>
+        /// <returns>An assembly</returns>
+        /// <exception cref="Exception">Unable to enter synchronized code to determine assembly loading</exception>
+        public static IAssembly resolve_or_load_assembly(string assemblySimpleName, string publicKeyToken, string assemblyFileLocation) {
+            return resolve_or_load_assembly(assemblySimpleName, publicKeyToken, assemblyFileLocation, false);
+        }
+
+        /// <summary>
+        /// Resolves or loads an assembly. If an assembly is already loaded, no need to reload it.
+        /// </summary>
+        /// <param name="assemblySimpleName">Simple Name of the assembly, such as "chocolatey"</param>
+        /// <param name="publicKeyToken">The public key token.</param>
+        /// <param name="assemblyFileLocation">The assembly file location. Typically the path to the DLL on disk.</param>
         /// <param name="ignoreExisting">Whether any existing library that has previously been loaded should be ignored or not.</param>
         /// <returns>An assembly</returns>
         /// <exception cref="Exception">Unable to enter synchronized code to determine assembly loading</exception>

--- a/tests/chocolatey-tests/commands/choco-install.Tests.ps1
+++ b/tests/chocolatey-tests/commands/choco-install.Tests.ps1
@@ -247,9 +247,11 @@ Describe "choco install" -Tag Chocolatey, InstallCommand {
                 $Output = Invoke-Choco install $env:CHOCOLATEY_TEST_PACKAGES_PATH\alloptions.packages.config --confirm --verbose --debug
 
                 # This is based on two observations: The addition explicitly outputs that it's the Package Configuration.
-                # The configuration output is also about 80 lines.
-                $StartofPackageConfiguration = [array]::IndexOf($Output.Lines, "Package Configuration: CommandName='install'|")
-                $PackageConfigurationOutput = $Output.Lines[$StartofPackageConfiguration..($StartofPackageConfiguration+80)] -join [Environment]::NewLine
+                # The configuration output is about 80 lines.
+                $StartOfPackageConfiguration = [array]::IndexOf($Output.Lines, "Package Configuration Start:")
+                $EndOfPackageConfiguration = [array]::IndexOf($Output.Lines, "Package Configuration End")
+
+                $PackageConfigurationOutput = $Output.Lines[$StartofPackageConfiguration..$EndOfPackageConfiguration] -join [Environment]::NewLine
             }
 
             # We are explicitly passing in a bad username and password here.


### PR DESCRIPTION
## Description Of Changes

Update the debugging output for the install from packages.config file to clearly delineate the start and end of the configuration output.

Add back the original definition of resolve_or_load_assembly to AssemblyResolution.

## Motivation and Context

The output of the Configuration when Licensed Extension is installed is different from when just Open Source is in play. As such, the tests for the new functionality was failing. This updates the output to enable us to better test the command.

Chocolatey GUI fails to load with the update to `resolve_or_load_assembly`, so added back the original definition.

## Testing

1. Downloaded build artifacts from build server and installed on VM
2. Installed Chocolatey GUI
3. Launched Chocolatey GUI
4. Confirmed it launched successfully
5. Installed Licensed Extension
6. Ensured the Pester tests for InstallCommand completed successfully.

## Change Types Made

* [x] Bug fix (non-breaking change)
* [ ] Feature / Enhancement (non-breaking change)
* [ ] Breaking change (fix or feature that could cause existing functionality to change)
* [ ] PowerShell code changes.

## Related Issue

Fixes #886
Fixes #2693 

## Change Checklist

* [ ] Requires a change to the documentation
* [ ] Documentation has been updated
* [ ] Tests to cover my changes, have been added
* [x] All new and existing tests passed.
* [ ] PowerShell v2 compatibility checked.
