### PR TITLE
(#2829) Adds Basic choco license Command

### DIFF
--- a/src/chocolatey.tests/chocolatey.tests.csproj
+++ b/src/chocolatey.tests/chocolatey.tests.csproj
@@ -153,6 +153,7 @@
   <ItemGroup>
     <Compile Include="infrastructure.app\attributes\CommandForAttributeSpecs.cs" />
     <Compile Include="infrastructure.app\commands\ChocolateyCacheCommandSpecs.cs" />
+    <Compile Include="infrastructure.app\commands\ChocolateyLicenseCommandSpecs.cs" />
     <Compile Include="infrastructure.app\commands\ChocolateyListCommandSpecs.cs" />
     <Compile Include="infrastructure.app\commands\ChocolateyApiKeyCommandSpecs.cs" />
     <Compile Include="infrastructure.app\commands\ChocolateyConfigCommandSpecs.cs" />

--- a/src/chocolatey.tests/infrastructure.app/commands/ChocolateyFeatureCommandSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/commands/ChocolateyFeatureCommandSpecs.cs
@@ -125,7 +125,7 @@ namespace chocolatey.tests.infrastructure.app.commands
             public void Should_throw_when_more_than_one_unparsed_arg_is_passed()
             {
                 Reset();
-                _unparsedArgs.Add("wtf");
+                _unparsedArgs.Add("abc");
                 _unparsedArgs.Add("bbq");
                 var errored = false;
                 Exception error = null;
@@ -170,7 +170,7 @@ namespace chocolatey.tests.infrastructure.app.commands
             public void Should_set_unrecognized_values_to_list_as_the_subcommand()
             {
                 Reset();
-                _unparsedArgs.Add("wtf");
+                _unparsedArgs.Add("abc");
                 _because();
 
                 Configuration.FeatureCommand.Command.Should().Be(FeatureCommandType.List);

--- a/src/chocolatey.tests/infrastructure.app/commands/ChocolateyLicenseCommandSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/commands/ChocolateyLicenseCommandSpecs.cs
@@ -1,0 +1,265 @@
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
+// Copyright © 2011 - 2017 RealDimensions Software, LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using chocolatey.infrastructure.app.attributes;
+using chocolatey.infrastructure.app.commands;
+using chocolatey.infrastructure.app.configuration;
+using chocolatey.infrastructure.app.domain;
+using FluentAssertions;
+using Moq;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+namespace chocolatey.tests.infrastructure.app.commands
+{
+    public class ChocolateyLicenseCommandSpecs
+    {
+        [ConcernFor("license")]
+        public abstract class ChocolateyLicenseCommandSpecsBase : TinySpec
+        {
+            protected ChocolateyLicenseCommand Command;
+            protected ChocolateyConfiguration Configuration = new ChocolateyConfiguration();
+
+            public override void Context()
+            {
+                Command = new ChocolateyLicenseCommand();
+            }
+        }
+
+        public class When_Implementing_Command_For : ChocolateyLicenseCommandSpecsBase
+        {
+            private List<CommandForAttribute> _results;
+
+            public override void Because()
+            {
+                _results = Command.GetType().GetCustomAttributes<CommandForAttribute>().ToList();
+            }
+
+            [Fact]
+            public void Should_Have_Expected_Number_Of_Commands()
+            {
+                _results.Should().HaveCount(1);
+            }
+
+            [InlineData("license")]
+            public void Should_Implement_Expected_Command(string name)
+            {
+                _results.Should().ContainSingle(r => r.CommandName == name);
+            }
+
+            [Fact]
+            public void Should_Specify_Expected_Version_For_All_Commands()
+            {
+                _results.Should().AllSatisfy(r => r.Version.Should().Be("2.5.0"));
+            }
+        }
+
+        public class When_parsing_additional_arguments_ : ChocolateyLicenseCommandSpecsBase
+        {
+            private readonly IList<string> _unparsedArgs = new List<string>();
+            private Action _because;
+
+            public override void Because()
+            {
+                _because = () => Command.ParseAdditionalArguments(_unparsedArgs, Configuration);
+            }
+
+            public new void Reset()
+            {
+                _unparsedArgs.Clear();
+            }
+
+            [Fact]
+            public void Should_use_the_first_unparsed_arg_as_the_subcommand()
+            {
+                Reset();
+                _unparsedArgs.Add("info");
+                _because();
+
+                Configuration.LicenseCommand.Command.Should().Be(LicenseCommandType.Info);
+            }
+
+            [Fact]
+            public void Should_throw_when_more_than_one_unparsed_arg_is_passed()
+            {
+                Reset();
+                _unparsedArgs.Add("wtf");
+                _unparsedArgs.Add("bbq");
+                var errored = false;
+                Exception error = null;
+
+                try
+                {
+                    _because();
+                }
+                catch (Exception ex)
+                {
+                    errored = true;
+                    error = ex;
+                }
+
+                errored.Should().BeTrue();
+                error.Should().NotBeNull();
+                error.Should().BeOfType<ApplicationException>();
+                error.Message.Should().Contain("A single license command must be listed");
+            }
+
+            [Fact]
+            public void Should_accept_info_as_the_subcommand()
+            {
+                Reset();
+                _unparsedArgs.Add("info");
+                _because();
+
+                Configuration.LicenseCommand.Command.Should().Be(LicenseCommandType.Info);
+            }
+
+            [Fact]
+            public void Should_accept_uppercase_info_as_the_subcommand()
+            {
+                Reset();
+                _unparsedArgs.Add("INFO");
+                _because();
+
+                Configuration.LicenseCommand.Command.Should().Be(LicenseCommandType.Info);
+            }
+
+            [Fact]
+            public void Should_set_unrecognized_values_to_info_as_the_subcommand()
+            {
+                Reset();
+                _unparsedArgs.Add("wtf");
+                _because();
+
+                Configuration.LicenseCommand.Command.Should().Be(LicenseCommandType.Info);
+            }
+
+            [Fact]
+            public void Should_default_to_list_as_the_subcommand()
+            {
+                Reset();
+                _because();
+
+                Configuration.LicenseCommand.Command.Should().Be(LicenseCommandType.Info);
+            }
+
+            [Fact]
+            public void Should_handle_passing_in_an_empty_string()
+            {
+                Reset();
+                _unparsedArgs.Add(" ");
+                _because();
+
+                Configuration.LicenseCommand.Command.Should().Be(LicenseCommandType.Info);
+            }
+        }
+
+        public class When_Help_Is_Called : ChocolateyLicenseCommandSpecsBase
+        {
+            public override void Because()
+            {
+                Command.HelpMessage(Configuration);
+            }
+
+            [Fact]
+            public void Should_log_a_message()
+            {
+                MockLogger.Verify(l => l.Info(It.IsAny<string>()), Times.AtLeastOnce);
+            }
+
+            [Fact]
+            public void Should_log_the_message_we_expect()
+            {
+                var messages = MockLogger.MessagesFor(LogLevel.Info);
+                messages.Should().HaveCount(19);
+                messages[0].Should().Contain("License Command");
+                messages[2].Should().Contain("Show information about the current Chocolatey CLI license.");
+            }
+        }
+
+        public class When_DryRun_Is_Called : ChocolateyLicenseCommandSpecsBase
+        {
+            public override void Because()
+            {
+                Configuration.LicenseCommand.Command = LicenseCommandType.Info;
+                Command.DryRun(Configuration);
+            }
+
+            [Fact]
+            public void Should_log_a_message()
+            {
+                MockLogger.Verify(l => l.Warn(It.IsAny<string>()), Times.AtLeastOnce);
+            }
+
+            [Fact]
+            public void Should_log_the_message_we_expect()
+            {
+                var messages = MockLogger.MessagesFor(LogLevel.Warn);
+                messages.Should().ContainSingle();
+                messages[0].Should().Contain("No Chocolatey license found.");
+            }
+        }
+
+        public class When_Run_Is_Called : ChocolateyLicenseCommandSpecsBase
+        {
+            public override void Because()
+            {
+                Configuration.LicenseCommand.Command = LicenseCommandType.Info;
+                Command.Run(Configuration);
+            }
+
+            [Fact]
+            public void Should_log_a_message()
+            {
+                MockLogger.Verify(l => l.Warn(It.IsAny<string>()), Times.AtLeastOnce);
+            }
+
+            [Fact]
+            public void Should_log_the_message_we_expect()
+            {
+                var messages = MockLogger.MessagesFor(LogLevel.Warn);
+                messages.Should().ContainSingle();
+                messages[0].Should().Contain("No Chocolatey license found.");
+            }
+        }
+
+        public class When_Run_Is_Called_With_Limit_Output : ChocolateyLicenseCommandSpecsBase
+        {
+            public override void Because()
+            {
+                Configuration.LicenseCommand.Command = LicenseCommandType.Info;
+                Configuration.RegularOutput = false;
+                Command.Run(Configuration);
+            }
+
+            [Fact]
+            public void Should_log_a_message()
+            {
+                MockLogger.Verify(l => l.Warn(It.IsAny<string>()), Times.AtLeastOnce);
+            }
+
+            [Fact]
+            public void Should_log_the_message_we_expect()
+            {
+                var messages = MockLogger.MessagesFor(LogLevel.Warn);
+                messages.Should().ContainSingle();
+                messages[0].Should().Contain("No Chocolatey license found.");
+            }
+        }
+    }
+}

--- a/src/chocolatey.tests/infrastructure.app/commands/ChocolateyLicenseCommandSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/commands/ChocolateyLicenseCommandSpecs.cs
@@ -98,7 +98,7 @@ namespace chocolatey.tests.infrastructure.app.commands
             public void Should_throw_when_more_than_one_unparsed_arg_is_passed()
             {
                 Reset();
-                _unparsedArgs.Add("wtf");
+                _unparsedArgs.Add("abc");
                 _unparsedArgs.Add("bbq");
                 var errored = false;
                 Exception error = null;
@@ -143,7 +143,7 @@ namespace chocolatey.tests.infrastructure.app.commands
             public void Should_set_unrecognized_values_to_info_as_the_subcommand()
             {
                 Reset();
-                _unparsedArgs.Add("wtf");
+                _unparsedArgs.Add("abc");
                 _because();
 
                 Configuration.LicenseCommand.Command.Should().Be(LicenseCommandType.Info);

--- a/src/chocolatey.tests/infrastructure.app/commands/ChocolateyPinCommandSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/commands/ChocolateyPinCommandSpecs.cs
@@ -181,7 +181,7 @@ namespace chocolatey.tests.infrastructure.app.commands
             public void Should_throw_when_more_than_one_unparsed_arg_is_passed()
             {
                 Reset();
-                _unparsedArgs.Add("wtf");
+                _unparsedArgs.Add("abc");
                 _unparsedArgs.Add("bbq");
                 var errored = false;
                 Exception error = null;
@@ -236,7 +236,7 @@ namespace chocolatey.tests.infrastructure.app.commands
             public void Should_set_unrecognized_values_to_list_as_the_subcommand()
             {
                 Reset();
-                _unparsedArgs.Add("wtf");
+                _unparsedArgs.Add("abc");
                 _because();
 
                 Configuration.PinCommand.Command.Should().Be(PinCommandType.List);

--- a/src/chocolatey.tests/infrastructure.app/commands/ChocolateySourceCommandSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/commands/ChocolateySourceCommandSpecs.cs
@@ -167,7 +167,7 @@ namespace chocolatey.tests.infrastructure.app.commands
             public void Should_throw_when_more_than_one_unparsed_arg_is_passed()
             {
                 Reset();
-                _unparsedArgs.Add("wtf");
+                _unparsedArgs.Add("abc");
                 _unparsedArgs.Add("bbq");
                 var errored = false;
                 Exception error = null;
@@ -242,7 +242,7 @@ namespace chocolatey.tests.infrastructure.app.commands
             public void Should_set_unrecognized_values_to_list_as_the_subcommand()
             {
                 Reset();
-                _unparsedArgs.Add("wtf");
+                _unparsedArgs.Add("abc");
                 _because();
 
                 Configuration.SourceCommand.Command.Should().Be(SourceCommandType.List);

--- a/src/chocolatey/chocolatey.csproj
+++ b/src/chocolatey/chocolatey.csproj
@@ -178,6 +178,7 @@
     <Compile Include="AssemblyExtensions.cs" />
     <Compile Include="ExceptionExtensions.cs" />
     <Compile Include="infrastructure.app\attributes\MultiServiceAttribute.cs" />
+    <Compile Include="infrastructure.app\commands\ChocolateyLicenseCommand.cs" />
     <Compile Include="infrastructure.app\commands\ChocolateyCacheCommand.cs" />
     <Compile Include="infrastructure.app\commands\ChocolateyListCommand.cs" />
     <Compile Include="infrastructure.app\commands\ChocolateyRuleCommand.cs" />
@@ -186,6 +187,7 @@
     <Compile Include="infrastructure.app\commands\ChocolateyCommandBase.cs" />
     <Compile Include="infrastructure.app\domain\ApiKeyCommandType.cs" />
     <Compile Include="infrastructure.app\domain\CacheCommandType.cs" />
+    <Compile Include="infrastructure.app\domain\LicenseCommandType.cs" />
     <Compile Include="infrastructure.app\domain\SourceTypes.cs" />
     <Compile Include="infrastructure.app\domain\ChocolateyPackageMetadata.cs" />
     <Compile Include="infrastructure.app\domain\TemplateCommandType.cs" />

--- a/src/chocolatey/infrastructure.app/commands/ChocolateyLicenseCommand.cs
+++ b/src/chocolatey/infrastructure.app/commands/ChocolateyLicenseCommand.cs
@@ -1,0 +1,209 @@
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
+// Copyright © 2011 - 2017 RealDimensions Software, LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using chocolatey.infrastructure.app.attributes;
+using chocolatey.infrastructure.app.configuration;
+using chocolatey.infrastructure.app.domain;
+using chocolatey.infrastructure.commandline;
+using chocolatey.infrastructure.commands;
+using chocolatey.infrastructure.licensing;
+using chocolatey.infrastructure.logging;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+
+namespace chocolatey.infrastructure.app.commands
+{
+    [CommandFor("license", "display Chocolatey license information", Version = "2.5.0")]
+    public class ChocolateyLicenseCommand : ChocolateyCommandBase, ICommand
+    {
+        private static readonly Regex _licenseCountRegex = new Regex(@"\[.*?(?<licensedMachineCount>\d+).*?\]");
+
+        public void ConfigureArgumentParser(OptionSet optionSet, ChocolateyConfiguration configuration)
+        {
+            // We don't currently expect to have any arguments
+        }
+
+        public void ParseAdditionalArguments(IList<string> unparsedArguments, ChocolateyConfiguration configuration)
+        {
+            if (unparsedArguments.Count > 1)
+            {
+                throw new ApplicationException("A single license command must be listed. Please see the help menu for those commands");
+            }
+
+            var command = LicenseCommandType.Unknown;
+            var unparsedCommand = unparsedArguments.DefaultIfEmpty(string.Empty).FirstOrDefault();
+            Enum.TryParse(unparsedCommand, true, out command);
+
+            if (command == LicenseCommandType.Unknown)
+            {
+                if (!string.IsNullOrWhiteSpace(unparsedCommand))
+                {
+                    this.Log().Warn("Unknown command {0}. Setting to info.".FormatWith(unparsedCommand));
+                }
+
+                command = LicenseCommandType.Info;
+            }
+
+            configuration.LicenseCommand.Command = command;
+        }
+
+        public void Validate(ChocolateyConfiguration configuration)
+        {
+            // We don't currently accept any arguments, so there is no validation
+        }
+
+        public bool MayRequireAdminAccess()
+        {
+            return false;
+        }
+
+        public void DryRun(ChocolateyConfiguration configuration)
+        {
+            Run(configuration);
+        }
+
+        public void Run(ChocolateyConfiguration config)
+        {
+            switch (config.LicenseCommand.Command)
+            {
+                case LicenseCommandType.Info:
+                    GetLicense(config);
+                    break;
+            }
+        }
+
+        private void GetLicense(ChocolateyConfiguration config)
+        {
+            var ourLicense = LicenseValidation.Validate();
+            var logger = config.RegularOutput ? ChocolateyLoggers.Normal : ChocolateyLoggers.LogFileOnly;
+
+            if (ourLicense.LicenseType == ChocolateyLicenseType.Foss || ourLicense.LicenseType == ChocolateyLicenseType.Unknown)
+            {
+                this.Log().Warn(logger, "No Chocolatey license found.");
+                return;
+            }
+
+            if (!ourLicense.IsValid)
+            {
+                this.Log().Warn(logger, "Invalid Chocolatey {0} license found: {1}", ourLicense.LicenseType, ourLicense.InvalidReason);
+                Environment.ExitCode = 1;
+                return;
+            }
+
+            var nodeCount = ParseLicenseStringForLicenseCount(ourLicense.Name);
+
+            if (config.RegularOutput)
+            {
+                this.Log().Info("Registered to:   {0}".FormatWith(ourLicense.Name));
+                this.Log().Info("Expiration Date: {0}".FormatWith(ourLicense.ExpirationDate?.ToString("dd MMMM yyyy")));
+                this.Log().Info("License type:    {0}".FormatWith(ourLicense.LicenseType));
+                this.Log().Info("Node Count:      {0}".FormatWith(nodeCount));
+            }
+            else
+            {
+                // Headers: Name, LicenseType, ExpirationDate, NodeCount
+                this.Log().Info("{0}|{1}|{2}|{3}".FormatWith(ourLicense.Name, ourLicense.LicenseType, ourLicense.ExpirationDate?.ToString("yyyy-MM-dd"), nodeCount));
+            }
+        }
+
+        /// <summary>
+        /// Parse the license count from the Name property of a Chocolatey license file.
+        /// </summary>
+        /// <param name="licenseName">The Name property of a Chocolatey license file
+        /// that should be parsed of the license count.
+        /// </param>
+        /// <remarks>
+        /// There are no tests for this method, but that is due to the fact that this
+        /// method is extracted from the Chocolatey Central Management
+        /// codebase, and it has _several_ tests for it, so it felt that these do not
+        /// need to be duplicated here.
+        /// </remarks>
+        /// <returns>The license count.</returns>
+        private int ParseLicenseStringForLicenseCount(string licenseName)
+        {
+            if (string.IsNullOrEmpty(licenseName))
+            {
+                return 0;
+            }
+
+            // Use Regex to find the licensed machine count
+            var match = _licenseCountRegex.Match(licenseName);
+
+            if (match.Success && int.TryParse(match.Groups["licensedMachineCount"].Value, out var licenseCount))
+            {
+                return licenseCount;
+            }
+
+            return 0;
+        }
+
+        protected override string GetCommandDescription(CommandForAttribute attribute, ChocolateyConfiguration configuration)
+        {
+            return @"Show information about the current Chocolatey CLI license.";
+        }
+
+        protected override IEnumerable<string> GetCommandExamples(CommandForAttribute[] attributes, ChocolateyConfiguration configuration)
+        {
+            return new[]
+            {
+                "choco license",
+                "choco license info"
+            };
+        }
+
+        protected override IEnumerable<string> GetCommandUsage(CommandForAttribute[] attributes, ChocolateyConfiguration configuration)
+        {
+            return new[]
+            {
+                "choco license [info] [<options/switches>]",
+            };
+        }
+
+#pragma warning disable IDE0022, IDE1006
+
+        [Obsolete("This overload is deprecated and will be removed in v3.")]
+        public virtual void configure_argument_parser(OptionSet optionSet, ChocolateyConfiguration configuration)
+            => ConfigureArgumentParser(optionSet, configuration);
+
+        [Obsolete("This overload is deprecated and will be removed in v3.")]
+        public virtual void handle_additional_argument_parsing(IList<string> unparsedArguments, ChocolateyConfiguration configuration)
+            => ParseAdditionalArguments(unparsedArguments, configuration);
+
+        [Obsolete("This overload is deprecated and will be removed in v3.")]
+        public virtual void handle_validation(ChocolateyConfiguration configuration)
+            => Validate(configuration);
+
+        [Obsolete("This overload is deprecated and will be removed in v3.")]
+        public virtual void help_message(ChocolateyConfiguration configuration)
+            => HelpMessage(configuration);
+
+        [Obsolete("This overload is deprecated and will be removed in v3.")]
+        public virtual bool may_require_admin_access()
+            => MayRequireAdminAccess();
+
+        [Obsolete("This overload is deprecated and will be removed in v3.")]
+        public virtual void noop(ChocolateyConfiguration configuration)
+            => DryRun(configuration);
+
+        [Obsolete("This overload is deprecated and will be removed in v3.")]
+        public virtual void run(ChocolateyConfiguration configuration)
+            => Run(configuration);
+
+#pragma warning restore IDE0022, IDE1006
+    }
+}

--- a/src/chocolatey/infrastructure.app/configuration/ChocolateyConfiguration.cs
+++ b/src/chocolatey/infrastructure.app/configuration/ChocolateyConfiguration.cs
@@ -53,6 +53,7 @@ namespace chocolatey.infrastructure.app.configuration
             PackCommand = new PackCommandConfiguration();
             PushCommand = new PushCommandConfiguration();
             PinCommand = new PinCommandConfiguration();
+            LicenseCommand = new LicenseCommandConfiguration();
             OutdatedCommand = new OutdatedCommandConfiguration();
             Proxy = new ProxyConfiguration();
             ExportCommand = new ExportCommandConfiguration();
@@ -472,6 +473,14 @@ NOTE: Hiding sensitive configuration data! Please double and triple
         public PinCommandConfiguration PinCommand { get; set; }
 
         /// <summary>
+        /// Configuration related specifically to License command
+        /// </summary>
+        /// <remarks>
+        ///   On .NET 4.0, get error CS0200 when private set - see http://stackoverflow.com/a/23809226/18475
+        /// </remarks>
+        public LicenseCommandConfiguration LicenseCommand { get; set; }
+
+        /// <summary>
         /// Configuration related specifically to Outdated command
         /// </summary>
         /// <remarks>
@@ -683,6 +692,12 @@ NOTE: Hiding sensitive configuration data! Please double and triple
     {
         public string Name { get; set; }
         public PinCommandType Command { get; set; }
+    }
+
+    [Serializable]
+    public sealed class LicenseCommandConfiguration
+    {
+        public LicenseCommandType Command { get; set; }
     }
 
     [Serializable]

--- a/src/chocolatey/infrastructure.app/domain/LicenseCommandType.cs
+++ b/src/chocolatey/infrastructure.app/domain/LicenseCommandType.cs
@@ -1,0 +1,24 @@
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
+// Copyright © 2011 - 2017 RealDimensions Software, LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace chocolatey.infrastructure.app.domain
+{
+    public enum LicenseCommandType
+    {
+        Unknown,
+        Info
+    }
+}

--- a/tests/pester-tests/commands/choco-license.Tests.ps1
+++ b/tests/pester-tests/commands/choco-license.Tests.ps1
@@ -1,0 +1,57 @@
+﻿Import-Module helpers/common-helpers
+
+Describe "choco license" -Tag Chocolatey, LicenseCommand {
+    BeforeDiscovery {
+        $HasLicensedExtension = Test-PackageIsEqualOrHigher -PackageName 'chocolatey.extension' -Version '6.0.0'
+    }
+
+    BeforeAll {
+        Remove-NuGetPaths
+        Initialize-ChocolateyTestInstall
+        New-ChocolateyInstallSnapshot
+    }
+
+    AfterAll {
+        Remove-ChocolateyTestInstall
+    }
+
+    Context "License (<_>)" -ForEach @("", "info", "bob") -Skip:($HasLicensedExtension) {
+        BeforeAll {
+            $Output = Invoke-Choco license $_
+        }
+
+        It "Exits successfully (0)" {
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
+        }
+
+        It "Reports available license" {
+            $ExpectedOutput = if($HasLicensedExtension) {
+                "Registered to:"
+            } else {
+                "No Chocolatey license found."
+            }
+            $Output.Lines | Should -Contain $ExpectedOutput -Because $Output.String
+        }
+    }
+
+    Context "Help Documentation (<_>) - OSS" -ForEach @("--help", "-?", "-help") {
+        BeforeAll {
+            $Output = Invoke-Choco license $_
+        }
+
+        It "Exits successfully (0)" {
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
+        }
+
+        It "Outputs Help for License" {
+            $Output.String | Should -Match "License Command" -Because $Output.String
+        }
+
+        It "Outputs help documentation for license command" {
+            $Output.Lines | Should -Contain "Show information about the current Chocolatey CLI license." -Because $Output.String
+        }
+    }
+
+    # This needs to be the last test in this block, to ensure NuGet configurations aren't being created.
+    Test-NuGetPaths
+}

--- a/tests/pester-tests/commands/choco-support.Tests.ps1
+++ b/tests/pester-tests/commands/choco-support.Tests.ps1
@@ -51,7 +51,7 @@ Describe "choco support" -Tag Chocolatey, SupportCommand {
             $ExpectedOutput = if($HasLicensedExtension) {
                 "As a licensed customer, you can reach out to"
             } else {
-                "As an open-source user of Chocolatey CLI, we are not able to"
+                "As a user of Chocolatey CLI open-source, we are unable to"
             }
             $Output.Lines | Should -Contain $ExpectedOutput -Because $Output.String
         }


### PR DESCRIPTION
## Description Of Changes
This PR adds a delightful new command, `choco license`.

It should offer read _and_ write, but at the moment just offers a basic output of the current license.

It doesn't yet have tests, either.

## Motivation and Context
This has been requested by awesome folk!

## Testing
1. We have tested it locally

## Change Types Made

* [ ] Bug fix (non-breaking change)
* [x] Feature / Enhancement (non-breaking change)
* [ ] Breaking change (fix or feature that could cause existing functionality to change)
* [ ] PowerShell code changes.

## Related Issue

Fixes #2829 

## Change Checklist

* [x] Requires a change to the documentation
* [ ] Documentation has been updated
* [ ] Tests to cover my changes, have been added
* [ ] All new and existing tests passed.
* [ ] PowerShell v2 compatibility checked.

