### PR TITLE
Removed `[A]ll - yes to all`

### DIFF
--- a/src/chocolatey.tests/infrastructure/commandline/InteractivePromptSpecs.cs
+++ b/src/chocolatey.tests/infrastructure/commandline/InteractivePromptSpecs.cs
@@ -666,7 +666,7 @@ namespace chocolatey.tests.infrastructure.commandline
             public override void Context()
             {
                 base.Context();
-                Choices.Add("all - yes to all");
+                Choices.Add("all scripts");
             }
 
             public override void Because()
@@ -683,17 +683,9 @@ namespace chocolatey.tests.infrastructure.commandline
             [Fact]
             public void Should_return_all_when_full_all_answer_is_given()
             {
-                Console.Setup(c => c.ReadLine()).Returns("all - yes to all");
+                Console.Setup(c => c.ReadLine()).Returns("all scripts");
                 var result = _prompt();
-                result.Should().Be("all - yes to all");
-            }
-
-            [Fact]
-            public void Should_return_all_when_only_all_is_given()
-            {
-                Console.Setup(c => c.ReadLine()).Returns("all");
-                var result = _prompt();
-                result.Should().Be("all - yes to all");
+                result.Should().Be("all scripts");
             }
         }
     }

--- a/src/chocolatey/infrastructure.app/configuration/ChocolateyConfiguration.cs
+++ b/src/chocolatey/infrastructure.app/configuration/ChocolateyConfiguration.cs
@@ -125,7 +125,7 @@ namespace chocolatey.infrastructure.app.configuration
                     if (property.Name == "PromptForConfirmation")
                     {
                         // We do not overwrite this value between backups as it is intended to be a global setting;
-                        // if a user has selected a "[A] yes to all" prompt interactively, this option is
+                        // if a user has selected a "[A]ll scripts" prompt interactively, this option is
                         // set and should be retained for the duration of the operations.
                         continue;
                     }

--- a/src/chocolatey/infrastructure.app/services/PowershellService.cs
+++ b/src/chocolatey/infrastructure.app/services/PowershellService.cs
@@ -279,7 +279,7 @@ namespace chocolatey.infrastructure.app.services
                         this.Log().Info(ChocolateyLoggers.Important, () => @"choco feature enable -n allowGlobalConfirmation");
 
                         var selection = InteractivePrompt.PromptForConfirmation(@"Do you want to run the script?",
-                            new[] { "yes", "all - yes to all", "no", "print" },
+                            new[] { "yes", "all scripts", "no", "print" },
                             defaultChoice: null,
                             requireAnswer: true,
                             allowShortAnswer: true,
@@ -305,7 +305,7 @@ namespace chocolatey.infrastructure.app.services
                             shouldRun = true;
                         }
 
-                        if (selection.IsEqualTo("all - yes to all"))
+                        if (selection.IsEqualTo("all scripts"))
                         {
                             configuration.PromptForConfirmation = false;
                             shouldRun = true;

--- a/tests/pester-tests/commands/choco-install.Tests.ps1
+++ b/tests/pester-tests/commands/choco-install.Tests.ps1
@@ -1704,8 +1704,8 @@ To install a local, or remote file, you may use:
             }
         }
 
-        It "Ran both installation scripts after selecting [A] Yes to all at the first prompt" {
-            $promptLine = "Do you want to run the script?([Y]es/[A]ll - yes to all/[N]o/[P]rint):"
+        It "Ran both installation scripts after selecting [A]ll scripts at the first prompt" {
+            $promptLine = "Do you want to run the script?([Y]es/[A]ll scripts/[N]o/[P]rint):"
             $prompts = $Output.Lines | Where-Object { $_ -eq $promptLine }
 
             $prompts.Count | Should -Be 1


### PR DESCRIPTION
## Description Of Changes
Changed the prompt of `Do you want to run this script?([Y]es/[A]ll - yes to all/[N]o/[P]rint)` to `Do you want to run this script?([Y]es/[A]ll/[N]o/[P]rint)`

## Motivation and Context
Unnecessary info as the command line app should assume the user knows what `[A]ll`, and this feature already exists for every other modern package manager on linux.

## Testing
No tests have been performed.

## Change Types Made

* [ ] Bug fix (non-breaking change)
* [x] Feature / Enhancement (non-breaking change)
* [ ] Breaking change (fix or feature that could cause existing functionality to change)
* [ ] PowerShell code changes.

## Related Issue
Resolves #2848 

## Change Checklist

* [x] Requires a change to the documentation
* [ ] Documentation has been updated
* [x] Tests to cover my changes, have been added
* [ ] All new and existing tests passed.
* [ ] PowerShell v2 compatibility checked.