### PR TITLE
(#2591) Add headers to limit output commands

### DIFF
--- a/src/chocolatey.resources/helpers/ChocolateyTabExpansion.ps1
+++ b/src/chocolatey.resources/helpers/ChocolateyTabExpansion.ps1
@@ -38,7 +38,7 @@ function script:chocoCmdOperations($commands, $command, $filter, $currentArgumen
 $script:chocoCommands = @('apikey','cache','config','export','feature','help','info','install','license','list','new','outdated','pack','pin','push','rule','search','source','support','template','uninstall','upgrade','--help','--version')
 
 # ensure these all have a space to start, or they will cause issues
-$allCommands = " --accept-license --cache-location='' --debug --fail-on-standard-error --force --help --ignore-http-cache --limit-output --log-file='' --no-color --no-progress --noop --online --proxy='' --proxy-bypass-list='' --proxy-bypass-on-local --proxy-password='' --proxy-user='' --skip-compatibility-checks --timeout='' --trace --use-system-powershell --verbose --yes"
+$allCommands = " --accept-license --cache-location='' --debug --fail-on-standard-error --force --help --ignore-http-cache --include-headers --limit-output --log-file='' --no-color --no-progress --noop --online --proxy='' --proxy-bypass-list='' --proxy-bypass-on-local --proxy-password='' --proxy-user='' --skip-compatibility-checks --timeout='' --trace --use-system-powershell --verbose --yes"
 
 $commandOptions = @{
     apikey    = "--api-key='' --source=''"

--- a/src/chocolatey/OutputHelpers.cs
+++ b/src/chocolatey/OutputHelpers.cs
@@ -1,0 +1,17 @@
+﻿using chocolatey.infrastructure.app.configuration;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace chocolatey
+{
+    public static class OutputHelpers
+    {
+        public static void LimitedOutput(params string[] output)
+        {
+            "chocolatey".Log().Info(output.Join("|"));
+        }
+    }
+}

--- a/src/chocolatey/StringResources.cs
+++ b/src/chocolatey/StringResources.cs
@@ -655,5 +655,15 @@ namespace chocolatey
             internal const string UnableToDowngrade = "A newer version of {0} (v{1}) is already installed.{2} Use --allow-downgrade or --force to attempt to install older versions.";
             internal const string DependencyFailedToInstall = "Failed to install {0} because a previous dependency failed.";
         }
+
+        public static class OptionDescriptions
+        {
+            public const string IncludeHeaders = "Include header names when --limit-output is used. Requires Chocolatey CLI 2.5.0+";
+        }
+
+        public static class Options
+        {
+            public const string IncludeHeaders = "include-headers";
+        }
     }
 }

--- a/src/chocolatey/chocolatey.csproj
+++ b/src/chocolatey/chocolatey.csproj
@@ -459,6 +459,7 @@
     <Compile Include="LogExtensions.cs" />
     <Compile Include="NuGetVersionExtensions.cs" />
     <Compile Include="ObjectExtensions.cs" />
+    <Compile Include="OutputHelpers.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="RuleResultExtensions.cs" />
     <Compile Include="StringExtensions.cs" />

--- a/src/chocolatey/infrastructure.app/ApplicationParameters.cs
+++ b/src/chocolatey/infrastructure.app/ApplicationParameters.cs
@@ -275,6 +275,7 @@ namespace chocolatey.infrastructure.app
             public static readonly string UsePackageRepositoryOptimizations = "usePackageRepositoryOptimizations";
             public static readonly string DisableCompatibilityChecks = "disableCompatibilityChecks";
             public static readonly string UsePackageHashValidation = "usePackageHashValidation";
+            public static readonly string AlwaysIncludeHeaders = "alwaysIncludeHeaders";
         }
 
         public static class Messages

--- a/src/chocolatey/infrastructure.app/builders/ConfigurationBuilder.cs
+++ b/src/chocolatey/infrastructure.app/builders/ConfigurationBuilder.cs
@@ -341,7 +341,8 @@ namespace chocolatey.infrastructure.app.builders
             config.Features.UsePackageRepositoryOptimizations = SetFeatureFlag(ApplicationParameters.Features.UsePackageRepositoryOptimizations, configFileSettings, defaultEnabled: true, description: "Use Package Repository Optimizations - Turn on optimizations for reducing bandwidth with repository queries during package install/upgrade/outdated operations. Should generally be left enabled, unless a repository needs to support older methods of query. When disabled, this makes queries similar to the way they were done in earlier versions of Chocolatey.");
             config.Features.UsePackageHashValidation = SetFeatureFlag(ApplicationParameters.Features.UsePackageHashValidation, configFileSettings, defaultEnabled: false, description: "Use Package Hash Validation - Check the hash of the downloaded package file against the source provided hash. Only supports sources that provide SHA512 hashes. Disabled by default. Available in 2.3.0+");
             config.PromptForConfirmation = !SetFeatureFlag(ApplicationParameters.Features.AllowGlobalConfirmation, configFileSettings, defaultEnabled: false, description: "Prompt for confirmation in scripts or bypass.");
-            config.DisableCompatibilityChecks = SetFeatureFlag(ApplicationParameters.Features.DisableCompatibilityChecks, configFileSettings, defaultEnabled: false, description: "Disable Compatibility Checks - Disable showing a warning when there is an incompatibility between Chocolatey CLI and Chocolatey Licensed Extension.");
+            config.DisableCompatibilityChecks = SetFeatureFlag(ApplicationParameters.Features.DisableCompatibilityChecks, configFileSettings, defaultEnabled: false, description: "Disable Compatibility Checks - Disable showing a warning when there is an incompatibility between Chocolatey CLI and Chocolatey Licensed Extension. Available in 1.1.0+");
+            config.IncludeHeaders = SetFeatureFlag(ApplicationParameters.Features.AlwaysIncludeHeaders, configFileSettings, defaultEnabled: false, description: StringResources.OptionDescriptions.IncludeHeaders);
         }
 
         private static bool SetFeatureFlag(string featureName, ConfigFileSettings configFileSettings, bool defaultEnabled, string description)
@@ -411,6 +412,9 @@ namespace chocolatey.infrastructure.app.builders
                         .Add("r|limitoutput|limit-output",
                              "LimitOutput - Limit the output to essential information",
                              option => config.RegularOutput = option == null)
+                        .Add(StringResources.Options.IncludeHeaders,
+                            StringResources.OptionDescriptions.IncludeHeaders,
+                            option => config.IncludeHeaders = true)
                         .Add("timeout=|execution-timeout=",
                              "CommandExecutionTimeout (in seconds) - The time to allow a command to finish before timing out. Overrides the default execution timeout in the configuration of {0} seconds. Supply '0' to disable the timeout.".FormatWith(config.CommandExecutionTimeoutSeconds.ToStringSafe()),
                             option =>
@@ -453,7 +457,7 @@ namespace chocolatey.infrastructure.app.builders
                         .Add("proxy-bypass-on-local",
                              "Proxy Bypass On Local - Bypass proxy for local connections. Requires explicit proxy (`--proxy` or config setting). Overrides the default proxy bypass on local setting of '{0}'.".FormatWith(config.Proxy.BypassOnLocal),
                              option => config.Proxy.BypassOnLocal = option != null)
-                         .Add("log-file=",
+                        .Add("log-file=",
                              "Log File to output to in addition to regular loggers.",
                              option => config.AdditionalLogFileLocation = option.UnquoteSafe())
                         .Add("skipcompatibilitychecks|skip-compatibility-checks",

--- a/src/chocolatey/infrastructure.app/commands/ChocolateyApiKeyCommand.cs
+++ b/src/chocolatey/infrastructure.app/commands/ChocolateyApiKeyCommand.cs
@@ -197,6 +197,10 @@ If you find other exit codes that we have not yet documented, please
                     _configSettingsService.SetApiKey(configuration);
                     break;
                 default:
+                    // This is required, since we only want to show the header if there are any ApiKeys
+                    // to be shown, which will be when we are printing the first ApiKey
+                    var hasHeaderRowBeenOutput = false;
+
                     _configSettingsService.GetApiKey(configuration, (key) =>
                     {
                         var authenticatedString = string.IsNullOrWhiteSpace(key.Key) ? string.Empty : "(Authenticated)";
@@ -207,7 +211,13 @@ If you find other exit codes that we have not yet documented, please
                         }
                         else
                         {
-                            this.Log().Info(() => "{0}|{1}".FormatWith(key.Source, authenticatedString));
+                            if (configuration.IncludeHeaders && !hasHeaderRowBeenOutput)
+                            {
+                                OutputHelpers.LimitedOutput("Source", "ApiKey");
+                                hasHeaderRowBeenOutput = true;
+                            }
+
+                            OutputHelpers.LimitedOutput(key.Source, authenticatedString);
                         }
                     });
                     break;

--- a/src/chocolatey/infrastructure.app/commands/ChocolateyLicenseCommand.cs
+++ b/src/chocolatey/infrastructure.app/commands/ChocolateyLicenseCommand.cs
@@ -116,8 +116,14 @@ namespace chocolatey.infrastructure.app.commands
             }
             else
             {
-                // Headers: Name, LicenseType, ExpirationDate, NodeCount
-                this.Log().Info("{0}|{1}|{2}|{3}".FormatWith(ourLicense.Name, ourLicense.LicenseType, ourLicense.ExpirationDate?.ToString("yyyy-MM-dd"), nodeCount));
+                // This if we get here, there is a license to display, it is "safe" to always
+                // output the header row
+                if (config.IncludeHeaders)
+                {
+                    OutputHelpers.LimitedOutput("Name", "Type", "ExpirationDate", "NodeCount");
+                }
+
+                OutputHelpers.LimitedOutput(ourLicense.Name, ourLicense.LicenseType.ToString(), ourLicense.ExpirationDate?.ToString("yyyy-MM-dd"), nodeCount.ToString());
             }
         }
 

--- a/src/chocolatey/infrastructure.app/commands/ChocolateyPinCommand.cs
+++ b/src/chocolatey/infrastructure.app/commands/ChocolateyPinCommand.cs
@@ -178,12 +178,22 @@ If you find other exit codes that we have not yet documented, please
             config.QuietOutput = quiet;
             config.Input = input;
 
+            // This is required, since we only want to show the header if there are any Pinned Packages
+            // to be shown, which will be when we are printing the first Pinned Package
+            var hasHeaderRowBeenOutput = false;
+
             foreach (var pkg in packages.OrEmpty())
             {
                 var pkgInfo = _packageInfoService.Get(pkg.PackageMetadata);
                 if (pkgInfo != null && pkgInfo.IsPinned)
                 {
-                    this.Log().Info(() => "{0}|{1}".FormatWith(pkgInfo.Package.Id, pkgInfo.Package.Version));
+                    if (!config.RegularOutput && config.IncludeHeaders && !hasHeaderRowBeenOutput)
+                    {
+                        OutputHelpers.LimitedOutput("Id", "Version");
+                        hasHeaderRowBeenOutput = true;
+                    }
+
+                    OutputHelpers.LimitedOutput(pkgInfo.Package.Id, pkgInfo.Package.Version.ToNormalizedStringChecked());
                 }
             }
         }

--- a/src/chocolatey/infrastructure.app/commands/ChocolateyRuleCommand.cs
+++ b/src/chocolatey/infrastructure.app/commands/ChocolateyRuleCommand.cs
@@ -185,6 +185,10 @@ namespace chocolatey.infrastructure.app.commands
                 }
             }
 
+            // This is required, since we only want to show the header if there are any Rules
+            // to be shown, which will be when we are printing the first Rule
+            var hasHeaderRowBeenOutput = false;
+
             foreach (var rule in rules)
             {
                 if (config.RegularOutput)
@@ -193,7 +197,13 @@ namespace chocolatey.infrastructure.app.commands
                 }
                 else
                 {
-                    this.Log().Info("{0}|{1}|{2}|{3}", rule.Severity, rule.Id, rule.Summary, rule.HelpUrl);
+                    if (config.IncludeHeaders && !hasHeaderRowBeenOutput)
+                    {
+                        OutputHelpers.LimitedOutput("Severity", "Id", "Summary", "HelpUrl");
+                        hasHeaderRowBeenOutput = true;
+                    }
+
+                    OutputHelpers.LimitedOutput(rule.Severity.ToString(), rule.Id, rule.Summary, rule.HelpUrl);
                 }
             }
         }

--- a/src/chocolatey/infrastructure.app/configuration/ChocolateyConfiguration.cs
+++ b/src/chocolatey/infrastructure.app/configuration/ChocolateyConfiguration.cs
@@ -60,6 +60,8 @@ namespace chocolatey.infrastructure.app.configuration
             TemplateCommand = new TemplateCommandConfiguration();
             CacheCommand = new CacheCommandConfiguration();
             RuleCommand = new RuleCommandConfiguration();
+            IncludeHeaders = false;
+
 #if DEBUG
             AllowUnofficialBuild = true;
 #endif
@@ -367,6 +369,7 @@ NOTE: Hiding sensitive configuration data! Please double and triple
         public string DownloadChecksumType { get; set; }
         public string DownloadChecksumType64 { get; set; }
         public bool PinPackage { get; set; }
+        public bool IncludeHeaders { get; set; }
 
         /// <summary>
         ///   Configuration values provided by choco.

--- a/src/chocolatey/infrastructure.app/services/ChocolateyPackageService.cs
+++ b/src/chocolatey/infrastructure.app/services/ChocolateyPackageService.cs
@@ -256,11 +256,8 @@ Did you know Pro / Business automatically syncs with Programs and
                 yield break;
             }
 
-            if (config.RegularOutput)
-            {
-                this.Log().Debug(() => "Searching for package information");
-            }
-
+            this.Log().Debug(() => "Searching for package information");
+ 
             var packages = new List<PackageResult>();
 
             IEnumerable<PackageResult> results;
@@ -844,7 +841,7 @@ Would have determined packages that are out of date based on what is
             if (config.RegularOutput)
             {
                 this.Log().Info(ChocolateyLoggers.Important, @"Outdated Packages
- Output is package name | current version | available version | pinned?
+ Output is Id | Version | Available Version | Pinned
 ");
             }
 

--- a/src/chocolatey/infrastructure.app/services/NugetService.cs
+++ b/src/chocolatey/infrastructure.app/services/NugetService.cs
@@ -192,8 +192,26 @@ that uses these options.");
 
             var decryptionFailures = new List<ChocolateyPackageInformation>();
 
+            // This is required, since we only want to show the header if there are any Packages
+            // to be shown, which will be when we are printing the first Package
+            var hasHeaderRowBeenOutput = false;
+
             foreach (var pkg in NugetList.GetPackages(config, _nugetLogger, _fileSystem))
             {
+                if (!config.QuietOutput && !config.RegularOutput && config.IncludeHeaders && !hasHeaderRowBeenOutput)
+                {
+                    if (config.ListCommand.IdOnly)
+                    {
+                        OutputHelpers.LimitedOutput("Id");
+                        hasHeaderRowBeenOutput = true;
+                    }
+                    else
+                    {
+                        OutputHelpers.LimitedOutput("Id", "Version");
+                        hasHeaderRowBeenOutput = true;
+                    }
+                }
+
                 var package = pkg; // for lamda access
                 string packageArgumentsUnencrypted = null;
 
@@ -1270,7 +1288,7 @@ Please see https://docs.chocolatey.org/en-us/troubleshooting for more
                         else
                         {
                             //last one is whether this package is pinned or not
-                            this.Log().Info("{0}|{1}|{1}|{2}".FormatWith(installedPackage.PackageMetadata.Id, installedPackage.Version, isPinned.ToStringSafe().ToLowerSafe()));
+                            OutputHelpers.LimitedOutput(installedPackage.PackageMetadata.Id, installedPackage.Version, isPinned.ToStringSafe().ToLowerSafe());
                         }
                     }
 
@@ -1291,7 +1309,7 @@ Please see https://docs.chocolatey.org/en-us/troubleshooting for more
                         }
                         else
                         {
-                            this.Log().Info("{0}|{1}|{1}|{2}".FormatWith(installedPackage.PackageMetadata.Id, installedPackage.Version, isPinned.ToStringSafe().ToLowerSafe()));
+                            OutputHelpers.LimitedOutput(installedPackage.PackageMetadata.Id, installedPackage.Version, isPinned.ToStringSafe().ToLowerSafe());
                         }
                     }
 
@@ -1317,7 +1335,7 @@ Please see https://docs.chocolatey.org/en-us/troubleshooting for more
                             }
                             else
                             {
-                                this.Log().Info("{0}|{1}|{2}|{3}".FormatWith(installedPackage.PackageMetadata.Id, installedPackage.Version, availablePackage.Identity.Version.ToNormalizedStringChecked(), isPinned.ToStringSafe().ToLowerSafe()));
+                                OutputHelpers.LimitedOutput(installedPackage.PackageMetadata.Id, installedPackage.Version, availablePackage.Identity.Version.ToNormalizedStringChecked(), isPinned.ToStringSafe().ToLowerSafe());
                             }
                         }
 
@@ -1345,7 +1363,7 @@ Please see https://docs.chocolatey.org/en-us/troubleshooting for more
                         }
                         else
                         {
-                            this.Log().Info("{0}|{1}|{2}|{3}".FormatWith(installedPackage.PackageMetadata.Id, installedPackage.Version, availablePackage.Identity.Version, isPinned.ToStringSafe().ToLowerSafe()));
+                            OutputHelpers.LimitedOutput(installedPackage.PackageMetadata.Id, installedPackage.Version, availablePackage.Identity.Version.ToStringSafe(), isPinned.ToStringSafe().ToLowerSafe());
                         }
                     }
 
@@ -1885,6 +1903,9 @@ Please see https://docs.chocolatey.org/en-us/troubleshooting for more
 
             config.CreateBackup();
 
+            // This is required, since we only want to show the header if there are any Outdated packages
+            // to be shown, which will be when we are printing the first Outdated package
+            var hasHeaderRowBeenOutput = false;
             foreach (var packageName in packageNames)
             {
                 // We need to ensure we are using a clean configuration file
@@ -1942,7 +1963,13 @@ Please see https://docs.chocolatey.org/en-us/troubleshooting for more
                 var logMessage = "You have {0} v{1} installed. Version {2} is available based on your source(s).{3} Source(s): \"{4}\"".FormatWith(installedPackage.Name, installedPackage.Version, latestPackage.Identity.Version, Environment.NewLine, config.Sources);
                 packageResult.Messages.Add(new ResultMessage(ResultType.Note, logMessage));
 
-                this.Log().Info("{0}|{1}|{2}|{3}".FormatWith(installedPackage.Name, installedPackage.Version, latestPackage.Identity.Version, isPinned.ToStringSafe().ToLowerSafe()));
+                if (!config.RegularOutput && config.IncludeHeaders && !hasHeaderRowBeenOutput)
+                {
+                    OutputHelpers.LimitedOutput("Id", "Version", "AvailableVersion", "Pinned");
+                    hasHeaderRowBeenOutput = true;
+                }
+
+                OutputHelpers.LimitedOutput(installedPackage.Name, installedPackage.Version, latestPackage.Identity.Version.ToNormalizedStringChecked(), isPinned.ToStringSafe().ToLowerSafe());
             }
 
             // Reset the configuration again once we are completely done with the processing of

--- a/tests/helpers/common/Chocolatey/Invoke-Choco.ps1
+++ b/tests/helpers/common/Chocolatey/Invoke-Choco.ps1
@@ -18,7 +18,7 @@
     )
     begin {
         $chocoPath = Get-ChocoPath
-        $firstArgument, [string[]]$remainingArguments = $Arguments
+        $firstArgument, [string[]]$remainingArguments = $Arguments.ForEach{$_}
         $arguments = @(
             $firstArgument
             '--allow-unofficial'

--- a/tests/pester-tests/commands/choco-apikey.Tests.ps1
+++ b/tests/pester-tests/commands/choco-apikey.Tests.ps1
@@ -119,7 +119,7 @@ Describe "choco <_>" -ForEach $Command -Tag Chocolatey, ApiKeyCommand {
             $key = $Key
             $config = $apiKeys.Where{ $_.source -eq "https://test.com/api/$key" }
             $config | Should -HaveCount 1
-            $config.key | Should -Not -BeNullOrEmpty # The key is encryped, so we don't test the value
+            $config.key | Should -Not -BeNullOrEmpty # The key is encrypted, so we don't test the value
         }
     }
 
@@ -163,7 +163,7 @@ Describe "choco <_>" -ForEach $Command -Tag Chocolatey, ApiKeyCommand {
             $key = $Key
             $config = $apiKeys.Where{ $_.source -eq "https://test.com/api/add/$key" }
             $config | Should -HaveCount 1
-            $config.key | Should -Not -BeNullOrEmpty # The key is encryped, so we don't test the value
+            $config.key | Should -Not -BeNullOrEmpty # The key is encrypted, so we don't test the value
         }
     }
 
@@ -211,7 +211,7 @@ Describe "choco <_>" -ForEach $Command -Tag Chocolatey, ApiKeyCommand {
             $key = $Key
             $config = $apiKeys.Where{ $_.source -eq "https://test.com/api/$key" }
             $config | Should -HaveCount 1
-            $config.key | Should -Not -BeNullOrEmpty # The key is encryped, so we don't test the value
+            $config.key | Should -Not -BeNullOrEmpty # The key is encrypted, so we don't test the value
         }
     }
 
@@ -259,7 +259,7 @@ Describe "choco <_>" -ForEach $Command -Tag Chocolatey, ApiKeyCommand {
             $key = $Key
             $config = $apiKeys.Where{ $_.source -eq "https://test.com/api/add/$key" }
             $config | Should -HaveCount 1
-            $config.key | Should -Not -BeNullOrEmpty # The key is encryped, so we don't test the value
+            $config.key | Should -Not -BeNullOrEmpty # The key is encrypted, so we don't test the value
         }
     }
 

--- a/tests/pester-tests/features/Headers.Tests.ps1
+++ b/tests/pester-tests/features/Headers.Tests.ps1
@@ -1,0 +1,169 @@
+Import-Module helpers/common-helpers
+
+Describe "choco headers tests" -Tag Chocolatey, HeadersFeature {
+    BeforeDiscovery {
+        $isLicensed = Test-PackageIsEqualOrHigher "chocolatey.extension" "0.0.0"
+
+        $Commands = @(
+            @{
+                Command = 'apikey'
+                CommandLine = 'list'
+                ExpectedHeaders = 'Source|ApiKey'
+                SkipTest = $false
+            }
+            @{
+                Command = 'config'
+                CommandLine = 'list'
+                ExpectedHeaders = 'Name|Value|Description'
+                SkipTest = $false
+            }
+            @{
+                Command = 'feature'
+                CommandLine = 'list'
+                ExpectedHeaders = 'Name|Enabled|Description'
+                SkipTest = $false
+            }
+            @{
+                Command = 'info'
+                CommandLine = "chocolatey", "--local-only"
+                ExpectedHeaders = 'Id|Version'
+                SkipTest = $false
+            }
+            @{
+                Command = 'license'
+                CommandLine = 'info'
+                ExpectedHeaders = 'Name|Type|ExpirationDate|NodeCount'
+                SkipTest = $isLicensed
+            }
+            @{
+                Command = 'list'
+                ExpectedHeaders = 'Id|Version'
+                SkipTest = $false
+            }
+            @{
+                Command = 'outdated'
+                ExpectedHeaders = 'Id|Version|AvailableVersion|Pinned'
+                SkipTest = $false
+            }
+            @{
+                # Needs to pin something...
+                Command = 'pin'
+                CommandLine = 'list'
+                ExpectedHeaders = 'Id|Version'
+                SkipTest = $false
+            }
+            @{
+                Command = 'rule'
+                CommandLine = 'list'
+                ExpectedHeaders = 'Severity|Id|Summary|HelpUrl'
+                SkipTest = $false
+            }
+            @{
+                Command = 'search'
+                CommandLine = 'windirstat'
+                ExpectedHeaders = 'Id|Version'
+                SkipTest = $false
+            }
+            @{
+                Command = 'source'
+                CommandLine = 'list'
+                ExpectedHeaders = 'Name|Source|Disabled|UserName|Certificate|Priority|BypassProxy|AllowSelfService|AdminOnly'
+                SkipTest = $false
+            }
+            @{
+                Command = 'template'
+                CommandLine = 'list'
+                ExpectedHeaders = 'Name|Version'
+                SkipTest = $false
+            }
+        )
+    }
+    BeforeAll {
+        Initialize-ChocolateyTestInstall
+
+        New-ChocolateyInstallSnapshot
+
+        # These are needed in order to test the choco pin list execution
+        # as well as the choco apikey list as the headers will only be shown
+        # when there is a pinned package
+        $null = Invoke-Choco pin add --name="chocolatey"
+
+        $null = Invoke-Choco apikey add --source "https://community.chocolatey.org/api/v2" --api-key "bob"
+    }
+
+    AfterAll {
+        Remove-ChocolateyTestInstall
+    }
+
+    Context "Outputs headers for <Command> when '--include-headers' provided configured" -ForEach $Commands -Skip:($SkipTest) {
+        BeforeAll {
+            Restore-ChocolateyInstallSnapshot -NoSnapshotCopy
+
+            $Output = Invoke-Choco $Command @CommandLine --limit-output --include-headers
+        }
+
+        It 'Exits success (0)' {
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
+        }
+
+        It "Includes appropriate header" {
+            # The headers are _only_ output if there is content to show, so grab the first line
+            # when there is actual content
+            $HeaderRow = if ($Output.Lines.Count -gt 1) {
+                $Output.Lines[0]
+            }
+
+            $HeaderRow | Should -Be $ExpectedHeaders -Because $Output.String
+        }
+    }
+
+    Context "Does not output headers for <Command> by default" -ForEach $Commands -Skip:($SkipTest) {
+        BeforeAll {
+            Restore-ChocolateyInstallSnapshot -NoSnapshotCopy
+
+            $Output = Invoke-Choco $Command @CommandLine --limit-output
+        }
+
+        It 'Exits success (0)' {
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
+        }
+
+        It "Does not include header" {
+            # The headers are _only_ output if there is content to show, so grab the first line
+            # when there is actual content
+            $HeaderRow = if ($Output.Lines.Count -gt 1) {
+                $Output.Lines[0]
+            }
+
+            $HeaderRow | Should -Not -Be $ExpectedHeaders -Because $Output.String
+        }
+    }
+
+    Context "Includes headers when feature enabled" -Skip:($SkipTest) {
+        BeforeAll {
+            Restore-ChocolateyInstallSnapshot
+
+            Enable-ChocolateyFeature -Name AlwaysIncludeHeaders
+        }
+
+        Context "Includes headers for <Command>" -ForEach $Commands {
+            BeforeAll {
+                $Output = Invoke-Choco $Command @CommandLine --limit-output
+            }
+
+            It 'Exits success (0)' {
+                $Output.ExitCode | Should -Be 0 -Because $Output.String
+            }
+
+            It "Includes appropriate header" {
+                # The headers are _only_ output if there is content to show, so grab the first line
+                # when there is actual content
+                $HeaderRow = if ($Output.Lines.Count -gt 1) {
+                    $Output.Lines[0]
+                }
+
+                $HeaderRow | Should -Be $ExpectedHeaders -Because $Output.String
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Description Of Changes

When a user asks for limited output from Chocolatey, it is not uncommon to pipe that output to `ConvertFrom-String` or `ConvertFrom-Csv` and manually add headers to get back an object. This allows for getting a header row back so that the end user doesn't need to add their own headers and discern what they are.

Adds a new feature that allows the user to always display the headers if desired. This defaults to off so that we don't break any existing scripts.

## Motivation and Context

Reduce the amount of work end users need to do in order to consume limited output.

## Testing

Ran through the tests in the Vagrant test environment. This resulted in two failures that appear unrelated to my changes. I will investigate those further before marking this PR as ready.

**NOTE:** This will require Chocolatey Licensed Extension changes. 

## Change Types Made

* [ ] Bug fix (non-breaking change)
* [x] Feature / Enhancement (non-breaking change)
* [ ] Breaking change (fix or feature that could cause existing functionality to change)
* [ ] PowerShell code changes.

## Related Issue

Fixes #2591 

## Change Checklist

* [ ] Requires a change to the documentation
* [ ] Documentation has been updated
* [x] Tests to cover my changes, have been added
* [ ] All new and existing tests passed.
* [ ] PowerShell v2 compatibility checked.