### PR TITLE
(#2851) fix license validation output

### DIFF
--- a/src/chocolatey/infrastructure/licensing/LicenseValidation.cs
+++ b/src/chocolatey/infrastructure/licensing/LicenseValidation.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.IO;
+using System.Linq;
 using chocolatey.infrastructure.app;
 using chocolatey.infrastructure.logging;
 using Rhino.Licensing;
@@ -36,6 +37,8 @@ namespace chocolatey.infrastructure.licensing
             };
 
             var regularLogOutput = ShouldLogErrorsToConsole();
+            var normalLogger = regularLogOutput ? ChocolateyLoggers.Normal : ChocolateyLoggers.LogFileOnly;
+            var importantLogger = regularLogOutput ? ChocolateyLoggers.Important : ChocolateyLoggers.LogFileOnly;
 
             var licenseFile = ApplicationParameters.LicenseFileLocation;
             var userLicenseFile = ApplicationParameters.UserLicenseFileLocation;
@@ -56,9 +59,9 @@ namespace chocolatey.infrastructure.licensing
                 {
                     if (Directory.GetFiles(licenseDirectory).Length != 0)
                     {
-                        "chocolatey".Log().Error(regularLogOutput ? ChocolateyLoggers.Normal : ChocolateyLoggers.LogFileOnly, @"Files found in directory '{0}' but not a
+                        "chocolatey".Log().Error(normalLogger, @"Files found in directory '{0}' but not a
  valid license file. License should be named '{1}'.".FormatWith(licenseDirectory, licenseFileName));
-                        "chocolatey".Log().Warn(ChocolateyLoggers.Important, @" Rename license file to '{0}' to allow commercial features.".FormatWith(licenseFileName));
+                        "chocolatey".Log().Warn(importantLogger, @" Rename license file to '{0}' to allow commercial features.".FormatWith(licenseFileName));
                     }
                 }
 
@@ -66,9 +69,9 @@ namespace chocolatey.infrastructure.licensing
                 // - user put the license file in the top level location and/or forgot to rename it
                 if (File.Exists(Path.Combine(ApplicationParameters.InstallLocation, licenseFileName)) || File.Exists(Path.Combine(ApplicationParameters.InstallLocation, licenseFileName + ".txt")))
                 {
-                    "chocolatey".Log().Error(regularLogOutput ? ChocolateyLoggers.Normal : ChocolateyLoggers.LogFileOnly, @"Chocolatey license found in the wrong location. File must be located at
+                    "chocolatey".Log().Error(normalLogger, @"Chocolatey license found in the wrong location. File must be located at
  '{0}'.".FormatWith(ApplicationParameters.LicenseFileLocation));
-                    "chocolatey".Log().Warn(regularLogOutput ? ChocolateyLoggers.Important : ChocolateyLoggers.LogFileOnly, @" Move license file to '{0}' to allow commercial features.".FormatWith(ApplicationParameters.LicenseFileLocation));
+                    "chocolatey".Log().Warn(importantLogger, @" Move license file to '{0}' to allow commercial features.".FormatWith(ApplicationParameters.LicenseFileLocation));
                 }
             }
 
@@ -94,7 +97,7 @@ namespace chocolatey.infrastructure.licensing
                 {
                     chocolateyLicense.IsValid = false;
                     chocolateyLicense.InvalidReason = e.Message;
-                    "chocolatey".Log().Error(regularLogOutput ? ChocolateyLoggers.Normal : ChocolateyLoggers.LogFileOnly, "A license was not found for a licensed version of Chocolatey:{0} {1}{0} {2}".FormatWith(Environment.NewLine, e.Message,
+                    "chocolatey".Log().Error(normalLogger, "A license was not found for a licensed version of Chocolatey:{0} {1}{0} {2}".FormatWith(Environment.NewLine, e.Message,
                         "A license was also not found in the user profile: '{0}'.".FormatWith(ApplicationParameters.UserLicenseFileLocation)));
                 }
                 catch (Exception e)
@@ -102,7 +105,7 @@ namespace chocolatey.infrastructure.licensing
                     //license may be invalid
                     chocolateyLicense.IsValid = false;
                     chocolateyLicense.InvalidReason = e.Message;
-                    "chocolatey".Log().Error(regularLogOutput ? ChocolateyLoggers.Normal : ChocolateyLoggers.LogFileOnly, "A license was found for a licensed version of Chocolatey, but is invalid:{0} {1}".FormatWith(Environment.NewLine, e.Message));
+                    "chocolatey".Log().Error(normalLogger, "A license was found for a licensed version of Chocolatey, but is invalid:{0} {1}".FormatWith(Environment.NewLine, e.Message));
                 }
 
                 var chocolateyLicenseType = ChocolateyLicenseType.Unknown;
@@ -140,6 +143,12 @@ namespace chocolatey.infrastructure.licensing
 
         private static bool ShouldLogErrorsToConsole()
         {
+            var limitOutputArguments = new string[]
+            {
+                "--limit-output",
+                "--limitoutput",
+                "-r"
+            };
             var args = Environment.GetCommandLineArgs();
             // I think this check is incorrect??? if --version is supposed to return false, it can return true at this point?
             if (args == null || args.Length < 2)
@@ -149,6 +158,11 @@ namespace chocolatey.infrastructure.licensing
 
             var firstArg = args[1].ToStringSafe();
             if (firstArg.IsEqualTo("-v") || firstArg.IsEqualTo("--version"))
+            {
+                return false;
+            }
+
+            if (args.Count(argument => limitOutputArguments.Contains(argument)) > 0)
             {
                 return false;
             }

--- a/tests/pester-tests/features/LimitOutput.Tests.ps1
+++ b/tests/pester-tests/features/LimitOutput.Tests.ps1
@@ -1,0 +1,63 @@
+﻿Import-Module helpers/common-helpers
+
+Describe "choco limit-output tests" -Tag Chocolatey, LimitOutputFeature {
+    BeforeDiscovery {
+        $Flags = @(
+            '-r'
+            '--limitoutput'
+            '--limit-output'
+        )
+    }
+
+    BeforeAll {
+        Initialize-ChocolateyTestInstall
+        New-ChocolateyInstallSnapshot
+    }
+
+    AfterAll {
+        Remove-ChocolateyTestInstall
+    }
+
+    Context 'Running with flag <_> with wrong license files existing' -ForEach $Flags {
+        BeforeAll {
+            $paths = Restore-ChocolateyInstallSnapshot
+            New-Item -Path "$($paths.InstallPath)\license" -ItemType Directory
+            Set-Content -Path "$($paths.InstallPath)\license\test.xml" -Value ""
+
+            $Output = Invoke-Choco help $_
+        }
+
+        It "Should not output Files not found in license directory." {
+            [array]$foundLine = $Output.Lines | Where-Object { $_ -match "Files found in directory|valid license file. License should be named"}
+            $foundLine.Count | Should -Be 0 -Because $Output.String
+        }
+    }
+
+    Context 'Running with <_> with license file in wrong location' -ForEach $Flags {
+        BeforeAll {
+            $paths = Restore-ChocolateyInstallSnapshot
+            Set-Content -Path "$($paths.InstallPath)\chocolatey.license.xml" -Value ""
+
+            $Output = Invoke-Choco help $_
+        }
+
+        It "Should not output license file being in wrong location" {
+            $Output.Lines | Should -Not -Contain "Chocolatey license found in the wrong location. File must be located at" -Because $Output.String
+        }
+    }
+
+    Context 'Running with <_> with invalid license file in correct location' -ForEach $Flags {
+        BeforeAll {
+            $paths = Restore-ChocolateyInstallSnapshot
+            New-Item -Path "$($paths.InstallPath)\license" -ItemType Directory
+            Set-Content -Path "$($paths.InstallPath)\license\chocolatey.license.xml" -Value ""
+
+            $Output = Invoke-Choco help $_
+        }
+
+        It "Should not output license being invalid" {
+            $Output.Lines | Should -Not -Contain "A license was found for a licensed version of Chocolatey, but is invalid:"
+            $Output.Lines | Should -Not -Contain "Could not validate existing license"
+        }
+    }
+}


### PR DESCRIPTION
## Description Of Changes

Update the logic used in LicenseValidation class to correctly detect when regular output is desired and when it's not.

## Motivation and Context

When there are certain license conditions, Chocolatey would report things to standard output even if the command issues was requesting to limit output.

## Testing

1. Put a file in the `license` directory and ran `choco list --local-only --limit-output`
2. Then ran `choco list --local-only --limitoutput`
3. Then ran `choco list --local-only -r`
4. Noted that there is some warnings and errors about missing directories (I followed these as far as I could, at least one is generated by a System provided library, and unlikely that we can suppress)
5. When the lib directory is there (which it is on a standard Chocolatey install), no errors are output.
6. Set an empty file as `license/chocolatey.license.xml`. Noted that limit output prevented the message about the license being invalid

This is currently a draft PR as I intend to add some Pester tests to verify that no extraneous output occurs when limit output is requested.

## Change Types Made

* [x] Bug fix (non-breaking change)
* [ ] Feature / Enhancement (non-breaking change)
* [ ] Breaking change (fix or feature that could cause existing functionality to change)
* [ ] PowerShell code changes.

## Related Issue

Fixes #2851

## Change Checklist

* [ ] Requires a change to the documentation
* [ ] Documentation has been updated
* [ ] Tests to cover my changes, have been added
* [ ] All new and existing tests passed.
* [ ] PowerShell v2 compatibility checked.
