### PR TITLE
(#2815) Add new choco feature get subcommand

### DIFF
--- a/src/chocolatey.tests/infrastructure.app/commands/ChocolateyConfigCommandSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/commands/ChocolateyConfigCommandSpecs.cs
@@ -111,7 +111,7 @@ namespace chocolatey.tests.infrastructure.app.commands
             }
 
             [Fact]
-            public void Should_call_service_source_list_when_command_is_list()
+            public void Should_call_service_config_list_when_command_is_list()
             {
                 Configuration.ConfigCommand.Command = ConfigCommandType.List;
                 _because();
@@ -119,7 +119,7 @@ namespace chocolatey.tests.infrastructure.app.commands
             }
 
             [Fact]
-            public void Should_call_service_source_disable_when_command_is_disable()
+            public void Should_call_service_config_get_when_command_is_get()
             {
                 Configuration.ConfigCommand.Command = ConfigCommandType.Get;
                 _because();
@@ -127,7 +127,7 @@ namespace chocolatey.tests.infrastructure.app.commands
             }
 
             [Fact]
-            public void Should_call_service_source_enable_when_command_is_enable()
+            public void Should_call_service_config_set_when_command_is_set()
             {
                 Configuration.ConfigCommand.Command = ConfigCommandType.Set;
                 _because();
@@ -135,7 +135,7 @@ namespace chocolatey.tests.infrastructure.app.commands
             }
 
             [Fact]
-            public void Should_call_service_source_unset_when_command_is_unset()
+            public void Should_call_service_config_unset_when_command_is_unset()
             {
                 Configuration.ConfigCommand.Command = ConfigCommandType.Unset;
                 _because();

--- a/src/chocolatey.tests/infrastructure.app/commands/ChocolateyConfigCommandSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/commands/ChocolateyConfigCommandSpecs.cs
@@ -33,57 +33,57 @@ namespace chocolatey.tests.infrastructure.app.commands
         [ConcernFor("config")]
         public abstract class ChocolateyConfigCommandSpecsBase : TinySpec
         {
-            protected ChocolateyConfigCommand command;
-            protected Mock<IChocolateyConfigSettingsService> configSettingsService = new Mock<IChocolateyConfigSettingsService>();
-            protected ChocolateyConfiguration configuration = new ChocolateyConfiguration();
+            protected ChocolateyConfigCommand Command;
+            protected Mock<IChocolateyConfigSettingsService> ConfigSettingsService = new Mock<IChocolateyConfigSettingsService>();
+            protected ChocolateyConfiguration Configuration = new ChocolateyConfiguration();
 
             public override void Context()
             {
-                command = new ChocolateyConfigCommand(configSettingsService.Object);
+                Command = new ChocolateyConfigCommand(ConfigSettingsService.Object);
             }
         }
 
         public class When_implementing_command_for : ChocolateyConfigCommandSpecsBase
         {
-            private List<string> results;
+            private List<string> _results;
 
             public override void Because()
             {
-                results = command.GetType().GetCustomAttributes(typeof(CommandForAttribute), false).Cast<CommandForAttribute>().Select(a => a.CommandName).ToList();
+                _results = Command.GetType().GetCustomAttributes(typeof(CommandForAttribute), false).Cast<CommandForAttribute>().Select(a => a.CommandName).ToList();
             }
 
             [Fact]
             public void Should_implement_config()
             {
-                results.ShouldContain("config");
+                _results.ShouldContain("config");
             }
         }
 
         public class When_configurating_the_argument_parser : ChocolateyConfigCommandSpecsBase
         {
-            private OptionSet optionSet;
+            private OptionSet _optionSet;
 
             public override void Context()
             {
                 base.Context();
-                optionSet = new OptionSet();
+                _optionSet = new OptionSet();
             }
 
             public override void Because()
             {
-                command.ConfigureArgumentParser(optionSet, configuration);
+                Command.ConfigureArgumentParser(_optionSet, Configuration);
             }
 
             [Fact]
             public void Should_add_name_to_the_option_set()
             {
-                optionSet.Contains("name").ShouldBeTrue();
+                _optionSet.Contains("name").ShouldBeTrue();
             }
 
             [Fact]
             public void Should_add_value_to_the_option_set()
             {
-                optionSet.Contains("value").ShouldBeTrue();
+                _optionSet.Contains("value").ShouldBeTrue();
             }
         }
 
@@ -91,55 +91,55 @@ namespace chocolatey.tests.infrastructure.app.commands
         {
             public override void Because()
             {
-                command.DryRun(configuration);
+                Command.DryRun(Configuration);
             }
 
             [Fact]
             public void Should_call_service_noop()
             {
-                configSettingsService.Verify(c => c.DryRun(configuration), Times.Once);
+                ConfigSettingsService.Verify(c => c.DryRun(Configuration), Times.Once);
             }
         }
 
         public class When_run_is_called : ChocolateyConfigCommandSpecsBase
         {
-            private Action because;
+            private Action _because;
 
             public override void Because()
             {
-                because = () => command.Run(configuration);
+                _because = () => Command.Run(Configuration);
             }
 
             [Fact]
             public void Should_call_service_source_list_when_command_is_list()
             {
-                configuration.ConfigCommand.Command = ConfigCommandType.List;
-                because();
-                configSettingsService.Verify(c => c.ListConfig(configuration), Times.Once);
+                Configuration.ConfigCommand.Command = ConfigCommandType.List;
+                _because();
+                ConfigSettingsService.Verify(c => c.ListConfig(Configuration), Times.Once);
             }
 
             [Fact]
             public void Should_call_service_source_disable_when_command_is_disable()
             {
-                configuration.ConfigCommand.Command = ConfigCommandType.Get;
-                because();
-                configSettingsService.Verify(c => c.GetConfig(configuration), Times.Once);
+                Configuration.ConfigCommand.Command = ConfigCommandType.Get;
+                _because();
+                ConfigSettingsService.Verify(c => c.GetConfig(Configuration), Times.Once);
             }
 
             [Fact]
             public void Should_call_service_source_enable_when_command_is_enable()
             {
-                configuration.ConfigCommand.Command = ConfigCommandType.Set;
-                because();
-                configSettingsService.Verify(c => c.SetConfig(configuration), Times.Once);
+                Configuration.ConfigCommand.Command = ConfigCommandType.Set;
+                _because();
+                ConfigSettingsService.Verify(c => c.SetConfig(Configuration), Times.Once);
             }
 
             [Fact]
             public void Should_call_service_source_unset_when_command_is_unset()
             {
-                configuration.ConfigCommand.Command = ConfigCommandType.Unset;
-                because();
-                configSettingsService.Verify(c => c.UnsetConfig(configuration), Times.Once);
+                Configuration.ConfigCommand.Command = ConfigCommandType.Unset;
+                _because();
+                ConfigSettingsService.Verify(c => c.UnsetConfig(Configuration), Times.Once);
             }
         }
     }

--- a/src/chocolatey.tests/infrastructure.app/commands/ChocolateyFeatureCommandSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/commands/ChocolateyFeatureCommandSpecs.cs
@@ -33,106 +33,106 @@ namespace chocolatey.tests.infrastructure.app.commands
         [ConcernFor("feature")]
         public abstract class ChocolateyFeatureCommandSpecsBase : TinySpec
         {
-            protected ChocolateyFeatureCommand command;
-            protected Mock<IChocolateyConfigSettingsService> configSettingsService = new Mock<IChocolateyConfigSettingsService>();
-            protected ChocolateyConfiguration configuration = new ChocolateyConfiguration();
+            protected ChocolateyFeatureCommand Command;
+            protected Mock<IChocolateyConfigSettingsService> ConfigSettingsService = new Mock<IChocolateyConfigSettingsService>();
+            protected ChocolateyConfiguration Configuration = new ChocolateyConfiguration();
 
             public override void Context()
             {
-                configuration.Sources = "https://localhost/somewhere/out/there";
-                command = new ChocolateyFeatureCommand(configSettingsService.Object);
+                Configuration.Sources = "https://localhost/somewhere/out/there";
+                Command = new ChocolateyFeatureCommand(ConfigSettingsService.Object);
             }
         }
 
         public class When_implementing_command_for : ChocolateyFeatureCommandSpecsBase
         {
-            private List<string> results;
+            private List<string> _results;
 
             public override void Because()
             {
-                results = command.GetType().GetCustomAttributes(typeof(CommandForAttribute), false).Cast<CommandForAttribute>().Select(a => a.CommandName).ToList();
+                _results = Command.GetType().GetCustomAttributes(typeof(CommandForAttribute), false).Cast<CommandForAttribute>().Select(a => a.CommandName).ToList();
             }
 
             [Fact]
             public void Should_implement_feature()
             {
-                results.ShouldContain("feature");
+                _results.ShouldContain("feature");
             }
 
             [Fact]
             public void Should_implement_features()
             {
-                results.ShouldContain("features");
+                _results.ShouldContain("features");
             }
         }
 
         public class When_configurating_the_argument_parser : ChocolateyFeatureCommandSpecsBase
         {
-            private OptionSet optionSet;
+            private OptionSet _optionSet;
 
             public override void Context()
             {
                 base.Context();
-                optionSet = new OptionSet();
-                configuration.Sources = "https://localhost/somewhere/out/there";
+                _optionSet = new OptionSet();
+                Configuration.Sources = "https://localhost/somewhere/out/there";
             }
 
             public override void Because()
             {
-                command.ConfigureArgumentParser(optionSet, configuration);
+                Command.ConfigureArgumentParser(_optionSet, Configuration);
             }
 
             [Fact]
             public void Should_add_name_to_the_option_set()
             {
-                optionSet.Contains("name").ShouldBeTrue();
+                _optionSet.Contains("name").ShouldBeTrue();
             }
 
             [Fact]
             public void Should_add_short_version_of_name_to_the_option_set()
             {
-                optionSet.Contains("n").ShouldBeTrue();
+                _optionSet.Contains("n").ShouldBeTrue();
             }
         }
 
         public class When_handling_additional_argument_parsing : ChocolateyFeatureCommandSpecsBase
         {
-            private readonly IList<string> unparsedArgs = new List<string>();
-            private Action because;
+            private readonly IList<string> _unparsedArgs = new List<string>();
+            private Action _because;
 
             public override void Because()
             {
-                because = () => command.ParseAdditionalArguments(unparsedArgs, configuration);
+                _because = () => Command.ParseAdditionalArguments(_unparsedArgs, Configuration);
             }
 
             public void Reset()
             {
-                unparsedArgs.Clear();
-                configSettingsService.ResetCalls();
+                _unparsedArgs.Clear();
+                ConfigSettingsService.ResetCalls();
             }
 
             [Fact]
             public void Should_use_the_first_unparsed_arg_as_the_subcommand()
             {
                 Reset();
-                unparsedArgs.Add("list");
-                because();
+                _unparsedArgs.Add("list");
+                _because();
 
-                configuration.FeatureCommand.Command.ShouldEqual(FeatureCommandType.List);
+                Configuration.FeatureCommand.Command.ShouldEqual(FeatureCommandType.List);
             }
 
             [Fact]
             public void Should_throw_when_more_than_one_unparsed_arg_is_passed()
             {
                 Reset();
-                unparsedArgs.Add("wtf");
-                unparsedArgs.Add("bbq");
+                _unparsedArgs.Add("wtf");
+                _unparsedArgs.Add("bbq");
                 var errored = false;
                 Exception error = null;
 
                 try
                 {
-                    because();
+                    _because();
                 }
                 catch (Exception ex)
                 {
@@ -150,72 +150,72 @@ namespace chocolatey.tests.infrastructure.app.commands
             public void Should_accept_enable_as_the_subcommand()
             {
                 Reset();
-                unparsedArgs.Add("enable");
-                because();
+                _unparsedArgs.Add("enable");
+                _because();
 
-                configuration.FeatureCommand.Command.ShouldEqual(FeatureCommandType.Enable);
+                Configuration.FeatureCommand.Command.ShouldEqual(FeatureCommandType.Enable);
             }
 
             [Fact]
             public void Should_accept_disable_as_the_subcommand()
             {
                 Reset();
-                unparsedArgs.Add("disable");
-                because();
+                _unparsedArgs.Add("disable");
+                _because();
 
-                configuration.FeatureCommand.Command.ShouldEqual(FeatureCommandType.Disable);
+                Configuration.FeatureCommand.Command.ShouldEqual(FeatureCommandType.Disable);
             }
 
             [Fact]
             public void Should_set_unrecognized_values_to_list_as_the_subcommand()
             {
                 Reset();
-                unparsedArgs.Add("wtf");
-                because();
+                _unparsedArgs.Add("wtf");
+                _because();
 
-                configuration.FeatureCommand.Command.ShouldEqual(FeatureCommandType.List);
+                Configuration.FeatureCommand.Command.ShouldEqual(FeatureCommandType.List);
             }
 
             [Fact]
             public void Should_default_to_list_as_the_subcommand()
             {
                 Reset();
-                because();
+                _because();
 
-                configuration.FeatureCommand.Command.ShouldEqual(FeatureCommandType.List);
+                Configuration.FeatureCommand.Command.ShouldEqual(FeatureCommandType.List);
             }
 
             [Fact]
             public void Should_handle_passing_in_an_empty_string()
             {
                 Reset();
-                unparsedArgs.Add(" ");
-                because();
+                _unparsedArgs.Add(" ");
+                _because();
 
-                configuration.FeatureCommand.Command.ShouldEqual(FeatureCommandType.List);
+                Configuration.FeatureCommand.Command.ShouldEqual(FeatureCommandType.List);
             }
         }
 
         public class When_validating : ChocolateyFeatureCommandSpecsBase
         {
-            private Action because;
+            private Action _because;
 
             public override void Because()
             {
-                because = () => command.Validate(configuration);
+                _because = () => Command.Validate(Configuration);
             }
 
             [Fact]
             public void Should_throw_when_command_is_not_list_and_name_is_not_set()
             {
-                configuration.FeatureCommand.Command = FeatureCommandType.Unknown;
-                configuration.FeatureCommand.Name = "";
+                Configuration.FeatureCommand.Command = FeatureCommandType.Unknown;
+                Configuration.FeatureCommand.Name = "";
                 var errored = false;
                 Exception error = null;
 
                 try
                 {
-                    because();
+                    _because();
                 }
                 catch (Exception ex)
                 {
@@ -226,23 +226,23 @@ namespace chocolatey.tests.infrastructure.app.commands
                 errored.ShouldBeTrue();
                 error.ShouldNotBeNull();
                 error.ShouldBeType<ApplicationException>();
-                error.Message.ShouldEqual("When specifying the subcommand '{0}', you must also specify --name.".FormatWith(configuration.FeatureCommand.Command.ToStringSafe().ToLower()));
+                error.Message.ShouldEqual("When specifying the subcommand '{0}', you must also specify --name.".FormatWith(Configuration.FeatureCommand.Command.ToStringSafe().ToLower()));
             }
 
             [Fact]
             public void Should_continue_when_command_is_list_and_name_is_not_set()
             {
-                configuration.FeatureCommand.Command = FeatureCommandType.List;
-                configuration.SourceCommand.Name = "";
-                because();
+                Configuration.FeatureCommand.Command = FeatureCommandType.List;
+                Configuration.SourceCommand.Name = "";
+                _because();
             }
 
             [Fact]
             public void Should_continue_when_command_is_not_list_and_name_is_set()
             {
-                configuration.FeatureCommand.Command = FeatureCommandType.List;
-                configuration.SourceCommand.Name = "bob";
-                because();
+                Configuration.FeatureCommand.Command = FeatureCommandType.List;
+                Configuration.SourceCommand.Name = "bob";
+                _because();
             }
         }
 
@@ -250,13 +250,13 @@ namespace chocolatey.tests.infrastructure.app.commands
         {
             public override void Because()
             {
-                command.DryRun(configuration);
+                Command.DryRun(Configuration);
             }
 
             [Fact]
             public void Should_call_service_noop()
             {
-                configSettingsService.Verify(c => c.DryRun(configuration), Times.Once);
+                ConfigSettingsService.Verify(c => c.DryRun(Configuration), Times.Once);
             }
         }
 
@@ -266,13 +266,15 @@ namespace chocolatey.tests.infrastructure.app.commands
 
             public override void Because()
             {
-                _because = () => command.Run(configuration);
+                _because = () => Command.Run(Configuration);
             }
 
             [Fact]
             public void Should_call_service_source_list_when_command_is_list()
             {
-                configuration.FeatureCommand.Command = FeatureCommandType.List;
+                Configuration.FeatureCommand.Command = FeatureCommandType.List;
+                _because();
+                ConfigSettingsService.Verify(c => c.ListFeatures(Configuration), Times.Once);
                 _because();
                 configSettingsService.Verify(c => c.ListFeatures(configuration), Times.Once);
             }
@@ -280,17 +282,17 @@ namespace chocolatey.tests.infrastructure.app.commands
             [Fact]
             public void Should_call_service_source_disable_when_command_is_disable()
             {
-                configuration.FeatureCommand.Command = FeatureCommandType.Disable;
+                Configuration.FeatureCommand.Command = FeatureCommandType.Disable;
                 _because();
-                configSettingsService.Verify(c => c.DisableFeature(configuration), Times.Once);
+                ConfigSettingsService.Verify(c => c.DisableFeature(Configuration), Times.Once);
             }
 
             [Fact]
             public void Should_call_service_source_enable_when_command_is_enable()
             {
-                configuration.FeatureCommand.Command = FeatureCommandType.Enable;
+                Configuration.FeatureCommand.Command = FeatureCommandType.Enable;
                 _because();
-                configSettingsService.Verify(c => c.EnableFeature(configuration), Times.Once);
+                ConfigSettingsService.Verify(c => c.EnableFeature(Configuration), Times.Once);
             }
         }
     }

--- a/src/chocolatey.tests/infrastructure.app/commands/ChocolateyFeatureCommandSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/commands/ChocolateyFeatureCommandSpecs.cs
@@ -275,8 +275,14 @@ namespace chocolatey.tests.infrastructure.app.commands
                 Configuration.FeatureCommand.Command = FeatureCommandType.List;
                 _because();
                 ConfigSettingsService.Verify(c => c.ListFeatures(Configuration), Times.Once);
+            }
+
+            [Fact]
+            public void Should_call_service_feature_get_when_command_is_get()
+            {
+                Configuration.FeatureCommand.Command = FeatureCommandType.Get;
                 _because();
-                configSettingsService.Verify(c => c.ListFeatures(configuration), Times.Once);
+                ConfigSettingsService.Verify(c => c.GetFeature(Configuration), Times.Once);
             }
 
             [Fact]

--- a/src/chocolatey.tests/infrastructure.app/commands/ChocolateyFeatureCommandSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/commands/ChocolateyFeatureCommandSpecs.cs
@@ -270,7 +270,7 @@ namespace chocolatey.tests.infrastructure.app.commands
             }
 
             [Fact]
-            public void Should_call_service_source_list_when_command_is_list()
+            public void Should_call_service_feature_list_when_command_is_list()
             {
                 Configuration.FeatureCommand.Command = FeatureCommandType.List;
                 _because();
@@ -280,7 +280,7 @@ namespace chocolatey.tests.infrastructure.app.commands
             }
 
             [Fact]
-            public void Should_call_service_source_disable_when_command_is_disable()
+            public void Should_call_service_feature_disable_when_command_is_disable()
             {
                 Configuration.FeatureCommand.Command = FeatureCommandType.Disable;
                 _because();
@@ -288,7 +288,7 @@ namespace chocolatey.tests.infrastructure.app.commands
             }
 
             [Fact]
-            public void Should_call_service_source_enable_when_command_is_enable()
+            public void Should_call_service_feature_enable_when_command_is_enable()
             {
                 Configuration.FeatureCommand.Command = FeatureCommandType.Enable;
                 _because();

--- a/src/chocolatey/infrastructure.app/domain/FeatureCommandType.cs
+++ b/src/chocolatey/infrastructure.app/domain/FeatureCommandType.cs
@@ -22,6 +22,7 @@ namespace chocolatey.infrastructure.app.domain
     {
         Unknown,
         List,
+        Get,
         Enable,
         Disable,
 

--- a/src/chocolatey/infrastructure.app/services/ChocolateyConfigSettingsService.cs
+++ b/src/chocolatey/infrastructure.app/services/ChocolateyConfigSettingsService.cs
@@ -231,6 +231,28 @@ namespace chocolatey.infrastructure.app.services
             }
         }
 
+        public void GetFeature(ChocolateyConfiguration configuration)
+        {
+            var feature = GetFeatureValue(configuration.FeatureCommand.Name);
+            if (feature == null)
+            {
+                throw new ApplicationException("No feature value by the name '{0}'".FormatWith(configuration.FeatureCommand.Name));
+            }
+
+            this.Log().Info("{0}".FormatWith(feature.Enabled ? "Enabled" : "Disabled"));
+        }
+
+        public ConfigFileFeatureSetting GetFeatureValue(string featureName)
+        {
+            var feature = ConfigFileSettings.Features.FirstOrDefault(f => f.Name.IsEqualTo(featureName));
+            if (feature == null)
+            {
+                return null;
+            }
+
+            return feature;
+        }
+
         public void DisableFeature(ChocolateyConfiguration configuration)
         {
             var feature = ConfigFileSettings.Features.FirstOrDefault(p => p.Name.IsEqualTo(configuration.FeatureCommand.Name));

--- a/src/chocolatey/infrastructure.app/services/IChocolateyConfigSettingsService.cs
+++ b/src/chocolatey/infrastructure.app/services/IChocolateyConfigSettingsService.cs
@@ -29,6 +29,7 @@ namespace chocolatey.infrastructure.app.services
         void DisableSource(ChocolateyConfiguration configuration);
         void EnableSource(ChocolateyConfiguration configuration);
         void ListFeatures(ChocolateyConfiguration configuration);
+        void GetFeature(ChocolateyConfiguration configuration);
         void DisableFeature(ChocolateyConfiguration configuration);
         void EnableFeature(ChocolateyConfiguration configuration);
         string GetApiKey(ChocolateyConfiguration configuration, Action<ConfigFileApiKeySetting> keyAction);


### PR DESCRIPTION
## Description Of Changes

Allows to filter the list of features by the name parameter (-n or --name)

## Motivation and Context

This makes it very easy to find a specific feature in an instant, without needing to search the entire list.
Further this feature was [requested](https://github.com/chocolatey/choco/issues/2815)

## Testing
1. Run `choco feature get bob`
2. Should error that feature can't be found
3. Run `choco feature get --name bob`
4. Should error that feature can't be found
5. Run `choco feature get checksumFiles`
6. Should return Enabled
7. Run `choco feature get --name checksumFiles`
8. Should return Enabled
9. Run `choco feature get allowGlobalConfirmation`
10. Should return Disabled
11. Run `choco feature get --name allowGlobalConfirmation`
12. Should return Disabled

## Change Types Made

* [ ] Bug fix (non-breaking change)
* [x] Feature / Enhancement (non-breaking change)
* [ ] Breaking change (fix or feature that could cause existing functionality to change)
* [ ] PowerShell code changes.

## Related Issue

* Fixes #2815
* https://app.clickup.com/t/20540031/PROJ-565

## Change Checklist

* [x] Requires a change to the documentation
* [ ] Documentation has been updated
* [x] Tests to cover my changes, have been added
* [x] All new and existing tests passed.
* [ ] PowerShell v2 compatibility checked.
