### PR TITLE
(#2013) Fix limited output of choco config list

### DIFF
--- a/src/chocolatey/infrastructure.app/services/ChocolateyConfigSettingsService.cs
+++ b/src/chocolatey/infrastructure.app/services/ChocolateyConfigSettingsService.cs
@@ -365,10 +365,17 @@ namespace chocolatey.infrastructure.app.services
 
         public void config_list(ChocolateyConfiguration configuration)
         {
-            this.Log().Info(ChocolateyLoggers.Important, "Settings");
             foreach (var config in configFileSettings.ConfigSettings)
             {
-                this.Log().Info(() => "{0} = {1} | {2}".format_with(config.Key, config.Value, config.Description));
+                if (configuration.RegularOutput)
+                {
+                    this.Log().Info(() => "{0} = {1} | {2}".format_with(config.Key, config.Value, config.Description));
+
+                }
+                else
+                {
+                    this.Log().Info(() => "{0}|{1}|{2}".format_with(config.Key, config.Value, config.Description));
+                }
             }
         }
 


### PR DESCRIPTION


## Description Of Changes

This PR changes the output of `choco config list --limit-output` to be more inline with how other commands format the returned data when `--limit-output` is passed as a parameter to the command.

## Motivation and Context

Consistency in the ability to parse the returned data with a _single_ mechanism makes scripting easier to maintain

## Testing

1. Debug with `choco config list -r` and observe that output of the config section is consistent with other sections

## Change Types Made


* [ ] Bug fix (non-breaking change)
* [ ] Feature / Enhancement (non-breaking change)
* [x] Breaking change (fix or feature that could cause existing functionality to change)
* [ ] PowerShell code changes.

## Related Issue

Fixes #2013

## Change Checklist

* [ ] Requires a change to the documentation
* [ ] Documentation has been updated
* [ ] Tests to cover my changes, have been added
* [ ] All new and existing tests passed.
* [ ] PowerShell v2 compatibility checked.
