### PR TITLE
(#2781) Add chocolateyPackageId to env variables

### DIFF
--- a/src/chocolatey/infrastructure.app/services/PowershellService.cs
+++ b/src/chocolatey/infrastructure.app/services/PowershellService.cs
@@ -435,6 +435,8 @@ namespace chocolatey.infrastructure.app.services
 
             Environment.SetEnvironmentVariable("chocolateyPackageName", package.Id);
             Environment.SetEnvironmentVariable("packageName", package.Id);
+            Environment.SetEnvironmentVariable("chocolateyPackageId", package.Id);
+            Environment.SetEnvironmentVariable("packageId", package.Id);
             Environment.SetEnvironmentVariable("chocolateyPackageTitle", package.Title);
             Environment.SetEnvironmentVariable("packageTitle", package.Title);
             Environment.SetEnvironmentVariable("chocolateyPackageVersion", package.Version.to_string());


### PR DESCRIPTION

## Description Of Changes

Adds a new `$env:ChocolateyPackageId` environment variable to the PowerShell host when installing/upgrading/uninstalling a Chocolatey package.

## Motivation and Context

The nuspec references a package by id, making `$env:ChocolateyPackageName` less idiomatic than `$env:ChocolateyPackageId`. The `$env:ChocolateyPackageName` variable is still available for use, to prevent existing packages from breaking, but moving forward this new env variable is more inline with the nuspec definition of id.

## Testing

1. Create sample package that emits $env:ChocolateyPackageId
2. Verifiy package id is output when installing package

## Change Types Made

* [ ] Bug fix (non-breaking change)
* [x] Feature / Enhancement (non-breaking change)
* [ ] Breaking change (fix or feature that could cause existing functionality to change)
* [ ] PowerShell code changes.

## Related Issue


Fixes #2781

## Change Checklist

* [x] Requires a change to the documentation
* [ ] Documentation has been updated
* [ ] Tests to cover my changes, have been added
* [x] All new and existing tests passed.
* [ ] PowerShell v2 compatibility checked.

