### PR TITLE
(#2899) Info command should warn when no id used

### DIFF
--- a/src/chocolatey.tests/infrastructure.app/commands/ChocolateyInfoCommandSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/commands/ChocolateyInfoCommandSpecs.cs
@@ -32,157 +32,157 @@ namespace chocolatey.tests.infrastructure.app.commands
         [ConcernFor("info")]
         public abstract class ChocolateyInfoCommandSpecsBase : TinySpec
         {
-            protected ChocolateyInfoCommand command;
-            protected Mock<IChocolateyPackageService> packageService = new Mock<IChocolateyPackageService>();
-            protected ChocolateyConfiguration configuration = new ChocolateyConfiguration();
+            protected ChocolateyInfoCommand Command;
+            protected Mock<IChocolateyPackageService> PackageService = new Mock<IChocolateyPackageService>();
+            protected ChocolateyConfiguration Configuration = new ChocolateyConfiguration();
 
             public override void Context()
             {
-                configuration.Sources = "bob";
-                command = new ChocolateyInfoCommand(packageService.Object);
+                Configuration.Sources = "bob";
+                Command = new ChocolateyInfoCommand(PackageService.Object);
             }
         }
 
         public class When_implementing_command_for : ChocolateyInfoCommandSpecsBase
         {
-            private List<string> results;
+            private List<string> _results;
 
             public override void Because()
             {
-                results = command.GetType().GetCustomAttributes(typeof(CommandForAttribute), false).Cast<CommandForAttribute>().Select(a => a.CommandName).ToList();
+                _results = Command.GetType().GetCustomAttributes(typeof(CommandForAttribute), false).Cast<CommandForAttribute>().Select(a => a.CommandName).ToList();
             }
 
             [Fact]
             public void Should_implement_info()
             {
-                results.ShouldContain("info");
+                _results.ShouldContain("info");
             }
         }
 
         public class When_configurating_the_argument_parser : ChocolateyInfoCommandSpecsBase
         {
-            private OptionSet optionSet;
+            private OptionSet _optionSet;
 
             public override void Context()
             {
                 base.Context();
-                optionSet = new OptionSet();
+                _optionSet = new OptionSet();
             }
 
             public override void Because()
             {
-                command.ConfigureArgumentParser(optionSet, configuration);
+                Command.ConfigureArgumentParser(_optionSet, Configuration);
             }
 
             [Fact]
             public void Should_add_source_to_the_option_set()
             {
-                optionSet.Contains("source").ShouldBeTrue();
+                _optionSet.Contains("source").ShouldBeTrue();
             }
 
             [Fact]
             public void Should_add_short_version_of_source_to_the_option_set()
             {
-                optionSet.Contains("s").ShouldBeTrue();
+                _optionSet.Contains("s").ShouldBeTrue();
             }
 
             [Fact]
             public void Should_add_localonly_to_the_option_set()
             {
-                optionSet.Contains("localonly").ShouldBeTrue();
+                _optionSet.Contains("localonly").ShouldBeTrue();
             }
 
             [Fact]
             public void Should_add_short_version_of_localonly_to_the_option_set()
             {
-                optionSet.Contains("l").ShouldBeTrue();
+                _optionSet.Contains("l").ShouldBeTrue();
             }
 
             [Fact]
             public void Should_add_prerelease_to_the_option_set()
             {
-                optionSet.Contains("prerelease").ShouldBeTrue();
+                _optionSet.Contains("prerelease").ShouldBeTrue();
             }
 
             [Fact]
             public void Should_add_short_version_of_prerelease_to_the_option_set()
             {
-                optionSet.Contains("pre").ShouldBeTrue();
+                _optionSet.Contains("pre").ShouldBeTrue();
             }
 
             [Fact]
             public void Should_add_user_to_the_option_set()
             {
-                optionSet.Contains("user").ShouldBeTrue();
+                _optionSet.Contains("user").ShouldBeTrue();
             }
 
             [Fact]
             public void Should_add_short_version_of_user_to_the_option_set()
             {
-                optionSet.Contains("u").ShouldBeTrue();
+                _optionSet.Contains("u").ShouldBeTrue();
             }
 
             [Fact]
             public void Should_add_password_to_the_option_set()
             {
-                optionSet.Contains("password").ShouldBeTrue();
+                _optionSet.Contains("password").ShouldBeTrue();
             }
 
             [Fact]
             public void Should_add_short_version_of_password_to_the_option_set()
             {
-                optionSet.Contains("p").ShouldBeTrue();
+                _optionSet.Contains("p").ShouldBeTrue();
             }
         }
 
         public class When_handling_additional_argument_parsing : ChocolateyInfoCommandSpecsBase
         {
-            private readonly IList<string> unparsedArgs = new List<string>();
-            private readonly string source = "https://somewhereoutthere";
-            private Action because;
+            private readonly IList<string> _unparsedArgs = new List<string>();
+            private readonly string _source = "https://somewhereoutthere";
+            private Action _because;
 
             public override void Context()
             {
                 base.Context();
-                unparsedArgs.Add("pkg1");
-                unparsedArgs.Add("pkg2");
-                configuration.Sources = source;
+                _unparsedArgs.Add("pkg1");
+                _unparsedArgs.Add("pkg2");
+                Configuration.Sources = _source;
             }
 
             public override void Because()
             {
-                because = () => command.ParseAdditionalArguments(unparsedArgs, configuration);
+                _because = () => Command.ParseAdditionalArguments(_unparsedArgs, Configuration);
             }
 
             [Fact]
             public void Should_set_unparsed_arguments_to_configuration_input()
             {
-                because();
-                configuration.Input.ShouldEqual("pkg1 pkg2");
+                _because();
+                Configuration.Input.ShouldEqual("pkg1 pkg2");
             }
 
             [Fact]
             public void Should_leave_source_as_set()
             {
-                configuration.ListCommand.LocalOnly = false;
-                because();
-                configuration.Sources.ShouldEqual(source);
+                Configuration.ListCommand.LocalOnly = false;
+                _because();
+                Configuration.Sources.ShouldEqual(_source);
             }
 
             [Fact]
             public void Should_set_exact_to_true()
             {
-                configuration.ListCommand.Exact = false;
-                because();
-                configuration.ListCommand.Exact.ShouldBeTrue();
+                Configuration.ListCommand.Exact = false;
+                _because();
+                Configuration.ListCommand.Exact.ShouldBeTrue();
             }
 
             [Fact]
             public void Should_set_verbose_to_true()
             {
-                configuration.Verbose = false;
-                because();
-                configuration.Verbose.ShouldBeTrue();
+                Configuration.Verbose = false;
+                _because();
+                Configuration.Verbose.ShouldBeTrue();
             }
         }
 
@@ -190,13 +190,13 @@ namespace chocolatey.tests.infrastructure.app.commands
         {
             public override void Because()
             {
-                command.DryRun(configuration);
+                Command.DryRun(Configuration);
             }
 
             [Fact]
             public void Should_call_service_list_noop()
             {
-                packageService.Verify(c => c.ListDryRun(configuration), Times.Once);
+                PackageService.Verify(c => c.ListDryRun(Configuration), Times.Once);
             }
         }
 
@@ -204,13 +204,13 @@ namespace chocolatey.tests.infrastructure.app.commands
         {
             public override void Because()
             {
-                command.Run(configuration);
+                Command.Run(Configuration);
             }
 
             [Fact]
             public void Should_call_service_list_run()
             {
-                packageService.Verify(c => c.List(configuration), Times.Once);
+                PackageService.Verify(c => c.List(Configuration), Times.Once);
             }
         }
     }

--- a/src/chocolatey.tests/infrastructure.app/commands/ChocolateyInfoCommandSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/commands/ChocolateyInfoCommandSpecs.cs
@@ -135,6 +135,61 @@ namespace chocolatey.tests.infrastructure.app.commands
             }
         }
 
+        public class When_handling_validation : ChocolateyInfoCommandSpecsBase
+        {
+            private Exception _error = null;
+            private Action _because;
+
+            public override void Context()
+            {
+                base.Context();
+            }
+
+            public override void Because()
+            {
+                _because = () => Command.Validate(Configuration);
+            }
+
+            [Fact]
+            public void Show_throw_when_package_id_is_not_set()
+            {
+                Configuration.Input = "";
+                _error = null;
+
+                try
+                {
+                    _because();
+                }
+                catch (Exception ex)
+                {
+                    _error = ex;
+                }
+
+                _error.ShouldNotBeNull();
+                _error.ShouldBeType<ApplicationException>();
+                _error.Message.ShouldContain("A single package name is required to run the choco info command.");
+            }
+
+            [Fact]
+            public void Should_throw_when_multiple_package_ids_set()
+            {
+                Configuration.Input = "foo bar";
+                _error = null;
+
+                try
+                {
+                    _because();
+                }
+                catch (Exception ex)
+                {
+                    _error = ex;
+                }
+
+                _error.ShouldNotBeNull();
+                _error.ShouldBeType<ApplicationException>();
+                _error.Message.ShouldContain("Only a single package name can be passed to the choco info command.");
+            }
+        }
         public class When_handling_additional_argument_parsing : ChocolateyInfoCommandSpecsBase
         {
             private readonly IList<string> _unparsedArgs = new List<string>();

--- a/src/chocolatey/infrastructure.app/commands/ChocolateyInfoCommand.cs
+++ b/src/chocolatey/infrastructure.app/commands/ChocolateyInfoCommand.cs
@@ -84,6 +84,24 @@ namespace chocolatey.infrastructure.app.commands
             configuration.ListCommand.Exact = true;
         }
 
+        public override void Validate(ChocolateyConfiguration configuration)
+        {
+            base.Validate(configuration);
+
+            if (string.IsNullOrWhiteSpace(configuration.Input))
+            {
+                throw new ApplicationException("A single package name is required to run the choco info command.");
+            }
+
+            // Validate only a single package has been passed to info
+            // TODO: Provide ability to get info on a list of packages. See https://github.com/chocolatey/choco/issues/2905
+            var input = configuration.Input.Split(' ');
+            if (input.Length > 1)
+            {
+                throw new ApplicationException("Only a single package name can be passed to the choco info command.");
+            }
+        }
+
         public override void HelpMessage(ChocolateyConfiguration configuration)
         {
             this.Log().Info(ChocolateyLoggers.Important, "Info Command");

--- a/tests/chocolatey-tests/commands/choco-info.Tests.ps1
+++ b/tests/chocolatey-tests/commands/choco-info.Tests.ps1
@@ -80,6 +80,34 @@ Describe "choco info" -Tag Chocolatey, InfoCommand {
         }
     }
 
+    Context "Listing package information when more than one package ID is provided" {
+        BeforeAll {
+            $Output = Invoke-Choco info foo bar
+        }
+
+        It "Exits with Failure (1)" {
+            $Output.ExitCode | Should -Be 1 -Because $Output.String
+        }
+
+        It "Reports a package ID is required" {
+            $Output.Lines | Should -Contain 'Only a single package name can be passed to the choco info command.'
+        }
+    }
+
+    Context "Listing package information when no package ID is provided" {
+        BeforeAll {
+            $Output = Invoke-Choco info
+        }
+
+        It "Exits with Failure (1)" {
+            $Output.ExitCode | Should -Be 1 -Because $Output.String
+        }
+
+        It "Reports a package ID is required" {
+            $Output.Lines | Should -Contain 'A single package name is required to run the choco info command.'
+        }
+    }
+
     # Issue: https://gitlab.com/chocolatey/collaborators/choco-licensed/-/issues/530 (NOTE: Proxy bypassing also works on Chocolatey FOSS)
     # These are skipped on Proxy tests because the proxy server can't be bypassed in that test environment.
     Context "Listing package information when using proxy and proxy bypass list in config" -Tag ProxySkip -Skip:(!$licensedProxyFixed) {

--- a/tests/chocolatey-tests/commands/choco-info.Tests.ps1
+++ b/tests/chocolatey-tests/commands/choco-info.Tests.ps1
@@ -6,6 +6,7 @@ Describe "choco info" -Tag Chocolatey, InfoCommand {
     }
 
     BeforeAll {
+        Remove-NuGetPaths
         Initialize-ChocolateyTestInstall
     }
 
@@ -23,7 +24,6 @@ Describe "choco info" -Tag Chocolatey, InfoCommand {
         }
 
         BeforeAll {
-            Remove-NuGetPaths
             $Output = Invoke-Choco info mvcmusicstore-web
             $Output.Lines = $Output.Lines
         }


### PR DESCRIPTION


## Description Of Changes

Throw errors when conditions are not correct: either no package was passed, or multiple packages were passed to `choco info`.

## Motivation and Context

Currently the output of the `choco info` command without any further input states `0 packages found.` This _should_ throw an error that input is required in the form of a single package id.

## Testing

1. Debug in Visual Studio with multiple input conditions: No input, single input, multiple input

## Change Types Made
<!-- Tick the boxes for the type of changes that have been made -->

* [x] Bug fix (non-breaking change)
* [ ] Feature / Enhancement (non-breaking change)
* [ ] Breaking change (fix or feature that could cause existing functionality to change)
* [ ] PowerShell code changes.

## Related Issue

Fixes #2899 

Fixes #

## Change Checklist

* [ ] Requires a change to the documentation
* [ ] Documentation has been updated
* [x] Tests to cover my changes, have been added
* [ ] All new and existing tests passed.
* [ ] PowerShell v2 compatibility checked.

<!-- PLEASE REMOVE ALL COMMENTS BEFORE SUBMITTING -->
