### PR TITLE
(#2738) Add net48 TFM folder in NuGet package 

### DIFF
--- a/recipe.cake
+++ b/recipe.cake
@@ -289,12 +289,14 @@ Task("Prepare-NuGet-Packages")
     .IsDependeeOf("Sign-Assemblies")
     .Does(() =>
 {
-    // Copy legal documents
     CleanDirectory(BuildParameters.Paths.Directories.NuGetNuspecDirectory + "/lib");
+    EnsureDirectoryExists(BuildParameters.Paths.Directories.NuGetNuspecDirectory + "/lib/net48");
+
+    // Copy legal documents
     CopyFile(BuildParameters.RootDirectoryPath + "/docs/legal/CREDITS.md", BuildParameters.Paths.Directories.NuGetNuspecDirectory + "/lib/CREDITS.txt");
 
-    CopyFiles(BuildParameters.Paths.Directories.PublishedLibraries + "/chocolatey_merged/*", BuildParameters.Paths.Directories.NuGetNuspecDirectory + "/lib");
-    CopyFile(BuildParameters.Paths.Directories.PublishedLibraries + "/chocolatey/chocolatey.xml", BuildParameters.Paths.Directories.NuGetNuspecDirectory + "/lib/chocolatey.xml");
+    CopyFiles(BuildParameters.Paths.Directories.PublishedLibraries + "/chocolatey_merged/*", BuildParameters.Paths.Directories.NuGetNuspecDirectory + "/lib/net48");
+    CopyFile(BuildParameters.Paths.Directories.PublishedLibraries + "/chocolatey/chocolatey.xml", BuildParameters.Paths.Directories.NuGetNuspecDirectory + "/lib/net48/chocolatey.xml");
 });
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/src/chocolatey.sln
+++ b/src/chocolatey.sln
@@ -41,6 +41,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "toplevel", "toplevel", "{18
 		..\CHANGELOG_LICENSED.md = ..\CHANGELOG_LICENSED.md
 		..\COMMITTERS.md = ..\COMMITTERS.md
 		..\CONTRIBUTING.md = ..\CONTRIBUTING.md
+		..\LICENSE = ..\LICENSE
+		..\NOTICE = ..\NOTICE
 		..\README.md = ..\README.md
 		..\TESTING.md = ..\TESTING.md
 	EndProjectSection


### PR DESCRIPTION
## Description Of Changes

Now that we are building specifically for .NET 4.8, we should add the
generated chocolatey.dll file to the correct TFM folder within the
NuGet package, so that it is correctly located, and extracted when
consuming the NuGet package.

The Credits.txt file has been left at the root level of the lib folder,
rather than replicating into each TFM folder.

## Motivation and Context

This makes it clear what framework the assembly is targetting.

## Testing

Ran build.bat locally, and then verified that the net48 folder existed in the generated nupkg file. This was done using NuGet Package Explorer.

## Change Types Made

* [ ] Bug fix (non-breaking change)
* [ ] Feature / Enhancement (non-breaking change)
* [ ] Breaking change (fix or feature that could cause existing functionality to change)
* [ ] PowerShell code changes.

## Related Issue

Relates to #2738 

## Change Checklist

* [ ] Requires a change to the documentation
* [ ] Documentation has been updated
* [ ] Tests to cover my changes, have been added
* [ ] All new and existing tests passed.
* [ ] PowerShell v2 compatibility checked.