### PR TITLE
(#2893) Switch from Should to FluentAssertions

### DIFF
--- a/src/chocolatey.tests.integration/chocolatey.tests.integration.csproj
+++ b/src/chocolatey.tests.integration/chocolatey.tests.integration.csproj
@@ -96,6 +96,9 @@
     <Reference Include="Chocolatey.NuGet.Versioning">
       <HintPath>..\packages\Chocolatey.NuGet.Versioning.3.2.0\lib\net472\Chocolatey.NuGet.Versioning.dll</HintPath>
     </Reference>
+    <Reference Include="FluentAssertions, Version=6.11.0.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
+      <HintPath>..\packages\FluentAssertions.6.11.0\lib\net47\FluentAssertions.dll</HintPath>
+    </Reference>
     <Reference Include="log4net, Version=2.0.12.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
       <HintPath>..\packages\log4net.2.0.12\lib\net45\log4net.dll</HintPath>
     </Reference>
@@ -110,9 +113,6 @@
     </Reference>
     <Reference Include="nunit.framework, Version=3.13.3.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
       <HintPath>..\packages\NUnit.3.13.3\lib\net40\nunit.framework.dll</HintPath>
-    </Reference>
-    <Reference Include="Should, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Should.1.1.20\lib\Should.dll</HintPath>
     </Reference>
     <Reference Include="SimpleInjector, Version=2.8.3.0, Culture=neutral, PublicKeyToken=984cb50dea722e99, processorArchitecture=MSIL">
       <HintPath>..\packages\SimpleInjector.2.8.3\lib\net45\SimpleInjector.dll</HintPath>
@@ -207,7 +207,9 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <Analyzer Include="..\packages\FluentAssertions.Analyzers.0.19.1\analyzers\dotnet\cs\FluentAssertions.Analyzers.dll" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>

--- a/src/chocolatey.tests.integration/chocolatey.tests.integration.csproj
+++ b/src/chocolatey.tests.integration/chocolatey.tests.integration.csproj
@@ -13,6 +13,7 @@
     <RootNamespace>chocolatey.tests.integration</RootNamespace>
     <AssemblyName>chocolatey.tests.integration</AssemblyName>
     <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
+    <LangVersion>7.3</LangVersion>
     <FileAlignment>512</FileAlignment>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <OverwriteReadOnlyFiles>true</OverwriteReadOnlyFiles>

--- a/src/chocolatey.tests.integration/infrastructure.app/builders/ConfigurationBuilderSpecs.cs
+++ b/src/chocolatey.tests.integration/infrastructure.app/builders/ConfigurationBuilderSpecs.cs
@@ -33,7 +33,7 @@ namespace chocolatey.tests.integration.infrastructure.app.builders
     using chocolatey.infrastructure.registration;
     using Microsoft.Win32;
     using scenarios;
-    using Should;
+    using FluentAssertions;
 
     public class ConfigurationBuilderSpecs
     {
@@ -140,31 +140,31 @@ namespace chocolatey.tests.integration.infrastructure.app.builders
                 if (!SystemSet && !ArgumentSet && !ConfigSet &&
                     !EnvironmentVariableSet)
                 {
-                    Configuration.Proxy.Location.ShouldEqual(string.Empty);
+                    Configuration.Proxy.Location.Should().Be(string.Empty);
                     return;
                 }
 
                 if (ArgumentSet)
                 {
-                    Configuration.Proxy.Location.ShouldEqual(CommandArgumentProxyValue);
+                    Configuration.Proxy.Location.Should().Be(CommandArgumentProxyValue);
                     return;
                 }
 
                 if (ConfigSet)
                 {
-                    Configuration.Proxy.Location.ShouldEqual(ConfigurationFileProxyValue);
+                    Configuration.Proxy.Location.Should().Be(ConfigurationFileProxyValue);
                     return;
                 }
 
                 if (EnvironmentVariableSet)
                 {
-                    Configuration.Proxy.Location.ShouldEqual(EnvironmentVariableProxyValue);
+                    Configuration.Proxy.Location.Should().Be(EnvironmentVariableProxyValue);
                     return;
                 }
 
                 if (SystemSet)
                 {
-                    Configuration.Proxy.Location.ShouldEqual(SystemLevelProxyValue);
+                    Configuration.Proxy.Location.Should().Be(SystemLevelProxyValue);
                     return;
                 }
             }
@@ -211,25 +211,25 @@ namespace chocolatey.tests.integration.infrastructure.app.builders
                 if (!ArgumentSet && !ConfigSet &&
                     !EnvironmentVariableSet)
                 {
-                    Configuration.Proxy.BypassList.ShouldEqual(string.Empty);
+                    Configuration.Proxy.BypassList.Should().Be(string.Empty);
                     return;
                 }
 
                 if (ArgumentSet)
                 {
-                    Configuration.Proxy.BypassList.ShouldEqual(CommandArgumentProxyValue);
+                    Configuration.Proxy.BypassList.Should().Be(CommandArgumentProxyValue);
                     return;
                 }
 
                 if (ConfigSet)
                 {
-                    Configuration.Proxy.BypassList.ShouldEqual(ConfigurationFileProxyValue);
+                    Configuration.Proxy.BypassList.Should().Be(ConfigurationFileProxyValue);
                     return;
                 }
 
                 if (EnvironmentVariableSet)
                 {
-                    Configuration.Proxy.BypassList.ShouldEqual(EnvironmentVariableProxyValue);
+                    Configuration.Proxy.BypassList.Should().Be(EnvironmentVariableProxyValue);
                     return;
                 }
             }

--- a/src/chocolatey.tests.integration/infrastructure.app/builders/ConfigurationBuilderSpecs.cs
+++ b/src/chocolatey.tests.integration/infrastructure.app/builders/ConfigurationBuilderSpecs.cs
@@ -140,7 +140,7 @@ namespace chocolatey.tests.integration.infrastructure.app.builders
                 if (!SystemSet && !ArgumentSet && !ConfigSet &&
                     !EnvironmentVariableSet)
                 {
-                    Configuration.Proxy.Location.Should().Be(string.Empty);
+                    Configuration.Proxy.Location.Should().BeEmpty();
                     return;
                 }
 
@@ -211,7 +211,7 @@ namespace chocolatey.tests.integration.infrastructure.app.builders
                 if (!ArgumentSet && !ConfigSet &&
                     !EnvironmentVariableSet)
                 {
-                    Configuration.Proxy.BypassList.Should().Be(string.Empty);
+                    Configuration.Proxy.BypassList.Should().BeEmpty();
                     return;
                 }
 

--- a/src/chocolatey.tests.integration/infrastructure.app/services/FilesServiceSpecs.cs
+++ b/src/chocolatey.tests.integration/infrastructure.app/services/FilesServiceSpecs.cs
@@ -101,7 +101,7 @@ namespace chocolatey.tests.integration.infrastructure.app.services
             [Fact]
             public void Should_return_a_special_code_for_locked_files()
             {
-                _result.Files.FirstOrDefault(x => x.Path == _theLockedFile).Checksum.Should().Be(ApplicationParameters.HashProviderFileLocked);
+                _result.Files.Should().ContainSingle(x => x.Path == _theLockedFile).Which.Checksum.Should().Be(ApplicationParameters.HashProviderFileLocked);
             }
         }
     }

--- a/src/chocolatey.tests.integration/infrastructure.app/services/FilesServiceSpecs.cs
+++ b/src/chocolatey.tests.integration/infrastructure.app/services/FilesServiceSpecs.cs
@@ -29,7 +29,7 @@ namespace chocolatey.tests.integration.infrastructure.app.services
     using chocolatey.infrastructure.services;
     using Moq;
     using NUnit.Framework;
-    using Should;
+    using FluentAssertions;
 
     public class FilesServiceSpecs
     {
@@ -101,7 +101,7 @@ namespace chocolatey.tests.integration.infrastructure.app.services
             [Fact]
             public void Should_return_a_special_code_for_locked_files()
             {
-                _result.Files.FirstOrDefault(x => x.Path == _theLockedFile).Checksum.ShouldEqual(ApplicationParameters.HashProviderFileLocked);
+                _result.Files.FirstOrDefault(x => x.Path == _theLockedFile).Checksum.Should().Be(ApplicationParameters.HashProviderFileLocked);
             }
         }
     }

--- a/src/chocolatey.tests.integration/infrastructure/commands/CommandExecutorSpecs.cs
+++ b/src/chocolatey.tests.integration/infrastructure/commands/CommandExecutorSpecs.cs
@@ -21,7 +21,7 @@ namespace chocolatey.tests.integration.infrastructure.commands
     using chocolatey.infrastructure.commands;
     using chocolatey.infrastructure.filesystem;
     using NUnit.Framework;
-    using Should;
+    using FluentAssertions;
 
     public class CommandExecutorSpecs
     {
@@ -64,19 +64,19 @@ namespace chocolatey.tests.integration.infrastructure.commands
             [Fact]
             public void Should_not_return_an_exit_code_of_zero()
             {
-                result.ShouldNotEqual(0);
+                result.Should().NotBe(0);
             }
 
             [Fact]
             public void Should_contain_error_output()
             {
-                errorOutput.ShouldNotBeNull();
+                errorOutput.Should().NotBeNull();
             }
 
             [Fact]
             public void Should_message_the_error()
             {
-                errorOutput.ShouldEqual("'bob123123' is not recognized as an internal or external command,operable program or batch file.");
+                errorOutput.Should().Be("'bob123123' is not recognized as an internal or external command,operable program or batch file.");
             }
         }
 
@@ -102,7 +102,7 @@ namespace chocolatey.tests.integration.infrastructure.commands
             [Fact]
             public void Should_have_an_error_message()
             {
-                result.ShouldNotBeNull();
+                result.Should().NotBeNull();
             }
         }
     }

--- a/src/chocolatey.tests.integration/infrastructure/cryptography/CryptoHashProviderSpecs.cs
+++ b/src/chocolatey.tests.integration/infrastructure/cryptography/CryptoHashProviderSpecs.cs
@@ -21,7 +21,7 @@ namespace chocolatey.tests.integration.infrastructure.cryptography
     using System.Security.Cryptography;
     using chocolatey.infrastructure.cryptography;
     using chocolatey.infrastructure.filesystem;
-    using Should;
+    using FluentAssertions;
 
     public class CryptoHashProviderSpecs
     {
@@ -60,7 +60,7 @@ namespace chocolatey.tests.integration.infrastructure.cryptography
             {
                 var expected = BitConverter.ToString(SHA256.Create().ComputeHash(File.ReadAllBytes(filePath))).Replace("-", string.Empty);
 
-                result.ShouldEqual(expected);
+                result.Should().Be(expected);
             }
         }
     }

--- a/src/chocolatey.tests.integration/infrastructure/filesystem/DotNetFileSystemSpecs.cs
+++ b/src/chocolatey.tests.integration/infrastructure/filesystem/DotNetFileSystemSpecs.cs
@@ -22,7 +22,7 @@ namespace chocolatey.tests.integration.infrastructure.filesystem
     using chocolatey.infrastructure.filesystem;
     using chocolatey.infrastructure.platforms;
     using NUnit.Framework;
-    using Should;
+    using FluentAssertions;
 
     public class DotNetFileSystemSpecs
     {
@@ -59,41 +59,39 @@ namespace chocolatey.tests.integration.infrastructure.filesystem
             [Fact]
             public void GetExecutablePath_should_find_existing_executable()
             {
-                FileSystem.GetExecutablePath("cmd").ShouldEqual(
+                FileSystem.GetExecutablePath("cmd").Should().BeEquivalentTo(
                     Platform.GetPlatform() == PlatformType.Windows
                         ? "C:\\Windows\\system32\\cmd.exe"
-                        : "cmd",
-                    StringComparer.OrdinalIgnoreCase
-                );
+                        : "cmd"
+                    );
             }
 
             [Fact]
             public void GetExecutablePath_should_find_existing_executable_with_extension()
             {
-                FileSystem.GetExecutablePath("cmd.exe").ShouldEqual(
+                FileSystem.GetExecutablePath("cmd.exe").Should().BeEquivalentTo(
                     Platform.GetPlatform() == PlatformType.Windows
                         ? "c:\\windows\\system32\\cmd.exe"
-                        : "cmd.exe",
-                    StringComparer.OrdinalIgnoreCase
+                        : "cmd.exe"
                 );
             }
 
             [Fact]
             public void GetExecutablePath_should_return_same_value_when_executable_is_not_found()
             {
-                FileSystem.GetExecutablePath("daslakjsfdasdfwea").ShouldEqual("daslakjsfdasdfwea");
+                FileSystem.GetExecutablePath("daslakjsfdasdfwea").Should().Be("daslakjsfdasdfwea");
             }
 
             [Fact]
             public void GetExecutablePath_should_return_empty_string_when_value_is_null()
             {
-                FileSystem.GetExecutablePath(null).ShouldEqual(string.Empty);
+                FileSystem.GetExecutablePath(null).Should().Be(string.Empty);
             }
 
             [Fact]
             public void GetExecutablePath_should_return_empty_string_when_value_is_empty_string()
             {
-                FileSystem.GetExecutablePath(string.Empty).ShouldEqual(string.Empty);
+                FileSystem.GetExecutablePath(string.Empty).Should().Be(string.Empty);
             }
         }
 
@@ -120,7 +118,7 @@ namespace chocolatey.tests.integration.infrastructure.filesystem
             [Fact]
             public void GetFiles_should_return_string_array_of_files()
             {
-                FileSystem.GetFiles(ContextPath, "*lipsum*", SearchOption.AllDirectories).ShouldEqual(FileArray);
+                FileSystem.GetFiles(ContextPath, "*lipsum*", SearchOption.AllDirectories).Should().BeEquivalentTo(FileArray);
             }
 
             [Fact]
@@ -132,8 +130,8 @@ namespace chocolatey.tests.integration.infrastructure.filesystem
                 var actual = FileSystem.GetFiles(ContextPath, "chocolateyInstall.ps1", SearchOption.AllDirectories).ToList();
                 FileSystem.DeleteFile(filePath);
 
-                actual.ShouldNotBeEmpty();
-                actual.Count().ShouldEqual(1);
+                actual.Should().NotBeEmpty();
+                actual.Count().Should().Be(1);
             }
 
             [Fact]
@@ -147,44 +145,44 @@ namespace chocolatey.tests.integration.infrastructure.filesystem
                 var actual = FileSystem.GetFiles(ContextPath, "chocolateyinstall.ps1", SearchOption.AllDirectories).ToList();
                 FileSystem.DeleteFile(filePath);
 
-                actual.ShouldNotBeEmpty();
-                actual.Count().ShouldEqual(1);
+                actual.Should().NotBeEmpty();
+                actual.Count().Should().Be(1);
             }
 
             [Fact]
             public void FileExists_should_return_true_if_file_exists()
             {
-                FileSystem.FileExists(TheTestFile).ShouldBeTrue();
+                FileSystem.FileExists(TheTestFile).Should().BeTrue();
             }
 
             [Fact]
             public void FileExists_should_return_false_if_file_does_not_exists()
             {
-                FileSystem.FileExists(Path.Combine(ContextPath, "IDontExist.txt")).ShouldBeFalse();
+                FileSystem.FileExists(Path.Combine(ContextPath, "IDontExist.txt")).Should().BeFalse();
             }
 
             [Fact]
             public void DirectoryExists_should_return_true_if_directory_exists()
             {
-                FileSystem.DirectoryExists(ContextPath).ShouldBeTrue();
+                FileSystem.DirectoryExists(ContextPath).Should().BeTrue();
             }
 
             [Fact]
             public void DirectoryExists_should_return_false_if_directory_does_not_exist()
             {
-                FileSystem.DirectoryExists(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "IDontExist")).ShouldBeFalse();
+                FileSystem.DirectoryExists(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "IDontExist")).Should().BeFalse();
             }
 
             [Fact]
             public void GetFileSize_should_return_correct_file_size()
             {
-                FileSystem.GetFileSize(TheTestFile).ShouldEqual(5377);
+                FileSystem.GetFileSize(TheTestFile).Should().Be(5377);
             }
 
             [Fact]
             public void GetDirectories_should_return_a_string_array_with_directories()
             {
-                FileSystem.GetDirectories(ContextPath).ShouldEqual(DirectoryArray);
+                FileSystem.GetDirectories(ContextPath).Should().BeEquivalentTo(DirectoryArray);
             }
         }
 
@@ -207,7 +205,7 @@ namespace chocolatey.tests.integration.infrastructure.filesystem
             [Fact]
             public void Visible_file_should_now_be_hidden()
             {
-                ((FileAttributes)FileSystem.GetFileInfoFor(SourceFile).Attributes & FileAttributes.Hidden).ShouldEqual(FileAttributes.Hidden);
+                ((FileAttributes)FileSystem.GetFileInfoFor(SourceFile).Attributes & FileAttributes.Hidden).Should().Be(FileAttributes.Hidden);
             }
 
             public override void AfterObservations()
@@ -234,7 +232,7 @@ namespace chocolatey.tests.integration.infrastructure.filesystem
             [Fact]
             public void Readonly_file_should_no_longer_be_readonly()
             {
-                ((FileAttributes)FileSystem.GetFileInfoFor(SourceFile).Attributes & FileAttributes.ReadOnly).ShouldNotEqual(FileAttributes.ReadOnly);
+                ((FileAttributes)FileSystem.GetFileInfoFor(SourceFile).Attributes & FileAttributes.ReadOnly).Should().NotBe(FileAttributes.ReadOnly);
             }
         }
 
@@ -258,13 +256,13 @@ namespace chocolatey.tests.integration.infrastructure.filesystem
             [Fact]
             public void Move_me_text_file_should_not_exist_in_the_source_path()
             {
-                FileSystem.FileExists(SourceFile).ShouldBeFalse();
+                FileSystem.FileExists(SourceFile).Should().BeFalse();
             }
 
             [Fact]
             public void Move_me_text_file_should_exist_in_destination_path()
             {
-                FileSystem.FileExists(DestFile).ShouldBeTrue();
+                FileSystem.FileExists(DestFile).Should().BeTrue();
             }
         }
 
@@ -291,13 +289,13 @@ namespace chocolatey.tests.integration.infrastructure.filesystem
             [Fact]
             public void Copy_me_text_file_should_exist_in_context_path()
             {
-                FileSystem.FileExists(SourceFile).ShouldBeTrue();
+                FileSystem.FileExists(SourceFile).Should().BeTrue();
             }
 
             [Fact]
             public void Move_me_text_file_should_exist_in_destination_path()
             {
-                FileSystem.FileExists(DestFile).ShouldBeTrue();
+                FileSystem.FileExists(DestFile).Should().BeTrue();
             }
         }
 
@@ -319,7 +317,7 @@ namespace chocolatey.tests.integration.infrastructure.filesystem
             [Fact]
             public void Delete_me_text_file_should_not_exist()
             {
-                FileSystem.FileExists(DeleteFile).ShouldBeFalse();
+                FileSystem.FileExists(DeleteFile).Should().BeFalse();
             }
         }
 
@@ -338,7 +336,7 @@ namespace chocolatey.tests.integration.infrastructure.filesystem
             [Fact]
             public void Test_directory_should_exist()
             {
-                FileSystem.DirectoryExists(TestDirectory).ShouldBeTrue();
+                FileSystem.DirectoryExists(TestDirectory).Should().BeTrue();
             }
         }
 
@@ -353,7 +351,7 @@ namespace chocolatey.tests.integration.infrastructure.filesystem
             [Fact]
             public void Should_have_correct_modified_date()
             {
-                FileSystem.GetFileModifiedDate(TheTestFile).ToShortDateString().ShouldEqual(DateTime.Now.AddDays(-1).ToShortDateString());
+                FileSystem.GetFileModifiedDate(TheTestFile).ToShortDateString().Should().Be(DateTime.Now.AddDays(-1).ToShortDateString());
             }
         }
     }

--- a/src/chocolatey.tests.integration/infrastructure/filesystem/DotNetFileSystemSpecs.cs
+++ b/src/chocolatey.tests.integration/infrastructure/filesystem/DotNetFileSystemSpecs.cs
@@ -23,6 +23,7 @@ namespace chocolatey.tests.integration.infrastructure.filesystem
     using chocolatey.infrastructure.platforms;
     using NUnit.Framework;
     using FluentAssertions;
+    using FluentAssertions.Extensions;
 
     public class DotNetFileSystemSpecs
     {
@@ -85,13 +86,13 @@ namespace chocolatey.tests.integration.infrastructure.filesystem
             [Fact]
             public void GetExecutablePath_should_return_empty_string_when_value_is_null()
             {
-                FileSystem.GetExecutablePath(null).Should().Be(string.Empty);
+                FileSystem.GetExecutablePath(null).Should().BeEmpty();
             }
 
             [Fact]
             public void GetExecutablePath_should_return_empty_string_when_value_is_empty_string()
             {
-                FileSystem.GetExecutablePath(string.Empty).Should().Be(string.Empty);
+                FileSystem.GetExecutablePath(string.Empty).Should().BeEmpty();
             }
         }
 
@@ -130,8 +131,7 @@ namespace chocolatey.tests.integration.infrastructure.filesystem
                 var actual = FileSystem.GetFiles(ContextPath, "chocolateyInstall.ps1", SearchOption.AllDirectories).ToList();
                 FileSystem.DeleteFile(filePath);
 
-                actual.Should().NotBeEmpty();
-                actual.Count().Should().Be(1);
+                actual.Should().ContainSingle();
             }
 
             [Fact]
@@ -145,8 +145,7 @@ namespace chocolatey.tests.integration.infrastructure.filesystem
                 var actual = FileSystem.GetFiles(ContextPath, "chocolateyinstall.ps1", SearchOption.AllDirectories).ToList();
                 FileSystem.DeleteFile(filePath);
 
-                actual.Should().NotBeEmpty();
-                actual.Count().Should().Be(1);
+                actual.Should().ContainSingle();
             }
 
             [Fact]
@@ -205,7 +204,7 @@ namespace chocolatey.tests.integration.infrastructure.filesystem
             [Fact]
             public void Visible_file_should_now_be_hidden()
             {
-                ((FileAttributes)FileSystem.GetFileInfoFor(SourceFile).Attributes & FileAttributes.Hidden).Should().Be(FileAttributes.Hidden);
+                ((FileAttributes)FileSystem.GetFileInfoFor(SourceFile).Attributes).Should().HaveFlag(FileAttributes.Hidden);
             }
 
             public override void AfterObservations()
@@ -232,7 +231,7 @@ namespace chocolatey.tests.integration.infrastructure.filesystem
             [Fact]
             public void Readonly_file_should_no_longer_be_readonly()
             {
-                ((FileAttributes)FileSystem.GetFileInfoFor(SourceFile).Attributes & FileAttributes.ReadOnly).Should().NotBe(FileAttributes.ReadOnly);
+                ((FileAttributes)FileSystem.GetFileInfoFor(SourceFile).Attributes).Should().NotHaveFlag(FileAttributes.ReadOnly);
             }
         }
 
@@ -351,7 +350,7 @@ namespace chocolatey.tests.integration.infrastructure.filesystem
             [Fact]
             public void Should_have_correct_modified_date()
             {
-                FileSystem.GetFileModifiedDate(TheTestFile).ToShortDateString().Should().Be(DateTime.Now.AddDays(-1).ToShortDateString());
+                FileSystem.GetFileModifiedDate(TheTestFile).Should().BeCloseTo(1.Days().Before(DateTime.Now), 5.Seconds());
             }
         }
     }

--- a/src/chocolatey.tests.integration/packages.config
+++ b/src/chocolatey.tests.integration/packages.config
@@ -6,13 +6,14 @@
   <package id="Chocolatey.NuGet.Packaging" version="3.2.0" targetFramework="net48" />
   <package id="Chocolatey.NuGet.Protocol" version="3.2.0" targetFramework="net48" />
   <package id="Chocolatey.NuGet.Versioning" version="3.2.0" targetFramework="net48" />
+  <package id="FluentAssertions" version="6.11.0" targetFramework="net48" />
+  <package id="FluentAssertions.Analyzers" version="0.19.1" targetFramework="net48" developmentDependency="true" />
   <package id="log4net" version="2.0.12" targetFramework="net48" />
   <package id="Microsoft.Web.Xdt" version="3.1.0" targetFramework="net48" />
   <package id="Moq" version="4.2.1402.2112" targetFramework="net40" />
   <package id="Newtonsoft.Json" version="13.0.1" targetFramework="net48" />
   <package id="NUnit" version="3.13.3" targetFramework="net48" />
   <package id="NUnit3TestAdapter" version="4.4.2" targetFramework="net48" />
-  <package id="Should" version="1.1.20" targetFramework="net48" />
   <package id="SimpleInjector" version="2.8.3" targetFramework="net48" />
   <package id="System.Reactive" version="5.0.0" targetFramework="net48" />
   <package id="System.Runtime.CompilerServices.Unsafe" version="4.5.3" targetFramework="net48" />

--- a/src/chocolatey.tests.integration/scenarios/InfoScenarios.cs
+++ b/src/chocolatey.tests.integration/scenarios/InfoScenarios.cs
@@ -83,8 +83,8 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_log_standalone_header_with_package_name_and_version()
             {
-                MockLogger.Messages.Keys.Should().Contain(LogLevel.Info.ToStringSafe());
-                MockLogger.Messages[LogLevel.Info.ToStringSafe()].Should().Contain("installpackage 1.0.0");
+                MockLogger.Messages.Should().ContainKey(LogLevel.Info.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains("installpackage 1.0.0"));
             }
 
             [Fact]
@@ -93,15 +93,15 @@ namespace chocolatey.tests.integration.scenarios
                 var lastWriteDate = File.GetLastWriteTimeUtc(Path.Combine("PackageOutput", "installpackage.1.0.0" + NuGetConstants.PackageExtension))
                     .ToShortDateString();
 
-                MockLogger.Messages.Keys.Should().Contain(LogLevel.Info.ToStringSafe());
-                MockLogger.Messages[LogLevel.Info.ToStringSafe()].Should().Contain(" Title: installpackage | Published: {0}\r\n Number of Downloads: n/a | Downloads for this version: n/a\r\n Package url\r\n Chocolatey Package Source: n/a\r\n Tags: installpackage admin\r\n Software Site: n/a\r\n Software License: n/a\r\n Summary: __REPLACE__\r\n Description: __REPLACE__\r\n".FormatWith(lastWriteDate));
+                MockLogger.Messages.Should().ContainKey(LogLevel.Info.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains(" Title: installpackage | Published: {0}\r\n Number of Downloads: n/a | Downloads for this version: n/a\r\n Package url\r\n Chocolatey Package Source: n/a\r\n Tags: installpackage admin\r\n Software Site: n/a\r\n Software License: n/a\r\n Summary: __REPLACE__\r\n Description: __REPLACE__\r\n".FormatWith(lastWriteDate)));
             }
 
             [Fact]
             public void Should_log_package_count_as_warning()
             {
-                MockLogger.Messages.Keys.Should().Contain(LogLevel.Warn.ToStringSafe());
-                MockLogger.Messages[LogLevel.Warn.ToStringSafe()].Should().Contain("1 packages found.");
+                MockLogger.Messages.Should().ContainKey(LogLevel.Warn.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains("1 packages found."));
             }
         }
 
@@ -122,8 +122,8 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_log_standalone_header_with_package_name_and_version()
             {
-                MockLogger.Messages.Keys.Should().Contain(LogLevel.Info.ToStringSafe());
-                MockLogger.Messages[LogLevel.Info.ToStringSafe()].Should().Contain("installpackage 1.0.0");
+                MockLogger.Messages.Should().ContainKey(LogLevel.Info.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains("installpackage 1.0.0"));
             }
 
             [Fact]
@@ -132,15 +132,15 @@ namespace chocolatey.tests.integration.scenarios
                 var lastWriteDate = File.GetLastWriteTimeUtc(Path.Combine("PackageOutput", "installpackage.1.0.0" + NuGetConstants.PackageExtension))
                     .ToShortDateString();
 
-                MockLogger.Messages.Keys.Should().Contain(LogLevel.Info.ToStringSafe());
-                MockLogger.Messages[LogLevel.Info.ToStringSafe()].Should().Contain(" Title: installpackage | Published: {0}\r\n Number of Downloads: n/a | Downloads for this version: n/a\r\n Package url\r\n Chocolatey Package Source: n/a\r\n Tags: installpackage admin\r\n Software Site: n/a\r\n Software License: n/a\r\n Summary: __REPLACE__\r\n Description: __REPLACE__\r\n".FormatWith(lastWriteDate));
+                MockLogger.Messages.Should().ContainKey(LogLevel.Info.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains(" Title: installpackage | Published: {0}\r\n Number of Downloads: n/a | Downloads for this version: n/a\r\n Package url\r\n Chocolatey Package Source: n/a\r\n Tags: installpackage admin\r\n Software Site: n/a\r\n Software License: n/a\r\n Summary: __REPLACE__\r\n Description: __REPLACE__\r\n".FormatWith(lastWriteDate)));
             }
 
             [Fact]
             public void Should_log_package_count_as_warning()
             {
-                MockLogger.Messages.Keys.Should().Contain(LogLevel.Warn.ToStringSafe());
-                MockLogger.Messages[LogLevel.Warn.ToStringSafe()].Should().Contain("1 packages found.");
+                MockLogger.Messages.Should().ContainKey(LogLevel.Warn.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains("1 packages found."));
             }
         }
 
@@ -161,8 +161,8 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_log_standalone_header_with_package_name_and_version()
             {
-                MockLogger.Messages.Keys.Should().Contain(LogLevel.Info.ToStringSafe());
-                MockLogger.Messages[LogLevel.Info.ToStringSafe()].Should().Contain("installpackage 1.0.0");
+                MockLogger.Messages.Should().ContainKey(LogLevel.Info.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains("installpackage 1.0.0"));
             }
 
             [Fact]
@@ -171,15 +171,15 @@ namespace chocolatey.tests.integration.scenarios
                 var lastWriteDate = File.GetLastWriteTimeUtc(Path.Combine("PackageOutput", "installpackage.1.0.0" + NuGetConstants.PackageExtension))
                     .ToShortDateString();
 
-                MockLogger.Messages.Keys.Should().Contain(LogLevel.Info.ToStringSafe());
-                MockLogger.Messages[LogLevel.Info.ToStringSafe()].Should().Contain(" Title: installpackage | Published: {0}\r\n Number of Downloads: n/a | Downloads for this version: n/a\r\n Package url\r\n Chocolatey Package Source: n/a\r\n Tags: installpackage admin\r\n Software Site: n/a\r\n Software License: n/a\r\n Summary: __REPLACE__\r\n Description: __REPLACE__\r\n".FormatWith(lastWriteDate));
+                MockLogger.Messages.Should().ContainKey(LogLevel.Info.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains(" Title: installpackage | Published: {0}\r\n Number of Downloads: n/a | Downloads for this version: n/a\r\n Package url\r\n Chocolatey Package Source: n/a\r\n Tags: installpackage admin\r\n Software Site: n/a\r\n Software License: n/a\r\n Summary: __REPLACE__\r\n Description: __REPLACE__\r\n".FormatWith(lastWriteDate)));
             }
 
             [Fact]
             public void Should_log_package_count_as_warning()
             {
-                MockLogger.Messages.Keys.Should().Contain(LogLevel.Warn.ToStringSafe());
-                MockLogger.Messages[LogLevel.Warn.ToStringSafe()].Should().Contain("1 packages found.");
+                MockLogger.Messages.Should().ContainKey(LogLevel.Warn.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains("1 packages found."));
             }
         }
 
@@ -202,8 +202,8 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_log_standalone_header_with_package_name_and_version()
             {
-                MockLogger.Messages.Keys.Should().Contain(LogLevel.Info.ToStringSafe());
-                MockLogger.Messages[LogLevel.Info.ToStringSafe()].Should().Contain("installpackage {0}".FormatWith(NormalizedVersion));
+                MockLogger.Messages.Should().ContainKey(LogLevel.Info.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains("installpackage {0}".FormatWith(NormalizedVersion)));
             }
 
             [Fact]
@@ -212,15 +212,15 @@ namespace chocolatey.tests.integration.scenarios
                 var lastWriteDate = File.GetLastWriteTimeUtc(Path.Combine("PackageOutput", "installpackage.{0}".FormatWith(NonNormalizedVersion) + NuGetConstants.PackageExtension))
                     .ToShortDateString();
 
-                MockLogger.Messages.Keys.Should().Contain(LogLevel.Info.ToStringSafe());
-                MockLogger.Messages[LogLevel.Info.ToStringSafe()].Should().Contain(" Title: installpackage | Published: {0}\r\n Number of Downloads: n/a | Downloads for this version: n/a\r\n Package url\r\n Chocolatey Package Source: n/a\r\n Tags: installpackage admin\r\n Software Site: n/a\r\n Software License: n/a\r\n Summary: __REPLACE__\r\n Description: __REPLACE__\r\n".FormatWith(lastWriteDate));
+                MockLogger.Messages.Should().ContainKey(LogLevel.Info.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains(" Title: installpackage | Published: {0}\r\n Number of Downloads: n/a | Downloads for this version: n/a\r\n Package url\r\n Chocolatey Package Source: n/a\r\n Tags: installpackage admin\r\n Software Site: n/a\r\n Software License: n/a\r\n Summary: __REPLACE__\r\n Description: __REPLACE__\r\n".FormatWith(lastWriteDate)));
             }
 
             [Fact]
             public void Should_log_package_count_as_warning()
             {
-                MockLogger.Messages.Keys.Should().Contain(LogLevel.Warn.ToStringSafe());
-                MockLogger.Messages[LogLevel.Warn.ToStringSafe()].Should().Contain("1 packages found.");
+                MockLogger.Messages.Should().ContainKey(LogLevel.Warn.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains("1 packages found."));
             }
         }
 
@@ -245,8 +245,8 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_log_standalone_header_with_package_name_and_version()
             {
-                MockLogger.Messages.Keys.Should().Contain(LogLevel.Info.ToStringSafe());
-                MockLogger.Messages[LogLevel.Info.ToStringSafe()].Should().Contain("installpackage {0}".FormatWith(NormalizedVersion));
+                MockLogger.Messages.Should().ContainKey(LogLevel.Info.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains("installpackage {0}".FormatWith(NormalizedVersion)));
             }
 
             [Fact]
@@ -255,15 +255,15 @@ namespace chocolatey.tests.integration.scenarios
                 var lastWriteDate = File.GetLastWriteTimeUtc(Path.Combine("PackageOutput", "installpackage.{0}".FormatWith(NonNormalizedVersion) + NuGetConstants.PackageExtension))
                     .ToShortDateString();
 
-                MockLogger.Messages.Keys.Should().Contain(LogLevel.Info.ToStringSafe());
-                MockLogger.Messages[LogLevel.Info.ToStringSafe()].Should().Contain(" Title: installpackage | Published: {0}\r\n Number of Downloads: n/a | Downloads for this version: n/a\r\n Package url\r\n Chocolatey Package Source: n/a\r\n Tags: installpackage admin\r\n Software Site: n/a\r\n Software License: n/a\r\n Summary: __REPLACE__\r\n Description: __REPLACE__\r\n".FormatWith(lastWriteDate));
+                MockLogger.Messages.Should().ContainKey(LogLevel.Info.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains(" Title: installpackage | Published: {0}\r\n Number of Downloads: n/a | Downloads for this version: n/a\r\n Package url\r\n Chocolatey Package Source: n/a\r\n Tags: installpackage admin\r\n Software Site: n/a\r\n Software License: n/a\r\n Summary: __REPLACE__\r\n Description: __REPLACE__\r\n".FormatWith(lastWriteDate)));
             }
 
             [Fact]
             public void Should_log_package_count_as_warning()
             {
-                MockLogger.Messages.Keys.Should().Contain(LogLevel.Warn.ToStringSafe());
-                MockLogger.Messages[LogLevel.Warn.ToStringSafe()].Should().Contain("1 packages found.");
+                MockLogger.Messages.Should().ContainKey(LogLevel.Warn.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains("1 packages found."));
             }
         }
 
@@ -288,8 +288,8 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_log_standalone_header_with_package_name_and_version()
             {
-                MockLogger.Messages.Keys.Should().Contain(LogLevel.Info.ToStringSafe());
-                MockLogger.Messages[LogLevel.Info.ToStringSafe()].Should().Contain("installpackage {0}".FormatWith(NormalizedVersion));
+                MockLogger.Messages.Should().ContainKey(LogLevel.Info.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains("installpackage {0}".FormatWith(NormalizedVersion)));
             }
 
             [Fact]
@@ -298,15 +298,15 @@ namespace chocolatey.tests.integration.scenarios
                 var lastWriteDate = File.GetLastWriteTimeUtc(Path.Combine("PackageOutput", "installpackage.{0}".FormatWith(NonNormalizedVersion) + NuGetConstants.PackageExtension))
                     .ToShortDateString();
 
-                MockLogger.Messages.Keys.Should().Contain(LogLevel.Info.ToStringSafe());
-                MockLogger.Messages[LogLevel.Info.ToStringSafe()].Should().Contain(" Title: installpackage | Published: {0}\r\n Number of Downloads: n/a | Downloads for this version: n/a\r\n Package url\r\n Chocolatey Package Source: n/a\r\n Tags: installpackage admin\r\n Software Site: n/a\r\n Software License: n/a\r\n Summary: __REPLACE__\r\n Description: __REPLACE__\r\n".FormatWith(lastWriteDate));
+                MockLogger.Messages.Should().ContainKey(LogLevel.Info.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains(" Title: installpackage | Published: {0}\r\n Number of Downloads: n/a | Downloads for this version: n/a\r\n Package url\r\n Chocolatey Package Source: n/a\r\n Tags: installpackage admin\r\n Software Site: n/a\r\n Software License: n/a\r\n Summary: __REPLACE__\r\n Description: __REPLACE__\r\n".FormatWith(lastWriteDate)));
             }
 
             [Fact]
             public void Should_log_package_count_as_warning()
             {
-                MockLogger.Messages.Keys.Should().Contain(LogLevel.Warn.ToStringSafe());
-                MockLogger.Messages[LogLevel.Warn.ToStringSafe()].Should().Contain("1 packages found.");
+                MockLogger.Messages.Should().ContainKey(LogLevel.Warn.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains("1 packages found."));
             }
         }
 
@@ -336,8 +336,8 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public new void Should_log_standalone_header_with_package_name_and_version()
             {
-                MockLogger.Messages.Keys.Should().Contain(LogLevel.Info.ToStringSafe());
-                MockLogger.Messages[LogLevel.Info.ToStringSafe()].Should().Contain("installpackage 1.0.0");
+                MockLogger.Messages.Should().ContainKey(LogLevel.Info.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains("installpackage 1.0.0"));
             }
 
             [Fact]
@@ -346,15 +346,15 @@ namespace chocolatey.tests.integration.scenarios
                 var lastWriteDate = File.GetLastWriteTimeUtc(Path.Combine("PackageOutput", "installpackage.1.0.0" + NuGetConstants.PackageExtension))
                     .ToShortDateString();
 
-                MockLogger.Messages.Keys.Should().Contain(LogLevel.Info.ToStringSafe());
-                MockLogger.Messages[LogLevel.Info.ToStringSafe()].Should().Contain(" Title: installpackage | Published: {0}\r\n Number of Downloads: n/a | Downloads for this version: n/a\r\n Package url\r\n Chocolatey Package Source: n/a\r\n Tags: installpackage admin\r\n Software Site: n/a\r\n Software License: n/a\r\n Summary: __REPLACE__\r\n Description: __REPLACE__\r\n".FormatWith(lastWriteDate));
+                MockLogger.Messages.Should().ContainKey(LogLevel.Info.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains(" Title: installpackage | Published: {0}\r\n Number of Downloads: n/a | Downloads for this version: n/a\r\n Package url\r\n Chocolatey Package Source: n/a\r\n Tags: installpackage admin\r\n Software Site: n/a\r\n Software License: n/a\r\n Summary: __REPLACE__\r\n Description: __REPLACE__\r\n".FormatWith(lastWriteDate)));
             }
 
             [Fact]
             public new void Should_log_package_count_as_warning()
             {
-                MockLogger.Messages.Keys.Should().Contain(LogLevel.Warn.ToStringSafe());
-                MockLogger.Messages[LogLevel.Warn.ToStringSafe()].Should().Contain("1 packages found.");
+                MockLogger.Messages.Should().ContainKey(LogLevel.Warn.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains("1 packages found."));
             }
         }
 
@@ -372,7 +372,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_show_only_one_result()
             {
-                Results.Count.Should().Be(1, "Expected 1 package to be returned!");
+                Results.Should().ContainSingle("Expected 1 package to be returned!");
             }
 
             [Fact]
@@ -422,7 +422,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_show_only_one_result()
             {
-                Results.Count.Should().Be(1, "Expected 1 package to be returned!");
+                Results.Should().ContainSingle( "Expected 1 package to be returned!");
             }
 
             [Fact]
@@ -478,7 +478,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_show_only_one_result()
             {
-                Results.Count.Should().Be(1, "Expected 1 package to be returned!");
+                Results.Should().ContainSingle( "Expected 1 package to be returned!");
             }
 
             [Fact]

--- a/src/chocolatey.tests.integration/scenarios/InfoScenarios.cs
+++ b/src/chocolatey.tests.integration/scenarios/InfoScenarios.cs
@@ -18,7 +18,7 @@ namespace chocolatey.tests.integration.scenarios
 
     using NUnit.Framework;
 
-    using Should;
+    using FluentAssertions;
 
     public class InfoScenarios
     {
@@ -83,8 +83,8 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_log_standalone_header_with_package_name_and_version()
             {
-                MockLogger.Messages.Keys.ShouldContain(LogLevel.Info.ToStringSafe());
-                MockLogger.Messages[LogLevel.Info.ToStringSafe()].ShouldContain("installpackage 1.0.0");
+                MockLogger.Messages.Keys.Should().Contain(LogLevel.Info.ToStringSafe());
+                MockLogger.Messages[LogLevel.Info.ToStringSafe()].Should().Contain("installpackage 1.0.0");
             }
 
             [Fact]
@@ -93,15 +93,15 @@ namespace chocolatey.tests.integration.scenarios
                 var lastWriteDate = File.GetLastWriteTimeUtc(Path.Combine("PackageOutput", "installpackage.1.0.0" + NuGetConstants.PackageExtension))
                     .ToShortDateString();
 
-                MockLogger.Messages.Keys.ShouldContain(LogLevel.Info.ToStringSafe());
-                MockLogger.Messages[LogLevel.Info.ToStringSafe()].ShouldContain(" Title: installpackage | Published: {0}\r\n Number of Downloads: n/a | Downloads for this version: n/a\r\n Package url\r\n Chocolatey Package Source: n/a\r\n Tags: installpackage admin\r\n Software Site: n/a\r\n Software License: n/a\r\n Summary: __REPLACE__\r\n Description: __REPLACE__\r\n".FormatWith(lastWriteDate));
+                MockLogger.Messages.Keys.Should().Contain(LogLevel.Info.ToStringSafe());
+                MockLogger.Messages[LogLevel.Info.ToStringSafe()].Should().Contain(" Title: installpackage | Published: {0}\r\n Number of Downloads: n/a | Downloads for this version: n/a\r\n Package url\r\n Chocolatey Package Source: n/a\r\n Tags: installpackage admin\r\n Software Site: n/a\r\n Software License: n/a\r\n Summary: __REPLACE__\r\n Description: __REPLACE__\r\n".FormatWith(lastWriteDate));
             }
 
             [Fact]
             public void Should_log_package_count_as_warning()
             {
-                MockLogger.Messages.Keys.ShouldContain(LogLevel.Warn.ToStringSafe());
-                MockLogger.Messages[LogLevel.Warn.ToStringSafe()].ShouldContain("1 packages found.");
+                MockLogger.Messages.Keys.Should().Contain(LogLevel.Warn.ToStringSafe());
+                MockLogger.Messages[LogLevel.Warn.ToStringSafe()].Should().Contain("1 packages found.");
             }
         }
 
@@ -122,8 +122,8 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_log_standalone_header_with_package_name_and_version()
             {
-                MockLogger.Messages.Keys.ShouldContain(LogLevel.Info.ToStringSafe());
-                MockLogger.Messages[LogLevel.Info.ToStringSafe()].ShouldContain("installpackage 1.0.0");
+                MockLogger.Messages.Keys.Should().Contain(LogLevel.Info.ToStringSafe());
+                MockLogger.Messages[LogLevel.Info.ToStringSafe()].Should().Contain("installpackage 1.0.0");
             }
 
             [Fact]
@@ -132,15 +132,15 @@ namespace chocolatey.tests.integration.scenarios
                 var lastWriteDate = File.GetLastWriteTimeUtc(Path.Combine("PackageOutput", "installpackage.1.0.0" + NuGetConstants.PackageExtension))
                     .ToShortDateString();
 
-                MockLogger.Messages.Keys.ShouldContain(LogLevel.Info.ToStringSafe());
-                MockLogger.Messages[LogLevel.Info.ToStringSafe()].ShouldContain(" Title: installpackage | Published: {0}\r\n Number of Downloads: n/a | Downloads for this version: n/a\r\n Package url\r\n Chocolatey Package Source: n/a\r\n Tags: installpackage admin\r\n Software Site: n/a\r\n Software License: n/a\r\n Summary: __REPLACE__\r\n Description: __REPLACE__\r\n".FormatWith(lastWriteDate));
+                MockLogger.Messages.Keys.Should().Contain(LogLevel.Info.ToStringSafe());
+                MockLogger.Messages[LogLevel.Info.ToStringSafe()].Should().Contain(" Title: installpackage | Published: {0}\r\n Number of Downloads: n/a | Downloads for this version: n/a\r\n Package url\r\n Chocolatey Package Source: n/a\r\n Tags: installpackage admin\r\n Software Site: n/a\r\n Software License: n/a\r\n Summary: __REPLACE__\r\n Description: __REPLACE__\r\n".FormatWith(lastWriteDate));
             }
 
             [Fact]
             public void Should_log_package_count_as_warning()
             {
-                MockLogger.Messages.Keys.ShouldContain(LogLevel.Warn.ToStringSafe());
-                MockLogger.Messages[LogLevel.Warn.ToStringSafe()].ShouldContain("1 packages found.");
+                MockLogger.Messages.Keys.Should().Contain(LogLevel.Warn.ToStringSafe());
+                MockLogger.Messages[LogLevel.Warn.ToStringSafe()].Should().Contain("1 packages found.");
             }
         }
 
@@ -161,8 +161,8 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_log_standalone_header_with_package_name_and_version()
             {
-                MockLogger.Messages.Keys.ShouldContain(LogLevel.Info.ToStringSafe());
-                MockLogger.Messages[LogLevel.Info.ToStringSafe()].ShouldContain("installpackage 1.0.0");
+                MockLogger.Messages.Keys.Should().Contain(LogLevel.Info.ToStringSafe());
+                MockLogger.Messages[LogLevel.Info.ToStringSafe()].Should().Contain("installpackage 1.0.0");
             }
 
             [Fact]
@@ -171,15 +171,15 @@ namespace chocolatey.tests.integration.scenarios
                 var lastWriteDate = File.GetLastWriteTimeUtc(Path.Combine("PackageOutput", "installpackage.1.0.0" + NuGetConstants.PackageExtension))
                     .ToShortDateString();
 
-                MockLogger.Messages.Keys.ShouldContain(LogLevel.Info.ToStringSafe());
-                MockLogger.Messages[LogLevel.Info.ToStringSafe()].ShouldContain(" Title: installpackage | Published: {0}\r\n Number of Downloads: n/a | Downloads for this version: n/a\r\n Package url\r\n Chocolatey Package Source: n/a\r\n Tags: installpackage admin\r\n Software Site: n/a\r\n Software License: n/a\r\n Summary: __REPLACE__\r\n Description: __REPLACE__\r\n".FormatWith(lastWriteDate));
+                MockLogger.Messages.Keys.Should().Contain(LogLevel.Info.ToStringSafe());
+                MockLogger.Messages[LogLevel.Info.ToStringSafe()].Should().Contain(" Title: installpackage | Published: {0}\r\n Number of Downloads: n/a | Downloads for this version: n/a\r\n Package url\r\n Chocolatey Package Source: n/a\r\n Tags: installpackage admin\r\n Software Site: n/a\r\n Software License: n/a\r\n Summary: __REPLACE__\r\n Description: __REPLACE__\r\n".FormatWith(lastWriteDate));
             }
 
             [Fact]
             public void Should_log_package_count_as_warning()
             {
-                MockLogger.Messages.Keys.ShouldContain(LogLevel.Warn.ToStringSafe());
-                MockLogger.Messages[LogLevel.Warn.ToStringSafe()].ShouldContain("1 packages found.");
+                MockLogger.Messages.Keys.Should().Contain(LogLevel.Warn.ToStringSafe());
+                MockLogger.Messages[LogLevel.Warn.ToStringSafe()].Should().Contain("1 packages found.");
             }
         }
 
@@ -202,8 +202,8 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_log_standalone_header_with_package_name_and_version()
             {
-                MockLogger.Messages.Keys.ShouldContain(LogLevel.Info.ToStringSafe());
-                MockLogger.Messages[LogLevel.Info.ToStringSafe()].ShouldContain("installpackage {0}".FormatWith(NormalizedVersion));
+                MockLogger.Messages.Keys.Should().Contain(LogLevel.Info.ToStringSafe());
+                MockLogger.Messages[LogLevel.Info.ToStringSafe()].Should().Contain("installpackage {0}".FormatWith(NormalizedVersion));
             }
 
             [Fact]
@@ -212,15 +212,15 @@ namespace chocolatey.tests.integration.scenarios
                 var lastWriteDate = File.GetLastWriteTimeUtc(Path.Combine("PackageOutput", "installpackage.{0}".FormatWith(NonNormalizedVersion) + NuGetConstants.PackageExtension))
                     .ToShortDateString();
 
-                MockLogger.Messages.Keys.ShouldContain(LogLevel.Info.ToStringSafe());
-                MockLogger.Messages[LogLevel.Info.ToStringSafe()].ShouldContain(" Title: installpackage | Published: {0}\r\n Number of Downloads: n/a | Downloads for this version: n/a\r\n Package url\r\n Chocolatey Package Source: n/a\r\n Tags: installpackage admin\r\n Software Site: n/a\r\n Software License: n/a\r\n Summary: __REPLACE__\r\n Description: __REPLACE__\r\n".FormatWith(lastWriteDate));
+                MockLogger.Messages.Keys.Should().Contain(LogLevel.Info.ToStringSafe());
+                MockLogger.Messages[LogLevel.Info.ToStringSafe()].Should().Contain(" Title: installpackage | Published: {0}\r\n Number of Downloads: n/a | Downloads for this version: n/a\r\n Package url\r\n Chocolatey Package Source: n/a\r\n Tags: installpackage admin\r\n Software Site: n/a\r\n Software License: n/a\r\n Summary: __REPLACE__\r\n Description: __REPLACE__\r\n".FormatWith(lastWriteDate));
             }
 
             [Fact]
             public void Should_log_package_count_as_warning()
             {
-                MockLogger.Messages.Keys.ShouldContain(LogLevel.Warn.ToStringSafe());
-                MockLogger.Messages[LogLevel.Warn.ToStringSafe()].ShouldContain("1 packages found.");
+                MockLogger.Messages.Keys.Should().Contain(LogLevel.Warn.ToStringSafe());
+                MockLogger.Messages[LogLevel.Warn.ToStringSafe()].Should().Contain("1 packages found.");
             }
         }
 
@@ -245,8 +245,8 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_log_standalone_header_with_package_name_and_version()
             {
-                MockLogger.Messages.Keys.ShouldContain(LogLevel.Info.ToStringSafe());
-                MockLogger.Messages[LogLevel.Info.ToStringSafe()].ShouldContain("installpackage {0}".FormatWith(NormalizedVersion));
+                MockLogger.Messages.Keys.Should().Contain(LogLevel.Info.ToStringSafe());
+                MockLogger.Messages[LogLevel.Info.ToStringSafe()].Should().Contain("installpackage {0}".FormatWith(NormalizedVersion));
             }
 
             [Fact]
@@ -255,15 +255,15 @@ namespace chocolatey.tests.integration.scenarios
                 var lastWriteDate = File.GetLastWriteTimeUtc(Path.Combine("PackageOutput", "installpackage.{0}".FormatWith(NonNormalizedVersion) + NuGetConstants.PackageExtension))
                     .ToShortDateString();
 
-                MockLogger.Messages.Keys.ShouldContain(LogLevel.Info.ToStringSafe());
-                MockLogger.Messages[LogLevel.Info.ToStringSafe()].ShouldContain(" Title: installpackage | Published: {0}\r\n Number of Downloads: n/a | Downloads for this version: n/a\r\n Package url\r\n Chocolatey Package Source: n/a\r\n Tags: installpackage admin\r\n Software Site: n/a\r\n Software License: n/a\r\n Summary: __REPLACE__\r\n Description: __REPLACE__\r\n".FormatWith(lastWriteDate));
+                MockLogger.Messages.Keys.Should().Contain(LogLevel.Info.ToStringSafe());
+                MockLogger.Messages[LogLevel.Info.ToStringSafe()].Should().Contain(" Title: installpackage | Published: {0}\r\n Number of Downloads: n/a | Downloads for this version: n/a\r\n Package url\r\n Chocolatey Package Source: n/a\r\n Tags: installpackage admin\r\n Software Site: n/a\r\n Software License: n/a\r\n Summary: __REPLACE__\r\n Description: __REPLACE__\r\n".FormatWith(lastWriteDate));
             }
 
             [Fact]
             public void Should_log_package_count_as_warning()
             {
-                MockLogger.Messages.Keys.ShouldContain(LogLevel.Warn.ToStringSafe());
-                MockLogger.Messages[LogLevel.Warn.ToStringSafe()].ShouldContain("1 packages found.");
+                MockLogger.Messages.Keys.Should().Contain(LogLevel.Warn.ToStringSafe());
+                MockLogger.Messages[LogLevel.Warn.ToStringSafe()].Should().Contain("1 packages found.");
             }
         }
 
@@ -288,8 +288,8 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_log_standalone_header_with_package_name_and_version()
             {
-                MockLogger.Messages.Keys.ShouldContain(LogLevel.Info.ToStringSafe());
-                MockLogger.Messages[LogLevel.Info.ToStringSafe()].ShouldContain("installpackage {0}".FormatWith(NormalizedVersion));
+                MockLogger.Messages.Keys.Should().Contain(LogLevel.Info.ToStringSafe());
+                MockLogger.Messages[LogLevel.Info.ToStringSafe()].Should().Contain("installpackage {0}".FormatWith(NormalizedVersion));
             }
 
             [Fact]
@@ -298,15 +298,15 @@ namespace chocolatey.tests.integration.scenarios
                 var lastWriteDate = File.GetLastWriteTimeUtc(Path.Combine("PackageOutput", "installpackage.{0}".FormatWith(NonNormalizedVersion) + NuGetConstants.PackageExtension))
                     .ToShortDateString();
 
-                MockLogger.Messages.Keys.ShouldContain(LogLevel.Info.ToStringSafe());
-                MockLogger.Messages[LogLevel.Info.ToStringSafe()].ShouldContain(" Title: installpackage | Published: {0}\r\n Number of Downloads: n/a | Downloads for this version: n/a\r\n Package url\r\n Chocolatey Package Source: n/a\r\n Tags: installpackage admin\r\n Software Site: n/a\r\n Software License: n/a\r\n Summary: __REPLACE__\r\n Description: __REPLACE__\r\n".FormatWith(lastWriteDate));
+                MockLogger.Messages.Keys.Should().Contain(LogLevel.Info.ToStringSafe());
+                MockLogger.Messages[LogLevel.Info.ToStringSafe()].Should().Contain(" Title: installpackage | Published: {0}\r\n Number of Downloads: n/a | Downloads for this version: n/a\r\n Package url\r\n Chocolatey Package Source: n/a\r\n Tags: installpackage admin\r\n Software Site: n/a\r\n Software License: n/a\r\n Summary: __REPLACE__\r\n Description: __REPLACE__\r\n".FormatWith(lastWriteDate));
             }
 
             [Fact]
             public void Should_log_package_count_as_warning()
             {
-                MockLogger.Messages.Keys.ShouldContain(LogLevel.Warn.ToStringSafe());
-                MockLogger.Messages[LogLevel.Warn.ToStringSafe()].ShouldContain("1 packages found.");
+                MockLogger.Messages.Keys.Should().Contain(LogLevel.Warn.ToStringSafe());
+                MockLogger.Messages[LogLevel.Warn.ToStringSafe()].Should().Contain("1 packages found.");
             }
         }
 
@@ -336,8 +336,8 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public new void Should_log_standalone_header_with_package_name_and_version()
             {
-                MockLogger.Messages.Keys.ShouldContain(LogLevel.Info.ToStringSafe());
-                MockLogger.Messages[LogLevel.Info.ToStringSafe()].ShouldContain("installpackage 1.0.0");
+                MockLogger.Messages.Keys.Should().Contain(LogLevel.Info.ToStringSafe());
+                MockLogger.Messages[LogLevel.Info.ToStringSafe()].Should().Contain("installpackage 1.0.0");
             }
 
             [Fact]
@@ -346,15 +346,15 @@ namespace chocolatey.tests.integration.scenarios
                 var lastWriteDate = File.GetLastWriteTimeUtc(Path.Combine("PackageOutput", "installpackage.1.0.0" + NuGetConstants.PackageExtension))
                     .ToShortDateString();
 
-                MockLogger.Messages.Keys.ShouldContain(LogLevel.Info.ToStringSafe());
-                MockLogger.Messages[LogLevel.Info.ToStringSafe()].ShouldContain(" Title: installpackage | Published: {0}\r\n Number of Downloads: n/a | Downloads for this version: n/a\r\n Package url\r\n Chocolatey Package Source: n/a\r\n Tags: installpackage admin\r\n Software Site: n/a\r\n Software License: n/a\r\n Summary: __REPLACE__\r\n Description: __REPLACE__\r\n".FormatWith(lastWriteDate));
+                MockLogger.Messages.Keys.Should().Contain(LogLevel.Info.ToStringSafe());
+                MockLogger.Messages[LogLevel.Info.ToStringSafe()].Should().Contain(" Title: installpackage | Published: {0}\r\n Number of Downloads: n/a | Downloads for this version: n/a\r\n Package url\r\n Chocolatey Package Source: n/a\r\n Tags: installpackage admin\r\n Software Site: n/a\r\n Software License: n/a\r\n Summary: __REPLACE__\r\n Description: __REPLACE__\r\n".FormatWith(lastWriteDate));
             }
 
             [Fact]
             public new void Should_log_package_count_as_warning()
             {
-                MockLogger.Messages.Keys.ShouldContain(LogLevel.Warn.ToStringSafe());
-                MockLogger.Messages[LogLevel.Warn.ToStringSafe()].ShouldContain("1 packages found.");
+                MockLogger.Messages.Keys.Should().Contain(LogLevel.Warn.ToStringSafe());
+                MockLogger.Messages[LogLevel.Warn.ToStringSafe()].Should().Contain("1 packages found.");
             }
         }
 
@@ -372,31 +372,31 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_show_only_one_result()
             {
-                Results.Count.ShouldEqual(1, "Expected 1 package to be returned!");
+                Results.Count.Should().Be(1, "Expected 1 package to be returned!");
             }
 
             [Fact]
             public void Should_set_exit_code_to_zero()
             {
-                Results[0].ExitCode.ShouldEqual(0);
+                Results[0].ExitCode.Should().Be(0);
             }
 
             [Fact]
             public void Should_not_be_reported_as_inconclusive()
             {
-                Results[0].Inconclusive.ShouldBeFalse();
+                Results[0].Inconclusive.Should().BeFalse();
             }
 
             [Fact]
             public void Should_report_expected_name()
             {
-                Results[0].Name.ShouldEqual("installpackage");
+                Results[0].Name.Should().Be("installpackage");
             }
 
             [Fact]
             public void Should_set_source_to_expected_value()
             {
-                Results[0].Source.ShouldEqual(
+                Results[0].Source.Should().Be(
                     ((Platform.GetPlatform() == PlatformType.Windows ? "file:///" : "file://") + Path.Combine(Environment.CurrentDirectory, "PackageOutput"))
                     .Replace("\\","/"));
             }
@@ -404,7 +404,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_set_expected_version()
             {
-                Results[0].Version.ShouldEqual("1.0.0");
+                Results[0].Version.Should().Be("1.0.0");
             }
         }
 
@@ -422,25 +422,25 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_show_only_one_result()
             {
-                Results.Count.ShouldEqual(1, "Expected 1 package to be returned!");
+                Results.Count.Should().Be(1, "Expected 1 package to be returned!");
             }
 
             [Fact]
             public void Should_set_exit_code_to_zero()
             {
-                Results[0].ExitCode.ShouldEqual(0);
+                Results[0].ExitCode.Should().Be(0);
             }
 
             [Fact]
             public void Should_not_be_reported_as_inconclusive()
             {
-                Results[0].Inconclusive.ShouldBeFalse();
+                Results[0].Inconclusive.Should().BeFalse();
             }
 
             [Fact]
             public void Should_report_expected_name()
             {
-                Results[0].Name.ShouldEqual("test-package");
+                Results[0].Name.Should().Be("test-package");
             }
 
             [Fact]
@@ -451,13 +451,13 @@ namespace chocolatey.tests.integration.scenarios
                     "PrioritySources",
                     "Priority1").Replace('\\', '/');
 
-                Results[0].Source.ShouldEqual(expectedSource);
+                Results[0].Source.Should().Be(expectedSource);
             }
 
             [Fact]
             public void Should_set_expected_version()
             {
-                Results[0].Version.ShouldEqual("0.1.0");
+                Results[0].Version.Should().Be("0.1.0");
             }
         }
 
@@ -478,25 +478,25 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_show_only_one_result()
             {
-                Results.Count.ShouldEqual(1, "Expected 1 package to be returned!");
+                Results.Count.Should().Be(1, "Expected 1 package to be returned!");
             }
 
             [Fact]
             public void Should_set_exit_code_to_zero()
             {
-                Results[0].ExitCode.ShouldEqual(0);
+                Results[0].ExitCode.Should().Be(0);
             }
 
             [Fact]
             public void Should_not_be_reported_as_inconclusive()
             {
-                Results[0].Inconclusive.ShouldBeFalse();
+                Results[0].Inconclusive.Should().BeFalse();
             }
 
             [Fact]
             public void Should_report_expected_name()
             {
-                Results[0].Name.ShouldEqual("upgradepackage");
+                Results[0].Name.Should().Be("upgradepackage");
             }
 
             [Fact]
@@ -507,13 +507,13 @@ namespace chocolatey.tests.integration.scenarios
                     "PrioritySources",
                     "Priority1").Replace('\\', '/');
 
-                Results[0].Source.ShouldEqual(expectedSource);
+                Results[0].Source.Should().Be(expectedSource);
             }
 
             [Fact]
             public void Should_set_expected_version()
             {
-                Results[0].Version.ShouldEqual("1.0.0");
+                Results[0].Version.Should().Be("1.0.0");
             }
         }
     }

--- a/src/chocolatey.tests.integration/scenarios/InstallScenarios.cs
+++ b/src/chocolatey.tests.integration/scenarios/InstallScenarios.cs
@@ -32,7 +32,7 @@ namespace chocolatey.tests.integration.scenarios
     using NuGet.Configuration;
     using NuGet.Packaging;
     using NUnit.Framework;
-    using Should;
+    using FluentAssertions;
     using IFileSystem = chocolatey.infrastructure.filesystem.IFileSystem;
 
     public class InstallScenarios
@@ -89,7 +89,7 @@ namespace chocolatey.tests.integration.scenarios
                     if (message.Contains("would have used NuGet to install packages")) expectedMessage = true;
                 }
 
-                expectedMessage.ShouldBeTrue();
+                expectedMessage.Should().BeTrue();
             }
 
             [Fact]
@@ -97,13 +97,13 @@ namespace chocolatey.tests.integration.scenarios
             [Platform(Exclude = "Mono")]
             public void Should_contain_a_message_that_it_would_have_run_a_powershell_script()
             {
-                MockLogger.ContainsMessage("chocolateyinstall.ps1", LogLevel.Info).ShouldBeTrue();
+                MockLogger.ContainsMessage("chocolateyinstall.ps1", LogLevel.Info).Should().BeTrue();
             }
 
             [Fact]
             public void Should_not_contain_a_message_that_it_would_have_run_powershell_modification_script()
             {
-                MockLogger.ContainsMessage("chocolateyBeforeModify.ps1", LogLevel.Info).ShouldBeFalse();
+                MockLogger.ContainsMessage("chocolateyBeforeModify.ps1", LogLevel.Info).Should().BeFalse();
             }
         }
 
@@ -138,7 +138,7 @@ namespace chocolatey.tests.integration.scenarios
                     if (message.Contains("would have used NuGet to install packages")) expectedMessage = true;
                 }
 
-                expectedMessage.ShouldBeTrue();
+                expectedMessage.Should().BeTrue();
             }
 
             [Fact]
@@ -150,7 +150,7 @@ namespace chocolatey.tests.integration.scenarios
                     if (message.Contains("somethingnonexisting not installed. The package was not found with the source(s) listed")) expectedMessage = true;
                 }
 
-                expectedMessage.ShouldBeTrue();
+                expectedMessage.Should().BeTrue();
             }
         }
 
@@ -196,7 +196,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, Configuration.PackageNames + NuGetConstants.PackageExtension);
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().ShouldEqual(TestVersion());
+                    packageReader.NuspecReader.GetVersion().ToStringSafe().Should().Be(TestVersion());
                 }
             }
 
@@ -276,7 +276,7 @@ namespace chocolatey.tests.integration.scenarios
                     if (message.Contains("is gui? False")) messageFound = true;
                 }
 
-                messageFound.ShouldBeTrue("GUI false message not found");
+                messageFound.Should().BeTrue("GUI false message not found");
             }
 
             [Fact]
@@ -303,7 +303,7 @@ namespace chocolatey.tests.integration.scenarios
                     if (message.Contains("is gui? True")) messageFound = true;
                 }
 
-                messageFound.ShouldBeTrue("GUI true message not found");
+                messageFound.Should().BeTrue("GUI true message not found");
             }
 
             [Fact]
@@ -315,37 +315,37 @@ namespace chocolatey.tests.integration.scenarios
                     if (message.Contains("1/1")) installedSuccessfully = true;
                 }
 
-                installedSuccessfully.ShouldBeTrue();
+                installedSuccessfully.Should().BeTrue();
             }
 
             [Fact]
             public void Should_have_a_successful_package_result()
             {
-                packageResult.Success.ShouldBeTrue();
+                packageResult.Success.Should().BeTrue();
             }
 
             [Fact]
             public void Should_not_have_inconclusive_package_result()
             {
-                packageResult.Inconclusive.ShouldBeFalse();
+                packageResult.Inconclusive.Should().BeFalse();
             }
 
             [Fact]
             public void Should_not_have_warning_package_result()
             {
-                packageResult.Warning.ShouldBeFalse();
+                packageResult.Warning.Should().BeFalse();
             }
 
             [Fact]
             public void Config_should_match_package_result_name()
             {
-                packageResult.Name.ShouldEqual(Configuration.PackageNames);
+                packageResult.Name.Should().Be(Configuration.PackageNames);
             }
 
             [Fact]
             public void Should_have_a_version_of_one_dot_zero_dot_zero()
             {
-                packageResult.Version.ShouldEqual(TestVersion());
+                packageResult.Version.Should().Be(TestVersion());
             }
 
             [Fact]
@@ -355,7 +355,7 @@ namespace chocolatey.tests.integration.scenarios
             {
                 var message = "installpackage v{0} has been installed".FormatWith(TestVersion());
 
-                MockLogger.ContainsMessage(message, LogLevel.Info).ShouldBeTrue();
+                MockLogger.ContainsMessage(message, LogLevel.Info).Should().BeTrue();
             }
 
             protected string TestVersion()
@@ -446,7 +446,7 @@ namespace chocolatey.tests.integration.scenarios
                     if (message.Contains("5/6")) installedSuccessfully = true;
                 }
 
-                installedSuccessfully.ShouldBeTrue();
+                installedSuccessfully.Should().BeTrue();
             }
 
             [Fact]
@@ -458,7 +458,7 @@ namespace chocolatey.tests.integration.scenarios
                     if (message.Contains("upgradepackage v1.0.0")) expectedMessage = true;
                 }
 
-                expectedMessage.ShouldBeTrue();
+                expectedMessage.Should().BeTrue();
             }
 
             [Fact]
@@ -468,7 +468,7 @@ namespace chocolatey.tests.integration.scenarios
                 {
                     if (packageResult.Value.Name.IsEqualTo("missingpackage")) continue;
 
-                    packageResult.Value.Success.ShouldBeTrue();
+                    packageResult.Value.Success.Should().BeTrue();
                 }
             }
 
@@ -479,7 +479,7 @@ namespace chocolatey.tests.integration.scenarios
                 {
                     if (!packageResult.Value.Name.IsEqualTo("missingpackage")) continue;
 
-                    packageResult.Value.Success.ShouldBeFalse();
+                    packageResult.Value.Success.Should().BeFalse();
                 }
             }
 
@@ -488,7 +488,7 @@ namespace chocolatey.tests.integration.scenarios
             {
                 foreach (var packageResult in Results)
                 {
-                    packageResult.Value.Inconclusive.ShouldBeFalse();
+                    packageResult.Value.Inconclusive.Should().BeFalse();
                 }
             }
 
@@ -497,7 +497,7 @@ namespace chocolatey.tests.integration.scenarios
             {
                 foreach (var packageResult in Results)
                 {
-                    packageResult.Value.Warning.ShouldBeFalse();
+                    packageResult.Value.Warning.Should().BeFalse();
                 }
             }
 
@@ -510,7 +510,7 @@ namespace chocolatey.tests.integration.scenarios
                     if (message.Contains("Installing from config file:")) expectedMessage = true;
                 }
 
-                expectedMessage.ShouldBeTrue();
+                expectedMessage.Should().BeTrue();
             }
 
             [Fact]
@@ -522,7 +522,7 @@ namespace chocolatey.tests.integration.scenarios
                     if (message.Contains("installpackage")) expectedMessage = true;
                 }
 
-                expectedMessage.ShouldBeTrue();
+                expectedMessage.Should().BeTrue();
             }
         }
 
@@ -556,7 +556,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, Configuration.PackageNames + NuGetConstants.PackageExtension);
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().ShouldEqual("1.0.0");
+                    packageReader.NuspecReader.GetVersion().ToStringSafe().Should().Be("1.0.0");
                 }
             }
 
@@ -569,7 +569,7 @@ namespace chocolatey.tests.integration.scenarios
                     if (message.Contains("0/1")) installWarning = true;
                 }
 
-                installWarning.ShouldBeTrue();
+                installWarning.Should().BeTrue();
             }
 
             [Fact]
@@ -584,19 +584,19 @@ namespace chocolatey.tests.integration.scenarios
                     }
                 }
 
-                installWarning.ShouldBeTrue();
+                installWarning.Should().BeTrue();
             }
 
             [Fact]
             public void Should_have_inconclusive_package_result()
             {
-                packageResult.Inconclusive.ShouldBeTrue();
+                packageResult.Inconclusive.Should().BeTrue();
             }
 
             [Fact]
             public void Should_ave_warning_package_result()
             {
-                packageResult.Warning.ShouldBeTrue();
+                packageResult.Warning.Should().BeTrue();
             }
         }
 
@@ -641,7 +641,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, Configuration.PackageNames + NuGetConstants.PackageExtension);
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().ShouldEqual("1.0.0");
+                    packageReader.NuspecReader.GetVersion().ToStringSafe().Should().Be("1.0.0");
                 }
             }
 
@@ -649,7 +649,7 @@ namespace chocolatey.tests.integration.scenarios
             public void Should_remove_and_re_add_the_package_files_in_the_lib_directory()
             {
                 var modifiedFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, "tools", "chocolateyinstall.ps1");
-                File.ReadAllText(modifiedFile).ShouldNotEqual(modifiedText);
+                File.ReadAllText(modifiedFile).Should().NotBe(modifiedText);
             }
 
             [Fact]
@@ -669,37 +669,37 @@ namespace chocolatey.tests.integration.scenarios
                     if (message.Contains("1/1")) installedSuccessfully = true;
                 }
 
-                installedSuccessfully.ShouldBeTrue();
+                installedSuccessfully.Should().BeTrue();
             }
 
             [Fact]
             public void Should_have_a_successful_package_result()
             {
-                packageResult.Success.ShouldBeTrue();
+                packageResult.Success.Should().BeTrue();
             }
 
             [Fact]
             public void Should_not_have_inconclusive_package_result()
             {
-                packageResult.Inconclusive.ShouldBeFalse();
+                packageResult.Inconclusive.Should().BeFalse();
             }
 
             [Fact]
             public void Should_not_have_warning_package_result()
             {
-                packageResult.Warning.ShouldBeFalse();
+                packageResult.Warning.Should().BeFalse();
             }
 
             [Fact]
             public void Config_should_match_package_result_name()
             {
-                packageResult.Name.ShouldEqual(Configuration.PackageNames);
+                packageResult.Name.Should().Be(Configuration.PackageNames);
             }
 
             [Fact]
             public void Should_have_a_version_of_one_dot_zero_dot_zero()
             {
-                packageResult.Version.ShouldEqual("1.0.0");
+                packageResult.Version.Should().Be("1.0.0");
             }
         }
 
@@ -735,7 +735,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, Configuration.PackageNames + NuGetConstants.PackageExtension);
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToNormalizedString().ShouldEqual("1.0.0");
+                    packageReader.NuspecReader.GetVersion().ToNormalizedString().Should().Be("1.0.0");
                 }
             }
 
@@ -743,7 +743,7 @@ namespace chocolatey.tests.integration.scenarios
             public void Should_restore_the_original_files_in_the_package_lib_folder()
             {
                 var modifiedFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, "tools", "chocolateyInstall.ps1");
-                File.ReadAllText(modifiedFile).ShouldEqual(modifiedText);
+                File.ReadAllText(modifiedFile).Should().Be(modifiedText);
             }
 
             [Fact]
@@ -763,25 +763,25 @@ namespace chocolatey.tests.integration.scenarios
                     if (message.Contains("0/1")) installedSuccessfully = true;
                 }
 
-                installedSuccessfully.ShouldBeTrue();
+                installedSuccessfully.Should().BeTrue();
             }
 
             [Fact]
             public void Should_not_have_a_successful_package_result()
             {
-                packageResult.Success.ShouldBeFalse();
+                packageResult.Success.Should().BeFalse();
             }
 
             [Fact]
             public void Should_not_have_inconclusive_package_result()
             {
-                packageResult.Inconclusive.ShouldBeFalse();
+                packageResult.Inconclusive.Should().BeFalse();
             }
 
             [Fact]
             public void Should_not_have_warning_package_result()
             {
-                packageResult.Warning.ShouldBeFalse();
+                packageResult.Warning.Should().BeFalse();
             }
         }
 
@@ -834,7 +834,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, Configuration.PackageNames + NuGetConstants.PackageExtension);
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().ShouldEqual("1.0.0");
+                    packageReader.NuspecReader.GetVersion().ToStringSafe().Should().Be("1.0.0");
                 }
             }
 
@@ -857,37 +857,37 @@ namespace chocolatey.tests.integration.scenarios
                     if (message.Contains("1/1")) expectedMessage = true;
                 }
 
-                expectedMessage.ShouldBeTrue();
+                expectedMessage.Should().BeTrue();
             }
 
             [Fact]
             public void Should_have_a_successful_package_result()
             {
-                packageResult.Success.ShouldBeTrue();
+                packageResult.Success.Should().BeTrue();
             }
 
             [Fact]
             public void Should_not_have_inconclusive_package_result()
             {
-                packageResult.Inconclusive.ShouldBeFalse();
+                packageResult.Inconclusive.Should().BeFalse();
             }
 
             [Fact]
             public void Should_not_have_warning_package_result()
             {
-                packageResult.Warning.ShouldBeFalse();
+                packageResult.Warning.Should().BeFalse();
             }
 
             [Fact]
             public void Config_should_match_package_result_name()
             {
-                packageResult.Name.ShouldEqual(Configuration.PackageNames);
+                packageResult.Name.Should().Be(Configuration.PackageNames);
             }
 
             [Fact]
             public void Should_have_a_version_of_one_dot_zero_dot_zero()
             {
-                packageResult.Version.ShouldEqual("1.0.0");
+                packageResult.Version.Should().Be("1.0.0");
             }
         }
 
@@ -934,7 +934,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, Configuration.PackageNames + NuGetConstants.PackageExtension);
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().ShouldEqual("1.0.0");
+                    packageReader.NuspecReader.GetVersion().ToStringSafe().Should().Be("1.0.0");
                 }
             }
 
@@ -955,25 +955,25 @@ namespace chocolatey.tests.integration.scenarios
                     if (message.Contains("0/1")) expectedMessage = true;
                 }
 
-                expectedMessage.ShouldBeTrue();
+                expectedMessage.Should().BeTrue();
             }
 
             [Fact]
             public void Should_not_have_a_successful_package_result()
             {
-                packageResult.Success.ShouldBeFalse();
+                packageResult.Success.Should().BeFalse();
             }
 
             [Fact]
             public void Should_have_inconclusive_package_result()
             {
-                packageResult.Inconclusive.ShouldBeTrue();
+                packageResult.Inconclusive.Should().BeTrue();
             }
 
             [Fact]
             public void Should_not_have_warning_package_result()
             {
-                packageResult.Warning.ShouldBeFalse();
+                packageResult.Warning.Should().BeFalse();
             }
         }
 
@@ -1010,25 +1010,25 @@ namespace chocolatey.tests.integration.scenarios
                     if (message.Contains("0/1")) installedSuccessfully = true;
                 }
 
-                installedSuccessfully.ShouldBeTrue();
+                installedSuccessfully.Should().BeTrue();
             }
 
             [Fact]
             public void Should_not_have_a_successful_package_result()
             {
-                packageResult.Success.ShouldBeFalse();
+                packageResult.Success.Should().BeFalse();
             }
 
             [Fact]
             public void Should_not_have_inconclusive_package_result()
             {
-                packageResult.Inconclusive.ShouldBeFalse();
+                packageResult.Inconclusive.Should().BeFalse();
             }
 
             [Fact]
             public void Should_not_have_warning_package_result()
             {
-                packageResult.Warning.ShouldBeFalse();
+                packageResult.Warning.Should().BeFalse();
             }
 
             [Fact]
@@ -1043,7 +1043,7 @@ namespace chocolatey.tests.integration.scenarios
                     }
                 }
 
-                errorFound.ShouldBeTrue();
+                errorFound.Should().BeTrue();
             }
 
             [Fact]
@@ -1058,13 +1058,13 @@ namespace chocolatey.tests.integration.scenarios
                     }
                 }
 
-                errorFound.ShouldBeTrue();
+                errorFound.Should().BeTrue();
             }
 
             [Fact]
             public void Should_have_a_version_of_one_dot_zero_dot_one()
             {
-                packageResult.Version.ShouldEqual("1.0.1");
+                packageResult.Version.Should().Be("1.0.1");
             }
         }
 
@@ -1101,25 +1101,25 @@ namespace chocolatey.tests.integration.scenarios
                     if (message.Contains("0/1")) installedSuccessfully = true;
                 }
 
-                installedSuccessfully.ShouldBeTrue();
+                installedSuccessfully.Should().BeTrue();
             }
 
             [Fact]
             public void Should_not_have_a_successful_package_result()
             {
-                packageResult.Success.ShouldBeFalse();
+                packageResult.Success.Should().BeFalse();
             }
 
             [Fact]
             public void Should_not_have_inconclusive_package_result()
             {
-                packageResult.Inconclusive.ShouldBeFalse();
+                packageResult.Inconclusive.Should().BeFalse();
             }
 
             [Fact]
             public void Should_not_have_warning_package_result()
             {
-                packageResult.Warning.ShouldBeFalse();
+                packageResult.Warning.Should().BeFalse();
             }
 
             [Fact]
@@ -1134,7 +1134,7 @@ namespace chocolatey.tests.integration.scenarios
                     }
                 }
 
-                errorFound.ShouldBeTrue();
+                errorFound.Should().BeTrue();
             }
 
             [Fact]
@@ -1149,7 +1149,7 @@ namespace chocolatey.tests.integration.scenarios
                     }
                 }
 
-                errorFound.ShouldBeTrue();
+                errorFound.Should().BeTrue();
             }
         }
 
@@ -1196,25 +1196,25 @@ namespace chocolatey.tests.integration.scenarios
                     if (message.Contains("0/1")) installedSuccessfully = true;
                 }
 
-                installedSuccessfully.ShouldBeTrue();
+                installedSuccessfully.Should().BeTrue();
             }
 
             [Fact]
             public void Should_not_have_a_successful_package_result()
             {
-                packageResult.Success.ShouldBeFalse();
+                packageResult.Success.Should().BeFalse();
             }
 
             [Fact]
             public void Should_not_have_inconclusive_package_result()
             {
-                packageResult.Inconclusive.ShouldBeFalse();
+                packageResult.Inconclusive.Should().BeFalse();
             }
 
             [Fact]
             public void Should_not_have_warning_package_result()
             {
-                packageResult.Warning.ShouldBeFalse();
+                packageResult.Warning.Should().BeFalse();
             }
 
             [Fact]
@@ -1229,7 +1229,7 @@ namespace chocolatey.tests.integration.scenarios
                     }
                 }
 
-                errorFound.ShouldBeTrue();
+                errorFound.Should().BeTrue();
             }
 
             [Fact]
@@ -1244,7 +1244,7 @@ namespace chocolatey.tests.integration.scenarios
                     }
                 }
 
-                errorFound.ShouldBeTrue();
+                errorFound.Should().BeTrue();
             }
         }
 
@@ -1287,7 +1287,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.Input, Configuration.Input + NuGetConstants.PackageExtension);
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToNormalizedString().ShouldEqual("1.0.0");
+                    packageReader.NuspecReader.GetVersion().ToNormalizedString().Should().Be("1.0.0");
                 }
             }
 
@@ -1300,37 +1300,37 @@ namespace chocolatey.tests.integration.scenarios
                     if (message.Contains("1/1")) installedSuccessfully = true;
                 }
 
-                installedSuccessfully.ShouldBeTrue();
+                installedSuccessfully.Should().BeTrue();
             }
 
             [Fact]
             public void Should_have_a_successful_package_result()
             {
-                packageResult.Success.ShouldBeTrue();
+                packageResult.Success.Should().BeTrue();
             }
 
             [Fact]
             public void Should_not_have_inconclusive_package_result()
             {
-                packageResult.Inconclusive.ShouldBeFalse();
+                packageResult.Inconclusive.Should().BeFalse();
             }
 
             [Fact]
             public void Should_not_have_warning_package_result()
             {
-                packageResult.Warning.ShouldBeFalse();
+                packageResult.Warning.Should().BeFalse();
             }
 
             [Fact]
             public void Config_should_match_package_result_name()
             {
-                packageResult.Name.ShouldEqual(Configuration.Input);
+                packageResult.Name.Should().Be(Configuration.Input);
             }
 
             [Fact]
             public void Should_have_a_version_of_one_dot_zero_dot_zero()
             {
-                packageResult.Version.ShouldEqual("1.0.0");
+                packageResult.Version.Should().Be("1.0.0");
             }
         }
 
@@ -1380,25 +1380,25 @@ namespace chocolatey.tests.integration.scenarios
                     if (message.Contains("0/1")) installedSuccessfully = true;
                 }
 
-                installedSuccessfully.ShouldBeTrue();
+                installedSuccessfully.Should().BeTrue();
             }
 
             [Fact]
             public void Should_not_have_a_successful_package_result()
             {
-                packageResult.Success.ShouldBeFalse();
+                packageResult.Success.Should().BeFalse();
             }
 
             [Fact]
             public void Should_not_have_inconclusive_package_result()
             {
-                packageResult.Inconclusive.ShouldBeFalse();
+                packageResult.Inconclusive.Should().BeFalse();
             }
 
             [Fact]
             public void Should_not_have_warning_package_result()
             {
-                packageResult.Warning.ShouldBeFalse();
+                packageResult.Warning.Should().BeFalse();
             }
 
             [Fact]
@@ -1413,7 +1413,7 @@ namespace chocolatey.tests.integration.scenarios
                     }
                 }
 
-                errorFound.ShouldBeTrue();
+                errorFound.Should().BeTrue();
             }
 
             [Fact]
@@ -1428,7 +1428,7 @@ namespace chocolatey.tests.integration.scenarios
                     }
                 }
 
-                errorFound.ShouldBeTrue();
+                errorFound.Should().BeTrue();
             }
         }
 
@@ -1479,7 +1479,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", "isdependency", "isdependency.nupkg");
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().ShouldEqual("1.0.0");
+                    packageReader.NuspecReader.GetVersion().ToStringSafe().Should().Be("1.0.0");
                 }
             }
 
@@ -1492,7 +1492,7 @@ namespace chocolatey.tests.integration.scenarios
                     if (message.Contains("3/3")) expectedMessage = true;
                 }
 
-                expectedMessage.ShouldBeTrue();
+                expectedMessage.Should().BeTrue();
             }
 
             [Fact]
@@ -1500,7 +1500,7 @@ namespace chocolatey.tests.integration.scenarios
             {
                 foreach (var packageResult in Results)
                 {
-                    packageResult.Value.Success.ShouldBeTrue();
+                    packageResult.Value.Success.Should().BeTrue();
                 }
             }
 
@@ -1509,7 +1509,7 @@ namespace chocolatey.tests.integration.scenarios
             {
                 foreach (var packageResult in Results)
                 {
-                    packageResult.Value.Inconclusive.ShouldBeFalse();
+                    packageResult.Value.Inconclusive.Should().BeFalse();
                 }
             }
 
@@ -1518,7 +1518,7 @@ namespace chocolatey.tests.integration.scenarios
             {
                 foreach (var packageResult in Results)
                 {
-                    packageResult.Value.Warning.ShouldBeFalse();
+                    packageResult.Value.Warning.Should().BeFalse();
                 }
             }
 
@@ -1527,7 +1527,7 @@ namespace chocolatey.tests.integration.scenarios
             {
                 foreach (var packageResult in Results)
                 {
-                    packageResult.Value.Version.ShouldEqual("1.0.0");
+                    packageResult.Value.Version.Should().Be("1.0.0");
                 }
             }
         }
@@ -1575,7 +1575,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, Configuration.PackageNames + NuGetConstants.PackageExtension);
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().ShouldEqual("1.0.0");
+                    packageReader.NuspecReader.GetVersion().ToStringSafe().Should().Be("1.0.0");
                 }
             }
 
@@ -1593,7 +1593,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", "isdependency", "isdependency.nupkg");
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().ShouldEqual("1.0.0");
+                    packageReader.NuspecReader.GetVersion().ToStringSafe().Should().Be("1.0.0");
                 }
             }
 
@@ -1606,7 +1606,7 @@ namespace chocolatey.tests.integration.scenarios
                     if (message.Contains("1/1")) expectedMessage = true;
                 }
 
-                expectedMessage.ShouldBeTrue();
+                expectedMessage.Should().BeTrue();
             }
 
             [Fact]
@@ -1614,7 +1614,7 @@ namespace chocolatey.tests.integration.scenarios
             {
                 foreach (var packageResult in Results)
                 {
-                    packageResult.Value.Success.ShouldBeTrue();
+                    packageResult.Value.Success.Should().BeTrue();
                 }
             }
 
@@ -1623,7 +1623,7 @@ namespace chocolatey.tests.integration.scenarios
             {
                 foreach (var packageResult in Results)
                 {
-                    packageResult.Value.Inconclusive.ShouldBeFalse();
+                    packageResult.Value.Inconclusive.Should().BeFalse();
                 }
             }
 
@@ -1632,7 +1632,7 @@ namespace chocolatey.tests.integration.scenarios
             {
                 foreach (var packageResult in Results)
                 {
-                    packageResult.Value.Warning.ShouldBeFalse();
+                    packageResult.Value.Warning.Should().BeFalse();
                 }
             }
 
@@ -1641,7 +1641,7 @@ namespace chocolatey.tests.integration.scenarios
             {
                 foreach (var packageResult in Results)
                 {
-                    packageResult.Value.Version.ShouldEqual("1.0.0");
+                    packageResult.Value.Version.Should().Be("1.0.0");
                 }
             }
         }
@@ -1696,7 +1696,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, Configuration.PackageNames + NuGetConstants.PackageExtension);
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().ShouldEqual("1.0.0");
+                    packageReader.NuspecReader.GetVersion().ToStringSafe().Should().Be("1.0.0");
                 }
             }
 
@@ -1723,7 +1723,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", "isdependency", "isdependency.nupkg");
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().ShouldEqual("1.0.0");
+                    packageReader.NuspecReader.GetVersion().ToStringSafe().Should().Be("1.0.0");
                 }
             }
 
@@ -1733,7 +1733,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", "isexactversiondependency", "isexactversiondependency.nupkg");
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().ShouldEqual("1.0.0");
+                    packageReader.NuspecReader.GetVersion().ToStringSafe().Should().Be("1.0.0");
                 }
             }
 
@@ -1746,7 +1746,7 @@ namespace chocolatey.tests.integration.scenarios
                     if (message.Contains("3/3")) installedSuccessfully = true;
                 }
 
-                installedSuccessfully.ShouldBeTrue();
+                installedSuccessfully.Should().BeTrue();
             }
 
             [Fact]
@@ -1754,7 +1754,7 @@ namespace chocolatey.tests.integration.scenarios
             {
                 foreach (var packageResult in Results)
                 {
-                    packageResult.Value.Success.ShouldBeTrue();
+                    packageResult.Value.Success.Should().BeTrue();
                 }
             }
 
@@ -1763,7 +1763,7 @@ namespace chocolatey.tests.integration.scenarios
             {
                 foreach (var packageResult in Results)
                 {
-                    packageResult.Value.Inconclusive.ShouldBeFalse();
+                    packageResult.Value.Inconclusive.Should().BeFalse();
                 }
             }
 
@@ -1772,7 +1772,7 @@ namespace chocolatey.tests.integration.scenarios
             {
                 foreach (var packageResult in Results)
                 {
-                    packageResult.Value.Warning.ShouldBeFalse();
+                    packageResult.Value.Warning.Should().BeFalse();
                 }
             }
         }
@@ -1821,7 +1821,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, Configuration.PackageNames + NuGetConstants.PackageExtension);
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().ShouldEqual("1.0.0");
+                    packageReader.NuspecReader.GetVersion().ToStringSafe().Should().Be("1.0.0");
                 }
             }
 
@@ -1839,7 +1839,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", "isdependency", "isdependency.nupkg");
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().ShouldEqual("1.0.0");
+                    packageReader.NuspecReader.GetVersion().ToStringSafe().Should().Be("1.0.0");
                 }
             }
 
@@ -1849,7 +1849,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", "isexactversiondependency", "isexactversiondependency.nupkg");
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().ShouldEqual("1.0.0");
+                    packageReader.NuspecReader.GetVersion().ToStringSafe().Should().Be("1.0.0");
                 }
             }
 
@@ -1862,7 +1862,7 @@ namespace chocolatey.tests.integration.scenarios
                     if (message.Contains("1/1")) installedSuccessfully = true;
                 }
 
-                installedSuccessfully.ShouldBeTrue();
+                installedSuccessfully.Should().BeTrue();
             }
 
             [Fact]
@@ -1870,7 +1870,7 @@ namespace chocolatey.tests.integration.scenarios
             {
                 foreach (var packageResult in Results)
                 {
-                    packageResult.Value.Success.ShouldBeTrue();
+                    packageResult.Value.Success.Should().BeTrue();
                 }
             }
 
@@ -1879,7 +1879,7 @@ namespace chocolatey.tests.integration.scenarios
             {
                 foreach (var packageResult in Results)
                 {
-                    packageResult.Value.Inconclusive.ShouldBeFalse();
+                    packageResult.Value.Inconclusive.Should().BeFalse();
                 }
             }
 
@@ -1888,7 +1888,7 @@ namespace chocolatey.tests.integration.scenarios
             {
                 foreach (var packageResult in Results)
                 {
-                    packageResult.Value.Warning.ShouldBeFalse();
+                    packageResult.Value.Warning.Should().BeFalse();
                 }
             }
         }
@@ -1938,7 +1938,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, Configuration.PackageNames + NuGetConstants.PackageExtension);
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().ShouldEqual("1.0.0");
+                    packageReader.NuspecReader.GetVersion().ToStringSafe().Should().Be("1.0.0");
                 }
             }
 
@@ -1965,7 +1965,7 @@ namespace chocolatey.tests.integration.scenarios
                     if (message.Contains("1/1")) installedSuccessfully = true;
                 }
 
-                installedSuccessfully.ShouldBeTrue();
+                installedSuccessfully.Should().BeTrue();
             }
 
             [Fact]
@@ -1973,7 +1973,7 @@ namespace chocolatey.tests.integration.scenarios
             {
                 foreach (var packageResult in Results)
                 {
-                    packageResult.Value.Success.ShouldBeTrue();
+                    packageResult.Value.Success.Should().BeTrue();
                 }
             }
 
@@ -1982,7 +1982,7 @@ namespace chocolatey.tests.integration.scenarios
             {
                 foreach (var packageResult in Results)
                 {
-                    packageResult.Value.Inconclusive.ShouldBeFalse();
+                    packageResult.Value.Inconclusive.Should().BeFalse();
                 }
             }
 
@@ -1991,7 +1991,7 @@ namespace chocolatey.tests.integration.scenarios
             {
                 foreach (var packageResult in Results)
                 {
-                    packageResult.Value.Warning.ShouldBeFalse();
+                    packageResult.Value.Warning.Should().BeFalse();
                 }
             }
         }
@@ -2035,7 +2035,7 @@ namespace chocolatey.tests.integration.scenarios
                     if (message.Contains("0/1")) installedSuccessfully = true;
                 }
 
-                installedSuccessfully.ShouldBeTrue();
+                installedSuccessfully.Should().BeTrue();
             }
 
             [Fact]
@@ -2043,7 +2043,7 @@ namespace chocolatey.tests.integration.scenarios
             {
                 foreach (var packageResult in Results)
                 {
-                    packageResult.Value.Success.ShouldBeFalse();
+                    packageResult.Value.Success.Should().BeFalse();
                 }
             }
 
@@ -2052,7 +2052,7 @@ namespace chocolatey.tests.integration.scenarios
             {
                 foreach (var packageResult in Results)
                 {
-                    packageResult.Value.Inconclusive.ShouldBeFalse();
+                    packageResult.Value.Inconclusive.Should().BeFalse();
                 }
             }
 
@@ -2061,7 +2061,7 @@ namespace chocolatey.tests.integration.scenarios
             {
                 foreach (var packageResult in Results)
                 {
-                    packageResult.Value.Warning.ShouldBeFalse();
+                    packageResult.Value.Warning.Should().BeFalse();
                 }
             }
 
@@ -2081,7 +2081,7 @@ namespace chocolatey.tests.integration.scenarios
                     }
                 }
 
-                errorFound.ShouldBeTrue();
+                errorFound.Should().BeTrue();
             }
 
             [Fact]
@@ -2100,7 +2100,7 @@ namespace chocolatey.tests.integration.scenarios
                     }
                 }
 
-                errorFound.ShouldBeTrue();
+                errorFound.Should().BeTrue();
             }
         }
 
@@ -2142,7 +2142,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, Configuration.PackageNames + NuGetConstants.PackageExtension);
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().ShouldEqual("2.1.0");
+                    packageReader.NuspecReader.GetVersion().ToStringSafe().Should().Be("2.1.0");
                 }
             }
 
@@ -2163,31 +2163,31 @@ namespace chocolatey.tests.integration.scenarios
                     if (message.Contains("1/1")) installedSuccessfully = true;
                 }
 
-                installedSuccessfully.ShouldBeTrue();
+                installedSuccessfully.Should().BeTrue();
             }
 
             [Fact]
             public void Should_have_a_successful_package_result()
             {
-                packageResult.Success.ShouldBeTrue();
+                packageResult.Success.Should().BeTrue();
             }
 
             [Fact]
             public void Should_not_have_inconclusive_package_result()
             {
-                packageResult.Inconclusive.ShouldBeFalse();
+                packageResult.Inconclusive.Should().BeFalse();
             }
 
             [Fact]
             public void Should_not_have_warning_package_result()
             {
-                packageResult.Warning.ShouldBeFalse();
+                packageResult.Warning.Should().BeFalse();
             }
 
             [Fact]
             public void Config_should_match_package_result_name()
             {
-                packageResult.Name.ShouldEqual(Configuration.PackageNames);
+                packageResult.Name.Should().Be(Configuration.PackageNames);
             }
         }
 
@@ -2232,7 +2232,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, Configuration.PackageNames + NuGetConstants.PackageExtension);
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().ShouldEqual("1.6.0");
+                    packageReader.NuspecReader.GetVersion().ToStringSafe().Should().Be("1.6.0");
                 }
             }
 
@@ -2250,7 +2250,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", "isdependency", "isdependency.nupkg");
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().ShouldEqual("1.1.0");
+                    packageReader.NuspecReader.GetVersion().ToStringSafe().Should().Be("1.1.0");
                 }
             }
 
@@ -2263,7 +2263,7 @@ namespace chocolatey.tests.integration.scenarios
                     if (message.Contains("3/3")) installedSuccessfully = true;
                 }
 
-                installedSuccessfully.ShouldBeTrue();
+                installedSuccessfully.Should().BeTrue();
             }
 
             [Fact]
@@ -2271,7 +2271,7 @@ namespace chocolatey.tests.integration.scenarios
             {
                 foreach (var packageResult in Results)
                 {
-                    packageResult.Value.Success.ShouldBeTrue();
+                    packageResult.Value.Success.Should().BeTrue();
                 }
             }
 
@@ -2280,7 +2280,7 @@ namespace chocolatey.tests.integration.scenarios
             {
                 foreach (var packageResult in Results)
                 {
-                    packageResult.Value.Inconclusive.ShouldBeFalse();
+                    packageResult.Value.Inconclusive.Should().BeFalse();
                 }
             }
 
@@ -2289,7 +2289,7 @@ namespace chocolatey.tests.integration.scenarios
             {
                 foreach (var packageResult in Results)
                 {
-                    packageResult.Value.Warning.ShouldBeFalse();
+                    packageResult.Value.Warning.Should().BeFalse();
                 }
             }
         }
@@ -2328,7 +2328,7 @@ namespace chocolatey.tests.integration.scenarios
                     if (message.Contains("0/1")) expectedMessage = true;
                 }
 
-                expectedMessage.ShouldBeTrue();
+                expectedMessage.Should().BeTrue();
             }
 
             [Fact]
@@ -2336,7 +2336,7 @@ namespace chocolatey.tests.integration.scenarios
             {
                 foreach (var packageResult in Results)
                 {
-                    packageResult.Value.Success.ShouldBeFalse();
+                    packageResult.Value.Success.Should().BeFalse();
                 }
             }
 
@@ -2345,7 +2345,7 @@ namespace chocolatey.tests.integration.scenarios
             {
                 foreach (var packageResult in Results)
                 {
-                    packageResult.Value.Inconclusive.ShouldBeFalse();
+                    packageResult.Value.Inconclusive.Should().BeFalse();
                 }
             }
 
@@ -2354,7 +2354,7 @@ namespace chocolatey.tests.integration.scenarios
             {
                 foreach (var packageResult in Results)
                 {
-                    packageResult.Value.Warning.ShouldBeFalse();
+                    packageResult.Value.Warning.Should().BeFalse();
                 }
             }
         }
@@ -2400,7 +2400,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, Configuration.PackageNames + NuGetConstants.PackageExtension);
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().ShouldEqual("1.6.0");
+                    packageReader.NuspecReader.GetVersion().ToStringSafe().Should().Be("1.6.0");
                 }
             }
 
@@ -2413,7 +2413,7 @@ namespace chocolatey.tests.integration.scenarios
                     if (message.Contains("1/1")) expectedMessage = true;
                 }
 
-                expectedMessage.ShouldBeTrue();
+                expectedMessage.Should().BeTrue();
             }
 
             [Fact]
@@ -2421,7 +2421,7 @@ namespace chocolatey.tests.integration.scenarios
             {
                 foreach (var packageResult in Results)
                 {
-                    packageResult.Value.Success.ShouldBeTrue();
+                    packageResult.Value.Success.Should().BeTrue();
                 }
             }
 
@@ -2430,7 +2430,7 @@ namespace chocolatey.tests.integration.scenarios
             {
                 foreach (var packageResult in Results)
                 {
-                    packageResult.Value.Inconclusive.ShouldBeFalse();
+                    packageResult.Value.Inconclusive.Should().BeFalse();
                 }
             }
 
@@ -2439,7 +2439,7 @@ namespace chocolatey.tests.integration.scenarios
             {
                 foreach (var packageResult in Results)
                 {
-                    packageResult.Value.Warning.ShouldBeFalse();
+                    packageResult.Value.Warning.Should().BeFalse();
                 }
             }
         }
@@ -2477,7 +2477,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", "isdependency", "isdependency.nupkg");
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().ShouldEqual("1.0.0");
+                    packageReader.NuspecReader.GetVersion().ToStringSafe().Should().Be("1.0.0");
                 }
             }
 
@@ -2490,7 +2490,7 @@ namespace chocolatey.tests.integration.scenarios
                     if (message.Contains("0/1")) installedSuccessfully = true;
                 }
 
-                installedSuccessfully.ShouldBeTrue();
+                installedSuccessfully.Should().BeTrue();
             }
 
             [Fact]
@@ -2498,7 +2498,7 @@ namespace chocolatey.tests.integration.scenarios
             {
                 foreach (var packageResult in Results)
                 {
-                    packageResult.Value.Success.ShouldBeFalse();
+                    packageResult.Value.Success.Should().BeFalse();
                 }
             }
 
@@ -2507,7 +2507,7 @@ namespace chocolatey.tests.integration.scenarios
             {
                 foreach (var packageResult in Results)
                 {
-                    packageResult.Value.Inconclusive.ShouldBeFalse();
+                    packageResult.Value.Inconclusive.Should().BeFalse();
                 }
             }
 
@@ -2516,7 +2516,7 @@ namespace chocolatey.tests.integration.scenarios
             {
                 foreach (var packageResult in Results)
                 {
-                    packageResult.Value.Warning.ShouldBeFalse();
+                    packageResult.Value.Warning.Should().BeFalse();
                 }
             }
 
@@ -2536,7 +2536,7 @@ namespace chocolatey.tests.integration.scenarios
                     }
                 }
 
-                errorFound.ShouldBeTrue();
+                errorFound.Should().BeTrue();
             }
 
             [Fact]
@@ -2555,7 +2555,7 @@ namespace chocolatey.tests.integration.scenarios
                     }
                 }
 
-                errorFound.ShouldBeTrue();
+                errorFound.Should().BeTrue();
             }
         }
 
@@ -2601,7 +2601,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", "isdependency", "isdependency.nupkg");
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().ShouldEqual("1.0.1");
+                    packageReader.NuspecReader.GetVersion().ToStringSafe().Should().Be("1.0.1");
                 }
             }
 
@@ -2614,7 +2614,7 @@ namespace chocolatey.tests.integration.scenarios
                     if (message.Contains("installed 2/2")) expectedMessage = true;
                 }
 
-                expectedMessage.ShouldBeTrue();
+                expectedMessage.Should().BeTrue();
             }
 
             [Fact]
@@ -2622,7 +2622,7 @@ namespace chocolatey.tests.integration.scenarios
             {
                 foreach (var packageResult in Results)
                 {
-                    packageResult.Value.Success.ShouldBeTrue();
+                    packageResult.Value.Success.Should().BeTrue();
                 }
             }
 
@@ -2631,7 +2631,7 @@ namespace chocolatey.tests.integration.scenarios
             {
                 foreach (var packageResult in Results)
                 {
-                    packageResult.Value.Inconclusive.ShouldBeFalse();
+                    packageResult.Value.Inconclusive.Should().BeFalse();
                 }
             }
 
@@ -2640,7 +2640,7 @@ namespace chocolatey.tests.integration.scenarios
             {
                 foreach (var packageResult in Results)
                 {
-                    packageResult.Value.Warning.ShouldBeFalse();
+                    packageResult.Value.Warning.Should().BeFalse();
                 }
             }
         }
@@ -2687,7 +2687,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", "isdependency", "isdependency.nupkg");
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().ShouldEqual("1.0.0");
+                    packageReader.NuspecReader.GetVersion().ToStringSafe().Should().Be("1.0.0");
                 }
             }
 
@@ -2697,7 +2697,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", "isexactversiondependency", "isexactversiondependency.nupkg");
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().ShouldEqual("1.0.0");
+                    packageReader.NuspecReader.GetVersion().ToStringSafe().Should().Be("1.0.0");
                 }
             }
 
@@ -2710,7 +2710,7 @@ namespace chocolatey.tests.integration.scenarios
                     if (message.Contains("installed 0/1")) expectedMessage = true;
                 }
 
-                expectedMessage.ShouldBeTrue();
+                expectedMessage.Should().BeTrue();
             }
 
             [Fact]
@@ -2718,7 +2718,7 @@ namespace chocolatey.tests.integration.scenarios
             {
                 foreach (var packageResult in Results)
                 {
-                    packageResult.Value.Success.ShouldBeFalse();
+                    packageResult.Value.Success.Should().BeFalse();
                 }
             }
 
@@ -2727,7 +2727,7 @@ namespace chocolatey.tests.integration.scenarios
             {
                 foreach (var packageResult in Results)
                 {
-                    packageResult.Value.Inconclusive.ShouldBeFalse();
+                    packageResult.Value.Inconclusive.Should().BeFalse();
                 }
             }
 
@@ -2736,7 +2736,7 @@ namespace chocolatey.tests.integration.scenarios
             {
                 foreach (var packageResult in Results)
                 {
-                    packageResult.Value.Warning.ShouldBeFalse();
+                    packageResult.Value.Warning.Should().BeFalse();
                 }
             }
 
@@ -2756,7 +2756,7 @@ namespace chocolatey.tests.integration.scenarios
                     }
                 }
 
-                errorFound.ShouldBeTrue();
+                errorFound.Should().BeTrue();
             }
         }
 
@@ -2799,7 +2799,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", "isexactversiondependency", "isexactversiondependency.nupkg");
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().ShouldEqual("2.0.0");
+                    packageReader.NuspecReader.GetVersion().ToStringSafe().Should().Be("2.0.0");
                 }
             }
 
@@ -2812,7 +2812,7 @@ namespace chocolatey.tests.integration.scenarios
                     if (message.Contains("installed 0/1")) expectedMessage = true;
                 }
 
-                expectedMessage.ShouldBeTrue();
+                expectedMessage.Should().BeTrue();
             }
 
             [Fact]
@@ -2820,7 +2820,7 @@ namespace chocolatey.tests.integration.scenarios
             {
                 foreach (var packageResult in Results)
                 {
-                    packageResult.Value.Success.ShouldBeFalse();
+                    packageResult.Value.Success.Should().BeFalse();
                 }
             }
 
@@ -2829,7 +2829,7 @@ namespace chocolatey.tests.integration.scenarios
             {
                 foreach (var packageResult in Results)
                 {
-                    packageResult.Value.Inconclusive.ShouldBeFalse();
+                    packageResult.Value.Inconclusive.Should().BeFalse();
                 }
             }
 
@@ -2838,7 +2838,7 @@ namespace chocolatey.tests.integration.scenarios
             {
                 foreach (var packageResult in Results)
                 {
-                    packageResult.Value.Warning.ShouldBeFalse();
+                    packageResult.Value.Warning.Should().BeFalse();
                 }
             }
 
@@ -2858,7 +2858,7 @@ namespace chocolatey.tests.integration.scenarios
                     }
                 }
 
-                errorFound.ShouldBeTrue();
+                errorFound.Should().BeTrue();
             }
         }
 
@@ -2916,7 +2916,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", "childdependencywithlooserversiondependency", "childdependencywithlooserversiondependency.nupkg");
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().ShouldEqual("1.0.0");
+                    packageReader.NuspecReader.GetVersion().ToStringSafe().Should().Be("1.0.0");
                 }
             }
 
@@ -2926,7 +2926,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", "isexactversiondependency", "isexactversiondependency.nupkg");
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().ShouldEqual("1.0.0");
+                    packageReader.NuspecReader.GetVersion().ToStringSafe().Should().Be("1.0.0");
                 }
             }
 
@@ -2939,7 +2939,7 @@ namespace chocolatey.tests.integration.scenarios
                     if (message.Contains("3/3")) expectedMessage = true;
                 }
 
-                expectedMessage.ShouldBeTrue();
+                expectedMessage.Should().BeTrue();
             }
 
             [Fact]
@@ -2947,7 +2947,7 @@ namespace chocolatey.tests.integration.scenarios
             {
                 foreach (var packageResult in Results)
                 {
-                    packageResult.Value.Success.ShouldBeTrue();
+                    packageResult.Value.Success.Should().BeTrue();
                 }
             }
 
@@ -2956,7 +2956,7 @@ namespace chocolatey.tests.integration.scenarios
             {
                 foreach (var packageResult in Results)
                 {
-                    packageResult.Value.Inconclusive.ShouldBeFalse();
+                    packageResult.Value.Inconclusive.Should().BeFalse();
                 }
             }
 
@@ -2965,7 +2965,7 @@ namespace chocolatey.tests.integration.scenarios
             {
                 foreach (var packageResult in Results)
                 {
-                    packageResult.Value.Warning.ShouldBeFalse();
+                    packageResult.Value.Warning.Should().BeFalse();
                 }
             }
         }
@@ -2995,7 +2995,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_have_thrown_exception_when_installing()
             {
-                _exception.ShouldBeType<ApplicationException>();
+                _exception.Should().BeOfType<ApplicationException>();
             }
 
             [Fact]
@@ -3009,7 +3009,7 @@ namespace chocolatey.tests.integration.scenarios
                     .AppendLine("  choco install installpackage --version=\"1.0.0\" --source=\"{0}\"".FormatWith(Configuration.Sources))
                     .ToString();
 
-                _exception.Message.ShouldEqual(expectedMessage);
+                _exception.Message.Should().Be(expectedMessage);
             }
 
             [Fact]
@@ -3062,7 +3062,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_have_thrown_exception_when_installing()
             {
-                _exception.ShouldBeType<ApplicationException>();
+                _exception.Should().BeOfType<ApplicationException>();
             }
 
             [Fact]
@@ -3076,7 +3076,7 @@ namespace chocolatey.tests.integration.scenarios
                     .AppendLine("  choco install installpackage --version=\"0.56.0-alpha-0544\" --prerelease --source=\"{0}\"".FormatWith(Configuration.Sources))
                     .ToString();
 
-                _exception.Message.ShouldEqual(expectedMessage);
+                _exception.Message.Should().Be(expectedMessage);
             }
 
             [Fact]
@@ -3132,7 +3132,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_have_thrown_exception_when_installing()
             {
-                _exception.ShouldBeType<ApplicationException>();
+                _exception.Should().BeOfType<ApplicationException>();
             }
 
             [Fact]
@@ -3146,7 +3146,7 @@ namespace chocolatey.tests.integration.scenarios
                     .AppendLine("  choco install installpackage --version=\"1.0.0\" --source=\"{0}\"".FormatWith(Configuration.Sources))
                     .ToString();
 
-                _exception.Message.ShouldEqual(expectedMessage);
+                _exception.Message.Should().Be(expectedMessage);
             }
 
             [Fact]
@@ -3200,13 +3200,13 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_have_thrown_exception_when_installing()
             {
-                _exception.ShouldBeType<ApplicationException>();
+                _exception.Should().BeOfType<ApplicationException>();
             }
 
             [Fact]
             public void Should_have_outputted_expected_exception_message()
             {
-                _exception.Message.ShouldEqual("Package name cannot point directly to a local, or remote file. Please use the --source argument and point it to a local file directory, UNC directory path or a NuGet feed instead.");
+                _exception.Message.Should().Be("Package name cannot point directly to a local, or remote file. Please use the --source argument and point it to a local file directory, UNC directory path or a NuGet feed instead.");
             }
 
             [Fact]
@@ -3260,13 +3260,13 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_have_thrown_exception_when_installing()
             {
-                _exception.ShouldBeType<ApplicationException>();
+                _exception.Should().BeOfType<ApplicationException>();
             }
 
             [Fact]
             public void Should_have_outputted_expected_exception_message()
             {
-                _exception.Message.ShouldEqual("Package name cannot point directly to a package manifest file. Please create a package by running 'choco pack' on the .nuspec file first.");
+                _exception.Message.Should().Be("Package name cannot point directly to a package manifest file. Please create a package by running 'choco pack' on the .nuspec file first.");
             }
 
             [Fact]
@@ -3323,7 +3323,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, Configuration.PackageNames + NuGetConstants.PackageExtension);
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().ShouldEqual("1.0.0");
+                    packageReader.NuspecReader.GetVersion().ToStringSafe().Should().Be("1.0.0");
                 }
             }
 
@@ -3336,49 +3336,49 @@ namespace chocolatey.tests.integration.scenarios
                     if (message.Contains("1/1")) installedSuccessfully = true;
                 }
 
-                installedSuccessfully.ShouldBeTrue();
+                installedSuccessfully.Should().BeTrue();
             }
 
             [Fact]
             public void Should_have_a_successful_package_result()
             {
-                packageResult.Success.ShouldBeTrue();
+                packageResult.Success.Should().BeTrue();
             }
 
             [Fact]
             public void Should_not_have_inconclusive_package_result()
             {
-                packageResult.Inconclusive.ShouldBeFalse();
+                packageResult.Inconclusive.Should().BeFalse();
             }
 
             [Fact]
             public void Should_not_have_warning_package_result()
             {
-                packageResult.Warning.ShouldBeFalse();
+                packageResult.Warning.Should().BeFalse();
             }
 
             [Fact]
             public void Should_have_a_version_of_one_dot_zero_dot_zero()
             {
-                packageResult.Version.ShouldEqual("1.0.0");
+                packageResult.Version.Should().Be("1.0.0");
             }
 
             [Fact]
             public void Should_not_change_the_test_value_in_the_config_due_to_XDT_InsertIfMissing()
             {
-                _xPathNavigator.SelectSingleNode("//configuration/appSettings/add[@key='test']/@value").TypedValue.ToStringSafe().ShouldEqual("default 1.0.0");
+                _xPathNavigator.SelectSingleNode("//configuration/appSettings/add[@key='test']/@value").TypedValue.ToStringSafe().Should().Be("default 1.0.0");
             }
 
             [Fact]
             public void Should_change_the_testReplace_value_in_the_config_due_to_XDT_Replace()
             {
-                _xPathNavigator.SelectSingleNode("//configuration/appSettings/add[@key='testReplace']/@value").TypedValue.ToStringSafe().ShouldEqual("1.0.0");
+                _xPathNavigator.SelectSingleNode("//configuration/appSettings/add[@key='testReplace']/@value").TypedValue.ToStringSafe().Should().Be("1.0.0");
             }
 
             [Fact]
             public void Should_add_the_insert_value_in_the_config_due_to_XDT_InsertIfMissing()
             {
-                _xPathNavigator.SelectSingleNode("//configuration/appSettings/add[@key='insert']/@value").TypedValue.ToStringSafe().ShouldEqual("1.0.0");
+                _xPathNavigator.SelectSingleNode("//configuration/appSettings/add[@key='insert']/@value").TypedValue.ToStringSafe().Should().Be("1.0.0");
             }
         }
 
@@ -3398,13 +3398,13 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_have_no_sources_enabled_result()
             {
-                MockLogger.ContainsMessage("Installation was NOT successful. There are no sources enabled for", LogLevel.Error).ShouldBeTrue();
+                MockLogger.ContainsMessage("Installation was NOT successful. There are no sources enabled for", LogLevel.Error).Should().BeTrue();
             }
 
             [Fact]
             public void Should_not_install_any_packages()
             {
-                Results.Count().ShouldEqual(0);
+                Results.Count().Should().Be(0);
             }
         }
 
@@ -3439,7 +3439,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, Configuration.PackageNames + NuGetConstants.PackageExtension);
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().ShouldEqual("1.0.0");
+                    packageReader.NuspecReader.GetVersion().ToStringSafe().Should().Be("1.0.0");
                 }
             }
 
@@ -3466,7 +3466,7 @@ namespace chocolatey.tests.integration.scenarios
                 foreach (string scriptName in hookScripts)
                 {
                     var hookScriptPath = Path.Combine(Scenario.get_top_level(), "hooks", Configuration.PackageNames.Replace(".hook", string.Empty), scriptName);
-                    File.ReadAllText(hookScriptPath).ShouldContain("Write-Output");
+                    File.ReadAllText(hookScriptPath).Should().Contain("Write-Output");
                 }
             }
 
@@ -3479,37 +3479,37 @@ namespace chocolatey.tests.integration.scenarios
                     if (message.Contains("1/1")) installedSuccessfully = true;
                 }
 
-                installedSuccessfully.ShouldBeTrue();
+                installedSuccessfully.Should().BeTrue();
             }
 
             [Fact]
             public void Should_have_a_successful_package_result()
             {
-                _packageResult.Success.ShouldBeTrue();
+                _packageResult.Success.Should().BeTrue();
             }
 
             [Fact]
             public void Should_not_have_inconclusive_package_result()
             {
-                _packageResult.Inconclusive.ShouldBeFalse();
+                _packageResult.Inconclusive.Should().BeFalse();
             }
 
             [Fact]
             public void Should_not_have_warning_package_result()
             {
-                _packageResult.Warning.ShouldBeFalse();
+                _packageResult.Warning.Should().BeFalse();
             }
 
             [Fact]
             public void Config_should_match_package_result_name()
             {
-                _packageResult.Name.ShouldEqual(Configuration.PackageNames);
+                _packageResult.Name.Should().Be(Configuration.PackageNames);
             }
 
             [Fact]
             public void Should_have_a_version_of_one_dot_zero_dot_zero()
             {
-                _packageResult.Version.ShouldEqual("1.0.0");
+                _packageResult.Version.Should().Be("1.0.0");
             }
 
         }
@@ -3552,7 +3552,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, Configuration.PackageNames + NuGetConstants.PackageExtension);
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().ShouldEqual("1.0.0");
+                    packageReader.NuspecReader.GetVersion().ToStringSafe().Should().Be("1.0.0");
                 }
             }
 
@@ -3632,7 +3632,7 @@ namespace chocolatey.tests.integration.scenarios
                     if (message.Contains("is gui? False")) messageFound = true;
                 }
 
-                messageFound.ShouldBeTrue("GUI false message not found");
+                messageFound.Should().BeTrue("GUI false message not found");
             }
 
             [Fact]
@@ -3659,7 +3659,7 @@ namespace chocolatey.tests.integration.scenarios
                     if (message.Contains("is gui? True")) messageFound = true;
                 }
 
-                messageFound.ShouldBeTrue("GUI true message not found");
+                messageFound.Should().BeTrue("GUI true message not found");
             }
 
             [Fact]
@@ -3671,37 +3671,37 @@ namespace chocolatey.tests.integration.scenarios
                     if (message.Contains("1/1")) installedSuccessfully = true;
                 }
 
-                installedSuccessfully.ShouldBeTrue();
+                installedSuccessfully.Should().BeTrue();
             }
 
             [Fact]
             public void Should_have_a_successful_package_result()
             {
-                _packageResult.Success.ShouldBeTrue();
+                _packageResult.Success.Should().BeTrue();
             }
 
             [Fact]
             public void Should_not_have_inconclusive_package_result()
             {
-                _packageResult.Inconclusive.ShouldBeFalse();
+                _packageResult.Inconclusive.Should().BeFalse();
             }
 
             [Fact]
             public void Should_not_have_warning_package_result()
             {
-                _packageResult.Warning.ShouldBeFalse();
+                _packageResult.Warning.Should().BeFalse();
             }
 
             [Fact]
             public void Config_should_match_package_result_name()
             {
-                _packageResult.Name.ShouldEqual(Configuration.PackageNames);
+                _packageResult.Name.Should().Be(Configuration.PackageNames);
             }
 
             [Fact]
             public void Should_have_a_version_of_one_dot_zero_dot_zero()
             {
-                _packageResult.Version.ShouldEqual("1.0.0");
+                _packageResult.Version.Should().Be("1.0.0");
             }
 
             [Fact]
@@ -3709,7 +3709,7 @@ namespace chocolatey.tests.integration.scenarios
             [Platform(Exclude = "Mono")]
             public void Should_have_executed_chocolateyInstall_script()
             {
-                MockLogger.ContainsMessage("installpackage v1.0.0 has been installed", LogLevel.Info).ShouldBeTrue();
+                MockLogger.ContainsMessage("installpackage v1.0.0 has been installed", LogLevel.Info).Should().BeTrue();
             }
 
             [Fact]
@@ -3717,7 +3717,7 @@ namespace chocolatey.tests.integration.scenarios
             [Platform(Exclude = "Mono")]
             public void Should_have_executed_pre_all_hook_script()
             {
-                MockLogger.ContainsMessage("pre-install-all.ps1 hook ran for installpackage 1.0.0", LogLevel.Info).ShouldBeTrue();
+                MockLogger.ContainsMessage("pre-install-all.ps1 hook ran for installpackage 1.0.0", LogLevel.Info).Should().BeTrue();
             }
 
             [Fact]
@@ -3725,7 +3725,7 @@ namespace chocolatey.tests.integration.scenarios
             [Platform(Exclude = "Mono")]
             public void Should_have_executed_post_all_hook_script()
             {
-                MockLogger.ContainsMessage("post-install-all.ps1 hook ran for installpackage 1.0.0", LogLevel.Info).ShouldBeTrue();
+                MockLogger.ContainsMessage("post-install-all.ps1 hook ran for installpackage 1.0.0", LogLevel.Info).Should().BeTrue();
             }
 
             [Fact]
@@ -3733,7 +3733,7 @@ namespace chocolatey.tests.integration.scenarios
             [Platform(Exclude = "Mono")]
             public void Should_have_executed_pre_installpackage_hook_script()
             {
-                MockLogger.ContainsMessage("pre-install-installpackage.ps1 hook ran for installpackage 1.0.0", LogLevel.Info).ShouldBeTrue();
+                MockLogger.ContainsMessage("pre-install-installpackage.ps1 hook ran for installpackage 1.0.0", LogLevel.Info).Should().BeTrue();
             }
 
             [Fact]
@@ -3741,7 +3741,7 @@ namespace chocolatey.tests.integration.scenarios
             [Platform(Exclude = "Mono")]
             public void Should_have_executed_post_installpackage_hook_script()
             {
-                MockLogger.ContainsMessage("post-install-installpackage.ps1 hook ran for installpackage 1.0.0", LogLevel.Info).ShouldBeTrue();
+                MockLogger.ContainsMessage("post-install-installpackage.ps1 hook ran for installpackage 1.0.0", LogLevel.Info).Should().BeTrue();
             }
 
             [Fact]
@@ -3749,7 +3749,7 @@ namespace chocolatey.tests.integration.scenarios
             [Platform(Exclude = "Mono")]
             public void Should_not_have_executed_uninstall_hook_script()
             {
-                MockLogger.ContainsMessage("post-uninstall-all.ps1 hook ran for installpackage 1.0.0", LogLevel.Info).ShouldBeFalse();
+                MockLogger.ContainsMessage("post-uninstall-all.ps1 hook ran for installpackage 1.0.0", LogLevel.Info).Should().BeFalse();
             }
 
             [Fact]
@@ -3757,7 +3757,7 @@ namespace chocolatey.tests.integration.scenarios
             [Platform(Exclude = "Mono")]
             public void Should_not_have_executed_upgradepackage_hook_script()
             {
-                MockLogger.ContainsMessage("pre-install-upgradepackage.ps1 hook ran for installpackage 1.0.0", LogLevel.Info).ShouldBeFalse();
+                MockLogger.ContainsMessage("pre-install-upgradepackage.ps1 hook ran for installpackage 1.0.0", LogLevel.Info).Should().BeFalse();
             }
 
             [Fact]
@@ -3765,7 +3765,7 @@ namespace chocolatey.tests.integration.scenarios
             [Platform(Exclude = "Mono")]
             public void Should_not_have_executed_beforemodify_hook_script()
             {
-                MockLogger.ContainsMessage("pre-beforemodify-all.ps1 hook ran for installpackage 1.0.0", LogLevel.Info).ShouldBeFalse();
+                MockLogger.ContainsMessage("pre-beforemodify-all.ps1 hook ran for installpackage 1.0.0", LogLevel.Info).Should().BeFalse();
             }
         }
 
@@ -3808,7 +3808,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, Configuration.PackageNames + NuGetConstants.PackageExtension);
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().ShouldEqual("1.0.0");
+                    packageReader.NuspecReader.GetVersion().ToStringSafe().Should().Be("1.0.0");
                 }
             }
 
@@ -3888,7 +3888,7 @@ namespace chocolatey.tests.integration.scenarios
                     if (message.Contains("is gui? False")) messageFound = true;
                 }
 
-                messageFound.ShouldBeTrue("GUI false message not found");
+                messageFound.Should().BeTrue("GUI false message not found");
             }
 
             [Fact]
@@ -3915,7 +3915,7 @@ namespace chocolatey.tests.integration.scenarios
                     if (message.Contains("is gui? True")) messageFound = true;
                 }
 
-                messageFound.ShouldBeTrue("GUI true message not found");
+                messageFound.Should().BeTrue("GUI true message not found");
             }
 
             [Fact]
@@ -3927,37 +3927,37 @@ namespace chocolatey.tests.integration.scenarios
                     if (message.Contains("1/1")) installedSuccessfully = true;
                 }
 
-                installedSuccessfully.ShouldBeTrue();
+                installedSuccessfully.Should().BeTrue();
             }
 
             [Fact]
             public void Should_have_a_successful_package_result()
             {
-                _packageResult.Success.ShouldBeTrue();
+                _packageResult.Success.Should().BeTrue();
             }
 
             [Fact]
             public void Should_not_have_inconclusive_package_result()
             {
-                _packageResult.Inconclusive.ShouldBeFalse();
+                _packageResult.Inconclusive.Should().BeFalse();
             }
 
             [Fact]
             public void Should_not_have_warning_package_result()
             {
-                _packageResult.Warning.ShouldBeFalse();
+                _packageResult.Warning.Should().BeFalse();
             }
 
             [Fact]
             public void Config_should_match_package_result_name()
             {
-                _packageResult.Name.ShouldEqual(Configuration.PackageNames);
+                _packageResult.Name.Should().Be(Configuration.PackageNames);
             }
 
             [Fact]
             public void Should_have_a_version_of_one_dot_zero_dot_zero()
             {
-                _packageResult.Version.ShouldEqual("1.0.0");
+                _packageResult.Version.Should().Be("1.0.0");
             }
 
             [Fact]
@@ -3965,7 +3965,7 @@ namespace chocolatey.tests.integration.scenarios
             [Platform(Exclude = "Mono")]
             public void Should_not_have_executed_chocolateyInstall_script()
             {
-                MockLogger.ContainsMessage("portablepackage v1.0.0 has been installed", LogLevel.Info).ShouldBeFalse();
+                MockLogger.ContainsMessage("portablepackage v1.0.0 has been installed", LogLevel.Info).Should().BeFalse();
             }
 
             [Fact]
@@ -3973,7 +3973,7 @@ namespace chocolatey.tests.integration.scenarios
             [Platform(Exclude = "Mono")]
             public void Should_have_executed_pre_all_hook_script()
             {
-                MockLogger.ContainsMessage("pre-install-all.ps1 hook ran for portablepackage 1.0.0", LogLevel.Info).ShouldBeTrue();
+                MockLogger.ContainsMessage("pre-install-all.ps1 hook ran for portablepackage 1.0.0", LogLevel.Info).Should().BeTrue();
             }
 
             [Fact]
@@ -3981,7 +3981,7 @@ namespace chocolatey.tests.integration.scenarios
             [Platform(Exclude = "Mono")]
             public void Should_have_executed_post_all_hook_script()
             {
-                MockLogger.ContainsMessage("post-install-all.ps1 hook ran for portablepackage 1.0.0", LogLevel.Info).ShouldBeTrue();
+                MockLogger.ContainsMessage("post-install-all.ps1 hook ran for portablepackage 1.0.0", LogLevel.Info).Should().BeTrue();
             }
 
             [Fact]
@@ -3989,7 +3989,7 @@ namespace chocolatey.tests.integration.scenarios
             [Platform(Exclude = "Mono")]
             public void Should_not_have_executed_uninstall_hook_script()
             {
-                MockLogger.ContainsMessage("post-uninstall-all.ps1 hook ran for portablepackage 1.0.0", LogLevel.Info).ShouldBeFalse();
+                MockLogger.ContainsMessage("post-uninstall-all.ps1 hook ran for portablepackage 1.0.0", LogLevel.Info).Should().BeFalse();
             }
 
             [Fact]
@@ -3997,7 +3997,7 @@ namespace chocolatey.tests.integration.scenarios
             [Platform(Exclude = "Mono")]
             public void Should_not_have_executed_upgradepackage_hook_script()
             {
-                MockLogger.ContainsMessage("pre-install-upgradepackage.ps1 hook ran for portablepackage 1.0.0", LogLevel.Info).ShouldBeFalse();
+                MockLogger.ContainsMessage("pre-install-upgradepackage.ps1 hook ran for portablepackage 1.0.0", LogLevel.Info).Should().BeFalse();
             }
 
             [Fact]
@@ -4005,7 +4005,7 @@ namespace chocolatey.tests.integration.scenarios
             [Platform(Exclude = "Mono")]
             public void Should_not_have_executed_beforemodify_hook_script()
             {
-                MockLogger.ContainsMessage("pre-beforemodify-all.ps1 hook ran for portablepackage 1.0.0", LogLevel.Info).ShouldBeFalse();
+                MockLogger.ContainsMessage("pre-beforemodify-all.ps1 hook ran for portablepackage 1.0.0", LogLevel.Info).Should().BeFalse();
             }
         }
 
@@ -4051,7 +4051,7 @@ namespace chocolatey.tests.integration.scenarios
 
                 using (var reader = new PackageFolderReader(packageDirectory))
                 {
-                    reader.NuspecReader.GetVersion().ToNormalizedString().ShouldEqual("2.0.0");
+                    reader.NuspecReader.GetVersion().ToNormalizedString().Should().Be("2.0.0");
                 }
             }
 
@@ -4080,37 +4080,37 @@ namespace chocolatey.tests.integration.scenarios
                     if (message.Contains("1/1")) installedSuccessfully = true;
                 }
 
-                installedSuccessfully.ShouldBeTrue();
+                installedSuccessfully.Should().BeTrue();
             }
 
             [Fact]
             public void Should_have_a_successful_package_result()
             {
-                packageResult.Success.ShouldBeTrue();
+                packageResult.Success.Should().BeTrue();
             }
 
             [Fact]
             public void Should_not_have_inconclusive_package_result()
             {
-                packageResult.Inconclusive.ShouldBeFalse();
+                packageResult.Inconclusive.Should().BeFalse();
             }
 
             [Fact]
             public void Should_not_have_warning_package_result()
             {
-                packageResult.Warning.ShouldBeFalse();
+                packageResult.Warning.Should().BeFalse();
             }
 
             [Fact]
             public void Config_should_match_package_result_name()
             {
-                packageResult.Name.ShouldEqual(Configuration.PackageNames);
+                packageResult.Name.Should().Be(Configuration.PackageNames);
             }
 
             [Fact]
             public void Should_have_a_version_of_two_dot_zero_dot_zero()
             {
-                packageResult.Version.ShouldEqual("2.0.0");
+                packageResult.Version.Should().Be("2.0.0");
             }
 
             [Fact]
@@ -4118,7 +4118,7 @@ namespace chocolatey.tests.integration.scenarios
             [Platform(Exclude = "Mono")]
             public void Should_have_reported_package_installed()
             {
-                MockLogger.ContainsMessage("isdependency 2.0.0 Installed", LogLevel.Info).ShouldBeTrue();
+                MockLogger.ContainsMessage("isdependency 2.0.0 Installed", LogLevel.Info).Should().BeTrue();
             }
         }
 
@@ -4144,7 +4144,7 @@ namespace chocolatey.tests.integration.scenarios
             {
                 foreach (var packageResult in Results)
                 {
-                    packageResult.Value.Success.ShouldBeFalse();
+                    packageResult.Value.Success.Should().BeFalse();
                 }
             }
 
@@ -4161,7 +4161,7 @@ namespace chocolatey.tests.integration.scenarios
             {
                 foreach (var packageResult in Results)
                 {
-                    packageResult.Value.Inconclusive.ShouldBeFalse();
+                    packageResult.Value.Inconclusive.Should().BeFalse();
                 }
             }
 
@@ -4170,7 +4170,7 @@ namespace chocolatey.tests.integration.scenarios
             {
                 foreach (var packageResult in Results)
                 {
-                    packageResult.Value.Warning.ShouldBeFalse();
+                    packageResult.Value.Warning.Should().BeFalse();
                 }
             }
 
@@ -4180,8 +4180,8 @@ namespace chocolatey.tests.integration.scenarios
                 foreach (var packageResult in Results)
                 {
                     var message = packageResult.Value.Messages.First();
-                    message.MessageType.ShouldEqual(ResultType.Error);
-                    message.Message.ShouldStartWith("non-existing not installed. The package was not found with the source(s) listed.");
+                    message.MessageType.Should().Be(ResultType.Error);
+                    message.Message.Should().StartWith("non-existing not installed. The package was not found with the source(s) listed.");
                 }
             }
         }
@@ -4231,7 +4231,7 @@ namespace chocolatey.tests.integration.scenarios
             {
                 foreach (var packageResult in Results)
                 {
-                    packageResult.Value.Version.ShouldEqual("1.0.0");
+                    packageResult.Value.Version.Should().Be("1.0.0");
                 }
             }
 
@@ -4244,7 +4244,7 @@ namespace chocolatey.tests.integration.scenarios
 
                 using (var reader = new PackageFolderReader(packageFolder))
                 {
-                    reader.NuspecReader.GetVersion().ToNormalizedString().ShouldEqual("1.0.0");
+                    reader.NuspecReader.GetVersion().ToNormalizedString().Should().Be("1.0.0");
                 }
             }
 
@@ -4253,7 +4253,7 @@ namespace chocolatey.tests.integration.scenarios
             {
                 foreach (var packageResult in Results)
                 {
-                    packageResult.Value.Inconclusive.ShouldBeFalse();
+                    packageResult.Value.Inconclusive.Should().BeFalse();
                 }
             }
 
@@ -4262,7 +4262,7 @@ namespace chocolatey.tests.integration.scenarios
             {
                 foreach (var packageResult in Results)
                 {
-                    packageResult.Value.Warning.ShouldBeFalse();
+                    packageResult.Value.Warning.Should().BeFalse();
                 }
             }
 
@@ -4271,7 +4271,7 @@ namespace chocolatey.tests.integration.scenarios
             {
                 foreach (var packageResult in Results)
                 {
-                    packageResult.Value.Success.ShouldBeTrue();
+                    packageResult.Value.Success.Should().BeTrue();
                 }
             }
         }
@@ -4320,7 +4320,7 @@ namespace chocolatey.tests.integration.scenarios
 
                 using (var reader = new PackageFolderReader(packageFolder))
                 {
-                    reader.NuspecReader.GetVersion().ToNormalizedString().ShouldEqual("1.0.0");
+                    reader.NuspecReader.GetVersion().ToNormalizedString().Should().Be("1.0.0");
                 }
             }
 
@@ -4329,7 +4329,7 @@ namespace chocolatey.tests.integration.scenarios
             {
                 foreach (var packageResult in Results)
                 {
-                    packageResult.Value.Version.ShouldEqual("1.0.0");
+                    packageResult.Value.Version.Should().Be("1.0.0");
                 }
             }
 
@@ -4338,7 +4338,7 @@ namespace chocolatey.tests.integration.scenarios
             {
                 foreach (var packageResult in Results)
                 {
-                    packageResult.Value.Inconclusive.ShouldBeFalse();
+                    packageResult.Value.Inconclusive.Should().BeFalse();
                 }
             }
 
@@ -4347,7 +4347,7 @@ namespace chocolatey.tests.integration.scenarios
             {
                 foreach (var packageResult in Results)
                 {
-                    packageResult.Value.Warning.ShouldBeFalse();
+                    packageResult.Value.Warning.Should().BeFalse();
                 }
             }
 
@@ -4356,7 +4356,7 @@ namespace chocolatey.tests.integration.scenarios
             {
                 foreach (var packageResult in Results)
                 {
-                    packageResult.Value.Success.ShouldBeTrue();
+                    packageResult.Value.Success.Should().BeTrue();
                 }
             }
         }
@@ -4427,7 +4427,7 @@ namespace chocolatey.tests.integration.scenarios
 
                 using (var reader = new PackageFolderReader(path))
                 {
-                    reader.NuspecReader.GetVersion().ToNormalizedString().ShouldEqual(version);
+                    reader.NuspecReader.GetVersion().ToNormalizedString().Should().Be(version);
                 }
             }
 
@@ -4435,7 +4435,7 @@ namespace chocolatey.tests.integration.scenarios
             public void Should_report_installed_version_of_package(string name, string version)
             {
                 var package = Results.First(r => r.Key == name);
-                package.Value.Version.ShouldEqual(version);
+                package.Value.Version.Should().Be(version);
             }
 
             [Fact]
@@ -4443,7 +4443,7 @@ namespace chocolatey.tests.integration.scenarios
             {
                 foreach (var packageResult in Results)
                 {
-                    packageResult.Value.Inconclusive.ShouldBeFalse();
+                    packageResult.Value.Inconclusive.Should().BeFalse();
                 }
             }
 
@@ -4452,7 +4452,7 @@ namespace chocolatey.tests.integration.scenarios
             {
                 foreach (var packageResult in Results)
                 {
-                    packageResult.Value.Warning.ShouldBeFalse();
+                    packageResult.Value.Warning.Should().BeFalse();
                 }
             }
 
@@ -4461,7 +4461,7 @@ namespace chocolatey.tests.integration.scenarios
             {
                 foreach (var packageResult in Results)
                 {
-                    packageResult.Value.Success.ShouldBeTrue();
+                    packageResult.Value.Success.Should().BeTrue();
                 }
             }
         }
@@ -4510,7 +4510,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, Configuration.PackageNames + NuGetConstants.PackageExtension);
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().ShouldEqual("1.0.0");
+                    packageReader.NuspecReader.GetVersion().ToStringSafe().Should().Be("1.0.0");
                 }
             }
 
@@ -4539,37 +4539,37 @@ namespace chocolatey.tests.integration.scenarios
                     if (message.Contains("1/1")) installedSuccessfully = true;
                 }
 
-                installedSuccessfully.ShouldBeTrue();
+                installedSuccessfully.Should().BeTrue();
             }
 
             [Fact]
             public void Should_have_a_successful_package_result()
             {
-                _packageResult.Success.ShouldBeTrue();
+                _packageResult.Success.Should().BeTrue();
             }
 
             [Fact]
             public void Should_not_have_inconclusive_package_result()
             {
-                _packageResult.Inconclusive.ShouldBeFalse();
+                _packageResult.Inconclusive.Should().BeFalse();
             }
 
             [Fact]
             public void Should_not_have_warning_package_result()
             {
-                _packageResult.Warning.ShouldBeFalse();
+                _packageResult.Warning.Should().BeFalse();
             }
 
             [Fact]
             public void Config_should_match_package_result_name()
             {
-                _packageResult.Name.ShouldEqual(Configuration.PackageNames);
+                _packageResult.Name.Should().Be(Configuration.PackageNames);
             }
 
             [Fact]
             public void Should_have_a_version_of_one_dot_zero_dot_zero()
             {
-                _packageResult.Version.ShouldEqual("1.0.0");
+                _packageResult.Version.Should().Be("1.0.0");
             }
 
             [Fact]
@@ -4577,7 +4577,7 @@ namespace chocolatey.tests.integration.scenarios
             [Platform(Exclude = "Mono")]
             public void Should_have_executed_chocolateyInstall_script()
             {
-                MockLogger.ContainsMessage("UpperCase 1.0.0 Installed", LogLevel.Info).ShouldBeTrue();
+                MockLogger.ContainsMessage("UpperCase 1.0.0 Installed", LogLevel.Info).Should().BeTrue();
             }
         }
 
@@ -4618,7 +4618,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, Configuration.PackageNames + NuGetConstants.PackageExtension);
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().ShouldEqual("1.0.0");
+                    packageReader.NuspecReader.GetVersion().ToStringSafe().Should().Be("1.0.0");
                 }
             }
 
@@ -4647,7 +4647,7 @@ namespace chocolatey.tests.integration.scenarios
                     if (message.Contains("1/1")) installedSuccessfully = true;
                 }
 
-                installedSuccessfully.ShouldBeTrue();
+                installedSuccessfully.Should().BeTrue();
             }
 
             [Fact]
@@ -4658,37 +4658,37 @@ namespace chocolatey.tests.integration.scenarios
                 {
                     if (message.Contains("Issues found with nuspec elements")) upgradeMessage = true;
                 }
-                upgradeMessage.ShouldBeTrue();
+                upgradeMessage.Should().BeTrue();
             }
 
             [Fact]
             public void Should_have_a_successful_package_result()
             {
-                _packageResult.Success.ShouldBeTrue();
+                _packageResult.Success.Should().BeTrue();
             }
 
             [Fact]
             public void Should_not_have_inconclusive_package_result()
             {
-                _packageResult.Inconclusive.ShouldBeFalse();
+                _packageResult.Inconclusive.Should().BeFalse();
             }
 
             [Fact]
             public void Should_have_warning_package_result()
             {
-                _packageResult.Warning.ShouldBeTrue();
+                _packageResult.Warning.Should().BeTrue();
             }
 
             [Fact]
             public void Config_should_match_package_result_name()
             {
-                _packageResult.Name.ShouldEqual(Configuration.PackageNames);
+                _packageResult.Name.Should().Be(Configuration.PackageNames);
             }
 
             [Fact]
             public void Should_have_a_version_of_one_dot_zero_dot_zero()
             {
-                _packageResult.Version.ShouldEqual("1.0.0");
+                _packageResult.Version.Should().Be("1.0.0");
             }
 
             [Fact]
@@ -4696,7 +4696,7 @@ namespace chocolatey.tests.integration.scenarios
             [Platform(Exclude = "Mono")]
             public void Should_have_executed_chocolateyInstall_script()
             {
-                MockLogger.ContainsMessage("unsupportedelements 1.0.0 Installed", LogLevel.Info).ShouldBeTrue();
+                MockLogger.ContainsMessage("unsupportedelements 1.0.0 Installed", LogLevel.Info).Should().BeTrue();
             }
         }
 
@@ -4740,7 +4740,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, Configuration.PackageNames + NuGetConstants.PackageExtension);
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToStringSafe().ShouldEqual(NonNormalizedVersion);
+                    packageReader.NuspecReader.GetVersion().ToStringSafe().Should().Be(NonNormalizedVersion);
                 }
             }
 
@@ -4769,37 +4769,37 @@ namespace chocolatey.tests.integration.scenarios
                     if (message.Contains("1/1")) installedSuccessfully = true;
                 }
 
-                installedSuccessfully.ShouldBeTrue();
+                installedSuccessfully.Should().BeTrue();
             }
 
             [Fact]
             public void Should_have_a_successful_package_result()
             {
-                _packageResult.Success.ShouldBeTrue();
+                _packageResult.Success.Should().BeTrue();
             }
 
             [Fact]
             public void Should_not_have_inconclusive_package_result()
             {
-                _packageResult.Inconclusive.ShouldBeFalse();
+                _packageResult.Inconclusive.Should().BeFalse();
             }
 
             [Fact]
             public void Should_not_have_warning_package_result()
             {
-                _packageResult.Warning.ShouldBeFalse();
+                _packageResult.Warning.Should().BeFalse();
             }
 
             [Fact]
             public void Config_should_match_package_result_name()
             {
-                _packageResult.Name.ShouldEqual(Configuration.PackageNames);
+                _packageResult.Name.Should().Be(Configuration.PackageNames);
             }
 
             [Fact]
             public void Result_should_have_the_correct_version()
             {
-                _packageResult.Version.ShouldEqual(NormalizedVersion);
+                _packageResult.Version.Should().Be(NonNormalizedVersion);
             }
 
             [Fact]
@@ -4807,9 +4807,9 @@ namespace chocolatey.tests.integration.scenarios
             [Platform(Exclude = "Mono")]
             public void Should_have_executed_chocolateyInstall_script()
             {
-                var message = "installpackage v{0} has been installed".FormatWith(NormalizedVersion);
+                var message = "installpackage v{0} has been installed".FormatWith(NonNormalizedVersion);
 
-                MockLogger.ContainsMessage(message, LogLevel.Info).ShouldBeTrue();
+                MockLogger.ContainsMessage(message, LogLevel.Info).Should().BeTrue();
             }
 
             [Fact]
@@ -4872,7 +4872,7 @@ namespace chocolatey.tests.integration.scenarios
                     if (message.Contains("is gui? False")) messageFound = true;
                 }
 
-                messageFound.ShouldBeTrue("GUI false message not found");
+                messageFound.Should().BeTrue("GUI false message not found");
             }
 
             [Fact]
@@ -4899,7 +4899,7 @@ namespace chocolatey.tests.integration.scenarios
                     if (message.Contains("is gui? True")) messageFound = true;
                 }
 
-                messageFound.ShouldBeTrue("GUI true message not found");
+                messageFound.Should().BeTrue("GUI true message not found");
             }
         }
 
@@ -4984,7 +4984,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", TargetPackageName, "{0}.nupkg".FormatWith(TargetPackageName));
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().ShouldEqual("2.0.0");
+                    packageReader.NuspecReader.GetVersion().ToStringSafe().Should().Be("2.0.0");
                 }
             }
 
@@ -4994,14 +4994,14 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", DependencyName, "{0}.nupkg".FormatWith(DependencyName));
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().ShouldEqual("2.0.0");
+                    packageReader.NuspecReader.GetVersion().ToStringSafe().Should().Be("2.0.0");
                 }
             }
 
             [Fact]
             public void Should_contain_a_message_that_everything_installed_successfully()
             {
-                MockLogger.ContainsMessage("installed 2/2", LogLevel.Warn).ShouldBeTrue();
+                MockLogger.ContainsMessage("installed 2/2", LogLevel.Warn).Should().BeTrue();
             }
 
             [Fact]
@@ -5009,7 +5009,7 @@ namespace chocolatey.tests.integration.scenarios
             [Platform(Exclude = "Mono")]
             public void Should_not_run_target_package_beforeModify_for_upgraded_version()
             {
-                MockLogger.ContainsMessage("Ran BeforeModify: {0} {1}".FormatWith(TargetPackageName, "2.0.0"), LogLevel.Info).ShouldBeFalse();
+                MockLogger.ContainsMessage("Ran BeforeModify: {0} {1}".FormatWith(TargetPackageName, "2.0.0"), LogLevel.Info).Should().BeFalse();
             }
 
             [Fact]
@@ -5017,7 +5017,7 @@ namespace chocolatey.tests.integration.scenarios
             [Platform(Exclude = "Mono")]
             public void Should_run_already_installed_dependency_package_beforeModify()
             {
-                MockLogger.ContainsMessage("Ran BeforeModify: {0} {1}".FormatWith(DependencyName, "1.0.0"), LogLevel.Info).ShouldBeTrue();
+                MockLogger.ContainsMessage("Ran BeforeModify: {0} {1}".FormatWith(DependencyName, "1.0.0"), LogLevel.Info).Should().BeTrue();
             }
 
             [Fact]
@@ -5025,7 +5025,7 @@ namespace chocolatey.tests.integration.scenarios
             [Platform(Exclude = "Mono")]
             public void Should_not_run_dependency_package_beforeModify_for_upgraded_version()
             {
-                MockLogger.ContainsMessage("Ran BeforeModify: {0} {1}".FormatWith(DependencyName, "2.0.0"), LogLevel.Info).ShouldBeFalse();
+                MockLogger.ContainsMessage("Ran BeforeModify: {0} {1}".FormatWith(DependencyName, "2.0.0"), LogLevel.Info).Should().BeFalse();
             }
 
             [Fact]
@@ -5033,7 +5033,7 @@ namespace chocolatey.tests.integration.scenarios
             {
                 foreach (var packageResult in Results)
                 {
-                    packageResult.Value.Success.ShouldBeTrue();
+                    packageResult.Value.Success.Should().BeTrue();
                 }
             }
 
@@ -5042,7 +5042,7 @@ namespace chocolatey.tests.integration.scenarios
             {
                 foreach (var packageResult in Results)
                 {
-                    packageResult.Value.Inconclusive.ShouldBeFalse();
+                    packageResult.Value.Inconclusive.Should().BeFalse();
                 }
             }
 
@@ -5051,7 +5051,7 @@ namespace chocolatey.tests.integration.scenarios
             {
                 foreach (var packageResult in Results)
                 {
-                    packageResult.Value.Warning.ShouldBeFalse();
+                    packageResult.Value.Warning.Should().BeFalse();
                 }
             }
         }

--- a/src/chocolatey.tests.integration/scenarios/ListScenarios.cs
+++ b/src/chocolatey.tests.integration/scenarios/ListScenarios.cs
@@ -21,7 +21,7 @@ namespace chocolatey.tests.integration.scenarios
     using chocolatey.infrastructure.app.services;
     using chocolatey.infrastructure.results;
     using NuGet.Configuration;
-    using Should;
+    using FluentAssertions;
 
     public class ListScenarios
     {
@@ -62,28 +62,28 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_contain_packages_and_versions_with_a_space_between_them()
             {
-                MockLogger.ContainsMessage("upgradepackage 1.0.0").ShouldBeTrue(userMessage: "Warnings: " + string.Join("\n", MockLogger.Messages["Info"]));
+                MockLogger.ContainsMessage("upgradepackage 1.0.0").Should().BeTrue("Warnings: " + string.Join("\n", MockLogger.Messages["Info"]));
             }
 
             [Fact]
             public void Should_not_contain_packages_and_versions_with_a_pipe_between_them()
             {
-                MockLogger.ContainsMessage("upgradepackage|1.0.0").ShouldBeFalse();
+                MockLogger.ContainsMessage("upgradepackage|1.0.0").Should().BeFalse();
             }
 
             [Fact]
             public void Should_contain_a_summary()
             {
-                MockLogger.ContainsMessage("packages installed").ShouldBeTrue();
+                MockLogger.ContainsMessage("packages installed").Should().BeTrue();
             }
 
             [Fact]
             public void Should_contain_debugging_messages()
             {
-                MockLogger.ContainsMessage("Searching for package information", LogLevel.Debug).ShouldBeTrue();
-                MockLogger.ContainsMessage("Running list with the following filter", LogLevel.Debug).ShouldBeTrue();
-                MockLogger.ContainsMessage("Start of List", LogLevel.Debug).ShouldBeTrue();
-                MockLogger.ContainsMessage("End of List", LogLevel.Debug).ShouldBeTrue();
+                MockLogger.ContainsMessage("Searching for package information", LogLevel.Debug).Should().BeTrue();
+                MockLogger.ContainsMessage("Running list with the following filter", LogLevel.Debug).Should().BeTrue();
+                MockLogger.ContainsMessage("Start of List", LogLevel.Debug).Should().BeTrue();
+                MockLogger.ContainsMessage("End of List", LogLevel.Debug).Should().BeTrue();
             }
         }
 
@@ -104,13 +104,13 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_contain_package_name()
             {
-                MockLogger.ContainsMessage("upgradepackage").ShouldBeTrue();
+                MockLogger.ContainsMessage("upgradepackage").Should().BeTrue();
             }
 
             [Fact]
             public void Should_not_contain_any_version_number()
             {
-                MockLogger.ContainsMessage(".0").ShouldBeFalse();
+                MockLogger.ContainsMessage(".0").Should().BeFalse();
             }
         }
 
@@ -132,35 +132,35 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_contain_packages_and_versions_with_a_pipe_between_them()
             {
-                MockLogger.ContainsMessage("upgradepackage|1.0.0").ShouldBeTrue();
+                MockLogger.ContainsMessage("upgradepackage|1.0.0").Should().BeTrue();
             }
 
             [Fact]
             public void Should_only_have_messages_related_to_package_information()
             {
                 var count = MockLogger.MessagesFor(LogLevel.Info).OrEmpty().Count();
-                count.ShouldEqual(2);
+                count.Should().Be(2);
             }
 
             [Fact]
             public void Should_not_contain_packages_and_versions_with_a_space_between_them()
             {
-                MockLogger.ContainsMessage("upgradepackage 1.0.0").ShouldBeFalse();
+                MockLogger.ContainsMessage("upgradepackage 1.0.0").Should().BeFalse();
             }
 
             [Fact]
             public void Should_not_contain_a_summary()
             {
-                MockLogger.ContainsMessage("packages installed").ShouldBeFalse();
+                MockLogger.ContainsMessage("packages installed").Should().BeFalse();
             }
 
             [Fact]
             public void Should_not_contain_debugging_messages()
             {
-                MockLogger.ContainsMessage("Searching for package information", LogLevel.Debug).ShouldBeFalse();
-                MockLogger.ContainsMessage("Running list with the following filter", LogLevel.Debug).ShouldBeFalse();
-                MockLogger.ContainsMessage("Start of List", LogLevel.Debug).ShouldBeFalse();
-                MockLogger.ContainsMessage("End of List", LogLevel.Debug).ShouldBeFalse();
+                MockLogger.ContainsMessage("Searching for package information", LogLevel.Debug).Should().BeFalse();
+                MockLogger.ContainsMessage("Running list with the following filter", LogLevel.Debug).Should().BeFalse();
+                MockLogger.ContainsMessage("Start of List", LogLevel.Debug).Should().BeFalse();
+                MockLogger.ContainsMessage("End of List", LogLevel.Debug).Should().BeFalse();
             }
         }
 
@@ -183,19 +183,19 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_contain_packages_id()
             {
-                MockLogger.ContainsMessage("upgradepackage").ShouldBeTrue();
+                MockLogger.ContainsMessage("upgradepackage").Should().BeTrue();
             }
 
             [Fact]
             public void Should_not_contain_any_version_number()
             {
-                MockLogger.ContainsMessage(".0").ShouldBeFalse();
+                MockLogger.ContainsMessage(".0").Should().BeFalse();
             }
 
             [Fact]
             public void Should_not_contain_pipe()
             {
-                MockLogger.ContainsMessage("|").ShouldBeFalse();
+                MockLogger.ContainsMessage("|").Should().BeFalse();
             }
         }
 
@@ -217,34 +217,34 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_contain_packages_and_versions_with_a_space_between_them()
             {
-                MockLogger.ContainsMessage("upgradepackage 1.0.0").ShouldBeTrue();
+                MockLogger.ContainsMessage("upgradepackage 1.0.0").Should().BeTrue();
             }
 
             [Fact]
             public void Should_contain_uppercase_id_package()
             {
-                MockLogger.ContainsMessage("UpperCase 1.1.0").ShouldBeTrue();
+                MockLogger.ContainsMessage("UpperCase 1.1.0").Should().BeTrue();
             }
 
             [Fact]
             public void Should_not_contain_packages_and_versions_with_a_pipe_between_them()
             {
-                MockLogger.ContainsMessage("upgradepackage|1.0.0").ShouldBeFalse();
+                MockLogger.ContainsMessage("upgradepackage|1.0.0").Should().BeFalse();
             }
 
             [Fact]
             public void Should_contain_a_summary()
             {
-                MockLogger.ContainsMessage("packages installed").ShouldBeTrue();
+                MockLogger.ContainsMessage("packages installed").Should().BeTrue();
             }
 
             [Fact]
             public void Should_contain_debugging_messages()
             {
-                MockLogger.ContainsMessage("Searching for package information", LogLevel.Debug).ShouldBeTrue();
-                MockLogger.ContainsMessage("Running list with the following filter", LogLevel.Debug).ShouldBeTrue();
-                MockLogger.ContainsMessage("Start of List", LogLevel.Debug).ShouldBeTrue();
-                MockLogger.ContainsMessage("End of List", LogLevel.Debug).ShouldBeTrue();
+                MockLogger.ContainsMessage("Searching for package information", LogLevel.Debug).Should().BeTrue();
+                MockLogger.ContainsMessage("Running list with the following filter", LogLevel.Debug).Should().BeTrue();
+                MockLogger.ContainsMessage("Start of List", LogLevel.Debug).Should().BeTrue();
+                MockLogger.ContainsMessage("End of List", LogLevel.Debug).Should().BeTrue();
             }
         }
     }

--- a/src/chocolatey.tests.integration/scenarios/ListScenarios.cs
+++ b/src/chocolatey.tests.integration/scenarios/ListScenarios.cs
@@ -22,6 +22,7 @@ namespace chocolatey.tests.integration.scenarios
     using chocolatey.infrastructure.results;
     using NuGet.Configuration;
     using FluentAssertions;
+    using FluentAssertions.Execution;
 
     public class ListScenarios
     {
@@ -80,10 +81,14 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_contain_debugging_messages()
             {
-                MockLogger.ContainsMessage("Searching for package information", LogLevel.Debug).Should().BeTrue();
-                MockLogger.ContainsMessage("Running list with the following filter", LogLevel.Debug).Should().BeTrue();
-                MockLogger.ContainsMessage("Start of List", LogLevel.Debug).Should().BeTrue();
-                MockLogger.ContainsMessage("End of List", LogLevel.Debug).Should().BeTrue();
+                MockLogger.Messages.Should().ContainKey(LogLevel.Debug.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains("Searching for package information"));
+                MockLogger.Messages.Should().ContainKey(LogLevel.Debug.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains("Running list with the following filter"));
+                MockLogger.Messages.Should().ContainKey(LogLevel.Debug.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains("Start of List"));
+                MockLogger.Messages.Should().ContainKey(LogLevel.Debug.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains("End of List"));
             }
         }
 
@@ -138,8 +143,9 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_only_have_messages_related_to_package_information()
             {
-                var count = MockLogger.MessagesFor(LogLevel.Info).OrEmpty().Count();
-                count.Should().Be(2);
+                MockLogger.Messages.Should()
+                    .ContainKey(LogLevel.Info.ToStringSafe())
+                    .WhoseValue.Should().HaveCount(2);
             }
 
             [Fact]
@@ -157,10 +163,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_not_contain_debugging_messages()
             {
-                MockLogger.ContainsMessage("Searching for package information", LogLevel.Debug).Should().BeFalse();
-                MockLogger.ContainsMessage("Running list with the following filter", LogLevel.Debug).Should().BeFalse();
-                MockLogger.ContainsMessage("Start of List", LogLevel.Debug).Should().BeFalse();
-                MockLogger.ContainsMessage("End of List", LogLevel.Debug).Should().BeFalse();
+                MockLogger.Messages.Should().NotContainKey(LogLevel.Debug.ToStringSafe());
             }
         }
 
@@ -241,10 +244,17 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_contain_debugging_messages()
             {
-                MockLogger.ContainsMessage("Searching for package information", LogLevel.Debug).Should().BeTrue();
-                MockLogger.ContainsMessage("Running list with the following filter", LogLevel.Debug).Should().BeTrue();
-                MockLogger.ContainsMessage("Start of List", LogLevel.Debug).Should().BeTrue();
-                MockLogger.ContainsMessage("End of List", LogLevel.Debug).Should().BeTrue();
+                using (new AssertionScope())
+                {
+                    MockLogger.Messages.Should().ContainKey(LogLevel.Debug.ToStringSafe())
+                        .WhoseValue.Should().Contain(m => m.Contains("Searching for package information"));
+                    MockLogger.Messages.Should().ContainKey(LogLevel.Debug.ToStringSafe())
+                        .WhoseValue.Should().Contain(m => m.Contains("Running list with the following filter"));
+                    MockLogger.Messages.Should().ContainKey(LogLevel.Debug.ToStringSafe())
+                        .WhoseValue.Should().Contain(m => m.Contains("Start of List"));
+                    MockLogger.Messages.Should().ContainKey(LogLevel.Debug.ToStringSafe())
+                        .WhoseValue.Should().Contain(m => m.Contains("End of List"));
+                }
             }
         }
     }

--- a/src/chocolatey.tests.integration/scenarios/PackScenarios.cs
+++ b/src/chocolatey.tests.integration/scenarios/PackScenarios.cs
@@ -28,7 +28,7 @@ namespace chocolatey.tests.integration.scenarios
 
     using NUnit.Framework;
 
-    using Should;
+    using FluentAssertions;
 
     public class PackScenarios
     {
@@ -71,7 +71,7 @@ namespace chocolatey.tests.integration.scenarios
             {
                 AddFile("myPackage.nuspec", string.Empty);
 
-                ServiceAct.ShouldThrow<XmlException>();
+                ServiceAct.Should().Throw<XmlException>();
             }
 
             [TestCase("")]
@@ -96,7 +96,7 @@ namespace chocolatey.tests.integration.scenarios
   </metadata>
 </package>".FormatWith(version));
 
-                ServiceAct.ShouldThrow<InvalidDataException>();
+                ServiceAct.Should().Throw<InvalidDataException>();
             }
         }
 
@@ -154,9 +154,9 @@ namespace chocolatey.tests.integration.scenarios
             public void Generated_package_should_be_in_current_directory()
             {
                 var infos = MockLogger.MessagesFor(LogLevel.Info);
-                infos.Count.ShouldEqual(2);
-                infos[0].ShouldEqual("Attempting to build package from 'myPackage.nuspec'.");
-                infos[1].ShouldEqual(string.Concat("Successfully created package '", PackagePath, "'"));
+                infos.Count.Should().Be(2);
+                infos[0].Should().Be("Attempting to build package from 'myPackage.nuspec'.");
+                infos[1].Should().Be(string.Concat("Successfully created package '", PackagePath, "'"));
 
                 FileAssert.Exists(PackagePath);
             }
@@ -168,7 +168,7 @@ namespace chocolatey.tests.integration.scenarios
                 {
                     var version = packageReader.NuspecReader.GetVersion();
 
-                    version.ToFullString().ShouldEqual(ExpectedNuspecVersion);
+                    version.ToFullString().Should().Be(ExpectedNuspecVersion);
                 }
             }
 
@@ -177,11 +177,11 @@ namespace chocolatey.tests.integration.scenarios
             {
                 if (string.IsNullOrEmpty(ExpectedSubDirectory))
                 {
-                    Configuration.Sources.ShouldEqual(Scenario.get_top_level());
+                    Configuration.Sources.Should().Be(Scenario.get_top_level());
                 }
                 else
                 {
-                    Configuration.Sources.ShouldEqual(ExpectedSubDirectory);
+                    Configuration.Sources.Should().Be(ExpectedSubDirectory);
                 }
             }
 
@@ -426,9 +426,9 @@ namespace chocolatey.tests.integration.scenarios
             public void Property_settings_should_be_logged_as_debug_messages()
             {
                 var messages = MockLogger.MessagesFor(LogLevel.Debug);
-                messages.Count.ShouldEqual(2);
-                messages.ShouldContain("Setting property 'commitId': 1234abcd");
-                messages.ShouldContain("Setting property 'version': 0.1.0");
+                messages.Count.Should().Be(2);
+                messages.Should().ContainEquivalentOf("Setting property 'commitId': 1234abcd");
+                messages.Should().ContainEquivalentOf("Setting property 'version': 0.1.0");
             }
         }
 
@@ -439,7 +439,7 @@ namespace chocolatey.tests.integration.scenarios
             {
                 AddFile("myPackage.nuspec", NuspecContentWithAllUnsupportedElements);
 
-                ServiceAct.ShouldThrow<System.IO.InvalidDataException>();
+                ServiceAct.Should().Throw<System.IO.InvalidDataException>();
             }
 
             [Fact]
@@ -447,7 +447,7 @@ namespace chocolatey.tests.integration.scenarios
             {
                 AddFile("myPackage.nuspec", NuspecContentWithServiceableElement);
 
-                ServiceAct.ShouldThrow<System.IO.InvalidDataException>();
+                ServiceAct.Should().Throw<System.IO.InvalidDataException>();
             }
 
             [Fact]
@@ -455,7 +455,7 @@ namespace chocolatey.tests.integration.scenarios
             {
                 AddFile("myPackage.nuspec", NuspecContentWithLicenseElement);
 
-                ServiceAct.ShouldThrow<System.IO.InvalidDataException>();
+                ServiceAct.Should().Throw<System.IO.InvalidDataException>();
             }
 
             [Fact]
@@ -463,7 +463,7 @@ namespace chocolatey.tests.integration.scenarios
             {
                 AddFile("myPackage.nuspec", NuspecContentWithRepositoryElement);
 
-                ServiceAct.ShouldThrow<System.IO.InvalidDataException>();
+                ServiceAct.Should().Throw<System.IO.InvalidDataException>();
             }
 
             [Fact]
@@ -471,7 +471,7 @@ namespace chocolatey.tests.integration.scenarios
             {
                 AddFile("myPackage.nuspec", NuspecContentWithPackageTypesElement);
 
-                ServiceAct.ShouldThrow<System.IO.InvalidDataException>();
+                ServiceAct.Should().Throw<System.IO.InvalidDataException>();
             }
 
             [Fact]
@@ -479,7 +479,7 @@ namespace chocolatey.tests.integration.scenarios
             {
                 AddFile("myPackage.nuspec", NuspecContentWithFrameWorkReferencesElement);
 
-                ServiceAct.ShouldThrow<System.IO.InvalidDataException>();
+                ServiceAct.Should().Throw<System.IO.InvalidDataException>();
             }
 
             [Fact]
@@ -487,7 +487,7 @@ namespace chocolatey.tests.integration.scenarios
             {
                 AddFile("myPackage.nuspec", NuspecContentWithReadmeElement);
 
-                ServiceAct.ShouldThrow<System.IO.InvalidDataException>();
+                ServiceAct.Should().Throw<System.IO.InvalidDataException>();
             }
 
             [Fact]
@@ -495,7 +495,7 @@ namespace chocolatey.tests.integration.scenarios
             {
                 AddFile("myPackage.nuspec", NuspecContentWithIconElement);
 
-                ServiceAct.ShouldThrow<System.IO.InvalidDataException>();
+                ServiceAct.Should().Throw<System.IO.InvalidDataException>();
             }
         }
 

--- a/src/chocolatey.tests.integration/scenarios/PackScenarios.cs
+++ b/src/chocolatey.tests.integration/scenarios/PackScenarios.cs
@@ -29,6 +29,7 @@ namespace chocolatey.tests.integration.scenarios
     using NUnit.Framework;
 
     using FluentAssertions;
+    using FluentAssertions.Execution;
 
     public class PackScenarios
     {
@@ -154,9 +155,13 @@ namespace chocolatey.tests.integration.scenarios
             public void Generated_package_should_be_in_current_directory()
             {
                 var infos = MockLogger.MessagesFor(LogLevel.Info);
-                infos.Count.Should().Be(2);
-                infos[0].Should().Be("Attempting to build package from 'myPackage.nuspec'.");
-                infos[1].Should().Be(string.Concat("Successfully created package '", PackagePath, "'"));
+
+                using (new AssertionScope())
+                {
+                    infos.Should().HaveCount(2);
+                    infos.Should().HaveElementAt(0, "Attempting to build package from 'myPackage.nuspec'.");
+                    infos.Should().HaveElementAt(1, string.Concat("Successfully created package '", PackagePath, "'"));
+                }
 
                 FileAssert.Exists(PackagePath);
             }
@@ -426,9 +431,13 @@ namespace chocolatey.tests.integration.scenarios
             public void Property_settings_should_be_logged_as_debug_messages()
             {
                 var messages = MockLogger.MessagesFor(LogLevel.Debug);
-                messages.Count.Should().Be(2);
-                messages.Should().ContainEquivalentOf("Setting property 'commitId': 1234abcd");
-                messages.Should().ContainEquivalentOf("Setting property 'version': 0.1.0");
+
+                using (new AssertionScope())
+                {
+                    messages.Should().HaveCount(2);
+                    messages.Should().ContainEquivalentOf("Setting property 'commitId': 1234abcd");
+                    messages.Should().ContainEquivalentOf("Setting property 'version': 0.1.0");
+                }
             }
         }
 

--- a/src/chocolatey.tests.integration/scenarios/PinScenarios.cs
+++ b/src/chocolatey.tests.integration/scenarios/PinScenarios.cs
@@ -30,7 +30,7 @@ namespace chocolatey.tests.integration.scenarios
     using NUnit.Framework;
 
     using NuGet.Configuration;
-    using Should;
+    using FluentAssertions;
 
     public class PinScenarios
     {
@@ -83,15 +83,15 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_not_contain_list_results()
             {
-                MockLogger.ContainsMessage("upgradepackage 1.0.0", LogLevel.Info).ShouldBeFalse();
-                MockLogger.ContainsMessage("upgradepackage 1.0.0", LogLevel.Warn).ShouldBeFalse();
-                MockLogger.ContainsMessage("upgradepackage 1.0.0", LogLevel.Error).ShouldBeFalse();
+                MockLogger.ContainsMessage("upgradepackage 1.0.0", LogLevel.Info).Should().BeFalse();
+                MockLogger.ContainsMessage("upgradepackage 1.0.0", LogLevel.Warn).Should().BeFalse();
+                MockLogger.ContainsMessage("upgradepackage 1.0.0", LogLevel.Error).Should().BeFalse();
             }
 
             [Fact]
             public void Should_not_contain_any_pins_by_default()
             {
-                MockLogger.ContainsMessage("upgradepackage|1.0.0").ShouldBeFalse();
+                MockLogger.ContainsMessage("upgradepackage|1.0.0").Should().BeFalse();
             }
         }
 
@@ -115,15 +115,15 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_not_contain_list_results()
             {
-                MockLogger.ContainsMessage("upgradepackage 1.0.0", LogLevel.Info).ShouldBeFalse();
-                MockLogger.ContainsMessage("upgradepackage 1.0.0", LogLevel.Warn).ShouldBeFalse();
-                MockLogger.ContainsMessage("upgradepackage 1.0.0", LogLevel.Error).ShouldBeFalse();
+                MockLogger.ContainsMessage("upgradepackage 1.0.0", LogLevel.Info).Should().BeFalse();
+                MockLogger.ContainsMessage("upgradepackage 1.0.0", LogLevel.Warn).Should().BeFalse();
+                MockLogger.ContainsMessage("upgradepackage 1.0.0", LogLevel.Error).Should().BeFalse();
             }
 
             [Fact]
             public void Should_contain_existing_pin_messages()
             {
-                MockLogger.ContainsMessage("upgradepackage|1.0.0").ShouldBeTrue();
+                MockLogger.ContainsMessage("upgradepackage|1.0.0").Should().BeTrue();
             }
         }
 
@@ -149,16 +149,16 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_not_contain_list_results()
             {
-                MockLogger.ContainsMessage("upgradepackage 1.0.0", LogLevel.Info).ShouldBeFalse();
-                MockLogger.ContainsMessage("upgradepackage 1.0.0", LogLevel.Warn).ShouldBeFalse();
-                MockLogger.ContainsMessage("upgradepackage 1.0.0", LogLevel.Error).ShouldBeFalse();
+                MockLogger.ContainsMessage("upgradepackage 1.0.0", LogLevel.Info).Should().BeFalse();
+                MockLogger.ContainsMessage("upgradepackage 1.0.0", LogLevel.Warn).Should().BeFalse();
+                MockLogger.ContainsMessage("upgradepackage 1.0.0", LogLevel.Error).Should().BeFalse();
             }
 
             [Fact]
             public void Should_contain_a_pin_message_for_each_existing_pin()
             {
-                MockLogger.ContainsMessage("installpackage|1.0.0").ShouldBeTrue();
-                MockLogger.ContainsMessage("upgradepackage|1.0.0").ShouldBeTrue();
+                MockLogger.ContainsMessage("installpackage|1.0.0").Should().BeTrue();
+                MockLogger.ContainsMessage("upgradepackage|1.0.0").Should().BeTrue();
             }
         }
 
@@ -180,7 +180,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_contain_success_message()
             {
-                MockLogger.ContainsMessage("Successfully added a pin for upgradepackage").ShouldBeTrue();
+                MockLogger.ContainsMessage("Successfully added a pin for upgradepackage").Should().BeTrue();
             }
         }
 
@@ -203,7 +203,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_contain_nothing_to_do_message()
             {
-                MockLogger.ContainsMessage("Nothing to change. Pin already set or removed.").ShouldBeTrue();
+                MockLogger.ContainsMessage("Nothing to change. Pin already set or removed.").Should().BeTrue();
             }
         }
 
@@ -251,7 +251,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_contain_success_message()
             {
-                MockLogger.ContainsMessage("Successfully removed a pin for upgradepackage").ShouldBeTrue();
+                MockLogger.ContainsMessage("Successfully removed a pin for upgradepackage").Should().BeTrue();
             }
         }
 
@@ -273,7 +273,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_contain_nothing_to_do_message()
             {
-                MockLogger.ContainsMessage("Nothing to change. Pin already set or removed.").ShouldBeTrue();
+                MockLogger.ContainsMessage("Nothing to change. Pin already set or removed.").Should().BeTrue();
             }
         }
 

--- a/src/chocolatey.tests.integration/scenarios/PinScenarios.cs
+++ b/src/chocolatey.tests.integration/scenarios/PinScenarios.cs
@@ -31,6 +31,7 @@ namespace chocolatey.tests.integration.scenarios
 
     using NuGet.Configuration;
     using FluentAssertions;
+    using Moq;
 
     public class PinScenarios
     {
@@ -83,9 +84,9 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_not_contain_list_results()
             {
-                MockLogger.ContainsMessage("upgradepackage 1.0.0", LogLevel.Info).Should().BeFalse();
-                MockLogger.ContainsMessage("upgradepackage 1.0.0", LogLevel.Warn).Should().BeFalse();
-                MockLogger.ContainsMessage("upgradepackage 1.0.0", LogLevel.Error).Should().BeFalse();
+                MockLogger.Messages.Should()
+                    .NotContainKeys(new string[]
+                        { LogLevel.Info.ToStringSafe(), LogLevel.Warn.ToStringSafe(), LogLevel.Error.ToStringSafe() });
             }
 
             [Fact]
@@ -115,9 +116,11 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_not_contain_list_results()
             {
-                MockLogger.ContainsMessage("upgradepackage 1.0.0", LogLevel.Info).Should().BeFalse();
-                MockLogger.ContainsMessage("upgradepackage 1.0.0", LogLevel.Warn).Should().BeFalse();
-                MockLogger.ContainsMessage("upgradepackage 1.0.0", LogLevel.Error).Should().BeFalse();
+                MockLogger.Messages.Should().ContainKey(LogLevel.Info.ToStringSafe())
+                    .WhoseValue.Should().NotContain(m => m.Contains("upgradepackage 1.0.0"));
+                MockLogger.Messages.Should()
+                    .NotContainKeys(new string[]
+                        { LogLevel.Warn.ToStringSafe(), LogLevel.Error.ToStringSafe() });
             }
 
             [Fact]
@@ -149,9 +152,11 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_not_contain_list_results()
             {
-                MockLogger.ContainsMessage("upgradepackage 1.0.0", LogLevel.Info).Should().BeFalse();
-                MockLogger.ContainsMessage("upgradepackage 1.0.0", LogLevel.Warn).Should().BeFalse();
-                MockLogger.ContainsMessage("upgradepackage 1.0.0", LogLevel.Error).Should().BeFalse();
+                MockLogger.Messages.Should().ContainKey(LogLevel.Info.ToStringSafe())
+                    .WhoseValue.Should().NotContain(m => m.Contains("upgradepackage 1.0.0"));
+                MockLogger.Messages.Should()
+                    .NotContainKeys(new string[]
+                        { LogLevel.Warn.ToStringSafe(), LogLevel.Error.ToStringSafe() });
             }
 
             [Fact]

--- a/src/chocolatey.tests.integration/scenarios/SearchScenarios.cs
+++ b/src/chocolatey.tests.integration/scenarios/SearchScenarios.cs
@@ -23,7 +23,7 @@ namespace chocolatey.tests.integration.scenarios
     using chocolatey.infrastructure.results;
     using NuGet.Configuration;
     using NUnit.Framework;
-    using Should;
+    using FluentAssertions;
 
     public class SearchScenarios
     {
@@ -74,9 +74,9 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_only_pick_up_package_from_highest_priority()
             {
-                Results.Count.ShouldEqual(1);
-                Results[0].Name.ShouldEqual("upgradepackage");
-                Results[0].Version.ShouldEqual("1.0.0");
+                Results.Count.Should().Be(1);
+                Results[0].Name.Should().Be("upgradepackage");
+                Results[0].Version.Should().Be("1.0.0");
             }
         }
 
@@ -111,11 +111,11 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_only_pick_up_package_from_highest_priority()
             {
-                Results.Count.ShouldEqual(2);
-                Results[0].Name.ShouldEqual("upgradepackage");
-                Results[0].Version.ShouldEqual("1.1.1-beta");
-                Results[1].Name.ShouldEqual("upgradepackage");
-                Results[1].Version.ShouldEqual("1.0.0");
+                Results.Count.Should().Be(2);
+                Results[0].Name.Should().Be("upgradepackage");
+                Results[0].Version.Should().Be("1.1.1-beta");
+                Results[1].Name.Should().Be("upgradepackage");
+                Results[1].Version.Should().Be("1.0.0");
             }
         }
 
@@ -151,15 +151,15 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_pick_up_packages_from_all_feeds_except_those_with_same_name()
             {
-                Results.Count.ShouldEqual(4);
-                Results[0].Name.ShouldEqual("conflictingdependency");
-                Results[0].Version.ShouldEqual("2.0.0");
-                Results[1].Name.ShouldEqual("hasdependency");
-                Results[1].Version.ShouldEqual("2.1.0");
-                Results[2].Name.ShouldEqual("isdependency");
-                Results[2].Version.ShouldEqual("2.1.0");
-                Results[3].Name.ShouldEqual("isexactdependency");
-                Results[3].Version.ShouldEqual("2.0.0");
+                Results.Count.Should().Be(4);
+                Results[0].Name.Should().Be("conflictingdependency");
+                Results[0].Version.Should().Be("2.0.0");
+                Results[1].Name.Should().Be("hasdependency");
+                Results[1].Version.Should().Be("2.1.0");
+                Results[2].Name.Should().Be("isdependency");
+                Results[2].Version.Should().Be("2.1.0");
+                Results[3].Name.Should().Be("isexactdependency");
+                Results[3].Version.Should().Be("2.0.0");
             }
         }
 
@@ -176,34 +176,34 @@ namespace chocolatey.tests.integration.scenarios
             [Platform(Exclude = "Mono")]
             public void Should_list_available_packages_only_once()
             {
-                MockLogger.ContainsMessageCount("upgradepackage").ShouldEqual(1);
+                MockLogger.ContainsMessageCount("upgradepackage").Should().Be(1);
             }
 
             [Fact]
             public void Should_contain_packages_and_versions_with_a_space_between_them()
             {
-                MockLogger.ContainsMessage("upgradepackage 1.1.0").ShouldBeTrue();
+                MockLogger.ContainsMessage("upgradepackage 1.1.0").Should().BeTrue();
             }
 
             [Fact]
             public void Should_not_contain_packages_and_versions_with_a_pipe_between_them()
             {
-                MockLogger.ContainsMessage("upgradepackage|1.1.0").ShouldBeFalse();
+                MockLogger.ContainsMessage("upgradepackage|1.1.0").Should().BeFalse();
             }
 
             [Fact]
             public void Should_contain_a_summary()
             {
-                MockLogger.ContainsMessage("packages found").ShouldBeTrue();
+                MockLogger.ContainsMessage("packages found").Should().BeTrue();
             }
 
             [Fact]
             public void Should_contain_debugging_messages()
             {
-                MockLogger.ContainsMessage("Searching for package information", LogLevel.Debug).ShouldBeTrue();
-                MockLogger.ContainsMessage("Running list with the following filter", LogLevel.Debug).ShouldBeTrue();
-                MockLogger.ContainsMessage("Start of List", LogLevel.Debug).ShouldBeTrue();
-                MockLogger.ContainsMessage("End of List", LogLevel.Debug).ShouldBeTrue();
+                MockLogger.ContainsMessage("Searching for package information", LogLevel.Debug).Should().BeTrue();
+                MockLogger.ContainsMessage("Running list with the following filter", LogLevel.Debug).Should().BeTrue();
+                MockLogger.ContainsMessage("Start of List", LogLevel.Debug).Should().BeTrue();
+                MockLogger.ContainsMessage("End of List", LogLevel.Debug).Should().BeTrue();
             }
         }
 
@@ -224,28 +224,28 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_contain_packages_and_versions_with_a_space_between_them()
             {
-                MockLogger.ContainsMessage("upgradepackage 1.1.0").ShouldBeTrue();
+                MockLogger.ContainsMessage("upgradepackage 1.1.0").Should().BeTrue();
             }
 
             [Fact]
             public void Should_not_contain_packages_that_do_not_match()
             {
-                MockLogger.ContainsMessage("installpackage").ShouldBeFalse();
+                MockLogger.ContainsMessage("installpackage").Should().BeFalse();
             }
 
             [Fact]
             public void Should_contain_a_summary()
             {
-                MockLogger.ContainsMessage("packages found").ShouldBeTrue();
+                MockLogger.ContainsMessage("packages found").Should().BeTrue();
             }
 
             [Fact]
             public void Should_contain_debugging_messages()
             {
-                MockLogger.ContainsMessage("Searching for package information", LogLevel.Debug).ShouldBeTrue();
-                MockLogger.ContainsMessage("Running list with the following filter", LogLevel.Debug).ShouldBeTrue();
-                MockLogger.ContainsMessage("Start of List", LogLevel.Debug).ShouldBeTrue();
-                MockLogger.ContainsMessage("End of List", LogLevel.Debug).ShouldBeTrue();
+                MockLogger.ContainsMessage("Searching for package information", LogLevel.Debug).Should().BeTrue();
+                MockLogger.ContainsMessage("Running list with the following filter", LogLevel.Debug).Should().BeTrue();
+                MockLogger.ContainsMessage("Start of List", LogLevel.Debug).Should().BeTrue();
+                MockLogger.ContainsMessage("End of List", LogLevel.Debug).Should().BeTrue();
             }
         }
 
@@ -266,35 +266,35 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_list_available_packages_as_many_times_as_they_show_on_the_feed()
             {
-                MockLogger.ContainsMessageCount("upgradepackage").ShouldNotEqual(0);
-                MockLogger.ContainsMessageCount("upgradepackage").ShouldNotEqual(1);
+                MockLogger.ContainsMessageCount("upgradepackage").Should().NotBe(0);
+                MockLogger.ContainsMessageCount("upgradepackage").Should().NotBe(1);
             }
 
             [Fact]
             public void Should_contain_packages_and_versions_with_a_space_between_them()
             {
-                MockLogger.ContainsMessage("upgradepackage 1.1.0").ShouldBeTrue();
+                MockLogger.ContainsMessage("upgradepackage 1.1.0").Should().BeTrue();
             }
 
             [Fact]
             public void Should_not_contain_packages_and_versions_with_a_pipe_between_them()
             {
-                MockLogger.ContainsMessage("upgradepackage|1.1.0").ShouldBeFalse();
+                MockLogger.ContainsMessage("upgradepackage|1.1.0").Should().BeFalse();
             }
 
             [Fact]
             public void Should_contain_a_summary()
             {
-                MockLogger.ContainsMessage("packages found").ShouldBeTrue();
+                MockLogger.ContainsMessage("packages found").Should().BeTrue();
             }
 
             [Fact]
             public void Should_contain_debugging_messages()
             {
-                MockLogger.ContainsMessage("Searching for package information", LogLevel.Debug).ShouldBeTrue();
-                MockLogger.ContainsMessage("Running list with the following filter", LogLevel.Debug).ShouldBeTrue();
-                MockLogger.ContainsMessage("Start of List", LogLevel.Debug).ShouldBeTrue();
-                MockLogger.ContainsMessage("End of List", LogLevel.Debug).ShouldBeTrue();
+                MockLogger.ContainsMessage("Searching for package information", LogLevel.Debug).Should().BeTrue();
+                MockLogger.ContainsMessage("Running list with the following filter", LogLevel.Debug).Should().BeTrue();
+                MockLogger.ContainsMessage("Start of List", LogLevel.Debug).Should().BeTrue();
+                MockLogger.ContainsMessage("End of List", LogLevel.Debug).Should().BeTrue();
             }
         }
 
@@ -315,46 +315,46 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_contain_packages_and_versions_with_a_space_between_them()
             {
-                MockLogger.ContainsMessage("upgradepackage 1.1.0").ShouldBeTrue();
+                MockLogger.ContainsMessage("upgradepackage 1.1.0").Should().BeTrue();
             }
 
             [Fact]
             public void Should_contain_description()
             {
-                MockLogger.ContainsMessage("Description: ").ShouldBeTrue();
+                MockLogger.ContainsMessage("Description: ").Should().BeTrue();
             }
 
             [Fact]
             public void Should_contain_tags()
             {
-                MockLogger.ContainsMessage("Tags: ").ShouldBeTrue();
+                MockLogger.ContainsMessage("Tags: ").Should().BeTrue();
             }
 
             [Fact]
             public void Should_contain_download_counts()
             {
-                MockLogger.ContainsMessage("Number of Downloads: ").ShouldBeTrue();
+                MockLogger.ContainsMessage("Number of Downloads: ").Should().BeTrue();
             }
 
             [Fact]
             public void Should_not_contain_packages_and_versions_with_a_pipe_between_them()
             {
-                MockLogger.ContainsMessage("upgradepackage|1.1.0").ShouldBeFalse();
+                MockLogger.ContainsMessage("upgradepackage|1.1.0").Should().BeFalse();
             }
 
             [Fact]
             public void Should_contain_a_summary()
             {
-                MockLogger.ContainsMessage("packages found").ShouldBeTrue();
+                MockLogger.ContainsMessage("packages found").Should().BeTrue();
             }
 
             [Fact]
             public void Should_contain_debugging_messages()
             {
-                MockLogger.ContainsMessage("Searching for package information", LogLevel.Debug).ShouldBeTrue();
-                MockLogger.ContainsMessage("Running list with the following filter", LogLevel.Debug).ShouldBeTrue();
-                MockLogger.ContainsMessage("Start of List", LogLevel.Debug).ShouldBeTrue();
-                MockLogger.ContainsMessage("End of List", LogLevel.Debug).ShouldBeTrue();
+                MockLogger.ContainsMessage("Searching for package information", LogLevel.Debug).Should().BeTrue();
+                MockLogger.ContainsMessage("Running list with the following filter", LogLevel.Debug).Should().BeTrue();
+                MockLogger.ContainsMessage("Start of List", LogLevel.Debug).Should().BeTrue();
+                MockLogger.ContainsMessage("End of List", LogLevel.Debug).Should().BeTrue();
             }
         }
 
@@ -375,13 +375,13 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_have_no_sources_enabled_result()
             {
-                MockLogger.ContainsMessage("Unable to search for packages when there are no sources enabled for", LogLevel.Error).ShouldBeTrue();
+                MockLogger.ContainsMessage("Unable to search for packages when there are no sources enabled for", LogLevel.Error).Should().BeTrue();
             }
 
             [Fact]
             public void Should_not_list_any_packages()
             {
-                Results.Count().ShouldEqual(0);
+                Results.Count().Should().Be(0);
             }
         }
 
@@ -413,34 +413,34 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_find_exactly_one_result()
             {
-                Results.Count.ShouldEqual(1);
+                Results.Count.Should().Be(1);
             }
 
             [Fact]
             public void Should_contain_packages_and_versions_with_a_space_between_them()
             {
-                MockLogger.ContainsMessage("exactpackage 1.0.0").ShouldBeTrue();
+                MockLogger.ContainsMessage("exactpackage 1.0.0").Should().BeTrue();
             }
 
             [Fact]
             public void Should_not_contain_packages_that_do_not_match()
             {
-                MockLogger.ContainsMessage("exactpackage.dontfind").ShouldBeFalse();
+                MockLogger.ContainsMessage("exactpackage.dontfind").Should().BeFalse();
             }
 
             [Fact]
             public void Should_contain_a_summary()
             {
-                MockLogger.ContainsMessage("packages found").ShouldBeTrue();
+                MockLogger.ContainsMessage("packages found").Should().BeTrue();
             }
 
             [Fact]
             public void Should_contain_debugging_messages()
             {
-                MockLogger.ContainsMessage("Searching for package information", LogLevel.Debug).ShouldBeTrue();
-                MockLogger.ContainsMessage("Running list with the following filter", LogLevel.Debug).ShouldBeTrue();
-                MockLogger.ContainsMessage("Start of List", LogLevel.Debug).ShouldBeTrue();
-                MockLogger.ContainsMessage("End of List", LogLevel.Debug).ShouldBeTrue();
+                MockLogger.ContainsMessage("Searching for package information", LogLevel.Debug).Should().BeTrue();
+                MockLogger.ContainsMessage("Running list with the following filter", LogLevel.Debug).Should().BeTrue();
+                MockLogger.ContainsMessage("Start of List", LogLevel.Debug).Should().BeTrue();
+                MockLogger.ContainsMessage("End of List", LogLevel.Debug).Should().BeTrue();
             }
         }
 
@@ -474,28 +474,28 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_not_have_any_results()
             {
-                Results.Count.ShouldEqual(0);
+                Results.Count.Should().Be(0);
             }
 
             [Fact]
             public void Should_not_contain_packages_that_do_not_match()
             {
-                MockLogger.ContainsMessage("exactpackage.dontfind").ShouldBeFalse();
+                MockLogger.ContainsMessage("exactpackage.dontfind").Should().BeFalse();
             }
 
             [Fact]
             public void Should_contain_a_summary()
             {
-                MockLogger.ContainsMessage("packages found").ShouldBeTrue();
+                MockLogger.ContainsMessage("packages found").Should().BeTrue();
             }
 
             [Fact]
             public void Should_contain_debugging_messages()
             {
-                MockLogger.ContainsMessage("Searching for package information", LogLevel.Debug).ShouldBeTrue();
-                MockLogger.ContainsMessage("Running list with the following filter", LogLevel.Debug).ShouldBeTrue();
-                MockLogger.ContainsMessage("Start of List", LogLevel.Debug).ShouldBeTrue();
-                MockLogger.ContainsMessage("End of List", LogLevel.Debug).ShouldBeTrue();
+                MockLogger.ContainsMessage("Searching for package information", LogLevel.Debug).Should().BeTrue();
+                MockLogger.ContainsMessage("Running list with the following filter", LogLevel.Debug).Should().BeTrue();
+                MockLogger.ContainsMessage("Start of List", LogLevel.Debug).Should().BeTrue();
+                MockLogger.ContainsMessage("End of List", LogLevel.Debug).Should().BeTrue();
             }
         }
 
@@ -528,21 +528,21 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_find_two_results()
             {
-                Results.Count.ShouldEqual(2);
+                Results.Count.Should().Be(2);
             }
 
             [Fact]
             public void Should_find_only_packages_with_exact_id()
             {
-                Results[0].PackageMetadata.Id.ShouldEqual("exactpackage");
-                Results[1].PackageMetadata.Id.ShouldEqual("exactpackage");
+                Results[0].PackageMetadata.Id.Should().Be("exactpackage");
+                Results[1].PackageMetadata.Id.Should().Be("exactpackage");
             }
 
             [Fact]
             public void Should_find_all_non_prerelease_versions_in_descending_order()
             {
-                Results[0].PackageMetadata.Version.ToNormalizedString().ShouldEqual("1.0.0");
-                Results[1].PackageMetadata.Version.ToNormalizedString().ShouldEqual("0.9.0");
+                Results[0].PackageMetadata.Version.ToNormalizedString().Should().Be("1.0.0");
+                Results[1].PackageMetadata.Version.ToNormalizedString().Should().Be("0.9.0");
             }
         }
 
@@ -576,23 +576,23 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_find_three_results()
             {
-                Results.Count.ShouldEqual(3);
+                Results.Count.Should().Be(3);
             }
 
             [Fact]
             public void Should_find_only_packages_with_exact_id()
             {
-                Results[0].PackageMetadata.Id.ShouldEqual("exactpackage");
-                Results[1].PackageMetadata.Id.ShouldEqual("exactpackage");
-                Results[2].PackageMetadata.Id.ShouldEqual("exactpackage");
+                Results[0].PackageMetadata.Id.Should().Be("exactpackage");
+                Results[1].PackageMetadata.Id.Should().Be("exactpackage");
+                Results[2].PackageMetadata.Id.Should().Be("exactpackage");
             }
 
             [Fact]
             public void Should_find_all_versions_in_descending_order()
             {
-                Results[0].PackageMetadata.Version.ToNormalizedString().ShouldEqual("1.0.0");
-                Results[1].PackageMetadata.Version.ToNormalizedString().ShouldEqual("1.0.0-beta1");
-                Results[2].PackageMetadata.Version.ToNormalizedString().ShouldEqual("0.9.0");
+                Results[0].PackageMetadata.Version.ToNormalizedString().Should().Be("1.0.0");
+                Results[1].PackageMetadata.Version.ToNormalizedString().Should().Be("1.0.0-beta1");
+                Results[2].PackageMetadata.Version.ToNormalizedString().Should().Be("0.9.0");
             }
         }
     }

--- a/src/chocolatey.tests.integration/scenarios/SearchScenarios.cs
+++ b/src/chocolatey.tests.integration/scenarios/SearchScenarios.cs
@@ -74,7 +74,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_only_pick_up_package_from_highest_priority()
             {
-                Results.Count.Should().Be(1);
+                Results.Should().ContainSingle();
                 Results[0].Name.Should().Be("upgradepackage");
                 Results[0].Version.Should().Be("1.0.0");
             }
@@ -111,7 +111,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_only_pick_up_package_from_highest_priority()
             {
-                Results.Count.Should().Be(2);
+                Results.Should().HaveCount(2);
                 Results[0].Name.Should().Be("upgradepackage");
                 Results[0].Version.Should().Be("1.1.1-beta");
                 Results[1].Name.Should().Be("upgradepackage");
@@ -151,7 +151,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_pick_up_packages_from_all_feeds_except_those_with_same_name()
             {
-                Results.Count.Should().Be(4);
+                Results.Should().HaveCount(4);
                 Results[0].Name.Should().Be("conflictingdependency");
                 Results[0].Version.Should().Be("2.0.0");
                 Results[1].Name.Should().Be("hasdependency");
@@ -200,10 +200,14 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_contain_debugging_messages()
             {
-                MockLogger.ContainsMessage("Searching for package information", LogLevel.Debug).Should().BeTrue();
-                MockLogger.ContainsMessage("Running list with the following filter", LogLevel.Debug).Should().BeTrue();
-                MockLogger.ContainsMessage("Start of List", LogLevel.Debug).Should().BeTrue();
-                MockLogger.ContainsMessage("End of List", LogLevel.Debug).Should().BeTrue();
+                MockLogger.Messages.Should().ContainKey(LogLevel.Debug.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains("Searching for package information"));
+                MockLogger.Messages.Should().ContainKey(LogLevel.Debug.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains("Running list with the following filter"));
+                MockLogger.Messages.Should().ContainKey(LogLevel.Debug.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains("Start of List"));
+                MockLogger.Messages.Should().ContainKey(LogLevel.Debug.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains("End of List"));
             }
         }
 
@@ -242,10 +246,14 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_contain_debugging_messages()
             {
-                MockLogger.ContainsMessage("Searching for package information", LogLevel.Debug).Should().BeTrue();
-                MockLogger.ContainsMessage("Running list with the following filter", LogLevel.Debug).Should().BeTrue();
-                MockLogger.ContainsMessage("Start of List", LogLevel.Debug).Should().BeTrue();
-                MockLogger.ContainsMessage("End of List", LogLevel.Debug).Should().BeTrue();
+                MockLogger.Messages.Should().ContainKey(LogLevel.Debug.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains("Searching for package information"));
+                MockLogger.Messages.Should().ContainKey(LogLevel.Debug.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains("Running list with the following filter"));
+                MockLogger.Messages.Should().ContainKey(LogLevel.Debug.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains("Start of List"));
+                MockLogger.Messages.Should().ContainKey(LogLevel.Debug.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains("End of List"));
             }
         }
 
@@ -291,10 +299,14 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_contain_debugging_messages()
             {
-                MockLogger.ContainsMessage("Searching for package information", LogLevel.Debug).Should().BeTrue();
-                MockLogger.ContainsMessage("Running list with the following filter", LogLevel.Debug).Should().BeTrue();
-                MockLogger.ContainsMessage("Start of List", LogLevel.Debug).Should().BeTrue();
-                MockLogger.ContainsMessage("End of List", LogLevel.Debug).Should().BeTrue();
+                MockLogger.Messages.Should().ContainKey(LogLevel.Debug.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains("Searching for package information"));
+                MockLogger.Messages.Should().ContainKey(LogLevel.Debug.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains("Running list with the following filter"));
+                MockLogger.Messages.Should().ContainKey(LogLevel.Debug.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains("Start of List"));
+                MockLogger.Messages.Should().ContainKey(LogLevel.Debug.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains("End of List"));
             }
         }
 
@@ -351,10 +363,14 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_contain_debugging_messages()
             {
-                MockLogger.ContainsMessage("Searching for package information", LogLevel.Debug).Should().BeTrue();
-                MockLogger.ContainsMessage("Running list with the following filter", LogLevel.Debug).Should().BeTrue();
-                MockLogger.ContainsMessage("Start of List", LogLevel.Debug).Should().BeTrue();
-                MockLogger.ContainsMessage("End of List", LogLevel.Debug).Should().BeTrue();
+                MockLogger.Messages.Should().ContainKey(LogLevel.Debug.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains("Searching for package information"));
+                MockLogger.Messages.Should().ContainKey(LogLevel.Debug.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains("Running list with the following filter"));
+                MockLogger.Messages.Should().ContainKey(LogLevel.Debug.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains("Start of List"));
+                MockLogger.Messages.Should().ContainKey(LogLevel.Debug.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains("End of List"));
             }
         }
 
@@ -375,13 +391,14 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_have_no_sources_enabled_result()
             {
-                MockLogger.ContainsMessage("Unable to search for packages when there are no sources enabled for", LogLevel.Error).Should().BeTrue();
+                MockLogger.Messages.Should().ContainKey(LogLevel.Error.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains("Unable to search for packages when there are no sources enabled for"));
             }
 
             [Fact]
             public void Should_not_list_any_packages()
             {
-                Results.Count().Should().Be(0);
+                Results.Should().BeEmpty();
             }
         }
 
@@ -413,7 +430,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_find_exactly_one_result()
             {
-                Results.Count.Should().Be(1);
+                Results.Should().ContainSingle();
             }
 
             [Fact]
@@ -437,10 +454,14 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_contain_debugging_messages()
             {
-                MockLogger.ContainsMessage("Searching for package information", LogLevel.Debug).Should().BeTrue();
-                MockLogger.ContainsMessage("Running list with the following filter", LogLevel.Debug).Should().BeTrue();
-                MockLogger.ContainsMessage("Start of List", LogLevel.Debug).Should().BeTrue();
-                MockLogger.ContainsMessage("End of List", LogLevel.Debug).Should().BeTrue();
+                MockLogger.Messages.Should().ContainKey(LogLevel.Debug.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains("Searching for package information"));
+                MockLogger.Messages.Should().ContainKey(LogLevel.Debug.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains("Running list with the following filter"));
+                MockLogger.Messages.Should().ContainKey(LogLevel.Debug.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains("Start of List"));
+                MockLogger.Messages.Should().ContainKey(LogLevel.Debug.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains("End of List"));
             }
         }
 
@@ -474,7 +495,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_not_have_any_results()
             {
-                Results.Count.Should().Be(0);
+                Results.Should().BeEmpty();
             }
 
             [Fact]
@@ -492,10 +513,14 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_contain_debugging_messages()
             {
-                MockLogger.ContainsMessage("Searching for package information", LogLevel.Debug).Should().BeTrue();
-                MockLogger.ContainsMessage("Running list with the following filter", LogLevel.Debug).Should().BeTrue();
-                MockLogger.ContainsMessage("Start of List", LogLevel.Debug).Should().BeTrue();
-                MockLogger.ContainsMessage("End of List", LogLevel.Debug).Should().BeTrue();
+                MockLogger.Messages.Should().ContainKey(LogLevel.Debug.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains("Searching for package information"));
+                MockLogger.Messages.Should().ContainKey(LogLevel.Debug.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains("Running list with the following filter"));
+                MockLogger.Messages.Should().ContainKey(LogLevel.Debug.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains("Start of List"));
+                MockLogger.Messages.Should().ContainKey(LogLevel.Debug.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains("End of List"));
             }
         }
 
@@ -528,7 +553,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_find_two_results()
             {
-                Results.Count.Should().Be(2);
+                Results.Should().HaveCount(2);
             }
 
             [Fact]
@@ -576,7 +601,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_find_three_results()
             {
-                Results.Count.Should().Be(3);
+                Results.Should().HaveCount(3);
             }
 
             [Fact]

--- a/src/chocolatey.tests.integration/scenarios/UninstallScenarios.cs
+++ b/src/chocolatey.tests.integration/scenarios/UninstallScenarios.cs
@@ -28,7 +28,7 @@ namespace chocolatey.tests.integration.scenarios
     using chocolatey.infrastructure.results;
     using NuGet.Configuration;
     using NUnit.Framework;
-    using Should;
+    using FluentAssertions;
     using IFileSystem = chocolatey.infrastructure.filesystem.IFileSystem;
 
     public class UninstallScenarios
@@ -89,7 +89,7 @@ namespace chocolatey.tests.integration.scenarios
                     if (message.Contains("Would have uninstalled installpackage v1.0.0")) expectedMessage = true;
                 }
 
-                expectedMessage.ShouldBeTrue();
+                expectedMessage.Should().BeTrue();
             }
 
             [Fact]
@@ -97,7 +97,7 @@ namespace chocolatey.tests.integration.scenarios
             [Platform(Exclude = "Mono")]
             public void Should_contain_a_message_that_it_would_have_run_a_powershell_script()
             {
-                MockLogger.ContainsMessage("chocolateyuninstall.ps1").ShouldBeTrue();
+                MockLogger.ContainsMessage("chocolateyuninstall.ps1").Should().BeTrue();
             }
 
             [Fact]
@@ -105,7 +105,7 @@ namespace chocolatey.tests.integration.scenarios
             [Platform(Exclude = "Mono")]
             public void Should_contain_a_message_that_it_would_have_run_powershell_modification_script()
             {
-                MockLogger.ContainsMessage("chocolateyBeforeModify.ps1").ShouldBeTrue();
+                MockLogger.ContainsMessage("chocolateyBeforeModify.ps1").Should().BeTrue();
             }
         }
 
@@ -132,7 +132,7 @@ namespace chocolatey.tests.integration.scenarios
                     if (message.Contains("somethingnonexisting is not installed. Cannot uninstall a non-existent package")) expectedMessage = true;
                 }
 
-                expectedMessage.ShouldBeTrue();
+                expectedMessage.Should().BeTrue();
             }
         }
 
@@ -199,31 +199,31 @@ namespace chocolatey.tests.integration.scenarios
                     if (message.Contains("1/1")) installedSuccessfully = true;
                 }
 
-                installedSuccessfully.ShouldBeTrue();
+                installedSuccessfully.Should().BeTrue();
             }
 
             [Fact]
             public void Should_have_a_successful_package_result()
             {
-                packageResult.Success.ShouldBeTrue();
+                packageResult.Success.Should().BeTrue();
             }
 
             [Fact]
             public void Should_not_have_inconclusive_package_result()
             {
-                packageResult.Inconclusive.ShouldBeFalse();
+                packageResult.Inconclusive.Should().BeFalse();
             }
 
             [Fact]
             public void Should_not_have_warning_package_result()
             {
-                packageResult.Warning.ShouldBeFalse();
+                packageResult.Warning.Should().BeFalse();
             }
 
             [Fact]
             public void Config_should_match_package_result_name()
             {
-                packageResult.Name.ShouldEqual(Configuration.PackageNames);
+                packageResult.Name.Should().Be(Configuration.PackageNames);
             }
 
             [Fact]
@@ -231,7 +231,7 @@ namespace chocolatey.tests.integration.scenarios
             [Platform(Exclude = "Mono")]
             public void Should_have_executed_chocolateyBeforeModify_script()
             {
-                MockLogger.ContainsMessage("installpackage 1.0.0 Before Modification", LogLevel.Info).ShouldBeTrue();
+                MockLogger.ContainsMessage("installpackage 1.0.0 Before Modification", LogLevel.Info).Should().BeTrue();
             }
 
             [Fact]
@@ -239,7 +239,7 @@ namespace chocolatey.tests.integration.scenarios
             [Platform(Exclude = "Mono")]
             public void Should_have_executed_chocolateyUninstall_script()
             {
-                MockLogger.ContainsMessage("installpackage 1.0.0 Uninstalled", LogLevel.Info).ShouldBeTrue();
+                MockLogger.ContainsMessage("installpackage 1.0.0 Uninstalled", LogLevel.Info).Should().BeTrue();
             }
         }
 
@@ -300,31 +300,31 @@ namespace chocolatey.tests.integration.scenarios
                     if (message.Contains("1/1")) installedSuccessfully = true;
                 }
 
-                installedSuccessfully.ShouldBeTrue();
+                installedSuccessfully.Should().BeTrue();
             }
 
             [Fact]
             public void Should_have_a_successful_package_result()
             {
-                packageResult.Success.ShouldBeTrue();
+                packageResult.Success.Should().BeTrue();
             }
 
             [Fact]
             public void Should_not_have_inconclusive_package_result()
             {
-                packageResult.Inconclusive.ShouldBeFalse();
+                packageResult.Inconclusive.Should().BeFalse();
             }
 
             [Fact]
             public void Should_not_have_warning_package_result()
             {
-                packageResult.Warning.ShouldBeFalse();
+                packageResult.Warning.Should().BeFalse();
             }
 
             [Fact]
             public void Config_should_match_package_result_name()
             {
-                packageResult.Name.ShouldEqual(Configuration.PackageNames);
+                packageResult.Name.Should().Be(Configuration.PackageNames);
             }
         }
 
@@ -346,7 +346,7 @@ namespace chocolatey.tests.integration.scenarios
             {
                 Action m = () => Service.Uninstall(Configuration);
 
-                m.ShouldThrow<ApplicationException>();
+                m.Should().Throw<ApplicationException>();
             }
         }
 
@@ -395,25 +395,25 @@ namespace chocolatey.tests.integration.scenarios
                     if (message.Contains("uninstalled 1/1")) expectedMessage = true;
                 }
 
-                expectedMessage.ShouldBeTrue();
+                expectedMessage.Should().BeTrue();
             }
 
             [Fact]
             public void Should_have_a_successful_package_result()
             {
-                _packageResult.Success.ShouldBeTrue();
+                _packageResult.Success.Should().BeTrue();
             }
 
             [Fact]
             public void Should_not_have_inconclusive_package_result()
             {
-                _packageResult.Inconclusive.ShouldBeFalse();
+                _packageResult.Inconclusive.Should().BeFalse();
             }
 
             [Fact]
             public void Should_not_have_warning_package_result()
             {
-                _packageResult.Warning.ShouldBeFalse();
+                _packageResult.Warning.Should().BeFalse();
             }
         }
 
@@ -482,25 +482,25 @@ namespace chocolatey.tests.integration.scenarios
                     if (message.Contains("uninstalled 1/1")) expectedMessage = true;
                 }
 
-                expectedMessage.ShouldBeTrue();
+                expectedMessage.Should().BeTrue();
             }
 
             [Fact]
             public void Should_have_a_successful_package_result()
             {
-                _packageResult.Success.ShouldBeTrue();
+                _packageResult.Success.Should().BeTrue();
             }
 
             [Fact]
             public void Should_not_have_inconclusive_package_result()
             {
-                _packageResult.Inconclusive.ShouldBeFalse();
+                _packageResult.Inconclusive.Should().BeFalse();
             }
 
             [Fact]
             public void Should_not_have_warning_package_result()
             {
-                _packageResult.Warning.ShouldBeFalse();
+                _packageResult.Warning.Should().BeFalse();
             }
         }
 
@@ -577,7 +577,7 @@ namespace chocolatey.tests.integration.scenarios
                     }
                 }
 
-                expectedMessage.ShouldBeTrue();
+                expectedMessage.Should().BeTrue();
             }
 
             [Fact]
@@ -589,25 +589,25 @@ namespace chocolatey.tests.integration.scenarios
                     if (message.Contains("uninstalled 0/1")) expectedMessage = true;
                 }
 
-                expectedMessage.ShouldBeTrue();
+                expectedMessage.Should().BeTrue();
             }
 
             [Fact]
             public void Should_not_have_a_successful_package_result()
             {
-                _packageResult.Success.ShouldBeFalse();
+                _packageResult.Success.Should().BeFalse();
             }
 
             [Fact]
             public void Should_not_have_inconclusive_package_result()
             {
-                _packageResult.Inconclusive.ShouldBeFalse();
+                _packageResult.Inconclusive.Should().BeFalse();
             }
 
             [Fact]
             public void Should_not_have_warning_package_result()
             {
-                _packageResult.Warning.ShouldBeFalse();
+                _packageResult.Warning.Should().BeFalse();
             }
         }
 
@@ -643,7 +643,7 @@ namespace chocolatey.tests.integration.scenarios
 
                 foreach (var file in files.OrEmpty())
                 {
-                    Path.GetFileName(file).ShouldEqual("dude.txt", "Expected files were not deleted.");
+                    Path.GetFileName(file).Should().Be("dude.txt", "Expected files were not deleted.");
                 }
             }
 
@@ -684,31 +684,31 @@ namespace chocolatey.tests.integration.scenarios
                     if (message.Contains("1/1")) installedSuccessfully = true;
                 }
 
-                installedSuccessfully.ShouldBeTrue();
+                installedSuccessfully.Should().BeTrue();
             }
 
             [Fact]
             public void Should_have_a_successful_package_result()
             {
-                packageResult.Success.ShouldBeTrue();
+                packageResult.Success.Should().BeTrue();
             }
 
             [Fact]
             public void Should_not_have_inconclusive_package_result()
             {
-                packageResult.Inconclusive.ShouldBeFalse();
+                packageResult.Inconclusive.Should().BeFalse();
             }
 
             [Fact]
             public void Should_not_have_warning_package_result()
             {
-                packageResult.Warning.ShouldBeFalse();
+                packageResult.Warning.Should().BeFalse();
             }
 
             [Fact]
             public void Config_should_match_package_result_name()
             {
-                packageResult.Name.ShouldEqual(Configuration.PackageNames);
+                packageResult.Name.Should().Be(Configuration.PackageNames);
             }
         }
 
@@ -744,7 +744,7 @@ namespace chocolatey.tests.integration.scenarios
 
                 foreach (var file in files.OrEmpty())
                 {
-                    Path.GetFileName(file).ShouldEqual("chocolateyInstall.ps1", "Expected files were not deleted.");
+                    Path.GetFileName(file).Should().Be("chocolateyInstall.ps1", "Expected files were not deleted.");
                 }
             }
 
@@ -785,31 +785,31 @@ namespace chocolatey.tests.integration.scenarios
                     if (message.Contains("1/1")) installedSuccessfully = true;
                 }
 
-                installedSuccessfully.ShouldBeTrue();
+                installedSuccessfully.Should().BeTrue();
             }
 
             [Fact]
             public void Should_have_a_successful_package_result()
             {
-                packageResult.Success.ShouldBeTrue();
+                packageResult.Success.Should().BeTrue();
             }
 
             [Fact]
             public void Should_not_have_inconclusive_package_result()
             {
-                packageResult.Inconclusive.ShouldBeFalse();
+                packageResult.Inconclusive.Should().BeFalse();
             }
 
             [Fact]
             public void Should_not_have_warning_package_result()
             {
-                packageResult.Warning.ShouldBeFalse();
+                packageResult.Warning.Should().BeFalse();
             }
 
             [Fact]
             public void Config_should_match_package_result_name()
             {
-                packageResult.Name.ShouldEqual(Configuration.PackageNames);
+                packageResult.Name.Should().Be(Configuration.PackageNames);
             }
         }
 
@@ -894,31 +894,31 @@ namespace chocolatey.tests.integration.scenarios
                     if (message.Contains("1/1")) installedSuccessfully = true;
                 }
 
-                installedSuccessfully.ShouldBeTrue();
+                installedSuccessfully.Should().BeTrue();
             }
 
             [Fact]
             public void Should_have_a_successful_package_result()
             {
-                packageResult.Success.ShouldBeTrue();
+                packageResult.Success.Should().BeTrue();
             }
 
             [Fact]
             public void Should_not_have_inconclusive_package_result()
             {
-                packageResult.Inconclusive.ShouldBeFalse();
+                packageResult.Inconclusive.Should().BeFalse();
             }
 
             [Fact]
             public void Should_not_have_warning_package_result()
             {
-                packageResult.Warning.ShouldBeFalse();
+                packageResult.Warning.Should().BeFalse();
             }
 
             [Fact]
             public void Config_should_match_package_result_name()
             {
-                packageResult.Name.ShouldEqual(Configuration.PackageNames);
+                packageResult.Name.Should().Be(Configuration.PackageNames);
             }
         }
 
@@ -947,7 +947,7 @@ namespace chocolatey.tests.integration.scenarios
                     if (message.Contains("somethingnonexisting is not installed. Cannot uninstall a non-existent package")) expectedMessage = true;
                 }
 
-                expectedMessage.ShouldBeTrue();
+                expectedMessage.Should().BeTrue();
             }
 
             [Fact]
@@ -959,25 +959,25 @@ namespace chocolatey.tests.integration.scenarios
                     if (message.Contains("0/1")) installedSuccessfully = true;
                 }
 
-                installedSuccessfully.ShouldBeTrue();
+                installedSuccessfully.Should().BeTrue();
             }
 
             [Fact]
             public void Should_not_have_a_successful_package_result()
             {
-                packageResult.Success.ShouldBeFalse();
+                packageResult.Success.Should().BeFalse();
             }
 
             [Fact]
             public void Should_not_have_inconclusive_package_result()
             {
-                packageResult.Inconclusive.ShouldBeFalse();
+                packageResult.Inconclusive.Should().BeFalse();
             }
 
             [Fact]
             public void Should_not_have_warning_package_result()
             {
-                packageResult.Warning.ShouldBeFalse();
+                packageResult.Warning.Should().BeFalse();
             }
 
             [Fact]
@@ -992,7 +992,7 @@ namespace chocolatey.tests.integration.scenarios
                     }
                 }
 
-                errorFound.ShouldBeTrue();
+                errorFound.Should().BeTrue();
             }
         }
 
@@ -1054,25 +1054,25 @@ namespace chocolatey.tests.integration.scenarios
                     if (message.Contains("0/1")) installedSuccessfully = true;
                 }
 
-                installedSuccessfully.ShouldBeTrue();
+                installedSuccessfully.Should().BeTrue();
             }
 
             [Fact]
             public void Should_not_have_a_successful_package_result()
             {
-                packageResult.Success.ShouldBeFalse();
+                packageResult.Success.Should().BeFalse();
             }
 
             [Fact]
             public void Should_not_have_inconclusive_package_result()
             {
-                packageResult.Inconclusive.ShouldBeFalse();
+                packageResult.Inconclusive.Should().BeFalse();
             }
 
             [Fact]
             public void Should_not_have_warning_package_result()
             {
-                packageResult.Warning.ShouldBeFalse();
+                packageResult.Warning.Should().BeFalse();
             }
 
             [Fact]
@@ -1087,7 +1087,7 @@ namespace chocolatey.tests.integration.scenarios
                     }
                 }
 
-                errorFound.ShouldBeTrue();
+                errorFound.Should().BeTrue();
             }
 
             [Fact]
@@ -1102,7 +1102,7 @@ namespace chocolatey.tests.integration.scenarios
                     }
                 }
 
-                errorFound.ShouldBeTrue();
+                errorFound.Should().BeTrue();
             }
         }
 
@@ -1150,31 +1150,31 @@ namespace chocolatey.tests.integration.scenarios
                     if (message.Contains("1/1")) installedSuccessfully = true;
                 }
 
-                installedSuccessfully.ShouldBeTrue();
+                installedSuccessfully.Should().BeTrue();
             }
 
             [Fact]
             public void Should_have_a_successful_package_result()
             {
-                _packageResult.Success.ShouldBeTrue();
+                _packageResult.Success.Should().BeTrue();
             }
 
             [Fact]
             public void Should_not_have_inconclusive_package_result()
             {
-                _packageResult.Inconclusive.ShouldBeFalse();
+                _packageResult.Inconclusive.Should().BeFalse();
             }
 
             [Fact]
             public void Should_not_have_warning_package_result()
             {
-                _packageResult.Warning.ShouldBeFalse();
+                _packageResult.Warning.Should().BeFalse();
             }
 
             [Fact]
             public void Config_should_match_package_result_name()
             {
-                _packageResult.Name.ShouldEqual(Configuration.PackageNames);
+                _packageResult.Name.Should().Be(Configuration.PackageNames);
             }
 
             [Fact]
@@ -1256,31 +1256,31 @@ namespace chocolatey.tests.integration.scenarios
                     if (message.Contains("1/1")) installedSuccessfully = true;
                 }
 
-                installedSuccessfully.ShouldBeTrue();
+                installedSuccessfully.Should().BeTrue();
             }
 
             [Fact]
             public void Should_have_a_successful_package_result()
             {
-                _packageResult.Success.ShouldBeTrue();
+                _packageResult.Success.Should().BeTrue();
             }
 
             [Fact]
             public void Should_not_have_inconclusive_package_result()
             {
-                _packageResult.Inconclusive.ShouldBeFalse();
+                _packageResult.Inconclusive.Should().BeFalse();
             }
 
             [Fact]
             public void Should_not_have_warning_package_result()
             {
-                _packageResult.Warning.ShouldBeFalse();
+                _packageResult.Warning.Should().BeFalse();
             }
 
             [Fact]
             public void Config_should_match_package_result_name()
             {
-                _packageResult.Name.ShouldEqual(Configuration.PackageNames);
+                _packageResult.Name.Should().Be(Configuration.PackageNames);
             }
 
             [Fact]
@@ -1288,7 +1288,7 @@ namespace chocolatey.tests.integration.scenarios
             [Platform(Exclude = "Mono")]
             public void Should_have_executed_chocolateyBeforeModify_script()
             {
-                MockLogger.ContainsMessage("installpackage 1.0.0 Before Modification", LogLevel.Info).ShouldBeTrue();
+                MockLogger.ContainsMessage("installpackage 1.0.0 Before Modification", LogLevel.Info).Should().BeTrue();
             }
 
             [Fact]
@@ -1296,7 +1296,7 @@ namespace chocolatey.tests.integration.scenarios
             [Platform(Exclude = "Mono")]
             public void Should_have_executed_chocolateyUninstall_script()
             {
-                MockLogger.ContainsMessage("installpackage 1.0.0 Uninstalled", LogLevel.Info).ShouldBeTrue();
+                MockLogger.ContainsMessage("installpackage 1.0.0 Uninstalled", LogLevel.Info).Should().BeTrue();
             }
 
             [Fact]
@@ -1304,7 +1304,7 @@ namespace chocolatey.tests.integration.scenarios
             [Platform(Exclude = "Mono")]
             public void Should_have_executed_pre_all_hook_script()
             {
-                MockLogger.ContainsMessage("pre-uninstall-all.ps1 hook ran for installpackage 1.0.0", LogLevel.Info).ShouldBeTrue();
+                MockLogger.ContainsMessage("pre-uninstall-all.ps1 hook ran for installpackage 1.0.0", LogLevel.Info).Should().BeTrue();
             }
 
             [Fact]
@@ -1312,7 +1312,7 @@ namespace chocolatey.tests.integration.scenarios
             [Platform(Exclude = "Mono")]
             public void Should_have_executed_post_all_hook_script()
             {
-                MockLogger.ContainsMessage("post-uninstall-all.ps1 hook ran for installpackage 1.0.0", LogLevel.Info).ShouldBeTrue();
+                MockLogger.ContainsMessage("post-uninstall-all.ps1 hook ran for installpackage 1.0.0", LogLevel.Info).Should().BeTrue();
             }
 
             [Fact]
@@ -1320,7 +1320,7 @@ namespace chocolatey.tests.integration.scenarios
             [Platform(Exclude = "Mono")]
             public void Should_have_executed_pre_installpackage_hook_script()
             {
-                MockLogger.ContainsMessage("pre-uninstall-installpackage.ps1 hook ran for installpackage 1.0.0", LogLevel.Info).ShouldBeTrue();
+                MockLogger.ContainsMessage("pre-uninstall-installpackage.ps1 hook ran for installpackage 1.0.0", LogLevel.Info).Should().BeTrue();
             }
 
             [Fact]
@@ -1328,7 +1328,7 @@ namespace chocolatey.tests.integration.scenarios
             [Platform(Exclude = "Mono")]
             public void Should_have_executed_post_installpackage_hook_script()
             {
-                MockLogger.ContainsMessage("post-uninstall-installpackage.ps1 hook ran for installpackage 1.0.0", LogLevel.Info).ShouldBeTrue();
+                MockLogger.ContainsMessage("post-uninstall-installpackage.ps1 hook ran for installpackage 1.0.0", LogLevel.Info).Should().BeTrue();
             }
 
             [Fact]
@@ -1336,7 +1336,7 @@ namespace chocolatey.tests.integration.scenarios
             [Platform(Exclude = "Mono")]
             public void Should_not_have_executed_upgradepackage_hook_script()
             {
-                MockLogger.ContainsMessage("pre-uninstall-upgradepackage.ps1 hook ran for installpackage 1.0.0", LogLevel.Info).ShouldBeFalse();
+                MockLogger.ContainsMessage("pre-uninstall-upgradepackage.ps1 hook ran for installpackage 1.0.0", LogLevel.Info).Should().BeFalse();
             }
 
             [Fact]
@@ -1344,7 +1344,7 @@ namespace chocolatey.tests.integration.scenarios
             [Platform(Exclude = "Mono")]
             public void Should_have_executed_pre_beforemodify_hook_script()
             {
-                MockLogger.ContainsMessage("pre-beforemodify-all.ps1 hook ran for installpackage 1.0.0", LogLevel.Info).ShouldBeTrue();
+                MockLogger.ContainsMessage("pre-beforemodify-all.ps1 hook ran for installpackage 1.0.0", LogLevel.Info).Should().BeTrue();
             }
 
             [Fact]
@@ -1352,7 +1352,7 @@ namespace chocolatey.tests.integration.scenarios
             [Platform(Exclude = "Mono")]
             public void Should_have_executed_post_beforemodify_hook_script()
             {
-                MockLogger.ContainsMessage("post-beforemodify-all.ps1 hook ran for installpackage 1.0.0", LogLevel.Info).ShouldBeTrue();
+                MockLogger.ContainsMessage("post-beforemodify-all.ps1 hook ran for installpackage 1.0.0", LogLevel.Info).Should().BeTrue();
             }
         }
 
@@ -1400,31 +1400,31 @@ namespace chocolatey.tests.integration.scenarios
                     if (message.Contains("1/1")) installedSuccessfully = true;
                 }
 
-                installedSuccessfully.ShouldBeTrue();
+                installedSuccessfully.Should().BeTrue();
             }
 
             [Fact]
             public void Should_have_a_successful_package_result()
             {
-                packageResult.Success.ShouldBeTrue();
+                packageResult.Success.Should().BeTrue();
             }
 
             [Fact]
             public void Should_not_have_inconclusive_package_result()
             {
-                packageResult.Inconclusive.ShouldBeFalse();
+                packageResult.Inconclusive.Should().BeFalse();
             }
 
             [Fact]
             public void Should_not_have_warning_package_result()
             {
-                packageResult.Warning.ShouldBeFalse();
+                packageResult.Warning.Should().BeFalse();
             }
 
             [Fact]
             public void Config_should_match_package_result_name()
             {
-                packageResult.Name.ShouldEqual(Configuration.PackageNames);
+                packageResult.Name.Should().Be(Configuration.PackageNames);
             }
 
             [Fact]
@@ -1432,7 +1432,7 @@ namespace chocolatey.tests.integration.scenarios
             [Platform(Exclude = "Mono")]
             public void Should_have_executed_chocolateyBeforeModify_script()
             {
-                MockLogger.ContainsMessage("UpperCase 1.1.0 Before Modification", LogLevel.Info).ShouldBeTrue();
+                MockLogger.ContainsMessage("UpperCase 1.1.0 Before Modification", LogLevel.Info).Should().BeTrue();
             }
 
             [Fact]
@@ -1440,7 +1440,7 @@ namespace chocolatey.tests.integration.scenarios
             [Platform(Exclude = "Mono")]
             public void Should_have_executed_chocolateyUninstall_script()
             {
-                MockLogger.ContainsMessage("UpperCase 1.1.0 Uninstalled", LogLevel.Info).ShouldBeTrue();
+                MockLogger.ContainsMessage("UpperCase 1.1.0 Uninstalled", LogLevel.Info).Should().BeTrue();
             }
         }
 
@@ -1448,8 +1448,7 @@ namespace chocolatey.tests.integration.scenarios
         {
             private PackageResult packageResult;
 
-            private const string NonNormalizedVersion = "0004.0004.00005.00";
-            private const string NormalizedVersion = "4.4.5";
+            private string NonNormalizedVersion = "0004.0004.00005.00";
 
             public override void Context()
             {
@@ -1519,31 +1518,31 @@ namespace chocolatey.tests.integration.scenarios
                     if (message.Contains("1/1")) installedSuccessfully = true;
                 }
 
-                installedSuccessfully.ShouldBeTrue();
+                installedSuccessfully.Should().BeTrue();
             }
 
             [Fact]
             public void Should_have_a_successful_package_result()
             {
-                packageResult.Success.ShouldBeTrue();
+                packageResult.Success.Should().BeTrue();
             }
 
             [Fact]
             public void Should_not_have_inconclusive_package_result()
             {
-                packageResult.Inconclusive.ShouldBeFalse();
+                packageResult.Inconclusive.Should().BeFalse();
             }
 
             [Fact]
             public void Should_not_have_warning_package_result()
             {
-                packageResult.Warning.ShouldBeFalse();
+                packageResult.Warning.Should().BeFalse();
             }
 
             [Fact]
             public void Config_should_match_package_result_name()
             {
-                packageResult.Name.ShouldEqual(Configuration.PackageNames);
+                packageResult.Name.Should().Be(Configuration.PackageNames);
             }
 
             [Fact]
@@ -1551,7 +1550,7 @@ namespace chocolatey.tests.integration.scenarios
             [Platform(Exclude = "Mono")]
             public void Should_have_executed_chocolateyBeforeModify_script()
             {
-                MockLogger.ContainsMessage("upgradepackage {0} Before Modification".FormatWith(NormalizedVersion), LogLevel.Info).ShouldBeTrue();
+                MockLogger.ContainsMessage("upgradepackage {0} Before Modification".FormatWith(NonNormalizedVersion), LogLevel.Info).Should().BeTrue();
             }
 
             [Fact]
@@ -1559,7 +1558,7 @@ namespace chocolatey.tests.integration.scenarios
             [Platform(Exclude = "Mono")]
             public void Should_have_executed_chocolateyUninstall_script()
             {
-                MockLogger.ContainsMessage("upgradepackage {0} Uninstalled".FormatWith(NormalizedVersion), LogLevel.Info).ShouldBeTrue();
+                MockLogger.ContainsMessage("upgradepackage {0} Uninstalled".FormatWith(NonNormalizedVersion), LogLevel.Info).Should().BeTrue();
             }
         }
 
@@ -1590,20 +1589,20 @@ namespace chocolatey.tests.integration.scenarios
             public void Should_uninstall_the_package()
             {
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", TargetPackageName, "{0}.nupkg".FormatWith(TargetPackageName));
-                File.Exists(packageFile).ShouldBeFalse();
+                File.Exists(packageFile).Should().BeFalse();
             }
 
             [Fact]
             public void Should_uninstall_the_dependency()
             {
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", DependencyName, "{0}.nupkg".FormatWith(DependencyName));
-                File.Exists(packageFile).ShouldBeFalse();
+                File.Exists(packageFile).Should().BeFalse();
             }
 
             [Fact]
             public void Should_contain_a_message_that_everything_uninstalled_successfully()
             {
-                MockLogger.ContainsMessage("uninstalled 2/2", LogLevel.Warn).ShouldBeTrue();
+                MockLogger.ContainsMessage("uninstalled 2/2", LogLevel.Warn).Should().BeTrue();
             }
 
             [Fact]
@@ -1611,7 +1610,7 @@ namespace chocolatey.tests.integration.scenarios
             [Platform(Exclude = "Mono")]
             public void Should_run_target_package_beforeModify()
             {
-                MockLogger.ContainsMessage("Ran BeforeModify: {0} {1}".FormatWith(TargetPackageName, "1.0.0"), LogLevel.Info).ShouldBeTrue();
+                MockLogger.ContainsMessage("Ran BeforeModify: {0} {1}".FormatWith(TargetPackageName, "1.0.0"), LogLevel.Info).Should().BeTrue();
             }
 
             [Fact]
@@ -1619,7 +1618,7 @@ namespace chocolatey.tests.integration.scenarios
             [Platform(Exclude = "Mono")]
             public void Should_run_dependency_package_beforeModify()
             {
-                MockLogger.ContainsMessage("Ran BeforeModify: {0} {1}".FormatWith(DependencyName, "1.0.0"), LogLevel.Info).ShouldBeTrue();
+                MockLogger.ContainsMessage("Ran BeforeModify: {0} {1}".FormatWith(DependencyName, "1.0.0"), LogLevel.Info).Should().BeTrue();
             }
 
             [Fact]
@@ -1627,7 +1626,7 @@ namespace chocolatey.tests.integration.scenarios
             {
                 foreach (var packageResult in Results)
                 {
-                    packageResult.Value.Success.ShouldBeTrue();
+                    packageResult.Value.Success.Should().BeTrue();
                 }
             }
 
@@ -1636,7 +1635,7 @@ namespace chocolatey.tests.integration.scenarios
             {
                 foreach (var packageResult in Results)
                 {
-                    packageResult.Value.Inconclusive.ShouldBeFalse();
+                    packageResult.Value.Inconclusive.Should().BeFalse();
                 }
             }
 
@@ -1645,7 +1644,7 @@ namespace chocolatey.tests.integration.scenarios
             {
                 foreach (var packageResult in Results)
                 {
-                    packageResult.Value.Warning.ShouldBeFalse();
+                    packageResult.Value.Warning.Should().BeFalse();
                 }
 
             }

--- a/src/chocolatey.tests.integration/scenarios/UninstallScenarios.cs
+++ b/src/chocolatey.tests.integration/scenarios/UninstallScenarios.cs
@@ -83,13 +83,8 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_contain_a_message_that_it_would_have_uninstalled_a_package()
             {
-                bool expectedMessage = false;
-                foreach (var message in MockLogger.MessagesFor(LogLevel.Warn).OrEmpty())
-                {
-                    if (message.Contains("Would have uninstalled installpackage v1.0.0")) expectedMessage = true;
-                }
-
-                expectedMessage.Should().BeTrue();
+                MockLogger.Messages.Should().ContainKey(LogLevel.Warn.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains("Would have uninstalled installpackage v1.0.0"));
             }
 
             [Fact]
@@ -126,13 +121,8 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_contain_a_message_that_it_was_unable_to_find_package()
             {
-                bool expectedMessage = false;
-                foreach (var message in MockLogger.MessagesFor(LogLevel.Error).OrEmpty())
-                {
-                    if (message.Contains("somethingnonexisting is not installed. Cannot uninstall a non-existent package")) expectedMessage = true;
-                }
-
-                expectedMessage.Should().BeTrue();
+                MockLogger.Messages.Should().ContainKey(LogLevel.Error.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains("somethingnonexisting is not installed. Cannot uninstall a non-existent package"));
             }
         }
 
@@ -193,13 +183,8 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_contain_a_warning_message_that_it_uninstalled_successfully()
             {
-                bool installedSuccessfully = false;
-                foreach (var message in MockLogger.MessagesFor(LogLevel.Warn).OrEmpty())
-                {
-                    if (message.Contains("1/1")) installedSuccessfully = true;
-                }
-
-                installedSuccessfully.Should().BeTrue();
+                MockLogger.Messages.Should().ContainKey(LogLevel.Warn.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains("1/1"));
             }
 
             [Fact]
@@ -231,7 +216,8 @@ namespace chocolatey.tests.integration.scenarios
             [Platform(Exclude = "Mono")]
             public void Should_have_executed_chocolateyBeforeModify_script()
             {
-                MockLogger.ContainsMessage("installpackage 1.0.0 Before Modification", LogLevel.Info).Should().BeTrue();
+                MockLogger.Messages.Should().ContainKey(LogLevel.Info.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains("installpackage 1.0.0 Before Modification"));
             }
 
             [Fact]
@@ -239,7 +225,8 @@ namespace chocolatey.tests.integration.scenarios
             [Platform(Exclude = "Mono")]
             public void Should_have_executed_chocolateyUninstall_script()
             {
-                MockLogger.ContainsMessage("installpackage 1.0.0 Uninstalled", LogLevel.Info).Should().BeTrue();
+                MockLogger.Messages.Should().ContainKey(LogLevel.Info.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains("installpackage 1.0.0 Uninstalled"));
             }
         }
 
@@ -294,13 +281,8 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_contain_a_warning_message_that_it_uninstalled_successfully()
             {
-                bool installedSuccessfully = false;
-                foreach (var message in MockLogger.MessagesFor(LogLevel.Warn).OrEmpty())
-                {
-                    if (message.Contains("1/1")) installedSuccessfully = true;
-                }
-
-                installedSuccessfully.Should().BeTrue();
+                MockLogger.Messages.Should().ContainKey(LogLevel.Warn.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains("1/1"));
             }
 
             [Fact]
@@ -389,13 +371,8 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_contain_a_message_that_it_uninstalled_successfully()
             {
-                bool expectedMessage = false;
-                foreach (var message in MockLogger.MessagesFor(LogLevel.Warn).OrEmpty())
-                {
-                    if (message.Contains("uninstalled 1/1")) expectedMessage = true;
-                }
-
-                expectedMessage.Should().BeTrue();
+                MockLogger.Messages.Should().ContainKey(LogLevel.Warn.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains("uninstalled 1/1"));
             }
 
             [Fact]
@@ -476,13 +453,8 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_contain_a_message_that_it_uninstalled_successfully()
             {
-                bool expectedMessage = false;
-                foreach (var message in MockLogger.MessagesFor(LogLevel.Warn).OrEmpty())
-                {
-                    if (message.Contains("uninstalled 1/1")) expectedMessage = true;
-                }
-
-                expectedMessage.Should().BeTrue();
+                MockLogger.Messages.Should().ContainKey(LogLevel.Warn.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains("uninstalled 1/1"));
             }
 
             [Fact]
@@ -567,29 +539,15 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_contain_a_message_about_not_all_files_are_removed()
             {
-                bool expectedMessage = false;
-
-                foreach (var message in MockLogger.MessagesFor(LogLevel.Error).OrEmpty())
-                {
-                    if (message.Contains("Unable to delete all existing package files. There will be leftover files requiring manual cleanup"))
-                    {
-                        expectedMessage = true;
-                    }
-                }
-
-                expectedMessage.Should().BeTrue();
+                MockLogger.Messages.Should().ContainKey(LogLevel.Error.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains("Unable to delete all existing package files. There will be leftover files requiring manual cleanup"));
             }
 
             [Fact]
             public void Should_contain_a_message_that_it_was_not_able_to_uninstall()
             {
-                bool expectedMessage = false;
-                foreach (var message in MockLogger.MessagesFor(LogLevel.Warn).OrEmpty())
-                {
-                    if (message.Contains("uninstalled 0/1")) expectedMessage = true;
-                }
-
-                expectedMessage.Should().BeTrue();
+                MockLogger.Messages.Should().ContainKey(LogLevel.Warn.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains("uninstalled 0/1"));
             }
 
             [Fact]
@@ -678,13 +636,8 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_contain_a_warning_message_that_it_uninstalled_successfully()
             {
-                bool installedSuccessfully = false;
-                foreach (var message in MockLogger.MessagesFor(LogLevel.Warn).OrEmpty())
-                {
-                    if (message.Contains("1/1")) installedSuccessfully = true;
-                }
-
-                installedSuccessfully.Should().BeTrue();
+                MockLogger.Messages.Should().ContainKey(LogLevel.Warn.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains("1/1"));
             }
 
             [Fact]
@@ -779,13 +732,8 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_contain_a_warning_message_that_it_uninstalled_successfully()
             {
-                bool installedSuccessfully = false;
-                foreach (var message in MockLogger.MessagesFor(LogLevel.Warn).OrEmpty())
-                {
-                    if (message.Contains("1/1")) installedSuccessfully = true;
-                }
-
-                installedSuccessfully.Should().BeTrue();
+                MockLogger.Messages.Should().ContainKey(LogLevel.Warn.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains("1/1"));
             }
 
             [Fact]
@@ -888,13 +836,8 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_contain_a_warning_message_that_it_uninstalled_successfully()
             {
-                bool installedSuccessfully = false;
-                foreach (var message in MockLogger.MessagesFor(LogLevel.Warn).OrEmpty())
-                {
-                    if (message.Contains("1/1")) installedSuccessfully = true;
-                }
-
-                installedSuccessfully.Should().BeTrue();
+                MockLogger.Messages.Should().ContainKey(LogLevel.Warn.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains("1/1"));
             }
 
             [Fact]
@@ -941,25 +884,15 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_contain_a_message_that_it_was_unable_to_find_package()
             {
-                bool expectedMessage = false;
-                foreach (var message in MockLogger.MessagesFor(LogLevel.Error).OrEmpty())
-                {
-                    if (message.Contains("somethingnonexisting is not installed. Cannot uninstall a non-existent package")) expectedMessage = true;
-                }
-
-                expectedMessage.Should().BeTrue();
+                MockLogger.Messages.Should().ContainKey(LogLevel.Error.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains("somethingnonexisting is not installed. Cannot uninstall a non-existent package"));
             }
 
             [Fact]
             public void Should_contain_a_warning_message_that_it_uninstalled_successfully()
             {
-                bool installedSuccessfully = false;
-                foreach (var message in MockLogger.MessagesFor(LogLevel.Warn).OrEmpty())
-                {
-                    if (message.Contains("0/1")) installedSuccessfully = true;
-                }
-
-                installedSuccessfully.Should().BeTrue();
+                MockLogger.Messages.Should().ContainKey(LogLevel.Warn.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains("0/1"));
             }
 
             [Fact]
@@ -983,16 +916,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_have_an_error_package_result()
             {
-                bool errorFound = false;
-                foreach (var message in packageResult.Messages)
-                {
-                    if (message.MessageType == ResultType.Error)
-                    {
-                        errorFound = true;
-                    }
-                }
-
-                errorFound.Should().BeTrue();
+                packageResult.Messages.Should().Contain(m => m.MessageType == ResultType.Error);
             }
         }
 
@@ -1048,13 +972,8 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_contain_a_warning_message_that_it_was_unable_to_install_a_package()
             {
-                bool installedSuccessfully = false;
-                foreach (var message in MockLogger.MessagesFor(LogLevel.Warn).OrEmpty())
-                {
-                    if (message.Contains("0/1")) installedSuccessfully = true;
-                }
-
-                installedSuccessfully.Should().BeTrue();
+                MockLogger.Messages.Should().ContainKey(LogLevel.Warn.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains("0/1"));
             }
 
             [Fact]
@@ -1078,31 +997,16 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_have_an_error_package_result()
             {
-                bool errorFound = false;
-                foreach (var message in packageResult.Messages)
-                {
-                    if (message.MessageType == ResultType.Error)
-                    {
-                        errorFound = true;
-                    }
-                }
-
-                errorFound.Should().BeTrue();
+                packageResult.Messages.Should().Contain(m => m.MessageType == ResultType.Error);
             }
 
             [Fact]
             public void Should_have_expected_error_in_package_result()
             {
-                bool errorFound = false;
-                foreach (var message in packageResult.Messages)
-                {
-                    if (message.MessageType == ResultType.Error)
-                    {
-                        if (message.Message.Contains("chocolateyUninstall.ps1")) errorFound = true;
-                    }
-                }
-
-                errorFound.Should().BeTrue();
+                Results.Should().AllSatisfy(r =>
+                    r.Value.Messages.Should().Contain(m =>
+                        m.MessageType == ResultType.Error &&
+                        m.Message.Contains("chocolateyUninstall.ps1")));
             }
         }
 
@@ -1144,13 +1048,8 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_contain_a_warning_message_that_it_uninstalled_successfully()
             {
-                bool installedSuccessfully = false;
-                foreach (var message in MockLogger.MessagesFor(LogLevel.Warn).OrEmpty())
-                {
-                    if (message.Contains("1/1")) installedSuccessfully = true;
-                }
-
-                installedSuccessfully.Should().BeTrue();
+                MockLogger.Messages.Should().ContainKey(LogLevel.Warn.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains("1/1"));
             }
 
             [Fact]
@@ -1250,13 +1149,8 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_contain_a_warning_message_that_it_uninstalled_successfully()
             {
-                bool installedSuccessfully = false;
-                foreach (var message in MockLogger.MessagesFor(LogLevel.Warn).OrEmpty())
-                {
-                    if (message.Contains("1/1")) installedSuccessfully = true;
-                }
-
-                installedSuccessfully.Should().BeTrue();
+                MockLogger.Messages.Should().ContainKey(LogLevel.Warn.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains("1/1"));
             }
 
             [Fact]
@@ -1288,7 +1182,8 @@ namespace chocolatey.tests.integration.scenarios
             [Platform(Exclude = "Mono")]
             public void Should_have_executed_chocolateyBeforeModify_script()
             {
-                MockLogger.ContainsMessage("installpackage 1.0.0 Before Modification", LogLevel.Info).Should().BeTrue();
+                MockLogger.Messages.Should().ContainKey(LogLevel.Info.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains("installpackage 1.0.0 Before Modification"));
             }
 
             [Fact]
@@ -1296,7 +1191,8 @@ namespace chocolatey.tests.integration.scenarios
             [Platform(Exclude = "Mono")]
             public void Should_have_executed_chocolateyUninstall_script()
             {
-                MockLogger.ContainsMessage("installpackage 1.0.0 Uninstalled", LogLevel.Info).Should().BeTrue();
+                MockLogger.Messages.Should().ContainKey(LogLevel.Info.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains("installpackage 1.0.0 Uninstalled"));
             }
 
             [Fact]
@@ -1304,7 +1200,8 @@ namespace chocolatey.tests.integration.scenarios
             [Platform(Exclude = "Mono")]
             public void Should_have_executed_pre_all_hook_script()
             {
-                MockLogger.ContainsMessage("pre-uninstall-all.ps1 hook ran for installpackage 1.0.0", LogLevel.Info).Should().BeTrue();
+                MockLogger.Messages.Should().ContainKey(LogLevel.Info.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains("pre-uninstall-all.ps1 hook ran for installpackage 1.0.0"));
             }
 
             [Fact]
@@ -1312,7 +1209,8 @@ namespace chocolatey.tests.integration.scenarios
             [Platform(Exclude = "Mono")]
             public void Should_have_executed_post_all_hook_script()
             {
-                MockLogger.ContainsMessage("post-uninstall-all.ps1 hook ran for installpackage 1.0.0", LogLevel.Info).Should().BeTrue();
+                MockLogger.Messages.Should().ContainKey(LogLevel.Info.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains("post-uninstall-all.ps1 hook ran for installpackage 1.0.0"));
             }
 
             [Fact]
@@ -1320,7 +1218,8 @@ namespace chocolatey.tests.integration.scenarios
             [Platform(Exclude = "Mono")]
             public void Should_have_executed_pre_installpackage_hook_script()
             {
-                MockLogger.ContainsMessage("pre-uninstall-installpackage.ps1 hook ran for installpackage 1.0.0", LogLevel.Info).Should().BeTrue();
+                MockLogger.Messages.Should().ContainKey(LogLevel.Info.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains("pre-uninstall-installpackage.ps1 hook ran for installpackage 1.0.0"));
             }
 
             [Fact]
@@ -1328,7 +1227,8 @@ namespace chocolatey.tests.integration.scenarios
             [Platform(Exclude = "Mono")]
             public void Should_have_executed_post_installpackage_hook_script()
             {
-                MockLogger.ContainsMessage("post-uninstall-installpackage.ps1 hook ran for installpackage 1.0.0", LogLevel.Info).Should().BeTrue();
+                MockLogger.Messages.Should().ContainKey(LogLevel.Info.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains("post-uninstall-installpackage.ps1 hook ran for installpackage 1.0.0"));
             }
 
             [Fact]
@@ -1336,7 +1236,8 @@ namespace chocolatey.tests.integration.scenarios
             [Platform(Exclude = "Mono")]
             public void Should_not_have_executed_upgradepackage_hook_script()
             {
-                MockLogger.ContainsMessage("pre-uninstall-upgradepackage.ps1 hook ran for installpackage 1.0.0", LogLevel.Info).Should().BeFalse();
+                MockLogger.Messages.Should().ContainKey(LogLevel.Info.ToStringSafe())
+                    .WhoseValue.Should().NotContain(m => m.Contains("pre-uninstall-upgradepackage.ps1 hook ran for installpackage 1.0.0"));
             }
 
             [Fact]
@@ -1344,7 +1245,8 @@ namespace chocolatey.tests.integration.scenarios
             [Platform(Exclude = "Mono")]
             public void Should_have_executed_pre_beforemodify_hook_script()
             {
-                MockLogger.ContainsMessage("pre-beforemodify-all.ps1 hook ran for installpackage 1.0.0", LogLevel.Info).Should().BeTrue();
+                MockLogger.Messages.Should().ContainKey(LogLevel.Info.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains("pre-beforemodify-all.ps1 hook ran for installpackage 1.0.0"));
             }
 
             [Fact]
@@ -1352,7 +1254,8 @@ namespace chocolatey.tests.integration.scenarios
             [Platform(Exclude = "Mono")]
             public void Should_have_executed_post_beforemodify_hook_script()
             {
-                MockLogger.ContainsMessage("post-beforemodify-all.ps1 hook ran for installpackage 1.0.0", LogLevel.Info).Should().BeTrue();
+                MockLogger.Messages.Should().ContainKey(LogLevel.Info.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains("post-beforemodify-all.ps1 hook ran for installpackage 1.0.0"));
             }
         }
 
@@ -1394,13 +1297,8 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_contain_a_warning_message_that_it_uninstalled_successfully()
             {
-                bool installedSuccessfully = false;
-                foreach (var message in MockLogger.MessagesFor(LogLevel.Warn).OrEmpty())
-                {
-                    if (message.Contains("1/1")) installedSuccessfully = true;
-                }
-
-                installedSuccessfully.Should().BeTrue();
+                MockLogger.Messages.Should().ContainKey(LogLevel.Warn.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains("1/1"));
             }
 
             [Fact]
@@ -1432,7 +1330,8 @@ namespace chocolatey.tests.integration.scenarios
             [Platform(Exclude = "Mono")]
             public void Should_have_executed_chocolateyBeforeModify_script()
             {
-                MockLogger.ContainsMessage("UpperCase 1.1.0 Before Modification", LogLevel.Info).Should().BeTrue();
+                MockLogger.Messages.Should().ContainKey(LogLevel.Info.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains("UpperCase 1.1.0 Before Modification"));
             }
 
             [Fact]
@@ -1440,7 +1339,8 @@ namespace chocolatey.tests.integration.scenarios
             [Platform(Exclude = "Mono")]
             public void Should_have_executed_chocolateyUninstall_script()
             {
-                MockLogger.ContainsMessage("UpperCase 1.1.0 Uninstalled", LogLevel.Info).Should().BeTrue();
+                MockLogger.Messages.Should().ContainKey(LogLevel.Info.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains("UpperCase 1.1.0 Uninstalled"));
             }
         }
 
@@ -1449,6 +1349,7 @@ namespace chocolatey.tests.integration.scenarios
             private PackageResult packageResult;
 
             private string NonNormalizedVersion = "0004.0004.00005.00";
+            private string NormalizedVersion = "4.4.5";
 
             public override void Context()
             {
@@ -1512,13 +1413,8 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_contain_a_warning_message_that_it_uninstalled_successfully()
             {
-                bool installedSuccessfully = false;
-                foreach (var message in MockLogger.MessagesFor(LogLevel.Warn).OrEmpty())
-                {
-                    if (message.Contains("1/1")) installedSuccessfully = true;
-                }
-
-                installedSuccessfully.Should().BeTrue();
+                MockLogger.Messages.Should().ContainKey(LogLevel.Warn.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains("1/1"));
             }
 
             [Fact]
@@ -1550,7 +1446,8 @@ namespace chocolatey.tests.integration.scenarios
             [Platform(Exclude = "Mono")]
             public void Should_have_executed_chocolateyBeforeModify_script()
             {
-                MockLogger.ContainsMessage("upgradepackage {0} Before Modification".FormatWith(NonNormalizedVersion), LogLevel.Info).Should().BeTrue();
+                MockLogger.Messages.Should().ContainKey(LogLevel.Info.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains("upgradepackage {0} Before Modification".FormatWith(NormalizedVersion)));
             }
 
             [Fact]
@@ -1558,7 +1455,8 @@ namespace chocolatey.tests.integration.scenarios
             [Platform(Exclude = "Mono")]
             public void Should_have_executed_chocolateyUninstall_script()
             {
-                MockLogger.ContainsMessage("upgradepackage {0} Uninstalled".FormatWith(NonNormalizedVersion), LogLevel.Info).Should().BeTrue();
+                MockLogger.Messages.Should().ContainKey(LogLevel.Info.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains("upgradepackage {0} Uninstalled".FormatWith(NormalizedVersion)));
             }
         }
 
@@ -1589,20 +1487,21 @@ namespace chocolatey.tests.integration.scenarios
             public void Should_uninstall_the_package()
             {
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", TargetPackageName, "{0}.nupkg".FormatWith(TargetPackageName));
-                File.Exists(packageFile).Should().BeFalse();
+                FileAssert.DoesNotExist(packageFile);
             }
 
             [Fact]
             public void Should_uninstall_the_dependency()
             {
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", DependencyName, "{0}.nupkg".FormatWith(DependencyName));
-                File.Exists(packageFile).Should().BeFalse();
+                FileAssert.DoesNotExist(packageFile);
             }
 
             [Fact]
             public void Should_contain_a_message_that_everything_uninstalled_successfully()
             {
-                MockLogger.ContainsMessage("uninstalled 2/2", LogLevel.Warn).Should().BeTrue();
+                MockLogger.Messages.Should().ContainKey(LogLevel.Warn.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains("uninstalled 2/2"));
             }
 
             [Fact]
@@ -1610,7 +1509,8 @@ namespace chocolatey.tests.integration.scenarios
             [Platform(Exclude = "Mono")]
             public void Should_run_target_package_beforeModify()
             {
-                MockLogger.ContainsMessage("Ran BeforeModify: {0} {1}".FormatWith(TargetPackageName, "1.0.0"), LogLevel.Info).Should().BeTrue();
+                MockLogger.Messages.Should().ContainKey(LogLevel.Info.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains("Ran BeforeModify: {0} {1}".FormatWith(TargetPackageName, "1.0.0")));
             }
 
             [Fact]
@@ -1618,34 +1518,26 @@ namespace chocolatey.tests.integration.scenarios
             [Platform(Exclude = "Mono")]
             public void Should_run_dependency_package_beforeModify()
             {
-                MockLogger.ContainsMessage("Ran BeforeModify: {0} {1}".FormatWith(DependencyName, "1.0.0"), LogLevel.Info).Should().BeTrue();
+                MockLogger.Messages.Should().ContainKey(LogLevel.Info.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains("Ran BeforeModify: {0} {1}".FormatWith(DependencyName, "1.0.0")));
             }
 
             [Fact]
             public void Should_have_a_successful_package_result()
             {
-                foreach (var packageResult in Results)
-                {
-                    packageResult.Value.Success.Should().BeTrue();
-                }
+                Results.Should().AllSatisfy(r => r.Value.Success.Should().BeTrue());
             }
 
             [Fact]
             public void Should_not_have_inconclusive_package_result()
             {
-                foreach (var packageResult in Results)
-                {
-                    packageResult.Value.Inconclusive.Should().BeFalse();
-                }
+                Results.Should().AllSatisfy(r => r.Value.Inconclusive.Should().BeFalse());
             }
 
             [Fact]
             public void Should_not_have_warning_package_result()
             {
-                foreach (var packageResult in Results)
-                {
-                    packageResult.Value.Warning.Should().BeFalse();
-                }
+                Results.Should().AllSatisfy(r => r.Value.Warning.Should().BeFalse());
 
             }
         }

--- a/src/chocolatey.tests.integration/scenarios/UpgradeScenarios.cs
+++ b/src/chocolatey.tests.integration/scenarios/UpgradeScenarios.cs
@@ -32,7 +32,7 @@ namespace chocolatey.tests.integration.scenarios
     using NuGet.Configuration;
     using NuGet.Packaging;
     using NUnit.Framework;
-    using Should;
+    using FluentAssertions;
     using static chocolatey.tests.integration.scenarios.InstallScenarios;
 
     public class UpgradeScenarios
@@ -80,7 +80,7 @@ namespace chocolatey.tests.integration.scenarios
             {
                 var shimFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, "tools", "console.exe");
 
-                File.ReadAllText(shimFile).ShouldEqual("1.0.0");
+                File.ReadAllText(shimFile).Should().Be("1.0.0");
             }
 
             [Fact]
@@ -92,7 +92,7 @@ namespace chocolatey.tests.integration.scenarios
                     if (message.Contains("You have upgradepackage v1.0.0 installed. Version 1.1.0 is available based on your source(s)")) expectedMessage = true;
                 }
 
-                expectedMessage.ShouldBeTrue();
+                expectedMessage.Should().BeTrue();
             }
 
             [Fact]
@@ -104,7 +104,7 @@ namespace chocolatey.tests.integration.scenarios
                     if (message.Contains("can upgrade 1/1")) expectedMessage = true;
                 }
 
-                expectedMessage.ShouldBeTrue();
+                expectedMessage.Should().BeTrue();
             }
 
             [Fact]
@@ -139,7 +139,7 @@ namespace chocolatey.tests.integration.scenarios
                     if (message.Contains("installpackage v1.0.0 is the latest version available based on your source(s)")) expectedMessage = true;
                 }
 
-                expectedMessage.ShouldBeTrue();
+                expectedMessage.Should().BeTrue();
             }
 
             [Fact]
@@ -151,7 +151,7 @@ namespace chocolatey.tests.integration.scenarios
                     if (message.Contains("can upgrade 0/1")) expectedMessage = true;
                 }
 
-                expectedMessage.ShouldBeTrue();
+                expectedMessage.Should().BeTrue();
             }
 
             [Fact]
@@ -186,7 +186,7 @@ namespace chocolatey.tests.integration.scenarios
                     if (message.Contains("nonexistentpackage not installed. The package was not found with the source(s) listed")) expectedMessage = true;
                 }
 
-                expectedMessage.ShouldBeTrue();
+                expectedMessage.Should().BeTrue();
             }
 
             [Fact]
@@ -198,7 +198,7 @@ namespace chocolatey.tests.integration.scenarios
                     if (message.Contains("can upgrade 0/0")) expectedMessage = true;
                 }
 
-                expectedMessage.ShouldBeTrue();
+                expectedMessage.Should().BeTrue();
             }
         }
 
@@ -239,7 +239,7 @@ namespace chocolatey.tests.integration.scenarios
             {
                 var shimFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, "tools", "console.exe");
 
-                File.ReadAllText(shimFile).ShouldEqual("1.1.0");
+                File.ReadAllText(shimFile).Should().Be("1.1.0");
             }
 
             [Fact]
@@ -248,7 +248,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, Configuration.PackageNames +  NuGetConstants.PackageExtension);
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().ShouldEqual("1.1.0");
+                    packageReader.NuspecReader.GetVersion().ToStringSafe().Should().Be("1.1.0");
                 }
             }
 
@@ -261,7 +261,7 @@ namespace chocolatey.tests.integration.scenarios
                     if (message.Contains("upgraded 1/1")) upgradedSuccessMessage = true;
                 }
 
-                upgradedSuccessMessage.ShouldBeTrue();
+                upgradedSuccessMessage.Should().BeTrue();
             }
 
             [Fact]
@@ -273,19 +273,19 @@ namespace chocolatey.tests.integration.scenarios
                     if (message.Contains("You have upgradepackage v1.0.0 installed. Version 1.1.0 is available based on your source")) upgradeMessage = true;
                 }
 
-                upgradeMessage.ShouldBeTrue();
+                upgradeMessage.Should().BeTrue();
             }
 
             [Fact]
             public void Should_have_a_successful_package_result()
             {
-                _packageResult.Success.ShouldBeTrue();
+                _packageResult.Success.Should().BeTrue();
             }
 
             [Fact]
             public void Should_not_have_inconclusive_package_result()
             {
-                _packageResult.Inconclusive.ShouldBeFalse();
+                _packageResult.Inconclusive.Should().BeFalse();
             }
 
             [Fact]
@@ -294,19 +294,19 @@ namespace chocolatey.tests.integration.scenarios
                 // For before modify scripts that fail, we add a warning message.
                 // So we will ignore any such warnings.
                 var messages = _packageResult.Messages.Where(m => m.MessageType == ResultType.Warn && !m.Message.ContainsSafe("chocolateyBeforeModify"));
-                messages.ShouldBeEmpty();
+                messages.Should().BeEmpty();
             }
 
             [Fact]
             public void Config_should_match_package_result_name()
             {
-                _packageResult.Name.ShouldEqual(Configuration.PackageNames);
+                _packageResult.Name.Should().Be(Configuration.PackageNames);
             }
 
             [Fact]
             public void Should_match_the_upgrade_version_of_one_dot_one_dot_zero()
             {
-                _packageResult.Version.ShouldEqual("1.1.0");
+                _packageResult.Version.Should().Be("1.1.0");
             }
 
             [Fact]
@@ -314,7 +314,7 @@ namespace chocolatey.tests.integration.scenarios
             [Platform(Exclude = "Mono")]
             public void Should_have_executed_chocolateyBeforeModify_script_for_original_package()
             {
-                MockLogger.ContainsMessage("upgradepackage 1.0.0 Before Modification", LogLevel.Info).ShouldBeTrue();
+                MockLogger.ContainsMessage("upgradepackage 1.0.0 Before Modification", LogLevel.Info).Should().BeTrue();
             }
 
             [Fact]
@@ -325,19 +325,19 @@ namespace chocolatey.tests.integration.scenarios
                 MockLogger.MessagesFor(LogLevel.Info).OrEmpty()
                     .SkipWhile(p => !p.Contains("upgradepackage 1.0.0 Before Modification"))
                     .Any(p => p.EndsWith("upgradepackage 1.1.0 Installed"))
-                    .ShouldBeTrue();
+                    .Should().BeTrue();
             }
 
             [Fact]
             public void Should_not_have_executed_chocolateyUninstall_script_for_original_package()
             {
-                MockLogger.ContainsMessage("upgradepackage 1.0.0 Uninstalled", LogLevel.Info).ShouldBeFalse();
+                MockLogger.ContainsMessage("upgradepackage 1.0.0 Uninstalled", LogLevel.Info).Should().BeFalse();
             }
 
             [Fact]
             public void Should_not_have_executed_chocolateyBeforeModify_script_for_new_package()
             {
-                MockLogger.ContainsMessage("upgradepackage 1.1.0 Before Modification", LogLevel.Info).ShouldBeFalse();
+                MockLogger.ContainsMessage("upgradepackage 1.1.0 Before Modification", LogLevel.Info).Should().BeFalse();
             }
 
             [Fact]
@@ -345,7 +345,7 @@ namespace chocolatey.tests.integration.scenarios
             [Platform(Exclude = "Mono")]
             public void Should_have_executed_chocolateyInstall_script_for_new_package()
             {
-                MockLogger.ContainsMessage("upgradepackage 1.1.0 Installed", LogLevel.Info).ShouldBeTrue();
+                MockLogger.ContainsMessage("upgradepackage 1.1.0 Installed", LogLevel.Info).Should().BeTrue();
             }
         }
 
@@ -378,7 +378,7 @@ namespace chocolatey.tests.integration.scenarios
                     if (message.Contains("upgradepackage v1.0.0 is the latest version available based on your source(s)")) expectedMessage = true;
                 }
 
-                expectedMessage.ShouldBeTrue();
+                expectedMessage.Should().BeTrue();
             }
 
             [Fact]
@@ -390,7 +390,7 @@ namespace chocolatey.tests.integration.scenarios
                     if (message.Contains("upgraded 0/1 ")) expectedMessage = true;
                 }
 
-                expectedMessage.ShouldBeTrue();
+                expectedMessage.Should().BeTrue();
             }
 
             [Fact]
@@ -416,32 +416,32 @@ namespace chocolatey.tests.integration.scenarios
 
                 using (var reader = new PackageFolderReader(packageFolder))
                 {
-                    reader.NuspecReader.GetVersion().ToNormalizedString().ShouldEqual("1.0.0");
+                    reader.NuspecReader.GetVersion().ToNormalizedString().Should().Be("1.0.0");
                 }
             }
 
             [Fact]
             public void Should_have_a_successful_package_result()
             {
-                _packageResult.Success.ShouldBeTrue();
+                _packageResult.Success.Should().BeTrue();
             }
 
             [Fact]
             public void Should_have_inconclusive_package_result()
             {
-                _packageResult.Inconclusive.ShouldBeTrue();
+                _packageResult.Inconclusive.Should().BeTrue();
             }
 
             [Fact]
             public void Should_not_have_warning_package_result()
             {
-                _packageResult.Warning.ShouldBeFalse();
+                _packageResult.Warning.Should().BeFalse();
             }
 
             [Fact]
             public void Should_match_the_original_package_version()
             {
-                _packageResult.Version.ShouldEqual("1.0.0");
+                _packageResult.Version.Should().Be("1.0.0");
             }
         }
 
@@ -470,7 +470,7 @@ namespace chocolatey.tests.integration.scenarios
                     if (message.Contains("upgradepackage v1.1.0 is the latest version available based on your source(s)")) expectedMessage = true;
                 }
 
-                expectedMessage.ShouldBeTrue();
+                expectedMessage.Should().BeTrue();
             }
 
             [Fact]
@@ -482,7 +482,7 @@ namespace chocolatey.tests.integration.scenarios
                     if (message.Contains("upgraded 0/1 ")) expectedMessage = true;
                 }
 
-                expectedMessage.ShouldBeTrue();
+                expectedMessage.Should().BeTrue();
             }
 
             [Fact]
@@ -507,32 +507,32 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, Configuration.PackageNames +  NuGetConstants.PackageExtension);
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().ShouldEqual("1.1.0");
+                    packageReader.NuspecReader.GetVersion().ToStringSafe().Should().Be("1.1.0");
                 }
             }
 
             [Fact]
             public void Should_have_a_successful_package_result()
             {
-                _packageResult.Success.ShouldBeTrue();
+                _packageResult.Success.Should().BeTrue();
             }
 
             [Fact]
             public void Should_have_inconclusive_package_result()
             {
-                _packageResult.Inconclusive.ShouldBeTrue();
+                _packageResult.Inconclusive.Should().BeTrue();
             }
 
             [Fact]
             public void Should_not_have_warning_package_result()
             {
-                _packageResult.Warning.ShouldBeFalse();
+                _packageResult.Warning.Should().BeFalse();
             }
 
             [Fact]
             public void Should_match_the_original_package_version()
             {
-                _packageResult.Version.ShouldEqual("1.1.0");
+                _packageResult.Version.Should().Be("1.1.0");
             }
         }
 
@@ -579,7 +579,7 @@ namespace chocolatey.tests.integration.scenarios
             {
                 var shimFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, "tools", "console.exe");
 
-                File.ReadAllText(shimFile).ShouldEqual("1.1.1-beta2");
+                File.ReadAllText(shimFile).Should().Be("1.1.1-beta2");
             }
 
             [Fact]
@@ -589,9 +589,9 @@ namespace chocolatey.tests.integration.scenarios
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
                     var version = packageReader.NuspecReader.GetVersion();
-                    version.Version.ToStringSafe().ShouldEqual("1.1.1.0");
-                    version.OriginalVersion.ToStringSafe().ShouldEqual("1.1.1-beta2");
-                    version.ToString().ShouldEqual("1.1.1-beta2");
+                    version.Version.ToStringSafe().Should().Be("1.1.1.0");
+                    version.OriginalVersion.ToStringSafe().Should().Be("1.1.1-beta2");
+                    version.ToString().Should().Be("1.1.1-beta2");
                 }
             }
 
@@ -604,7 +604,7 @@ namespace chocolatey.tests.integration.scenarios
                     if (message.Contains("upgraded 1/1")) upgradedSuccessMessage = true;
                 }
 
-                upgradedSuccessMessage.ShouldBeTrue();
+                upgradedSuccessMessage.Should().BeTrue();
             }
 
             [Fact]
@@ -616,19 +616,19 @@ namespace chocolatey.tests.integration.scenarios
                     if (message.Contains("You have upgradepackage v1.0.0 installed. Version 1.1.1-beta2 is available based on your source")) upgradeMessage = true;
                 }
 
-                upgradeMessage.ShouldBeTrue();
+                upgradeMessage.Should().BeTrue();
             }
 
             [Fact]
             public void Should_have_a_successful_package_result()
             {
-                _packageResult.Success.ShouldBeTrue();
+                _packageResult.Success.Should().BeTrue();
             }
 
             [Fact]
             public void Should_not_have_inconclusive_package_result()
             {
-                _packageResult.Inconclusive.ShouldBeFalse();
+                _packageResult.Inconclusive.Should().BeFalse();
             }
 
             [Fact]
@@ -637,19 +637,19 @@ namespace chocolatey.tests.integration.scenarios
                 // For before modify scripts that fail, we add a warning message.
                 // So we will ignore any such warnings.
                 var messages = _packageResult.Messages.Where(m => m.MessageType == ResultType.Warn && !m.Message.ContainsSafe("chocolateyBeforeModify"));
-                messages.ShouldBeEmpty();
+                messages.Should().BeEmpty();
             }
 
             [Fact]
             public void Config_should_match_package_result_name()
             {
-                _packageResult.Name.ShouldEqual(Configuration.PackageNames);
+                _packageResult.Name.Should().Be(Configuration.PackageNames);
             }
 
             [Fact]
             public void Should_match_the_upgrade_version_of_the_new_beta()
             {
-                _packageResult.Version.ShouldEqual("1.1.1-beta2");
+                _packageResult.Version.Should().Be("1.1.1-beta2");
             }
 
             [Fact]
@@ -657,7 +657,7 @@ namespace chocolatey.tests.integration.scenarios
             [Platform(Exclude = "Mono")]
             public void Should_have_executed_chocolateyBeforeModify_script_for_original_package()
             {
-                MockLogger.ContainsMessage("upgradepackage 1.0.0 Before Modification", LogLevel.Info).ShouldBeTrue();
+                MockLogger.ContainsMessage("upgradepackage 1.0.0 Before Modification", LogLevel.Info).Should().BeTrue();
             }
 
             [Fact]
@@ -668,19 +668,19 @@ namespace chocolatey.tests.integration.scenarios
                 MockLogger.MessagesFor(LogLevel.Info).OrEmpty()
                     .SkipWhile(p => !p.Contains("upgradepackage 1.0.0 Before Modification"))
                     .Any(p => p.EndsWith("upgradepackage 1.1.1-beta2 Installed"))
-                    .ShouldBeTrue();
+                    .Should().BeTrue();
             }
 
             [Fact]
             public void Should_not_have_executed_chocolateyUninstall_script_for_original_package()
             {
-                MockLogger.ContainsMessage("upgradepackage 1.0.0 Uninstalled", LogLevel.Info).ShouldBeFalse();
+                MockLogger.ContainsMessage("upgradepackage 1.0.0 Uninstalled", LogLevel.Info).Should().BeFalse();
             }
 
             [Fact]
             public void Should_not_have_executed_chocolateyBeforeModify_script_for_new_package()
             {
-                MockLogger.ContainsMessage("upgradepackage 1.1.1-beta2 Before Modification", LogLevel.Info).ShouldBeFalse();
+                MockLogger.ContainsMessage("upgradepackage 1.1.1-beta2 Before Modification", LogLevel.Info).Should().BeFalse();
             }
 
             [Fact]
@@ -688,7 +688,7 @@ namespace chocolatey.tests.integration.scenarios
             [Platform(Exclude = "Mono")]
             public void Should_have_executed_chocolateyInstall_script_for_new_package()
             {
-                MockLogger.ContainsMessage("upgradepackage 1.1.1-beta2 Installed", LogLevel.Info).ShouldBeTrue();
+                MockLogger.ContainsMessage("upgradepackage 1.1.1-beta2 Installed", LogLevel.Info).Should().BeTrue();
             }
         }
 
@@ -737,7 +737,7 @@ namespace chocolatey.tests.integration.scenarios
             {
                 var shimFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, "tools", "console.exe");
 
-                File.ReadAllText(shimFile).ShouldEqual("1.1.1-beta.1");
+                File.ReadAllText(shimFile).Should().Be("1.1.1-beta.1");
             }
 
             [Fact]
@@ -747,9 +747,9 @@ namespace chocolatey.tests.integration.scenarios
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
                     var version = packageReader.NuspecReader.GetVersion();
-                    version.Version.ToStringSafe().ShouldEqual("1.1.1.0");
-                    version.OriginalVersion.ToStringSafe().ShouldEqual("1.1.1-beta.1");
-                    version.ToString().ShouldEqual("1.1.1-beta.1");
+                    version.Version.ToStringSafe().Should().Be("1.1.1.0");
+                    version.OriginalVersion.ToStringSafe().Should().Be("1.1.1-beta.1");
+                    version.ToString().Should().Be("1.1.1-beta.1");
                 }
             }
 
@@ -762,7 +762,7 @@ namespace chocolatey.tests.integration.scenarios
                     if (message.Contains("upgraded 1/1")) upgradedSuccessMessage = true;
                 }
 
-                upgradedSuccessMessage.ShouldBeTrue();
+                upgradedSuccessMessage.Should().BeTrue();
             }
 
             [Fact]
@@ -774,19 +774,19 @@ namespace chocolatey.tests.integration.scenarios
                     if (message.Contains("You have upgradepackage v1.0.0 installed. Version 1.1.1-beta.1 is available based on your source")) upgradeMessage = true;
                 }
 
-                upgradeMessage.ShouldBeTrue();
+                upgradeMessage.Should().BeTrue();
             }
 
             [Fact]
             public void Should_have_a_successful_package_result()
             {
-                _packageResult.Success.ShouldBeTrue();
+                _packageResult.Success.Should().BeTrue();
             }
 
             [Fact]
             public void Should_not_have_inconclusive_package_result()
             {
-                _packageResult.Inconclusive.ShouldBeFalse();
+                _packageResult.Inconclusive.Should().BeFalse();
             }
 
             [Fact]
@@ -795,19 +795,19 @@ namespace chocolatey.tests.integration.scenarios
                 // For before modify scripts that fail, we add a warning message.
                 // So we will ignore any such warnings.
                 var messages = _packageResult.Messages.Where(m => m.MessageType == ResultType.Warn && !m.Message.ContainsSafe("chocolateyBeforeModify"));
-                messages.ShouldBeEmpty();
+                messages.Should().BeEmpty();
             }
 
             [Fact]
             public void Config_should_match_package_result_name()
             {
-                _packageResult.Name.ShouldEqual(Configuration.PackageNames);
+                _packageResult.Name.Should().Be(Configuration.PackageNames);
             }
 
             [Fact]
             public void Should_match_the_upgrade_version_of_the_new_beta()
             {
-                _packageResult.Version.ShouldEqual("1.1.1-beta.1");
+                _packageResult.Version.Should().Be("1.1.1-beta.1");
             }
 
             [Fact]
@@ -815,7 +815,7 @@ namespace chocolatey.tests.integration.scenarios
             [Platform(Exclude = "Mono")]
             public void Should_have_executed_chocolateyBeforeModify_script_for_original_package()
             {
-                MockLogger.ContainsMessage("upgradepackage 1.0.0 Before Modification", LogLevel.Info).ShouldBeTrue();
+                MockLogger.ContainsMessage("upgradepackage 1.0.0 Before Modification", LogLevel.Info).Should().BeTrue();
             }
 
             [Fact]
@@ -826,19 +826,19 @@ namespace chocolatey.tests.integration.scenarios
                 MockLogger.MessagesFor(LogLevel.Info).OrEmpty()
                     .SkipWhile(p => !p.Contains("upgradepackage 1.0.0 Before Modification"))
                     .Any(p => p.EndsWith("upgradepackage 1.1.1-beta.1 Installed"))
-                    .ShouldBeTrue();
+                    .Should().BeTrue();
             }
 
             [Fact]
             public void Should_not_have_executed_chocolateyUninstall_script_for_original_package()
             {
-                MockLogger.ContainsMessage("upgradepackage 1.0.0 Uninstalled", LogLevel.Info).ShouldBeFalse();
+                MockLogger.ContainsMessage("upgradepackage 1.0.0 Uninstalled", LogLevel.Info).Should().BeFalse();
             }
 
             [Fact]
             public void Should_not_have_executed_chocolateyBeforeModify_script_for_new_package()
             {
-                MockLogger.ContainsMessage("upgradepackage 1.1.1-beta.1 Before Modification", LogLevel.Info).ShouldBeFalse();
+                MockLogger.ContainsMessage("upgradepackage 1.1.1-beta.1 Before Modification", LogLevel.Info).Should().BeFalse();
             }
 
             [Fact]
@@ -846,7 +846,7 @@ namespace chocolatey.tests.integration.scenarios
             [Platform(Exclude = "Mono")]
             public void Should_have_executed_chocolateyInstall_script_for_new_package()
             {
-                MockLogger.ContainsMessage("upgradepackage 1.1.1-beta.1 Installed", LogLevel.Info).ShouldBeTrue();
+                MockLogger.ContainsMessage("upgradepackage 1.1.1-beta.1 Installed", LogLevel.Info).Should().BeTrue();
             }
         }
 
@@ -895,7 +895,7 @@ namespace chocolatey.tests.integration.scenarios
             {
                 var shimFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, "tools", "console.exe");
 
-                File.ReadAllText(shimFile).ShouldEqual("1.1.1-beta2");
+                File.ReadAllText(shimFile).Should().Be("1.1.1-beta2");
             }
 
             [Fact]
@@ -906,9 +906,9 @@ namespace chocolatey.tests.integration.scenarios
                 {
                     var version = packageReader.NuspecReader.GetVersion();
 
-                    version.Version.ToStringSafe().ShouldEqual("1.1.1.0");
-                    version.OriginalVersion.ToStringSafe().ShouldEqual("1.1.1-beta2");
-                    version.ToNormalizedStringChecked().ShouldEqual("1.1.1-beta2");
+                    version.Version.ToStringSafe().Should().Be("1.1.1.0");
+                    version.OriginalVersion.ToStringSafe().Should().Be("1.1.1-beta2");
+                    version.ToStringSafe().Should().Be("1.1.1-beta2");
                 }
             }
 
@@ -921,7 +921,7 @@ namespace chocolatey.tests.integration.scenarios
                     if (message.Contains("upgraded 1/1")) upgradedSuccessMessage = true;
                 }
 
-                upgradedSuccessMessage.ShouldBeTrue();
+                upgradedSuccessMessage.Should().BeTrue();
             }
 
             [Fact]
@@ -933,37 +933,37 @@ namespace chocolatey.tests.integration.scenarios
                     if (message.Contains("You have upgradepackage v1.1.1-beta installed. Version 1.1.1-beta2 is available based on your source")) upgradeMessage = true;
                 }
 
-                upgradeMessage.ShouldBeTrue();
+                upgradeMessage.Should().BeTrue();
             }
 
             [Fact]
             public void Should_have_a_successful_package_result()
             {
-                _packageResult.Success.ShouldBeTrue();
+                _packageResult.Success.Should().BeTrue();
             }
 
             [Fact]
             public void Should_not_have_inconclusive_package_result()
             {
-                _packageResult.Inconclusive.ShouldBeFalse();
+                _packageResult.Inconclusive.Should().BeFalse();
             }
 
             [Fact]
             public void Should_not_have_warning_package_result()
             {
-                _packageResult.Warning.ShouldBeFalse();
+                _packageResult.Warning.Should().BeFalse();
             }
 
             [Fact]
             public void Config_should_match_package_result_name()
             {
-                _packageResult.Name.ShouldEqual(Configuration.PackageNames);
+                _packageResult.Name.Should().Be(Configuration.PackageNames);
             }
 
             [Fact]
             public void Should_match_the_upgrade_version_of_the_new_beta()
             {
-                _packageResult.Version.ShouldEqual("1.1.1-beta2");
+                _packageResult.Version.Should().Be("1.1.1-beta2");
             }
 
             [Fact]
@@ -971,7 +971,7 @@ namespace chocolatey.tests.integration.scenarios
             [Platform(Exclude = "Mono")]
             public void Should_have_executed_chocolateyBeforeModify_script_for_original_package()
             {
-                MockLogger.ContainsMessage("upgradepackage 1.1.1-beta Before Modification", LogLevel.Info).ShouldBeTrue();
+                MockLogger.ContainsMessage("upgradepackage 1.1.1-beta Before Modification", LogLevel.Info).Should().BeTrue();
             }
 
             [Fact]
@@ -982,19 +982,19 @@ namespace chocolatey.tests.integration.scenarios
                 MockLogger.MessagesFor(LogLevel.Info).OrEmpty()
                     .SkipWhile(p => !p.Contains("upgradepackage 1.1.1-beta Before Modification"))
                     .Any(p => p.EndsWith("upgradepackage 1.1.1-beta2 Installed"))
-                    .ShouldBeTrue();
+                    .Should().BeTrue();
             }
 
             [Fact]
             public void Should_not_have_executed_chocolateyUninstall_script_for_original_package()
             {
-                MockLogger.ContainsMessage("upgradepackage 1.1.1-beta Uninstalled", LogLevel.Info).ShouldBeFalse();
+                MockLogger.ContainsMessage("upgradepackage 1.1.1-beta Uninstalled", LogLevel.Info).Should().BeFalse();
             }
 
             [Fact]
             public void Should_not_have_executed_chocolateyBeforeModify_script_for_new_package()
             {
-                MockLogger.ContainsMessage("upgradepackage 1.1.1-beta2 Before Modification", LogLevel.Info).ShouldBeFalse();
+                MockLogger.ContainsMessage("upgradepackage 1.1.1-beta2 Before Modification", LogLevel.Info).Should().BeFalse();
             }
 
             [Fact]
@@ -1002,7 +1002,7 @@ namespace chocolatey.tests.integration.scenarios
             [Platform(Exclude = "Mono")]
             public void Should_have_executed_chocolateyInstall_script_for_new_package()
             {
-                MockLogger.ContainsMessage("upgradepackage 1.1.1-beta2 Installed", LogLevel.Info).ShouldBeTrue();
+                MockLogger.ContainsMessage("upgradepackage 1.1.1-beta2 Installed", LogLevel.Info).Should().BeTrue();
             }
         }
 
@@ -1053,7 +1053,7 @@ namespace chocolatey.tests.integration.scenarios
             {
                 var shimFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, "tools", "console.exe");
 
-                File.ReadAllText(shimFile).ShouldEqual("1.1.1-beta.1");
+                File.ReadAllText(shimFile).Should().Be("1.1.1-beta.1");
             }
 
             [Fact]
@@ -1064,9 +1064,9 @@ namespace chocolatey.tests.integration.scenarios
                 {
                     var version = packageReader.NuspecReader.GetVersion();
 
-                    version.Version.ToStringSafe().ShouldEqual("1.1.1.0");
-                    version.OriginalVersion.ToStringSafe().ShouldEqual("1.1.1-beta.1");
-                    version.ToNormalizedStringChecked().ShouldEqual("1.1.1-beta.1");
+                    version.Version.ToStringSafe().Should().Be("1.1.1.0");
+                    version.OriginalVersion.ToStringSafe().Should().Be("1.1.1-beta.1");
+                    version.ToStringSafe().Should().Be("1.1.1-beta.1");
                 }
             }
 
@@ -1079,7 +1079,7 @@ namespace chocolatey.tests.integration.scenarios
                     if (message.Contains("upgraded 1/1")) upgradedSuccessMessage = true;
                 }
 
-                upgradedSuccessMessage.ShouldBeTrue();
+                upgradedSuccessMessage.Should().BeTrue();
             }
 
             [Fact]
@@ -1091,37 +1091,37 @@ namespace chocolatey.tests.integration.scenarios
                     if (message.Contains("You have upgradepackage v1.1.1-beta installed. Version 1.1.1-beta.1 is available based on your source")) upgradeMessage = true;
                 }
 
-                upgradeMessage.ShouldBeTrue();
+                upgradeMessage.Should().BeTrue();
             }
 
             [Fact]
             public void Should_have_a_successful_package_result()
             {
-                _packageResult.Success.ShouldBeTrue();
+                _packageResult.Success.Should().BeTrue();
             }
 
             [Fact]
             public void Should_not_have_inconclusive_package_result()
             {
-                _packageResult.Inconclusive.ShouldBeFalse();
+                _packageResult.Inconclusive.Should().BeFalse();
             }
 
             [Fact]
             public void Should_not_have_warning_package_result()
             {
-                _packageResult.Warning.ShouldBeFalse();
+                _packageResult.Warning.Should().BeFalse();
             }
 
             [Fact]
             public void Config_should_match_package_result_name()
             {
-                _packageResult.Name.ShouldEqual(Configuration.PackageNames);
+                _packageResult.Name.Should().Be(Configuration.PackageNames);
             }
 
             [Fact]
             public void Should_match_the_upgrade_version_of_the_new_beta()
             {
-                _packageResult.Version.ShouldEqual("1.1.1-beta.1");
+                _packageResult.Version.Should().Be("1.1.1-beta.1");
             }
 
             [Fact]
@@ -1129,7 +1129,7 @@ namespace chocolatey.tests.integration.scenarios
             [Platform(Exclude = "Mono")]
             public void Should_have_executed_chocolateyBeforeModify_script_for_original_package()
             {
-                MockLogger.ContainsMessage("upgradepackage 1.1.1-beta Before Modification", LogLevel.Info).ShouldBeTrue();
+                MockLogger.ContainsMessage("upgradepackage 1.1.1-beta Before Modification", LogLevel.Info).Should().BeTrue();
             }
 
             [Fact]
@@ -1140,19 +1140,19 @@ namespace chocolatey.tests.integration.scenarios
                 MockLogger.MessagesFor(LogLevel.Info).OrEmpty()
                     .SkipWhile(p => !p.Contains("upgradepackage 1.1.1-beta Before Modification"))
                     .Any(p => p.EndsWith("upgradepackage 1.1.1-beta.1 Installed"))
-                    .ShouldBeTrue();
+                    .Should().BeTrue();
             }
 
             [Fact]
             public void Should_not_have_executed_chocolateyUninstall_script_for_original_package()
             {
-                MockLogger.ContainsMessage("upgradepackage 1.1.1-beta Uninstalled", LogLevel.Info).ShouldBeFalse();
+                MockLogger.ContainsMessage("upgradepackage 1.1.1-beta Uninstalled", LogLevel.Info).Should().BeFalse();
             }
 
             [Fact]
             public void Should_not_have_executed_chocolateyBeforeModify_script_for_new_package()
             {
-                MockLogger.ContainsMessage("upgradepackage 1.1.1-beta.1 Before Modification", LogLevel.Info).ShouldBeFalse();
+                MockLogger.ContainsMessage("upgradepackage 1.1.1-beta.1 Before Modification", LogLevel.Info).Should().BeFalse();
             }
 
             [Fact]
@@ -1160,7 +1160,7 @@ namespace chocolatey.tests.integration.scenarios
             [Platform(Exclude = "Mono")]
             public void Should_have_executed_chocolateyInstall_script_for_new_package()
             {
-                MockLogger.ContainsMessage("upgradepackage 1.1.1-beta.1 Installed", LogLevel.Info).ShouldBeTrue();
+                MockLogger.ContainsMessage("upgradepackage 1.1.1-beta.1 Installed", LogLevel.Info).Should().BeTrue();
             }
         }
 
@@ -1210,7 +1210,7 @@ namespace chocolatey.tests.integration.scenarios
             {
                 var shimFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, "tools", "console.exe");
 
-                File.ReadAllText(shimFile).ShouldEqual("1.1.1-beta2");
+                File.ReadAllText(shimFile).Should().Be("1.1.1-beta2");
             }
 
             [Fact]
@@ -1221,9 +1221,9 @@ namespace chocolatey.tests.integration.scenarios
                 {
                     var version = packageReader.NuspecReader.GetVersion();
 
-                    version.Version.ToStringSafe().ShouldEqual("1.1.1.0");
-                    version.OriginalVersion.ToStringSafe().ShouldEqual("1.1.1-beta2");
-                    version.ToNormalizedStringChecked().ShouldEqual("1.1.1-beta2");
+                    version.Version.ToStringSafe().Should().Be("1.1.1.0");
+                    version.OriginalVersion.ToStringSafe().Should().Be("1.1.1-beta2");
+                    version.ToStringSafe().Should().Be("1.1.1-beta2");
                 }
             }
 
@@ -1236,7 +1236,7 @@ namespace chocolatey.tests.integration.scenarios
                     if (message.Contains("upgraded 1/1")) upgradedSuccessMessage = true;
                 }
 
-                upgradedSuccessMessage.ShouldBeTrue();
+                upgradedSuccessMessage.Should().BeTrue();
             }
 
             [Fact]
@@ -1248,37 +1248,37 @@ namespace chocolatey.tests.integration.scenarios
                     if (message.Contains("You have upgradepackage v1.1.1-beta.1 installed. Version 1.1.1-beta2 is available based on your source")) upgradeMessage = true;
                 }
 
-                upgradeMessage.ShouldBeTrue();
+                upgradeMessage.Should().BeTrue();
             }
 
             [Fact]
             public void Should_have_a_successful_package_result()
             {
-                _packageResult.Success.ShouldBeTrue();
+                _packageResult.Success.Should().BeTrue();
             }
 
             [Fact]
             public void Should_not_have_inconclusive_package_result()
             {
-                _packageResult.Inconclusive.ShouldBeFalse();
+                _packageResult.Inconclusive.Should().BeFalse();
             }
 
             [Fact]
             public void Should_not_have_warning_package_result()
             {
-                _packageResult.Warning.ShouldBeFalse();
+                _packageResult.Warning.Should().BeFalse();
             }
 
             [Fact]
             public void Config_should_match_package_result_name()
             {
-                _packageResult.Name.ShouldEqual(Configuration.PackageNames);
+                _packageResult.Name.Should().Be(Configuration.PackageNames);
             }
 
             [Fact]
             public void Should_match_the_upgrade_version_of_the_new_beta()
             {
-                _packageResult.Version.ShouldEqual("1.1.1-beta2");
+                _packageResult.Version.Should().Be("1.1.1-beta2");
             }
 
             [Fact]
@@ -1286,7 +1286,7 @@ namespace chocolatey.tests.integration.scenarios
             [Platform(Exclude = "Mono")]
             public void Should_have_executed_chocolateyBeforeModify_script_for_original_package()
             {
-                MockLogger.ContainsMessage("upgradepackage 1.1.1-beta.1 Before Modification", LogLevel.Info).ShouldBeTrue();
+                MockLogger.ContainsMessage("upgradepackage 1.1.1-beta.1 Before Modification", LogLevel.Info).Should().BeTrue();
             }
 
             [Fact]
@@ -1297,19 +1297,19 @@ namespace chocolatey.tests.integration.scenarios
                 MockLogger.MessagesFor(LogLevel.Info).OrEmpty()
                     .SkipWhile(p => !p.Contains("upgradepackage 1.1.1-beta.1 Before Modification"))
                     .Any(p => p.EndsWith("upgradepackage 1.1.1-beta2 Installed"))
-                    .ShouldBeTrue();
+                    .Should().BeTrue();
             }
 
             [Fact]
             public void Should_not_have_executed_chocolateyUninstall_script_for_original_package()
             {
-                MockLogger.ContainsMessage("upgradepackage 1.1.1-beta.1 Uninstalled", LogLevel.Info).ShouldBeFalse();
+                MockLogger.ContainsMessage("upgradepackage 1.1.1-beta.1 Uninstalled", LogLevel.Info).Should().BeFalse();
             }
 
             [Fact]
             public void Should_not_have_executed_chocolateyBeforeModify_script_for_new_package()
             {
-                MockLogger.ContainsMessage("upgradepackage 1.1.1-beta2 Before Modification", LogLevel.Info).ShouldBeFalse();
+                MockLogger.ContainsMessage("upgradepackage 1.1.1-beta2 Before Modification", LogLevel.Info).Should().BeFalse();
             }
 
             [Fact]
@@ -1317,7 +1317,7 @@ namespace chocolatey.tests.integration.scenarios
             [Platform(Exclude = "Mono")]
             public void Should_have_executed_chocolateyInstall_script_for_new_package()
             {
-                MockLogger.ContainsMessage("upgradepackage 1.1.1-beta2 Installed", LogLevel.Info).ShouldBeTrue();
+                MockLogger.ContainsMessage("upgradepackage 1.1.1-beta2 Installed", LogLevel.Info).Should().BeTrue();
             }
         }
 
@@ -1349,7 +1349,7 @@ namespace chocolatey.tests.integration.scenarios
                     if (message.Contains("upgradepackage v1.1.1-beta is newer")) expectedMessage = true;
                 }
 
-                expectedMessage.ShouldBeTrue();
+                expectedMessage.Should().BeTrue();
             }
 
             [Fact]
@@ -1361,7 +1361,7 @@ namespace chocolatey.tests.integration.scenarios
                     if (message.Contains("upgraded 0/1 ")) expectedMessage = true;
                 }
 
-                expectedMessage.ShouldBeTrue();
+                expectedMessage.Should().BeTrue();
             }
 
             [Fact]
@@ -1387,34 +1387,34 @@ namespace chocolatey.tests.integration.scenarios
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
                     var version = packageReader.NuspecReader.GetVersion();
-                    version.Version.ToStringSafe().ShouldEqual("1.1.1.0");
-                    version.OriginalVersion.ShouldEqual("1.1.1-beta");
-                    version.ToNormalizedStringChecked().ShouldEqual("1.1.1-beta");
+                    version.Version.ToStringSafe().Should().Be("1.1.1.0");
+                    version.OriginalVersion.Should().Be("1.1.1-beta");
+                    version.ToStringSafe().Should().Be("1.1.1-beta");
                 }
             }
 
             [Fact]
             public void Should_have_a_successful_package_result()
             {
-                _packageResult.Success.ShouldBeTrue();
+                _packageResult.Success.Should().BeTrue();
             }
 
             [Fact]
             public void Should_have_inconclusive_package_result()
             {
-                _packageResult.Inconclusive.ShouldBeTrue();
+                _packageResult.Inconclusive.Should().BeTrue();
             }
 
             [Fact]
             public void Should_not_have_warning_package_result()
             {
-                _packageResult.Warning.ShouldBeFalse();
+                _packageResult.Warning.Should().BeFalse();
             }
 
             [Fact]
             public void Should_only_find_the_last_stable_version()
             {
-                _packageResult.Version.ShouldEqual("1.1.0");
+                _packageResult.Version.Should().Be("1.1.0");
             }
         }
 
@@ -1447,7 +1447,7 @@ namespace chocolatey.tests.integration.scenarios
                     if (message.Contains("upgradepackage v1.1.1-beta is newer")) expectedMessage = true;
                 }
 
-                expectedMessage.ShouldBeTrue();
+                expectedMessage.Should().BeTrue();
             }
 
             [Fact]
@@ -1459,7 +1459,7 @@ namespace chocolatey.tests.integration.scenarios
                     if (message.Contains("upgraded 0/1 ")) expectedMessage = true;
                 }
 
-                expectedMessage.ShouldBeTrue();
+                expectedMessage.Should().BeTrue();
             }
 
             [Fact]
@@ -1485,34 +1485,34 @@ namespace chocolatey.tests.integration.scenarios
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
                     var version = packageReader.NuspecReader.GetVersion();
-                    version.Version.ToStringSafe().ShouldEqual("1.1.1.0");
-                    version.OriginalVersion.ShouldEqual("1.1.1-beta");
-                    version.ToNormalizedStringChecked().ShouldEqual("1.1.1-beta");
+                    version.Version.ToStringSafe().Should().Be("1.1.1.0");
+                    version.OriginalVersion.Should().Be("1.1.1-beta");
+                    version.ToStringSafe().Should().Be("1.1.1-beta");
                 }
             }
 
             [Fact]
             public void Should_have_a_successful_package_result()
             {
-                _packageResult.Success.ShouldBeTrue();
+                _packageResult.Success.Should().BeTrue();
             }
 
             [Fact]
             public void Should_have_inconclusive_package_result()
             {
-                _packageResult.Inconclusive.ShouldBeTrue();
+                _packageResult.Inconclusive.Should().BeTrue();
             }
 
             [Fact]
             public void Should_not_have_warning_package_result()
             {
-                _packageResult.Warning.ShouldBeFalse();
+                _packageResult.Warning.Should().BeFalse();
             }
 
             [Fact]
             public void Should_only_find_the_last_stable_version()
             {
-                _packageResult.Version.ShouldEqual("1.1.0");
+                _packageResult.Version.Should().Be("1.1.0");
             }
         }
 
@@ -1552,7 +1552,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, Configuration.PackageNames +  NuGetConstants.PackageExtension);
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().ShouldEqual("1.1.0");
+                    packageReader.NuspecReader.GetVersion().ToStringSafe().Should().Be("1.1.0");
                 }
             }
 
@@ -1569,7 +1569,7 @@ namespace chocolatey.tests.integration.scenarios
             {
                 var shimFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, "tools", "console.exe");
 
-                File.ReadAllText(shimFile).ShouldEqual("1.1.0");
+                File.ReadAllText(shimFile).Should().Be("1.1.0");
             }
 
             [Fact]
@@ -1581,7 +1581,7 @@ namespace chocolatey.tests.integration.scenarios
                     if (message.Contains("upgraded 1/1")) upgradedSuccessMessage = true;
                 }
 
-                upgradedSuccessMessage.ShouldBeTrue();
+                upgradedSuccessMessage.Should().BeTrue();
             }
 
             [Fact]
@@ -1593,19 +1593,19 @@ namespace chocolatey.tests.integration.scenarios
                     if (message.Contains("You have upgradepackage v1.0.0 installed. Version 1.1.0 is available based on your source")) upgradeMessage = true;
                 }
 
-                upgradeMessage.ShouldBeTrue();
+                upgradeMessage.Should().BeTrue();
             }
 
             [Fact]
             public void Should_have_a_successful_package_result()
             {
-                _packageResult.Success.ShouldBeTrue();
+                _packageResult.Success.Should().BeTrue();
             }
 
             [Fact]
             public void Should_not_have_inconclusive_package_result()
             {
-                _packageResult.Inconclusive.ShouldBeFalse();
+                _packageResult.Inconclusive.Should().BeFalse();
             }
 
             [Fact]
@@ -1614,19 +1614,19 @@ namespace chocolatey.tests.integration.scenarios
                 // For before modify scripts that fail, we add a warning message.
                 // So we will ignore any such warnings.
                 var messages = _packageResult.Messages.Where(m => m.MessageType == ResultType.Warn && !m.Message.ContainsSafe("chocolateyBeforeModify"));
-                messages.ShouldBeEmpty();
+                messages.Should().BeEmpty();
             }
 
             [Fact]
             public void Config_should_match_package_result_name()
             {
-                _packageResult.Name.ShouldEqual(Configuration.PackageNames);
+                _packageResult.Name.Should().Be(Configuration.PackageNames);
             }
 
             [Fact]
             public void Should_match_the_upgrade_version_of_one_dot_one_dot_zero()
             {
-                _packageResult.Version.ShouldEqual("1.1.0");
+                _packageResult.Version.Should().Be("1.1.0");
             }
         }
 
@@ -1655,7 +1655,7 @@ namespace chocolatey.tests.integration.scenarios
                     if (message.Contains("installpackage v1.0.0 is the latest version available based on your source(s)")) expectedMessage = true;
                 }
 
-                expectedMessage.ShouldBeTrue();
+                expectedMessage.Should().BeTrue();
             }
 
             [Fact]
@@ -1667,7 +1667,7 @@ namespace chocolatey.tests.integration.scenarios
                     if (message.Contains("upgraded 0/1 ")) expectedMessage = true;
                 }
 
-                expectedMessage.ShouldBeTrue();
+                expectedMessage.Should().BeTrue();
             }
 
             [Fact]
@@ -1692,32 +1692,32 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, Configuration.PackageNames +  NuGetConstants.PackageExtension);
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().ShouldEqual("1.0.0");
+                    packageReader.NuspecReader.GetVersion().ToStringSafe().Should().Be("1.0.0");
                 }
             }
 
             [Fact]
             public void Should_have_a_successful_package_result()
             {
-                _packageResult.Success.ShouldBeTrue();
+                _packageResult.Success.Should().BeTrue();
             }
 
             [Fact]
             public void Should_have_inconclusive_package_result()
             {
-                _packageResult.Inconclusive.ShouldBeTrue();
+                _packageResult.Inconclusive.Should().BeTrue();
             }
 
             [Fact]
             public void Should_not_have_warning_package_result()
             {
-                _packageResult.Warning.ShouldBeFalse();
+                _packageResult.Warning.Should().BeFalse();
             }
 
             [Fact]
             public void Should_match_the_existing_version_of_one_dot_zero_dot_zero()
             {
-                _packageResult.Version.ShouldEqual("1.0.0");
+                _packageResult.Version.Should().Be("1.0.0");
             }
         }
 
@@ -1747,7 +1747,7 @@ namespace chocolatey.tests.integration.scenarios
                     if (message.Contains("installpackage v1.0.0 is the latest version available based on your source(s)")) expectedMessage = true;
                 }
 
-                expectedMessage.ShouldBeTrue();
+                expectedMessage.Should().BeTrue();
             }
 
             [Fact]
@@ -1759,7 +1759,7 @@ namespace chocolatey.tests.integration.scenarios
                     if (message.Contains("upgraded 1/1")) expectedMessage = true;
                 }
 
-                expectedMessage.ShouldBeTrue();
+                expectedMessage.Should().BeTrue();
             }
 
             [Fact]
@@ -1784,32 +1784,32 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, Configuration.PackageNames +  NuGetConstants.PackageExtension);
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().ShouldEqual("1.0.0");
+                    packageReader.NuspecReader.GetVersion().ToStringSafe().Should().Be("1.0.0");
                 }
             }
 
             [Fact]
             public void Should_have_a_successful_package_result()
             {
-                _packageResult.Success.ShouldBeTrue();
+                _packageResult.Success.Should().BeTrue();
             }
 
             [Fact]
             public void Should_not_have_inconclusive_package_result()
             {
-                _packageResult.Inconclusive.ShouldBeFalse();
+                _packageResult.Inconclusive.Should().BeFalse();
             }
 
             [Fact]
             public void Should_not_have_warning_package_result()
             {
-                _packageResult.Warning.ShouldBeFalse();
+                _packageResult.Warning.Should().BeFalse();
             }
 
             [Fact]
             public void Should_match_the_existing_version_of_one_dot_zero_dot_zero()
             {
-                _packageResult.Version.ShouldEqual("1.0.0");
+                _packageResult.Version.Should().Be("1.0.0");
             }
         }
 
@@ -1831,7 +1831,7 @@ namespace chocolatey.tests.integration.scenarios
             {
                 Action m = () => Service.Upgrade(Configuration);
 
-                m.ShouldThrow<ApplicationException>();
+                m.Should().Throw<ApplicationException>();
             }
         }
 
@@ -1875,7 +1875,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, Configuration.PackageNames +  NuGetConstants.PackageExtension);
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().ShouldEqual("1.1.0");
+                    packageReader.NuspecReader.GetVersion().ToStringSafe().Should().Be("1.1.0");
                 }
             }
 
@@ -1892,7 +1892,7 @@ namespace chocolatey.tests.integration.scenarios
             {
                 var shimFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, "tools", "console.exe");
 
-                File.ReadAllText(shimFile).ShouldEqual("1.1.0");
+                File.ReadAllText(shimFile).Should().Be("1.1.0");
             }
 
             [Fact]
@@ -1904,7 +1904,7 @@ namespace chocolatey.tests.integration.scenarios
                     if (message.Contains("upgraded 1/1")) upgradedSuccessMessage = true;
                 }
 
-                upgradedSuccessMessage.ShouldBeTrue();
+                upgradedSuccessMessage.Should().BeTrue();
             }
 
             [Fact]
@@ -1916,19 +1916,19 @@ namespace chocolatey.tests.integration.scenarios
                     if (message.Contains("You have upgradepackage v1.0.0 installed. Version 1.1.0 is available based on your source")) upgradeMessage = true;
                 }
 
-                upgradeMessage.ShouldBeTrue();
+                upgradeMessage.Should().BeTrue();
             }
 
             [Fact]
             public void Should_have_a_successful_package_result()
             {
-                _packageResult.Success.ShouldBeTrue();
+                _packageResult.Success.Should().BeTrue();
             }
 
             [Fact]
             public void Should_not_have_inconclusive_package_result()
             {
-                _packageResult.Inconclusive.ShouldBeFalse();
+                _packageResult.Inconclusive.Should().BeFalse();
             }
 
             [Fact]
@@ -1937,7 +1937,7 @@ namespace chocolatey.tests.integration.scenarios
                 // For before modify scripts that fail, we add a warning message.
                 // So we will ignore any such warnings.
                 var messages = _packageResult.Messages.Where(m => m.MessageType == ResultType.Warn && !m.Message.ContainsSafe("chocolateyBeforeModify"));
-                messages.ShouldBeEmpty();
+                messages.Should().BeEmpty();
             }
         }
 
@@ -1989,7 +1989,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, Configuration.PackageNames +  NuGetConstants.PackageExtension);
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().ShouldEqual("1.1.0");
+                    packageReader.NuspecReader.GetVersion().ToStringSafe().Should().Be("1.1.0");
                 }
             }
 
@@ -2018,7 +2018,7 @@ namespace chocolatey.tests.integration.scenarios
             {
                 var shimFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, "tools", "console.exe");
 
-                File.ReadAllText(shimFile).ShouldEqual("1.1.0");
+                File.ReadAllText(shimFile).Should().Be("1.1.0");
             }
 
             [Fact]
@@ -2030,7 +2030,7 @@ namespace chocolatey.tests.integration.scenarios
                     if (message.Contains("upgraded 1/1")) upgradedSuccessMessage = true;
                 }
 
-                upgradedSuccessMessage.ShouldBeTrue();
+                upgradedSuccessMessage.Should().BeTrue();
             }
 
             [Fact]
@@ -2042,19 +2042,19 @@ namespace chocolatey.tests.integration.scenarios
                     if (message.Contains("You have upgradepackage v1.0.0 installed. Version 1.1.0 is available based on your source")) upgradeMessage = true;
                 }
 
-                upgradeMessage.ShouldBeTrue();
+                upgradeMessage.Should().BeTrue();
             }
 
             [Fact]
             public void Should_have_a_successful_package_result()
             {
-                _packageResult.Success.ShouldBeTrue();
+                _packageResult.Success.Should().BeTrue();
             }
 
             [Fact]
             public void Should_not_have_inconclusive_package_result()
             {
-                _packageResult.Inconclusive.ShouldBeFalse();
+                _packageResult.Inconclusive.Should().BeFalse();
             }
 
             [Fact]
@@ -2063,7 +2063,7 @@ namespace chocolatey.tests.integration.scenarios
                 // For before modify scripts that fail, we add a warning message.
                 // So we will ignore any such warnings.
                 var messages = _packageResult.Messages.Where(m => m.MessageType == ResultType.Warn && !m.Message.ContainsSafe("chocolateyBeforeModify"));
-                messages.ShouldBeEmpty();
+                messages.Should().BeEmpty();
             }
         }
 
@@ -2116,7 +2116,7 @@ namespace chocolatey.tests.integration.scenarios
             {
                 var shimFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, "tools", "console.exe");
 
-                File.ReadAllText(shimFile).ShouldEqual("1.0.0");
+                File.ReadAllText(shimFile).Should().Be("1.0.0");
             }
 
             [Fact]
@@ -2125,7 +2125,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, Configuration.PackageNames +  NuGetConstants.PackageExtension);
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().ShouldEqual("1.0.0");
+                    packageReader.NuspecReader.GetVersion().ToStringSafe().Should().Be("1.0.0");
                 }
             }
 
@@ -2138,7 +2138,7 @@ namespace chocolatey.tests.integration.scenarios
                     if (message.Contains("upgraded 0/1")) upgradedSuccessMessage = true;
                 }
 
-                upgradedSuccessMessage.ShouldBeTrue();
+                upgradedSuccessMessage.Should().BeTrue();
             }
 
             [Fact]
@@ -2150,25 +2150,25 @@ namespace chocolatey.tests.integration.scenarios
                     if (message.Contains("You have upgradepackage v1.0.0 installed. Version 1.1.0 is available based on your source")) upgradeMessage = true;
                 }
 
-                upgradeMessage.ShouldBeTrue();
+                upgradeMessage.Should().BeTrue();
             }
 
             [Fact]
             public void Should_not_have_a_successful_package_result()
             {
-                _packageResult.Success.ShouldBeFalse();
+                _packageResult.Success.Should().BeFalse();
             }
 
             [Fact]
             public void Should_not_have_inconclusive_package_result()
             {
-                _packageResult.Inconclusive.ShouldBeFalse();
+                _packageResult.Inconclusive.Should().BeFalse();
             }
 
             [Fact]
             public void Should_not_have_warning_package_result()
             {
-                _packageResult.Warning.ShouldBeFalse();
+                _packageResult.Warning.Should().BeFalse();
             }
         }
 
@@ -2202,7 +2202,7 @@ namespace chocolatey.tests.integration.scenarios
             {
                 var shimFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, "tools", "console.exe");
 
-                File.ReadAllText(shimFile).ShouldEqual("1.1.0");
+                File.ReadAllText(shimFile).Should().Be("1.1.0");
             }
 
             [Fact]
@@ -2211,7 +2211,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, Configuration.PackageNames +  NuGetConstants.PackageExtension);
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().ShouldEqual("1.1.0");
+                    packageReader.NuspecReader.GetVersion().ToStringSafe().Should().Be("1.1.0");
                 }
             }
 
@@ -2224,19 +2224,19 @@ namespace chocolatey.tests.integration.scenarios
                     if (message.Contains("upgraded 1/1")) upgradedSuccessMessage = true;
                 }
 
-                upgradedSuccessMessage.ShouldBeTrue();
+                upgradedSuccessMessage.Should().BeTrue();
             }
 
             [Fact]
             public void Should_have_a_successful_package_result()
             {
-                _packageResult.Success.ShouldBeTrue();
+                _packageResult.Success.Should().BeTrue();
             }
 
             [Fact]
             public void Should_not_have_inconclusive_package_result()
             {
-                _packageResult.Inconclusive.ShouldBeFalse();
+                _packageResult.Inconclusive.Should().BeFalse();
             }
 
             [Fact]
@@ -2245,13 +2245,13 @@ namespace chocolatey.tests.integration.scenarios
                 // For before modify scripts that fail, we add a warning message.
                 // So we will ignore any such warnings.
                 var messages = _packageResult.Messages.Where(m => m.MessageType == ResultType.Warn && !m.Message.ContainsSafe("chocolateyBeforeModify"));
-                messages.ShouldBeEmpty();
+                messages.Should().BeEmpty();
             }
 
             [Fact]
             public void Should_match_the_upgrade_version_of_one_dot_one_dot_zero()
             {
-                _packageResult.Version.ShouldEqual("1.1.0");
+                _packageResult.Version.Should().Be("1.1.0");
             }
         }
 
@@ -2277,7 +2277,7 @@ namespace chocolatey.tests.integration.scenarios
             {
                 var fileChanged = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, "tools", "chocolateyinstall.ps1");
 
-                File.ReadAllText(fileChanged).ShouldNotEqual("hellow");
+                File.ReadAllText(fileChanged).Should().NotBe("hellow");
             }
 
             [Fact]
@@ -2285,7 +2285,7 @@ namespace chocolatey.tests.integration.scenarios
             {
                 var shimFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, "tools", "console.exe");
 
-                File.ReadAllText(shimFile).ShouldEqual("1.1.0");
+                File.ReadAllText(shimFile).Should().Be("1.1.0");
             }
 
             [Fact]
@@ -2294,7 +2294,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, Configuration.PackageNames +  NuGetConstants.PackageExtension);
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().ShouldEqual("1.1.0");
+                    packageReader.NuspecReader.GetVersion().ToStringSafe().Should().Be("1.1.0");
                 }
             }
 
@@ -2307,19 +2307,19 @@ namespace chocolatey.tests.integration.scenarios
                     if (message.Contains("upgraded 1/1")) upgradedSuccessMessage = true;
                 }
 
-                upgradedSuccessMessage.ShouldBeTrue();
+                upgradedSuccessMessage.Should().BeTrue();
             }
 
             [Fact]
             public void Should_have_a_successful_package_result()
             {
-                _packageResult.Success.ShouldBeTrue();
+                _packageResult.Success.Should().BeTrue();
             }
 
             [Fact]
             public void Should_not_have_inconclusive_package_result()
             {
-                _packageResult.Inconclusive.ShouldBeFalse();
+                _packageResult.Inconclusive.Should().BeFalse();
             }
 
             [Fact]
@@ -2328,13 +2328,13 @@ namespace chocolatey.tests.integration.scenarios
                 // For before modify scripts that fail, we add a warning message.
                 // So we will ignore any such warnings.
                 var messages = _packageResult.Messages.Where(m => m.MessageType == ResultType.Warn && !m.Message.ContainsSafe("chocolateyBeforeModify"));
-                messages.ShouldBeEmpty();
+                messages.Should().BeEmpty();
             }
 
             [Fact]
             public void Should_match_the_upgrade_version_of_one_dot_one_dot_zero()
             {
-                _packageResult.Version.ShouldEqual("1.1.0");
+                _packageResult.Version.Should().Be("1.1.0");
             }
         }
 
@@ -2371,7 +2371,7 @@ namespace chocolatey.tests.integration.scenarios
                     if (message.Contains("nonexistentpackage not installed. The package was not found with the source(s) listed")) expectedMessage = true;
                 }
 
-                expectedMessage.ShouldBeTrue();
+                expectedMessage.Should().BeTrue();
             }
 
             [Fact]
@@ -2383,25 +2383,25 @@ namespace chocolatey.tests.integration.scenarios
                     if (message.Contains("upgraded 0/1")) expectedMessage = true;
                 }
 
-                expectedMessage.ShouldBeTrue();
+                expectedMessage.Should().BeTrue();
             }
 
             [Fact]
             public void Should_not_have_a_successful_package_result()
             {
-                _packageResult.Success.ShouldBeFalse();
+                _packageResult.Success.Should().BeFalse();
             }
 
             [Fact]
             public void Should_not_have_inconclusive_package_result()
             {
-                _packageResult.Inconclusive.ShouldBeFalse();
+                _packageResult.Inconclusive.Should().BeFalse();
             }
 
             [Fact]
             public void Should_not_have_warning_package_result()
             {
-                _packageResult.Warning.ShouldBeFalse();
+                _packageResult.Warning.Should().BeFalse();
             }
 
             [Fact]
@@ -2416,7 +2416,7 @@ namespace chocolatey.tests.integration.scenarios
                     }
                 }
 
-                errorFound.ShouldBeTrue();
+                errorFound.Should().BeTrue();
             }
 
             [Fact]
@@ -2431,7 +2431,7 @@ namespace chocolatey.tests.integration.scenarios
                     }
                 }
 
-                errorFound.ShouldBeTrue();
+                errorFound.Should().BeTrue();
             }
         }
 
@@ -2483,25 +2483,25 @@ namespace chocolatey.tests.integration.scenarios
                     if (message.Contains("upgraded 1/1")) upgradedSuccessMessage = true;
                 }
 
-                upgradedSuccessMessage.ShouldBeTrue();
+                upgradedSuccessMessage.Should().BeTrue();
             }
 
             [Fact]
             public void Should_have_a_successful_package_result()
             {
-                _packageResult.Success.ShouldBeTrue();
+                _packageResult.Success.Should().BeTrue();
             }
 
             [Fact]
             public void Should_not_have_inconclusive_package_result()
             {
-                _packageResult.Inconclusive.ShouldBeFalse();
+                _packageResult.Inconclusive.Should().BeFalse();
             }
 
             [Fact]
             public void Should_not_have_warning_package_result()
             {
-                _packageResult.Warning.ShouldBeFalse();
+                _packageResult.Warning.Should().BeFalse();
             }
         }
 
@@ -2542,25 +2542,25 @@ namespace chocolatey.tests.integration.scenarios
                     if (message.Contains("0/1")) notInstalled = true;
                 }
 
-                notInstalled.ShouldBeTrue();
+                notInstalled.Should().BeTrue();
             }
 
             [Fact]
             public void Should_not_have_a_successful_package_result()
             {
-                _packageResult.Success.ShouldBeFalse();
+                _packageResult.Success.Should().BeFalse();
             }
 
             [Fact]
             public void Should_not_have_inconclusive_package_result()
             {
-                _packageResult.Inconclusive.ShouldBeFalse();
+                _packageResult.Inconclusive.Should().BeFalse();
             }
 
             [Fact]
             public void Should_not_have_warning_package_result()
             {
-                _packageResult.Warning.ShouldBeFalse();
+                _packageResult.Warning.Should().BeFalse();
             }
 
             [Fact]
@@ -2575,7 +2575,7 @@ namespace chocolatey.tests.integration.scenarios
                     }
                 }
 
-                errorFound.ShouldBeTrue();
+                errorFound.Should().BeTrue();
             }
 
             [Fact]
@@ -2590,7 +2590,7 @@ namespace chocolatey.tests.integration.scenarios
                     }
                 }
 
-                errorFound.ShouldBeTrue();
+                errorFound.Should().BeTrue();
             }
         }
 
@@ -2626,7 +2626,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, Configuration.PackageNames +  NuGetConstants.PackageExtension);
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().ShouldEqual("1.0.0");
+                    packageReader.NuspecReader.GetVersion().ToStringSafe().Should().Be("1.0.0");
                 }
             }
 
@@ -2644,7 +2644,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib-bad", Configuration.PackageNames, "2.0.0", Configuration.PackageNames +  NuGetConstants.PackageExtension);
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().ShouldEqual("2.0.0");
+                    packageReader.NuspecReader.GetVersion().ToStringSafe().Should().Be("2.0.0");
                 }
             }
 
@@ -2665,25 +2665,25 @@ namespace chocolatey.tests.integration.scenarios
                     if (message.Contains("0/1")) installedSuccessfully = true;
                 }
 
-                installedSuccessfully.ShouldBeTrue();
+                installedSuccessfully.Should().BeTrue();
             }
 
             [Fact]
             public void Should_not_have_a_successful_package_result()
             {
-                _packageResult.Success.ShouldBeFalse();
+                _packageResult.Success.Should().BeFalse();
             }
 
             [Fact]
             public void Should_not_have_inconclusive_package_result()
             {
-                _packageResult.Inconclusive.ShouldBeFalse();
+                _packageResult.Inconclusive.Should().BeFalse();
             }
 
             [Fact]
             public void Should_not_have_warning_package_result()
             {
-                _packageResult.Warning.ShouldBeFalse();
+                _packageResult.Warning.Should().BeFalse();
             }
 
             [Fact]
@@ -2698,7 +2698,7 @@ namespace chocolatey.tests.integration.scenarios
                     }
                 }
 
-                errorFound.ShouldBeTrue();
+                errorFound.Should().BeTrue();
             }
 
             [Fact]
@@ -2713,7 +2713,7 @@ namespace chocolatey.tests.integration.scenarios
                     }
                 }
 
-                errorFound.ShouldBeTrue();
+                errorFound.Should().BeTrue();
             }
         }
 
@@ -2741,7 +2741,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", "hasdependency", "hasdependency.nupkg");
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().ShouldEqual("2.1.0");
+                    packageReader.NuspecReader.GetVersion().ToStringSafe().Should().Be("2.1.0");
                 }
             }
 
@@ -2751,7 +2751,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", "isdependency", "isdependency.nupkg");
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().ShouldEqual("2.1.0");
+                    packageReader.NuspecReader.GetVersion().ToStringSafe().Should().Be("2.1.0");
                 }
             }
 
@@ -2761,7 +2761,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", "isexactversiondependency", "isexactversiondependency.nupkg");
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().ShouldEqual("2.0.0");
+                    packageReader.NuspecReader.GetVersion().ToStringSafe().Should().Be("2.0.0");
                 }
             }
 
@@ -2774,7 +2774,7 @@ namespace chocolatey.tests.integration.scenarios
                     if (message.Contains("upgraded 3/3")) expectedMessage = true;
                 }
 
-                expectedMessage.ShouldBeTrue();
+                expectedMessage.Should().BeTrue();
             }
 
             [Fact]
@@ -2782,7 +2782,7 @@ namespace chocolatey.tests.integration.scenarios
             {
                 foreach (var packageResult in Results)
                 {
-                    packageResult.Value.Success.ShouldBeTrue();
+                    packageResult.Value.Success.Should().BeTrue();
                 }
             }
 
@@ -2791,7 +2791,7 @@ namespace chocolatey.tests.integration.scenarios
             {
                 foreach (var packageResult in Results)
                 {
-                    packageResult.Value.Inconclusive.ShouldBeFalse();
+                    packageResult.Value.Inconclusive.Should().BeFalse();
                 }
             }
 
@@ -2800,7 +2800,7 @@ namespace chocolatey.tests.integration.scenarios
             {
                 foreach (var packageResult in Results)
                 {
-                    packageResult.Value.Warning.ShouldBeFalse();
+                    packageResult.Value.Warning.Should().BeFalse();
                 }
             }
         }
@@ -2829,7 +2829,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", "hasdependency", "hasdependency.nupkg");
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().ShouldEqual("1.0.0");
+                    packageReader.NuspecReader.GetVersion().ToStringSafe().Should().Be("1.0.0");
                 }
             }
 
@@ -2839,7 +2839,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", "isdependency", "isdependency.nupkg");
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().ShouldEqual("1.0.0");
+                    packageReader.NuspecReader.GetVersion().ToStringSafe().Should().Be("1.0.0");
                 }
             }
 
@@ -2849,7 +2849,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", "isexactversiondependency", "isexactversiondependency.nupkg");
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().ShouldEqual("1.0.0");
+                    packageReader.NuspecReader.GetVersion().ToStringSafe().Should().Be("1.0.0");
                 }
             }
 
@@ -2862,7 +2862,7 @@ namespace chocolatey.tests.integration.scenarios
                     if (message.Contains("upgraded 0/1")) expectedMessage = true;
                 }
 
-                expectedMessage.ShouldBeTrue();
+                expectedMessage.Should().BeTrue();
             }
 
             [Fact]
@@ -2870,7 +2870,7 @@ namespace chocolatey.tests.integration.scenarios
             {
                 foreach (var packageResult in Results)
                 {
-                    packageResult.Value.Success.ShouldBeFalse();
+                    packageResult.Value.Success.Should().BeFalse();
                 }
             }
 
@@ -2879,7 +2879,7 @@ namespace chocolatey.tests.integration.scenarios
             {
                 foreach (var packageResult in Results)
                 {
-                    packageResult.Value.Inconclusive.ShouldBeFalse();
+                    packageResult.Value.Inconclusive.Should().BeFalse();
                 }
             }
 
@@ -2888,7 +2888,7 @@ namespace chocolatey.tests.integration.scenarios
             {
                 foreach (var packageResult in Results)
                 {
-                    packageResult.Value.Warning.ShouldBeFalse();
+                    packageResult.Value.Warning.Should().BeFalse();
                 }
             }
 
@@ -2908,7 +2908,7 @@ namespace chocolatey.tests.integration.scenarios
                     }
                 }
 
-                errorFound.ShouldBeTrue();
+                errorFound.Should().BeTrue();
             }
 
             [Fact]
@@ -2927,7 +2927,7 @@ namespace chocolatey.tests.integration.scenarios
                     }
                 }
 
-                errorFound.ShouldBeTrue();
+                errorFound.Should().BeTrue();
             }
         }
 
@@ -2956,7 +2956,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", "hasdependency", "hasdependency.nupkg");
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().ShouldEqual("2.1.0");
+                    packageReader.NuspecReader.GetVersion().ToStringSafe().Should().Be("2.1.0");
                 }
             }
 
@@ -2966,7 +2966,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", "isdependency", "isdependency.nupkg");
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().ShouldEqual("1.0.0");
+                    packageReader.NuspecReader.GetVersion().ToStringSafe().Should().Be("1.0.0");
                 }
             }
 
@@ -2976,7 +2976,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", "isexactversiondependency", "isexactversiondependency.nupkg");
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().ShouldEqual("1.0.0");
+                    packageReader.NuspecReader.GetVersion().ToStringSafe().Should().Be("1.0.0");
                 }
             }
 
@@ -2989,7 +2989,7 @@ namespace chocolatey.tests.integration.scenarios
                     if (message.Contains("upgraded 1/1")) expectedMessage = true;
                 }
 
-                expectedMessage.ShouldBeTrue();
+                expectedMessage.Should().BeTrue();
             }
 
             [Fact]
@@ -2997,7 +2997,7 @@ namespace chocolatey.tests.integration.scenarios
             {
                 foreach (var packageResult in Results)
                 {
-                    packageResult.Value.Success.ShouldBeTrue();
+                    packageResult.Value.Success.Should().BeTrue();
                 }
             }
 
@@ -3006,7 +3006,7 @@ namespace chocolatey.tests.integration.scenarios
             {
                 foreach (var packageResult in Results)
                 {
-                    packageResult.Value.Inconclusive.ShouldBeFalse();
+                    packageResult.Value.Inconclusive.Should().BeFalse();
                 }
             }
 
@@ -3015,7 +3015,7 @@ namespace chocolatey.tests.integration.scenarios
             {
                 foreach (var packageResult in Results)
                 {
-                    packageResult.Value.Warning.ShouldBeFalse();
+                    packageResult.Value.Warning.Should().BeFalse();
                 }
             }
         }
@@ -3044,7 +3044,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", "isdependency", "isdependency.nupkg");
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().ShouldEqual("1.1.0");
+                    packageReader.NuspecReader.GetVersion().ToStringSafe().Should().Be("1.1.0");
                 }
             }
 
@@ -3054,7 +3054,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", "hasdependency", "hasdependency.nupkg");
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().ShouldEqual("1.0.0");
+                    packageReader.NuspecReader.GetVersion().ToStringSafe().Should().Be("1.0.0");
                 }
             }
 
@@ -3064,7 +3064,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", "isexactversiondependency", "isexactversiondependency.nupkg");
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().ShouldEqual("1.0.0");
+                    packageReader.NuspecReader.GetVersion().ToStringSafe().Should().Be("1.0.0");
                 }
             }
 
@@ -3077,7 +3077,7 @@ namespace chocolatey.tests.integration.scenarios
                     if (message.Contains("upgraded 1/1")) expectedMessage = true;
                 }
 
-                expectedMessage.ShouldBeTrue();
+                expectedMessage.Should().BeTrue();
             }
 
             [Fact]
@@ -3085,7 +3085,7 @@ namespace chocolatey.tests.integration.scenarios
             {
                 foreach (var packageResult in Results)
                 {
-                    packageResult.Value.Success.ShouldBeTrue();
+                    packageResult.Value.Success.Should().BeTrue();
                 }
             }
 
@@ -3094,7 +3094,7 @@ namespace chocolatey.tests.integration.scenarios
             {
                 foreach (var packageResult in Results)
                 {
-                    packageResult.Value.Inconclusive.ShouldBeFalse();
+                    packageResult.Value.Inconclusive.Should().BeFalse();
                 }
             }
 
@@ -3103,7 +3103,7 @@ namespace chocolatey.tests.integration.scenarios
             {
                 foreach (var packageResult in Results)
                 {
-                    packageResult.Value.Warning.ShouldBeFalse();
+                    packageResult.Value.Warning.Should().BeFalse();
                 }
             }
         }
@@ -3132,7 +3132,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", "isdependency", "isdependency.nupkg");
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().ShouldEqual("2.1.0");
+                    packageReader.NuspecReader.GetVersion().ToStringSafe().Should().Be("2.1.0");
                 }
             }
 
@@ -3142,7 +3142,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", "hasdependency", "hasdependency.nupkg");
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().ShouldEqual("2.1.0");
+                    packageReader.NuspecReader.GetVersion().ToStringSafe().Should().Be("2.1.0");
                 }
             }
 
@@ -3152,7 +3152,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", "isexactversiondependency", "isexactversiondependency.nupkg");
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().ShouldEqual("2.0.0");
+                    packageReader.NuspecReader.GetVersion().ToStringSafe().Should().Be("2.0.0");
                 }
             }
 
@@ -3165,7 +3165,7 @@ namespace chocolatey.tests.integration.scenarios
                     if (message.Contains("upgraded 3/3")) expectedMessage = true;
                 }
 
-                expectedMessage.ShouldBeTrue();
+                expectedMessage.Should().BeTrue();
             }
 
             [Fact]
@@ -3173,7 +3173,7 @@ namespace chocolatey.tests.integration.scenarios
             {
                 foreach (var packageResult in Results)
                 {
-                    packageResult.Value.Success.ShouldBeTrue();
+                    packageResult.Value.Success.Should().BeTrue();
                 }
             }
 
@@ -3182,7 +3182,7 @@ namespace chocolatey.tests.integration.scenarios
             {
                 foreach (var packageResult in Results)
                 {
-                    packageResult.Value.Inconclusive.ShouldBeFalse();
+                    packageResult.Value.Inconclusive.Should().BeFalse();
                 }
             }
 
@@ -3191,7 +3191,7 @@ namespace chocolatey.tests.integration.scenarios
             {
                 foreach (var packageResult in Results)
                 {
-                    packageResult.Value.Warning.ShouldBeFalse();
+                    packageResult.Value.Warning.Should().BeFalse();
                 }
             }
         }
@@ -3222,7 +3222,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", "isdependency", "isdependency.nupkg");
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().ShouldEqual("2.1.0");
+                    packageReader.NuspecReader.GetVersion().ToStringSafe().Should().Be("2.1.0");
                 }
             }
 
@@ -3232,7 +3232,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", "hasdependency", "hasdependency.nupkg");
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().ShouldEqual("2.1.0");
+                    packageReader.NuspecReader.GetVersion().ToStringSafe().Should().Be("2.1.0");
                 }
             }
 
@@ -3242,7 +3242,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", "isexactversiondependency", "isexactversiondependency.nupkg");
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().ShouldEqual("2.0.0");
+                    packageReader.NuspecReader.GetVersion().ToStringSafe().Should().Be("2.0.0");
                 }
             }
 
@@ -3255,7 +3255,7 @@ namespace chocolatey.tests.integration.scenarios
                     if (message.Contains("upgraded 3/3")) expectedMessage = true;
                 }
 
-                expectedMessage.ShouldBeTrue();
+                expectedMessage.Should().BeTrue();
             }
 
             [Fact]
@@ -3263,7 +3263,7 @@ namespace chocolatey.tests.integration.scenarios
             {
                 foreach (var packageResult in Results)
                 {
-                    packageResult.Value.Success.ShouldBeTrue();
+                    packageResult.Value.Success.Should().BeTrue();
                 }
             }
 
@@ -3272,7 +3272,7 @@ namespace chocolatey.tests.integration.scenarios
             {
                 foreach (var packageResult in Results)
                 {
-                    packageResult.Value.Inconclusive.ShouldBeFalse();
+                    packageResult.Value.Inconclusive.Should().BeFalse();
                 }
             }
 
@@ -3281,7 +3281,7 @@ namespace chocolatey.tests.integration.scenarios
             {
                 foreach (var packageResult in Results)
                 {
-                    packageResult.Value.Warning.ShouldBeFalse();
+                    packageResult.Value.Warning.Should().BeFalse();
                 }
             }
         }
@@ -3312,7 +3312,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", "isdependency", "isdependency.nupkg");
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().ShouldEqual("1.1.0");
+                    packageReader.NuspecReader.GetVersion().ToStringSafe().Should().Be("1.1.0");
                 }
             }
 
@@ -3322,7 +3322,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", "hasdependency", "hasdependency.nupkg");
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().ShouldEqual("1.0.0");
+                    packageReader.NuspecReader.GetVersion().ToStringSafe().Should().Be("1.0.0");
                 }
             }
 
@@ -3332,7 +3332,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", "isexactversiondependency", "isexactversiondependency.nupkg");
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().ShouldEqual("1.0.0");
+                    packageReader.NuspecReader.GetVersion().ToStringSafe().Should().Be("1.0.0");
                 }
             }
 
@@ -3345,7 +3345,7 @@ namespace chocolatey.tests.integration.scenarios
                     if (message.Contains("upgraded 1/1")) expectedMessage = true;
                 }
 
-                expectedMessage.ShouldBeTrue();
+                expectedMessage.Should().BeTrue();
             }
 
             [Fact]
@@ -3353,7 +3353,7 @@ namespace chocolatey.tests.integration.scenarios
             {
                 foreach (var packageResult in Results)
                 {
-                    packageResult.Value.Success.ShouldBeTrue();
+                    packageResult.Value.Success.Should().BeTrue();
                 }
             }
 
@@ -3362,7 +3362,7 @@ namespace chocolatey.tests.integration.scenarios
             {
                 foreach (var packageResult in Results)
                 {
-                    packageResult.Value.Inconclusive.ShouldBeFalse();
+                    packageResult.Value.Inconclusive.Should().BeFalse();
                 }
             }
 
@@ -3371,7 +3371,7 @@ namespace chocolatey.tests.integration.scenarios
             {
                 foreach (var packageResult in Results)
                 {
-                    packageResult.Value.Warning.ShouldBeFalse();
+                    packageResult.Value.Warning.Should().BeFalse();
                 }
             }
 
@@ -3388,7 +3388,7 @@ namespace chocolatey.tests.integration.scenarios
                     }
                 }
 
-                expectedMessage.ShouldBeTrue();
+                expectedMessage.Should().BeTrue();
             }
         }
 
@@ -3420,7 +3420,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", "isdependency", "isdependency.nupkg");
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().ShouldEqual("1.1.0");
+                    packageReader.NuspecReader.GetVersion().ToStringSafe().Should().Be("1.1.0");
                 }
             }
 
@@ -3430,7 +3430,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", "hasdependency", "hasdependency.nupkg");
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().ShouldEqual("1.0.0");
+                    packageReader.NuspecReader.GetVersion().ToStringSafe().Should().Be("1.0.0");
                 }
             }
 
@@ -3440,7 +3440,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", "isexactversiondependency", "isexactversiondependency.nupkg");
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().ShouldEqual("1.0.0");
+                    packageReader.NuspecReader.GetVersion().ToStringSafe().Should().Be("1.0.0");
                 }
             }
 
@@ -3453,7 +3453,7 @@ namespace chocolatey.tests.integration.scenarios
                     if (message.Contains("upgraded 2/2")) expectedMessage = true;
                 }
 
-                expectedMessage.ShouldBeTrue();
+                expectedMessage.Should().BeTrue();
             }
 
             [Fact]
@@ -3461,7 +3461,7 @@ namespace chocolatey.tests.integration.scenarios
             {
                 foreach (var packageResult in Results)
                 {
-                    packageResult.Value.Success.ShouldBeTrue();
+                    packageResult.Value.Success.Should().BeTrue();
                 }
             }
 
@@ -3470,7 +3470,7 @@ namespace chocolatey.tests.integration.scenarios
             {
                 foreach (var packageResult in Results)
                 {
-                    packageResult.Value.Inconclusive.ShouldBeFalse();
+                    packageResult.Value.Inconclusive.Should().BeFalse();
                 }
             }
 
@@ -3479,7 +3479,7 @@ namespace chocolatey.tests.integration.scenarios
             {
                 foreach (var packageResult in Results)
                 {
-                    packageResult.Value.Warning.ShouldBeFalse();
+                    packageResult.Value.Warning.Should().BeFalse();
                 }
             }
 
@@ -3497,7 +3497,7 @@ namespace chocolatey.tests.integration.scenarios
                     }
                 }
 
-                expectedMessage.ShouldBeTrue();
+                expectedMessage.Should().BeTrue();
             }
         }
 
@@ -3529,7 +3529,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", "isdependency", "isdependency.nupkg");
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().ShouldEqual("1.1.0");
+                    packageReader.NuspecReader.GetVersion().ToStringSafe().Should().Be("1.1.0");
                 }
             }
 
@@ -3539,7 +3539,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", "hasdependency", "hasdependency.nupkg");
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().ShouldEqual("1.0.0");
+                    packageReader.NuspecReader.GetVersion().ToStringSafe().Should().Be("1.0.0");
                 }
             }
 
@@ -3549,7 +3549,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", "isexactversiondependency", "isexactversiondependency.nupkg");
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().ShouldEqual("1.0.0");
+                    packageReader.NuspecReader.GetVersion().ToStringSafe().Should().Be("1.0.0");
                 }
             }
 
@@ -3562,7 +3562,7 @@ namespace chocolatey.tests.integration.scenarios
                     if (message.Contains("upgraded 1/1")) expectedMessage = true;
                 }
 
-                expectedMessage.ShouldBeTrue();
+                expectedMessage.Should().BeTrue();
             }
 
             [Fact]
@@ -3570,7 +3570,7 @@ namespace chocolatey.tests.integration.scenarios
             {
                 foreach (var packageResult in Results)
                 {
-                    packageResult.Value.Success.ShouldBeTrue();
+                    packageResult.Value.Success.Should().BeTrue();
                 }
             }
 
@@ -3579,7 +3579,7 @@ namespace chocolatey.tests.integration.scenarios
             {
                 foreach (var packageResult in Results)
                 {
-                    packageResult.Value.Inconclusive.ShouldBeFalse();
+                    packageResult.Value.Inconclusive.Should().BeFalse();
                 }
             }
 
@@ -3588,7 +3588,7 @@ namespace chocolatey.tests.integration.scenarios
             {
                 foreach (var packageResult in Results)
                 {
-                    packageResult.Value.Warning.ShouldBeFalse();
+                    packageResult.Value.Warning.Should().BeFalse();
                 }
             }
 
@@ -3605,7 +3605,7 @@ namespace chocolatey.tests.integration.scenarios
                     }
                 }
 
-                expectedMessage.ShouldBeTrue();
+                expectedMessage.Should().BeTrue();
             }
         }
 
@@ -3636,7 +3636,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", "isdependency", "isdependency.nupkg");
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().ShouldEqual("1.0.0");
+                    packageReader.NuspecReader.GetVersion().ToStringSafe().Should().Be("1.0.0");
                 }
             }
 
@@ -3646,7 +3646,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", "hasdependency", "hasdependency.nupkg");
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().ShouldEqual("1.0.0");
+                    packageReader.NuspecReader.GetVersion().ToStringSafe().Should().Be("1.0.0");
                 }
             }
 
@@ -3656,7 +3656,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", "isexactversiondependency", "isexactversiondependency.nupkg");
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().ShouldEqual("1.0.0");
+                    packageReader.NuspecReader.GetVersion().ToStringSafe().Should().Be("1.0.0");
                 }
             }
 
@@ -3669,7 +3669,7 @@ namespace chocolatey.tests.integration.scenarios
                     if (message.Contains("upgraded 0/1")) expectedMessage = true;
                 }
 
-                expectedMessage.ShouldBeTrue();
+                expectedMessage.Should().BeTrue();
             }
 
             [Fact]
@@ -3677,7 +3677,7 @@ namespace chocolatey.tests.integration.scenarios
             {
                 foreach (var packageResult in Results)
                 {
-                    packageResult.Value.Success.ShouldBeFalse();
+                    packageResult.Value.Success.Should().BeFalse();
                 }
             }
 
@@ -3686,7 +3686,7 @@ namespace chocolatey.tests.integration.scenarios
             {
                 foreach (var packageResult in Results)
                 {
-                    packageResult.Value.Inconclusive.ShouldBeFalse();
+                    packageResult.Value.Inconclusive.Should().BeFalse();
                 }
             }
 
@@ -3695,7 +3695,7 @@ namespace chocolatey.tests.integration.scenarios
             {
                 foreach (var packageResult in Results)
                 {
-                    packageResult.Value.Warning.ShouldBeFalse();
+                    packageResult.Value.Warning.Should().BeFalse();
                 }
             }
 
@@ -3708,7 +3708,7 @@ namespace chocolatey.tests.integration.scenarios
                     if (message.Contains("Unable to resolve dependency chain. This may be caused by a parent package depending on this package, try specifying a specific version to use or don't ignore any dependencies!")) expectedMessage = true;
                 }
 
-                expectedMessage.ShouldBeTrue();
+                expectedMessage.Should().BeTrue();
             }
         }
 
@@ -3740,7 +3740,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, Configuration.PackageNames +  NuGetConstants.PackageExtension);
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().ShouldEqual("1.1.0");
+                    packageReader.NuspecReader.GetVersion().ToStringSafe().Should().Be("1.1.0");
                 }
             }
 
@@ -3753,19 +3753,19 @@ namespace chocolatey.tests.integration.scenarios
                     if (message.Contains("upgraded 1/1")) upgradedSuccessMessage = true;
                 }
 
-                upgradedSuccessMessage.ShouldBeTrue();
+                upgradedSuccessMessage.Should().BeTrue();
             }
 
             [Fact]
             public void Should_have_a_successful_package_result()
             {
-                _packageResult.Success.ShouldBeTrue();
+                _packageResult.Success.Should().BeTrue();
             }
 
             [Fact]
             public void Should_not_have_inconclusive_package_result()
             {
-                _packageResult.Inconclusive.ShouldBeFalse();
+                _packageResult.Inconclusive.Should().BeFalse();
             }
 
             [Fact]
@@ -3774,13 +3774,13 @@ namespace chocolatey.tests.integration.scenarios
                 // For before modify scripts that fail, we add a warning message.
                 // So we will ignore any such warnings.
                 var messages = _packageResult.Messages.Where(m => m.MessageType == ResultType.Warn && !m.Message.ContainsSafe("chocolateyBeforeModify"));
-                messages.ShouldBeEmpty();
+                messages.Should().BeEmpty();
             }
 
             [Fact]
             public void Should_match_the_upgrade_version_of_one_dot_one_dot_zero()
             {
-                _packageResult.Version.ShouldEqual("1.1.0");
+                _packageResult.Version.Should().Be("1.1.0");
             }
 
             // any file in a nuget package will overwrite an existing file
@@ -3790,25 +3790,25 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_not_change_the_test_value_in_the_config_from_original_one_dot_zero_dot_zero_due_to_upgrade_and_XDT_InsertIfMissing()
             {
-                _xPathNavigator.SelectSingleNode("//configuration/appSettings/add[@key='test']/@value").TypedValue.ToStringSafe().ShouldEqual("default 1.0.0");
+                _xPathNavigator.SelectSingleNode("//configuration/appSettings/add[@key='test']/@value").TypedValue.ToStringSafe().Should().Be("default 1.0.0");
             }
 
             [Fact]
             public void Should_change_the_testReplace_value_in_the_config_due_to_XDT_Replace()
             {
-                _xPathNavigator.SelectSingleNode("//configuration/appSettings/add[@key='testReplace']/@value").TypedValue.ToStringSafe().ShouldEqual("1.1.0");
+                _xPathNavigator.SelectSingleNode("//configuration/appSettings/add[@key='testReplace']/@value").TypedValue.ToStringSafe().Should().Be("1.1.0");
             }
 
             [Fact]
             public void Should_not_change_the_insert_value_in_the_config_due_to_upgrade_and_XDT_InsertIfMissing()
             {
-                _xPathNavigator.SelectSingleNode("//configuration/appSettings/add[@key='insert']/@value").TypedValue.ToStringSafe().ShouldEqual("1.0.0");
+                _xPathNavigator.SelectSingleNode("//configuration/appSettings/add[@key='insert']/@value").TypedValue.ToStringSafe().Should().Be("1.0.0");
             }
 
             [Fact]
             public void Should_add_the_insertNew_value_in_the_config_due_to_XDT_InsertIfMissing()
             {
-                _xPathNavigator.SelectSingleNode("//configuration/appSettings/add[@key='insertNew']/@value").TypedValue.ToStringSafe().ShouldEqual("1.1.0");
+                _xPathNavigator.SelectSingleNode("//configuration/appSettings/add[@key='insertNew']/@value").TypedValue.ToStringSafe().Should().Be("1.1.0");
             }
         }
 
@@ -3843,7 +3843,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, Configuration.PackageNames +  NuGetConstants.PackageExtension);
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().ShouldEqual("1.1.0");
+                    packageReader.NuspecReader.GetVersion().ToStringSafe().Should().Be("1.1.0");
                 }
             }
 
@@ -3856,19 +3856,19 @@ namespace chocolatey.tests.integration.scenarios
                     if (message.Contains("upgraded 1/1")) upgradedSuccessMessage = true;
                 }
 
-                upgradedSuccessMessage.ShouldBeTrue();
+                upgradedSuccessMessage.Should().BeTrue();
             }
 
             [Fact]
             public void Should_have_a_successful_package_result()
             {
-                _packageResult.Success.ShouldBeTrue();
+                _packageResult.Success.Should().BeTrue();
             }
 
             [Fact]
             public void Should_not_have_inconclusive_package_result()
             {
-                _packageResult.Inconclusive.ShouldBeFalse();
+                _packageResult.Inconclusive.Should().BeFalse();
             }
 
             [Fact]
@@ -3877,13 +3877,13 @@ namespace chocolatey.tests.integration.scenarios
                 // For before modify scripts that fail, we add a warning message.
                 // So we will ignore any such warnings.
                 var messages = _packageResult.Messages.Where(m => m.MessageType == ResultType.Warn && !m.Message.ContainsSafe("chocolateyBeforeModify"));
-                messages.ShouldBeEmpty();
+                messages.Should().BeEmpty();
             }
 
             [Fact]
             public void Should_match_the_upgrade_version_of_one_dot_one_dot_zero()
             {
-                _packageResult.Version.ShouldEqual("1.1.0");
+                _packageResult.Version.Should().Be("1.1.0");
             }
 
             // any file in a nuget package will overwrite an existing file
@@ -3893,31 +3893,31 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_not_change_the_test_value_in_the_config_from_original_one_dot_zero_dot_zero_due_to_upgrade_and_XDT_InsertIfMissing()
             {
-                _xPathNavigator.SelectSingleNode("//configuration/appSettings/add[@key='test']/@value").TypedValue.ToStringSafe().ShouldEqual("default 1.0.0");
+                _xPathNavigator.SelectSingleNode("//configuration/appSettings/add[@key='test']/@value").TypedValue.ToStringSafe().Should().Be("default 1.0.0");
             }
 
             [Fact]
             public void Should_change_the_testReplace_value_in_the_config_due_to_XDT_Replace()
             {
-                _xPathNavigator.SelectSingleNode("//configuration/appSettings/add[@key='testReplace']/@value").TypedValue.ToStringSafe().ShouldEqual("1.1.0");
+                _xPathNavigator.SelectSingleNode("//configuration/appSettings/add[@key='testReplace']/@value").TypedValue.ToStringSafe().Should().Be("1.1.0");
             }
 
             [Fact]
             public void Should_not_change_the_insert_value_in_the_config_due_to_upgrade_and_XDT_InsertIfMissing()
             {
-                _xPathNavigator.SelectSingleNode("//configuration/appSettings/add[@key='insert']/@value").TypedValue.ToStringSafe().ShouldEqual("1.0.0");
+                _xPathNavigator.SelectSingleNode("//configuration/appSettings/add[@key='insert']/@value").TypedValue.ToStringSafe().Should().Be("1.0.0");
             }
 
             [Fact]
             public void Should_add_the_insertNew_value_in_the_config_due_to_XDT_InsertIfMissing()
             {
-                _xPathNavigator.SelectSingleNode("//configuration/appSettings/add[@key='insertNew']/@value").TypedValue.ToStringSafe().ShouldEqual("1.1.0");
+                _xPathNavigator.SelectSingleNode("//configuration/appSettings/add[@key='insertNew']/@value").TypedValue.ToStringSafe().Should().Be("1.1.0");
             }
 
             [Fact]
             public void Should_have_a_config_with_the_comment_from_the_original()
             {
-                File.ReadAllText(_xmlFilePath).ShouldContain(CommentAdded);
+                File.ReadAllText(_xmlFilePath).Should().Contain(CommentAdded);
             }
         }
 
@@ -3937,13 +3937,13 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_have_no_sources_enabled_result()
             {
-                MockLogger.ContainsMessage("Upgrading was NOT successful. There are no sources enabled for", LogLevel.Error).ShouldBeTrue();
+                MockLogger.ContainsMessage("Upgrading was NOT successful. There are no sources enabled for", LogLevel.Error).Should().BeTrue();
             }
 
             [Fact]
             public void Should_not_have_any_packages_upgraded()
             {
-                Results.Count().ShouldEqual(0);
+                Results.Count().Should().Be(0);
             }
         }
 
@@ -3963,23 +3963,23 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_report_for_all_installed_packages()
             {
-                Results.Count().ShouldEqual(3);
+                Results.Count().Should().Be(3);
             }
 
             [Fact]
             public void Should_upgrade_packages_with_upgrades()
             {
                 var upgradePackageResult = Results.Where(x => x.Key == "upgradepackage").ToList();
-                upgradePackageResult.Count.ShouldEqual(1, "upgradepackage must be there once");
-                upgradePackageResult.First().Value.Version.ShouldEqual("1.1.0");
+                upgradePackageResult.Count.Should().Be(1, "upgradepackage must be there once");
+                upgradePackageResult.First().Value.Version.Should().Be("1.1.0");
             }
 
             [Fact]
             public void Should_skip_packages_without_upgrades()
             {
                 var installPackageResult = Results.Where(x => x.Key == "installpackage").ToList();
-                installPackageResult.Count.ShouldEqual(1, "installpackage must be there once");
-                installPackageResult.First().Value.Version.ShouldEqual("1.0.0");
+                installPackageResult.Count.Should().Be(1, "installpackage must be there once");
+                installPackageResult.First().Value.Version.Should().Be("1.0.0");
             }
         }
 
@@ -4002,15 +4002,15 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_report_for_all_installed_packages()
             {
-                Results.Count().ShouldEqual(3);
+                Results.Count().Should().Be(3);
             }
 
             [Fact]
             public void Should_upgrade_packages_with_upgrades()
             {
                 var upgradePackageResult = Results.Where(x => x.Key == "upgradepackage").ToList();
-                upgradePackageResult.Count.ShouldEqual(1, "upgradepackage must be there once");
-                upgradePackageResult.First().Value.Version.ShouldEqual("1.1.1-beta2");
+                upgradePackageResult.Count.Should().Be(1, "upgradepackage must be there once");
+                upgradePackageResult.First().Value.Version.Should().Be("1.1.1-beta2");
             }
 
             [Fact]
@@ -4020,9 +4020,9 @@ namespace chocolatey.tests.integration.scenarios
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
                     var version = packageReader.NuspecReader.GetVersion();
-                    version.Version.ToStringSafe().ShouldEqual("1.1.1.0");
-                    version.OriginalVersion.ShouldEqual("1.1.1-beta2");
-                    version.ToNormalizedStringChecked().ShouldEqual("1.1.1-beta2");
+                    version.Version.ToStringSafe().Should().Be("1.1.1.0");
+                    version.OriginalVersion.Should().Be("1.1.1-beta2");
+                    version.ToStringSafe().Should().Be("1.1.1-beta2");
                 }
             }
 
@@ -4030,8 +4030,8 @@ namespace chocolatey.tests.integration.scenarios
             public void Should_skip_packages_without_upgrades()
             {
                 var installPackageResult = Results.Where(x => x.Key == "installpackage").ToList();
-                installPackageResult.Count.ShouldEqual(1, "installpackage must be there once");
-                installPackageResult.First().Value.Version.ShouldEqual("1.0.0");
+                installPackageResult.Count.Should().Be(1, "installpackage must be there once");
+                installPackageResult.First().Value.Version.Should().Be("1.0.0");
             }
         }
 
@@ -4056,16 +4056,16 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_report_for_all_installed_packages()
             {
-                Results.Count().ShouldEqual(3);
+                Results.Count().Should().Be(3);
             }
 
             [Fact]
             public void Should_upgrade_packages_with_upgrades()
             {
                 var upgradePackageResult = Results.Where(x => x.Key == "upgradepackage").ToList();
-                upgradePackageResult.Count.ShouldEqual(1, "upgradepackage must be there once");
+                upgradePackageResult.Count.Should().Be(1, "upgradepackage must be there once");
                 // available version will show as last stable
-                upgradePackageResult.First().Value.Version.ShouldEqual("1.1.0");
+                upgradePackageResult.First().Value.Version.Should().Be("1.1.0");
             }
 
             [Fact]
@@ -4075,9 +4075,9 @@ namespace chocolatey.tests.integration.scenarios
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
                     var version = packageReader.NuspecReader.GetVersion();
-                    version.Version.ToStringSafe().ShouldEqual("1.1.1.0");
-                    version.OriginalVersion.ShouldEqual("1.1.1-beta");
-                    version.ToNormalizedStringChecked().ShouldEqual("1.1.1-beta");
+                    version.Version.ToStringSafe().Should().Be("1.1.1.0");
+                    version.OriginalVersion.Should().Be("1.1.1-beta");
+                    version.ToStringSafe().Should().Be("1.1.1-beta");
                 }
             }
 
@@ -4085,8 +4085,8 @@ namespace chocolatey.tests.integration.scenarios
             public void Should_skip_packages_without_upgrades()
             {
                 var installPackageResult = Results.Where(x => x.Key == "installpackage").ToList();
-                installPackageResult.Count.ShouldEqual(1, "installpackage must be there once");
-                installPackageResult.First().Value.Version.ShouldEqual("1.0.0");
+                installPackageResult.Count.Should().Be(1, "installpackage must be there once");
+                installPackageResult.First().Value.Version.Should().Be("1.0.0");
             }
         }
 
@@ -4112,7 +4112,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_have_a_single_package_result()
             {
-                Results.Count.ShouldEqual(1, "The returned package results do not have a single value!");
+                Results.Count.Should().Be(1, "The returned package results do not have a single value!");
             }
 
             [Fact]
@@ -4144,7 +4144,7 @@ namespace chocolatey.tests.integration.scenarios
 
                 FileAssert.Exists(shimFile);
 
-                File.ReadAllText(shimFile).ShouldEqual("1.1.1-beta.1");
+                File.ReadAllText(shimFile).Should().Be("1.1.1-beta.1");
             }
 
             [Fact]
@@ -4153,7 +4153,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, Configuration.PackageNames + NuGetConstants.PackageExtension);
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().ShouldEqual("1.1.1-beta.1");
+                    packageReader.NuspecReader.GetVersion().ToStringSafe().Should().Be("1.1.1-beta.1");
                 }
             }
 
@@ -4166,7 +4166,7 @@ namespace chocolatey.tests.integration.scenarios
                     if (message.Contains("upgraded 1/1")) upgradedSuccessMessage = true;
                 }
 
-                upgradedSuccessMessage.ShouldBeTrue();
+                upgradedSuccessMessage.Should().BeTrue();
             }
 
             [Fact]
@@ -4178,19 +4178,19 @@ namespace chocolatey.tests.integration.scenarios
                     if (message.Contains("You have upgradepackage v1.0.0 installed. Version 1.1.1-beta.1 is available based on your source")) upgradeMessage = true;
                 }
 
-                upgradeMessage.ShouldBeTrue();
+                upgradeMessage.Should().BeTrue();
             }
 
             [Fact]
             public void Should_have_a_successful_package_result()
             {
-                _packageResult.Success.ShouldBeTrue();
+                _packageResult.Success.Should().BeTrue();
             }
 
             [Fact]
             public void Should_not_have_inconclusive_package_result()
             {
-                _packageResult.Inconclusive.ShouldBeFalse();
+                _packageResult.Inconclusive.Should().BeFalse();
             }
 
             [Fact]
@@ -4199,19 +4199,19 @@ namespace chocolatey.tests.integration.scenarios
                 // For before modify scripts that fail, we add a warning message.
                 // So we will ignore any such warnings.
                 var messages = _packageResult.Messages.Where(m => m.MessageType == ResultType.Warn && !m.Message.ContainsSafe("chocolateyBeforeModify"));
-                messages.ShouldBeEmpty();
+                messages.Should().BeEmpty();
             }
 
             [Fact]
             public void Config_should_match_package_result_name()
             {
-                _packageResult.Name.ShouldEqual(Configuration.PackageNames);
+                _packageResult.Name.Should().Be(Configuration.PackageNames);
             }
 
             [Fact]
             public void Should_match_the_upgrade_version_of_one_dot_one_dot_zero()
             {
-                _packageResult.Version.ShouldEqual("1.1.1-beta.1");
+                _packageResult.Version.Should().Be("1.1.1-beta.1");
             }
 
             [Fact]
@@ -4219,7 +4219,7 @@ namespace chocolatey.tests.integration.scenarios
             [Platform(Exclude = "Mono")]
             public void Should_have_executed_chocolateyBeforeModify_script_for_original_package()
             {
-                MockLogger.ContainsMessage("upgradepackage 1.0.0 Before Modification", LogLevel.Info).ShouldBeTrue();
+                MockLogger.ContainsMessage("upgradepackage 1.0.0 Before Modification", LogLevel.Info).Should().BeTrue();
             }
 
             [Fact]
@@ -4230,19 +4230,19 @@ namespace chocolatey.tests.integration.scenarios
                 MockLogger.MessagesFor(LogLevel.Info).OrEmpty()
                     .SkipWhile(p => !p.Contains("upgradepackage 1.0.0 Before Modification"))
                     .Any(p => p.EndsWith("upgradepackage 1.1.1-beta.1 Installed"))
-                    .ShouldBeTrue();
+                    .Should().BeTrue();
             }
 
             [Fact]
             public void Should_not_have_executed_chocolateyUninstall_script_for_original_package()
             {
-                MockLogger.ContainsMessage("upgradepackage 1.0.0 Uninstalled", LogLevel.Info).ShouldBeFalse();
+                MockLogger.ContainsMessage("upgradepackage 1.0.0 Uninstalled", LogLevel.Info).Should().BeFalse();
             }
 
             [Fact]
             public void Should_not_have_executed_chocolateyBeforeModify_script_for_new_package()
             {
-                MockLogger.ContainsMessage("upgradepackage 1.1.0 Before Modification", LogLevel.Info).ShouldBeFalse();
+                MockLogger.ContainsMessage("upgradepackage 1.1.0 Before Modification", LogLevel.Info).Should().BeFalse();
             }
 
             [Fact]
@@ -4252,7 +4252,7 @@ namespace chocolatey.tests.integration.scenarios
             {
                 const string expectedMessage = "upgradepackage 1.1.1-beta.1 Installed";
 
-                MockLogger.ContainsMessage(expectedMessage, LogLevel.Info).ShouldBeTrue("No log message containing the sentence '{0}' could be found!".FormatWith(expectedMessage));
+                MockLogger.ContainsMessage(expectedMessage, LogLevel.Info).Should().BeTrue("No log message containing the sentence '{0}' could be found!".FormatWith(expectedMessage));
             }
         }
 
@@ -4273,15 +4273,15 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_report_for_all_non_skipped_packages()
             {
-                Results.Count().ShouldEqual(1);
-                Results.First().Key.ShouldEqual("installpackage");
+                Results.Count().Should().Be(1);
+                Results.First().Key.Should().Be("installpackage");
             }
 
             [Fact]
             public void Should_skip_packages_in_except_list()
             {
                 var upgradePackageResult = Results.Where(x => x.Key == "upgradepackage").ToList();
-                upgradePackageResult.Count.ShouldEqual(0, "upgradepackage should not be in the results list");
+                upgradePackageResult.Count.Should().Be(0, "upgradepackage should not be in the results list");
             }
         }
 
@@ -4332,7 +4332,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, Configuration.PackageNames + NuGetConstants.PackageExtension);
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().ShouldEqual("2.0.0");
+                    packageReader.NuspecReader.GetVersion().ToStringSafe().Should().Be("2.0.0");
                 }
             }
 
@@ -4345,7 +4345,7 @@ namespace chocolatey.tests.integration.scenarios
                     if (message.Contains("upgraded 1/1")) upgradedSuccessMessage = true;
                 }
 
-                upgradedSuccessMessage.ShouldBeTrue();
+                upgradedSuccessMessage.Should().BeTrue();
             }
 
             [Fact]
@@ -4357,37 +4357,37 @@ namespace chocolatey.tests.integration.scenarios
                     if (message.Contains("You have scriptpackage.hook v1.0.0 installed. Version 2.0.0 is available based on your source")) upgradeMessage = true;
                 }
 
-                upgradeMessage.ShouldBeTrue();
+                upgradeMessage.Should().BeTrue();
             }
 
             [Fact]
             public void Should_have_a_successful_package_result()
             {
-                _packageResult.Success.ShouldBeTrue();
+                _packageResult.Success.Should().BeTrue();
             }
 
             [Fact]
             public void Should_not_have_inconclusive_package_result()
             {
-                _packageResult.Inconclusive.ShouldBeFalse();
+                _packageResult.Inconclusive.Should().BeFalse();
             }
 
             [Fact]
             public void Should_not_have_warning_package_result()
             {
-                _packageResult.Warning.ShouldBeFalse();
+                _packageResult.Warning.Should().BeFalse();
             }
 
             [Fact]
             public void Config_should_match_package_result_name()
             {
-                _packageResult.Name.ShouldEqual(Configuration.PackageNames);
+                _packageResult.Name.Should().Be(Configuration.PackageNames);
             }
 
             [Fact]
             public void Should_match_the_upgrade_version_of_two_dot_zero_dot_zero()
             {
-                _packageResult.Version.ShouldEqual("2.0.0");
+                _packageResult.Version.Should().Be("2.0.0");
             }
 
             [Fact]
@@ -4405,7 +4405,7 @@ namespace chocolatey.tests.integration.scenarios
                 foreach (string scriptName in hookScripts)
                 {
                     var hookScriptPath = Path.Combine(Scenario.get_top_level(), "hooks", Configuration.PackageNames.Replace(".hook", string.Empty), scriptName);
-                    File.ReadAllText(hookScriptPath).ShouldContain("Write-Output");
+                    File.ReadAllText(hookScriptPath).Should().Contain("Write-Output");
                 }
             }
 
@@ -4469,7 +4469,7 @@ namespace chocolatey.tests.integration.scenarios
             {
                 var shimFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, "tools", "console.exe");
 
-                File.ReadAllText(shimFile).ShouldEqual("1.1.0");
+                File.ReadAllText(shimFile).Should().Be("1.1.0");
             }
 
             [Fact]
@@ -4478,7 +4478,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, Configuration.PackageNames + NuGetConstants.PackageExtension);
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().ShouldEqual("1.1.0");
+                    packageReader.NuspecReader.GetVersion().ToStringSafe().Should().Be("1.1.0");
                 }
             }
 
@@ -4491,7 +4491,7 @@ namespace chocolatey.tests.integration.scenarios
                     if (message.Contains("upgraded 1/1")) upgradedSuccessMessage = true;
                 }
 
-                upgradedSuccessMessage.ShouldBeTrue();
+                upgradedSuccessMessage.Should().BeTrue();
             }
 
             [Fact]
@@ -4503,19 +4503,19 @@ namespace chocolatey.tests.integration.scenarios
                     if (message.Contains("You have upgradepackage v1.0.0 installed. Version 1.1.0 is available based on your source")) upgradeMessage = true;
                 }
 
-                upgradeMessage.ShouldBeTrue();
+                upgradeMessage.Should().BeTrue();
             }
 
             [Fact]
             public void Should_have_a_successful_package_result()
             {
-                _packageResult.Success.ShouldBeTrue();
+                _packageResult.Success.Should().BeTrue();
             }
 
             [Fact]
             public void Should_not_have_inconclusive_package_result()
             {
-                _packageResult.Inconclusive.ShouldBeFalse();
+                _packageResult.Inconclusive.Should().BeFalse();
             }
 
             [Fact]
@@ -4524,19 +4524,19 @@ namespace chocolatey.tests.integration.scenarios
                 // For before modify scripts that fail, we add a warning message.
                 // So we will ignore any such warnings.
                 var messages = _packageResult.Messages.Where(m => m.MessageType == ResultType.Warn && !m.Message.ContainsSafe("chocolateyBeforeModify"));
-                messages.ShouldBeEmpty();
+                messages.Should().BeEmpty();
             }
 
             [Fact]
             public void Config_should_match_package_result_name()
             {
-                _packageResult.Name.ShouldEqual(Configuration.PackageNames);
+                _packageResult.Name.Should().Be(Configuration.PackageNames);
             }
 
             [Fact]
             public void Should_match_the_upgrade_version_of_one_dot_one_dot_zero()
             {
-                _packageResult.Version.ShouldEqual("1.1.0");
+                _packageResult.Version.Should().Be("1.1.0");
             }
 
             [Fact]
@@ -4544,7 +4544,7 @@ namespace chocolatey.tests.integration.scenarios
             [Platform(Exclude = "Mono")]
             public void Should_have_executed_chocolateyBeforeModify_script_for_original_package()
             {
-                MockLogger.ContainsMessage("upgradepackage 1.0.0 Before Modification", LogLevel.Info).ShouldBeTrue();
+                MockLogger.ContainsMessage("upgradepackage 1.0.0 Before Modification", LogLevel.Info).Should().BeTrue();
             }
 
             [Fact]
@@ -4555,19 +4555,19 @@ namespace chocolatey.tests.integration.scenarios
                 MockLogger.MessagesFor(LogLevel.Info).OrEmpty()
                     .SkipWhile(p => !p.Contains("upgradepackage 1.0.0 Before Modification"))
                     .Any(p => p.EndsWith("upgradepackage 1.1.0 Installed"))
-                    .ShouldBeTrue();
+                    .Should().BeTrue();
             }
 
             [Fact]
             public void Should_not_have_executed_chocolateyUninstall_script_for_original_package()
             {
-                MockLogger.ContainsMessage("upgradepackage 1.0.0 Uninstalled", LogLevel.Info).ShouldBeFalse();
+                MockLogger.ContainsMessage("upgradepackage 1.0.0 Uninstalled", LogLevel.Info).Should().BeFalse();
             }
 
             [Fact]
             public void Should_not_have_executed_chocolateyBeforeModify_script_for_new_package()
             {
-                MockLogger.ContainsMessage("upgradepackage 1.1.0 Before Modification", LogLevel.Info).ShouldBeFalse();
+                MockLogger.ContainsMessage("upgradepackage 1.1.0 Before Modification", LogLevel.Info).Should().BeFalse();
             }
 
             [Fact]
@@ -4575,7 +4575,7 @@ namespace chocolatey.tests.integration.scenarios
             [Platform(Exclude = "Mono")]
             public void Should_have_executed_chocolateyInstall_script_for_new_package()
             {
-                MockLogger.ContainsMessage("upgradepackage 1.1.0 Installed", LogLevel.Info).ShouldBeTrue();
+                MockLogger.ContainsMessage("upgradepackage 1.1.0 Installed", LogLevel.Info).Should().BeTrue();
             }
 
             [Fact]
@@ -4583,7 +4583,7 @@ namespace chocolatey.tests.integration.scenarios
             [Platform(Exclude = "Mono")]
             public void Should_have_executed_pre_all_hook_script()
             {
-                MockLogger.ContainsMessage("pre-install-all.ps1 hook ran for upgradepackage 1.1.0", LogLevel.Info).ShouldBeTrue();
+                MockLogger.ContainsMessage("pre-install-all.ps1 hook ran for upgradepackage 1.1.0", LogLevel.Info).Should().BeTrue();
             }
 
             [Fact]
@@ -4591,7 +4591,7 @@ namespace chocolatey.tests.integration.scenarios
             [Platform(Exclude = "Mono")]
             public void Should_have_executed_post_all_hook_script()
             {
-                MockLogger.ContainsMessage("post-install-all.ps1 hook ran for upgradepackage 1.1.0", LogLevel.Info).ShouldBeTrue();
+                MockLogger.ContainsMessage("post-install-all.ps1 hook ran for upgradepackage 1.1.0", LogLevel.Info).Should().BeTrue();
             }
 
             [Fact]
@@ -4599,7 +4599,7 @@ namespace chocolatey.tests.integration.scenarios
             [Platform(Exclude = "Mono")]
             public void Should_have_executed_pre_upgradepackage_hook_script()
             {
-                MockLogger.ContainsMessage("pre-install-upgradepackage.ps1 hook ran for upgradepackage 1.1.0", LogLevel.Info).ShouldBeTrue();
+                MockLogger.ContainsMessage("pre-install-upgradepackage.ps1 hook ran for upgradepackage 1.1.0", LogLevel.Info).Should().BeTrue();
             }
 
             [Fact]
@@ -4607,7 +4607,7 @@ namespace chocolatey.tests.integration.scenarios
             [Platform(Exclude = "Mono")]
             public void Should_have_executed_post_upgradepackage_hook_script()
             {
-                MockLogger.ContainsMessage("post-install-upgradepackage.ps1 hook ran for upgradepackage 1.1.0", LogLevel.Info).ShouldBeTrue();
+                MockLogger.ContainsMessage("post-install-upgradepackage.ps1 hook ran for upgradepackage 1.1.0", LogLevel.Info).Should().BeTrue();
             }
 
             [Fact]
@@ -4615,7 +4615,7 @@ namespace chocolatey.tests.integration.scenarios
             [Platform(Exclude = "Mono")]
             public void Should_not_have_executed_uninstall_hook_script()
             {
-                MockLogger.ContainsMessage("post-uninstall-all.ps1 hook ran for upgradepackage 1.1.0", LogLevel.Info).ShouldBeFalse();
+                MockLogger.ContainsMessage("post-uninstall-all.ps1 hook ran for upgradepackage 1.1.0", LogLevel.Info).Should().BeFalse();
             }
 
             [Fact]
@@ -4623,7 +4623,7 @@ namespace chocolatey.tests.integration.scenarios
             [Platform(Exclude = "Mono")]
             public void Should_not_have_executed_installpackage_hook_script()
             {
-                MockLogger.ContainsMessage("pre-install-installpackage.ps1 hook ran for upgradepackage 1.1.0", LogLevel.Info).ShouldBeFalse();
+                MockLogger.ContainsMessage("pre-install-installpackage.ps1 hook ran for upgradepackage 1.1.0", LogLevel.Info).Should().BeFalse();
             }
 
             [Fact]
@@ -4631,7 +4631,7 @@ namespace chocolatey.tests.integration.scenarios
             [Platform(Exclude = "Mono")]
             public void Should_have_executed_beforemodify_hook_script_for_previous_version()
             {
-                MockLogger.ContainsMessage("pre-beforemodify-all.ps1 hook ran for upgradepackage 1.0.0", LogLevel.Info).ShouldBeTrue();
+                MockLogger.ContainsMessage("pre-beforemodify-all.ps1 hook ran for upgradepackage 1.0.0", LogLevel.Info).Should().BeTrue();
             }
 
             [Fact]
@@ -4639,7 +4639,7 @@ namespace chocolatey.tests.integration.scenarios
             [Platform(Exclude = "Mono")]
             public void Should_not_have_executed_beforemodify_hook_script_for_upgrade_version()
             {
-                MockLogger.ContainsMessage("pre-beforemodify-all.ps1 hook ran for upgradepackage 1.1.0", LogLevel.Info).ShouldBeFalse();
+                MockLogger.ContainsMessage("pre-beforemodify-all.ps1 hook ran for upgradepackage 1.1.0", LogLevel.Info).Should().BeFalse();
             }
         }
         public class When_upgrading_an_existing_package_with_uppercase_id : ScenariosBase
@@ -4688,7 +4688,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, Configuration.PackageNames + NuGetConstants.PackageExtension);
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().ShouldEqual("1.1.0");
+                    packageReader.NuspecReader.GetVersion().ToStringSafe().Should().Be("1.1.0");
                 }
             }
 
@@ -4701,7 +4701,7 @@ namespace chocolatey.tests.integration.scenarios
                     if (message.Contains("upgraded 1/1")) upgradedSuccessMessage = true;
                 }
 
-                upgradedSuccessMessage.ShouldBeTrue();
+                upgradedSuccessMessage.Should().BeTrue();
             }
 
             [Fact]
@@ -4713,37 +4713,37 @@ namespace chocolatey.tests.integration.scenarios
                     if (message.Contains("You have UpperCase v1.0.0 installed. Version 1.1.0 is available based on your source")) upgradeMessage = true;
                 }
 
-                upgradeMessage.ShouldBeTrue();
+                upgradeMessage.Should().BeTrue();
             }
 
             [Fact]
             public void Should_have_a_successful_package_result()
             {
-                _packageResult.Success.ShouldBeTrue();
+                _packageResult.Success.Should().BeTrue();
             }
 
             [Fact]
             public void Should_not_have_inconclusive_package_result()
             {
-                _packageResult.Inconclusive.ShouldBeFalse();
+                _packageResult.Inconclusive.Should().BeFalse();
             }
 
             [Fact]
             public void Should_not_have_warning_package_result()
             {
-                _packageResult.Warning.ShouldBeFalse();
+                _packageResult.Warning.Should().BeFalse();
             }
 
             [Fact]
             public void Config_should_match_package_result_name()
             {
-                _packageResult.Name.ShouldEqual(Configuration.PackageNames);
+                _packageResult.Name.Should().Be(Configuration.PackageNames);
             }
 
             [Fact]
             public void Should_match_the_upgrade_version_of_one_dot_one_dot_zero()
             {
-                _packageResult.Version.ShouldEqual("1.1.0");
+                _packageResult.Version.Should().Be("1.1.0");
             }
 
             [Fact]
@@ -4751,7 +4751,7 @@ namespace chocolatey.tests.integration.scenarios
             [Platform(Exclude = "Mono")]
             public void Should_have_executed_chocolateyBeforeModify_script_for_original_package()
             {
-                MockLogger.ContainsMessage("UpperCase 1.0.0 Before Modification", LogLevel.Info).ShouldBeTrue();
+                MockLogger.ContainsMessage("UpperCase 1.0.0 Before Modification", LogLevel.Info).Should().BeTrue();
             }
 
             [Fact]
@@ -4762,19 +4762,19 @@ namespace chocolatey.tests.integration.scenarios
                 MockLogger.MessagesFor(LogLevel.Info).OrEmpty()
                     .SkipWhile(p => !p.Contains("UpperCase 1.0.0 Before Modification"))
                     .Any(p => p.EndsWith("UpperCase 1.1.0 Installed"))
-                    .ShouldBeTrue();
+                    .Should().BeTrue();
             }
 
             [Fact]
             public void Should_not_have_executed_chocolateyUninstall_script_for_original_package()
             {
-                MockLogger.ContainsMessage("UpperCase 1.0.0 Uninstalled", LogLevel.Info).ShouldBeFalse();
+                MockLogger.ContainsMessage("UpperCase 1.0.0 Uninstalled", LogLevel.Info).Should().BeFalse();
             }
 
             [Fact]
             public void Should_not_have_executed_chocolateyBeforeModify_script_for_new_package()
             {
-                MockLogger.ContainsMessage("UpperCase 1.1.0 Before Modification", LogLevel.Info).ShouldBeFalse();
+                MockLogger.ContainsMessage("UpperCase 1.1.0 Before Modification", LogLevel.Info).Should().BeFalse();
             }
 
             [Fact]
@@ -4782,7 +4782,7 @@ namespace chocolatey.tests.integration.scenarios
             [Platform(Exclude = "Mono")]
             public void Should_have_executed_chocolateyInstall_script_for_new_package()
             {
-                MockLogger.ContainsMessage("UpperCase 1.1.0 Installed", LogLevel.Info).ShouldBeTrue();
+                MockLogger.ContainsMessage("UpperCase 1.1.0 Installed", LogLevel.Info).Should().BeTrue();
             }
         }
 
@@ -4824,7 +4824,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, Configuration.PackageNames + NuGetConstants.PackageExtension);
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().ShouldEqual("1.1.0");
+                    packageReader.NuspecReader.GetVersion().ToStringSafe().Should().Be("1.1.0");
                 }
             }
 
@@ -4837,7 +4837,7 @@ namespace chocolatey.tests.integration.scenarios
                     if (message.Contains("upgraded 1/1")) upgradedSuccessMessage = true;
                 }
 
-                upgradedSuccessMessage.ShouldBeTrue();
+                upgradedSuccessMessage.Should().BeTrue();
             }
 
             [Fact]
@@ -4849,7 +4849,7 @@ namespace chocolatey.tests.integration.scenarios
                     if (message.Contains("You have unsupportedelements v1.0.0 installed. Version 1.1.0 is available based on your source")) upgradeMessage = true;
                 }
 
-                upgradeMessage.ShouldBeTrue();
+                upgradeMessage.Should().BeTrue();
             }
 
             [Fact]
@@ -4860,37 +4860,37 @@ namespace chocolatey.tests.integration.scenarios
                 {
                     if (message.Contains("Issues found with nuspec elements")) upgradeMessage = true;
                 }
-                upgradeMessage.ShouldBeTrue();
+                upgradeMessage.Should().BeTrue();
             }
 
             [Fact]
             public void Should_have_a_successful_package_result()
             {
-                _packageResult.Success.ShouldBeTrue();
+                _packageResult.Success.Should().BeTrue();
             }
 
             [Fact]
             public void Should_not_have_inconclusive_package_result()
             {
-                _packageResult.Inconclusive.ShouldBeFalse();
+                _packageResult.Inconclusive.Should().BeFalse();
             }
 
             [Fact]
             public void Should_have_warning_package_result()
             {
-                _packageResult.Warning.ShouldBeTrue();
+                _packageResult.Warning.Should().BeTrue();
             }
 
             [Fact]
             public void Config_should_match_package_result_name()
             {
-                _packageResult.Name.ShouldEqual(Configuration.PackageNames);
+                _packageResult.Name.Should().Be(Configuration.PackageNames);
             }
 
             [Fact]
             public void Should_match_the_upgrade_version_of_one_dot_one_dot_zero()
             {
-                _packageResult.Version.ShouldEqual("1.1.0");
+                _packageResult.Version.Should().Be("1.1.0");
             }
 
             [Fact]
@@ -4898,7 +4898,7 @@ namespace chocolatey.tests.integration.scenarios
             [Platform(Exclude = "Mono")]
             public void Should_have_executed_chocolateyBeforeModify_script_for_original_package()
             {
-                MockLogger.ContainsMessage("unsupportedelements 1.0.0 Before Modification", LogLevel.Info).ShouldBeTrue();
+                MockLogger.ContainsMessage("unsupportedelements 1.0.0 Before Modification", LogLevel.Info).Should().BeTrue();
             }
 
             [Fact]
@@ -4909,19 +4909,19 @@ namespace chocolatey.tests.integration.scenarios
                 MockLogger.MessagesFor(LogLevel.Info).OrEmpty()
                     .SkipWhile(p => !p.Contains("unsupportedelements 1.0.0 Before Modification"))
                     .Any(p => p.EndsWith("unsupportedelements 1.1.0 Installed"))
-                    .ShouldBeTrue();
+                    .Should().BeTrue();
             }
 
             [Fact]
             public void Should_not_have_executed_chocolateyUninstall_script_for_original_package()
             {
-                MockLogger.ContainsMessage("unsupportedelements 1.0.0 Uninstalled", LogLevel.Info).ShouldBeFalse();
+                MockLogger.ContainsMessage("unsupportedelements 1.0.0 Uninstalled", LogLevel.Info).Should().BeFalse();
             }
 
             [Fact]
             public void Should_not_have_executed_chocolateyBeforeModify_script_for_new_package()
             {
-                MockLogger.ContainsMessage("unsupportedelements 1.1.0 Before Modification", LogLevel.Info).ShouldBeFalse();
+                MockLogger.ContainsMessage("unsupportedelements 1.1.0 Before Modification", LogLevel.Info).Should().BeFalse();
             }
 
             [Fact]
@@ -4929,7 +4929,7 @@ namespace chocolatey.tests.integration.scenarios
             [Platform(Exclude = "Mono")]
             public void Should_have_executed_chocolateyInstall_script_for_new_package()
             {
-                MockLogger.ContainsMessage("unsupportedelements 1.1.0 Installed", LogLevel.Info).ShouldBeTrue();
+                MockLogger.ContainsMessage("unsupportedelements 1.1.0 Installed", LogLevel.Info).Should().BeTrue();
             }
         }
 
@@ -4981,7 +4981,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, Configuration.PackageNames + NuGetConstants.PackageExtension);
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToStringSafe().ShouldEqual(NonNormalizedVersion);
+                    packageReader.NuspecReader.GetVersion().ToStringSafe().Should().Be(NonNormalizedVersion);
                 }
             }
 
@@ -4994,7 +4994,7 @@ namespace chocolatey.tests.integration.scenarios
                     if (message.Contains("upgraded 1/1")) upgradedSuccessMessage = true;
                 }
 
-                upgradedSuccessMessage.ShouldBeTrue();
+                upgradedSuccessMessage.Should().BeTrue();
             }
 
             [Fact]
@@ -5006,19 +5006,19 @@ namespace chocolatey.tests.integration.scenarios
                     if (message.Contains("You have upgradepackage v1.0.0 installed. Version {0} is available based on your source".FormatWith(NonNormalizedVersion))) upgradeMessage = true;
                 }
 
-                upgradeMessage.ShouldBeTrue();
+                upgradeMessage.Should().BeTrue();
             }
 
             [Fact]
             public void Should_have_a_successful_package_result()
             {
-                _packageResult.Success.ShouldBeTrue();
+                _packageResult.Success.Should().BeTrue();
             }
 
             [Fact]
             public void Should_not_have_inconclusive_package_result()
             {
-                _packageResult.Inconclusive.ShouldBeFalse();
+                _packageResult.Inconclusive.Should().BeFalse();
             }
 
             [Fact]
@@ -5027,19 +5027,19 @@ namespace chocolatey.tests.integration.scenarios
                 // For before modify scripts that fail, we add a warning message.
                 // So we will ignore any such warnings.
                 var messages = _packageResult.Messages.Where(m => m.MessageType == ResultType.Warn && !m.Message.ContainsSafe("chocolateyBeforeModify"));
-                messages.ShouldBeEmpty();
+                messages.Should().BeEmpty();
             }
 
             [Fact]
             public void Config_should_match_package_result_name()
             {
-                _packageResult.Name.ShouldEqual(Configuration.PackageNames);
+                _packageResult.Name.Should().Be(Configuration.PackageNames);
             }
 
             [Fact]
             public void Should_match_the_upgrade_version()
             {
-                _packageResult.Version.ShouldEqual(NormalizedVersion);
+                _packageResult.Version.Should().Be(NonNormalizedVersion);
             }
 
             [Fact]
@@ -5047,7 +5047,7 @@ namespace chocolatey.tests.integration.scenarios
             [Platform(Exclude = "Mono")]
             public void Should_have_executed_chocolateyBeforeModify_script_for_original_package()
             {
-                MockLogger.ContainsMessage("upgradepackage 1.0.0 Before Modification", LogLevel.Info).ShouldBeTrue();
+                MockLogger.ContainsMessage("upgradepackage 1.0.0 Before Modification", LogLevel.Info).Should().BeTrue();
             }
 
             [Fact]
@@ -5057,20 +5057,20 @@ namespace chocolatey.tests.integration.scenarios
             {
                 MockLogger.MessagesFor(LogLevel.Info).OrEmpty()
                     .SkipWhile(p => !p.Contains("upgradepackage 1.0.0 Before Modification"))
-                    .Any(p => p.EndsWith("upgradepackage {0} Installed".FormatWith(NormalizedVersion)))
-                    .ShouldBeTrue();
+                    .Any(p => p.EndsWith("upgradepackage {0} Installed".FormatWith(NonNormalizedVersion)))
+                    .Should().BeTrue();
             }
 
             [Fact]
             public void Should_not_have_executed_chocolateyUninstall_script_for_original_package()
             {
-                MockLogger.ContainsMessage("upgradepackage 1.0.0 Uninstalled", LogLevel.Info).ShouldBeFalse();
+                MockLogger.ContainsMessage("upgradepackage 1.0.0 Uninstalled", LogLevel.Info).Should().BeFalse();
             }
 
             [Fact]
             public void Should_not_have_executed_chocolateyBeforeModify_script_for_new_package()
             {
-                MockLogger.ContainsMessage("upgradepackage {0} Before Modification".FormatWith(NormalizedVersion), LogLevel.Info).ShouldBeFalse();
+                MockLogger.ContainsMessage("upgradepackage {0} Before Modification".FormatWith(NonNormalizedVersion), LogLevel.Info).Should().BeFalse();
             }
 
             [Fact]
@@ -5078,7 +5078,7 @@ namespace chocolatey.tests.integration.scenarios
             [Platform(Exclude = "Mono")]
             public void Should_have_executed_chocolateyInstall_script_for_new_package()
             {
-                MockLogger.ContainsMessage("upgradepackage {0} Installed".FormatWith(NormalizedVersion), LogLevel.Info).ShouldBeTrue();
+                MockLogger.ContainsMessage("upgradepackage {0} Installed".FormatWith(NonNormalizedVersion), LogLevel.Info).Should().BeTrue();
             }
         }
 
@@ -5167,14 +5167,14 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", DependencyName, "{0}.nupkg".FormatWith(DependencyName));
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().ShouldEqual("2.0.0");
+                    packageReader.NuspecReader.GetVersion().ToStringSafe().Should().Be("2.0.0");
                 }
             }
 
             [Fact]
             public void Should_contain_a_message_that_everything_upgraded_successfully()
             {
-                MockLogger.ContainsMessage("upgraded 2/2", LogLevel.Warn).ShouldBeTrue();
+                MockLogger.ContainsMessage("upgraded 2/2", LogLevel.Warn).Should().BeTrue();
             }
 
             [Fact]
@@ -5182,7 +5182,7 @@ namespace chocolatey.tests.integration.scenarios
             [Platform(Exclude = "Mono")]
             public void Should_run_beforemodify_hook_script_for_previous_version_of_target()
             {
-                MockLogger.ContainsMessage("pre-beforemodify-all.ps1 hook ran for {0} {1}".FormatWith(TargetPackageName, "1.0.0"), LogLevel.Info).ShouldBeTrue();
+                MockLogger.ContainsMessage("pre-beforemodify-all.ps1 hook ran for {0} {1}".FormatWith(TargetPackageName, "1.0.0"), LogLevel.Info).Should().BeTrue();
             }
 
             [Fact]
@@ -5190,7 +5190,7 @@ namespace chocolatey.tests.integration.scenarios
             [Platform(Exclude = "Mono")]
             public void Should_run_already_installed_target_package_beforeModify()
             {
-                MockLogger.ContainsMessage("Ran BeforeModify: {0} {1}".FormatWith(TargetPackageName, "1.0.0"), LogLevel.Info).ShouldBeTrue();
+                MockLogger.ContainsMessage("Ran BeforeModify: {0} {1}".FormatWith(TargetPackageName, "1.0.0"), LogLevel.Info).Should().BeTrue();
             }
 
             [Fact]
@@ -5198,7 +5198,7 @@ namespace chocolatey.tests.integration.scenarios
             [Platform(Exclude = "Mono")]
             public void Should_not_run_beforemodify_hook_script_for_upgrade_version_of_target()
             {
-                MockLogger.ContainsMessage("pre-beforemodify-all.ps1 hook ran for {0} {1}".FormatWith(TargetPackageName, "2.0.0"), LogLevel.Info).ShouldBeFalse();
+                MockLogger.ContainsMessage("pre-beforemodify-all.ps1 hook ran for {0} {1}".FormatWith(TargetPackageName, "2.0.0"), LogLevel.Info).Should().BeFalse();
             }
 
             [Fact]
@@ -5206,7 +5206,7 @@ namespace chocolatey.tests.integration.scenarios
             [Platform(Exclude = "Mono")]
             public void Should_not_run_target_package_beforeModify_for_upgraded_version()
             {
-                MockLogger.ContainsMessage("Ran BeforeModify: {0} {1}".FormatWith(TargetPackageName, "2.0.0"), LogLevel.Info).ShouldBeFalse();
+                MockLogger.ContainsMessage("Ran BeforeModify: {0} {1}".FormatWith(TargetPackageName, "2.0.0"), LogLevel.Info).Should().BeFalse();
             }
 
             [Fact]
@@ -5214,7 +5214,7 @@ namespace chocolatey.tests.integration.scenarios
             [Platform(Exclude = "Mono")]
             public void Should_run_pre_all_hook_script_for_upgraded_version_of_target()
             {
-                MockLogger.ContainsMessage("pre-install-all.ps1 hook ran for {0} {1}".FormatWith(TargetPackageName, "2.0.0"), LogLevel.Info).ShouldBeTrue();
+                MockLogger.ContainsMessage("pre-install-all.ps1 hook ran for {0} {1}".FormatWith(TargetPackageName, "2.0.0"), LogLevel.Info).Should().BeTrue();
             }
 
             [Fact]
@@ -5222,7 +5222,7 @@ namespace chocolatey.tests.integration.scenarios
             [Platform(Exclude = "Mono")]
             public void Should_run_post_all_hook_script_for_upgraded_version_of_target()
             {
-                MockLogger.ContainsMessage("post-install-all.ps1 hook ran for {0} {1}".FormatWith(TargetPackageName, "2.0.0"), LogLevel.Info).ShouldBeTrue();
+                MockLogger.ContainsMessage("post-install-all.ps1 hook ran for {0} {1}".FormatWith(TargetPackageName, "2.0.0"), LogLevel.Info).Should().BeTrue();
             }
 
             [Fact]
@@ -5230,7 +5230,7 @@ namespace chocolatey.tests.integration.scenarios
             [Platform(Exclude = "Mono")]
             public void Should_run_beforemodify_hook_script_for_previous_version_of_dependency()
             {
-                MockLogger.ContainsMessage("pre-beforemodify-all.ps1 hook ran for {0} {1}".FormatWith(DependencyName, "1.0.0"), LogLevel.Info).ShouldBeTrue();
+                MockLogger.ContainsMessage("pre-beforemodify-all.ps1 hook ran for {0} {1}".FormatWith(DependencyName, "1.0.0"), LogLevel.Info).Should().BeTrue();
             }
 
             [Fact]
@@ -5238,7 +5238,7 @@ namespace chocolatey.tests.integration.scenarios
             [Platform(Exclude = "Mono")]
             public void Should_run_already_installed_dependency_package_beforeModify()
             {
-                MockLogger.ContainsMessage("Ran BeforeModify: {0} {1}".FormatWith(DependencyName, "1.0.0"), LogLevel.Info).ShouldBeTrue();
+                MockLogger.ContainsMessage("Ran BeforeModify: {0} {1}".FormatWith(DependencyName, "1.0.0"), LogLevel.Info).Should().BeTrue();
             }
 
             [Fact]
@@ -5246,7 +5246,7 @@ namespace chocolatey.tests.integration.scenarios
             [Platform(Exclude = "Mono")]
             public void Should_not_run_beforemodify_hook_script_for_upgrade_version_of_dependency()
             {
-                MockLogger.ContainsMessage("pre-beforemodify-all.ps1 hook ran for {0} {1}".FormatWith(DependencyName, "2.0.0"), LogLevel.Info).ShouldBeFalse();
+                MockLogger.ContainsMessage("pre-beforemodify-all.ps1 hook ran for {0} {1}".FormatWith(DependencyName, "2.0.0"), LogLevel.Info).Should().BeFalse();
             }
 
             [Fact]
@@ -5254,7 +5254,7 @@ namespace chocolatey.tests.integration.scenarios
             [Platform(Exclude = "Mono")]
             public void Should_not_run_dependency_package_beforeModify_for_upgraded_version()
             {
-                MockLogger.ContainsMessage("Ran BeforeModify: {0} {1}".FormatWith(DependencyName, "2.0.0"), LogLevel.Info).ShouldBeFalse();
+                MockLogger.ContainsMessage("Ran BeforeModify: {0} {1}".FormatWith(DependencyName, "2.0.0"), LogLevel.Info).Should().BeFalse();
             }
 
             [Fact]
@@ -5262,7 +5262,7 @@ namespace chocolatey.tests.integration.scenarios
             [Platform(Exclude = "Mono")]
             public void Should_run_pre_all_hook_script_for_upgraded_version_of_dependency()
             {
-                MockLogger.ContainsMessage("pre-install-all.ps1 hook ran for {0} {1}".FormatWith(DependencyName, "2.0.0"), LogLevel.Info).ShouldBeTrue();
+                MockLogger.ContainsMessage("pre-install-all.ps1 hook ran for {0} {1}".FormatWith(DependencyName, "2.0.0"), LogLevel.Info).Should().BeTrue();
             }
 
             [Fact]
@@ -5270,7 +5270,7 @@ namespace chocolatey.tests.integration.scenarios
             [Platform(Exclude = "Mono")]
             public void Should_run_post_all_hook_script_for_upgraded_version_of_dependency()
             {
-                MockLogger.ContainsMessage("post-install-all.ps1 hook ran for {0} {1}".FormatWith(DependencyName, "2.0.0"), LogLevel.Info).ShouldBeTrue();
+                MockLogger.ContainsMessage("post-install-all.ps1 hook ran for {0} {1}".FormatWith(DependencyName, "2.0.0"), LogLevel.Info).Should().BeTrue();
             }
 
             [Fact]
@@ -5278,7 +5278,7 @@ namespace chocolatey.tests.integration.scenarios
             {
                 foreach (var packageResult in Results)
                 {
-                    packageResult.Value.Success.ShouldBeTrue();
+                    packageResult.Value.Success.Should().BeTrue();
                 }
             }
 
@@ -5287,7 +5287,7 @@ namespace chocolatey.tests.integration.scenarios
             {
                 foreach (var packageResult in Results)
                 {
-                    packageResult.Value.Inconclusive.ShouldBeFalse();
+                    packageResult.Value.Inconclusive.Should().BeFalse();
                 }
             }
 
@@ -5296,7 +5296,7 @@ namespace chocolatey.tests.integration.scenarios
             {
                 foreach (var packageResult in Results)
                 {
-                    packageResult.Value.Warning.ShouldBeFalse();
+                    packageResult.Value.Warning.Should().BeFalse();
                 }
             }
         }

--- a/src/chocolatey.tests.integration/scenarios/UpgradeScenarios.cs
+++ b/src/chocolatey.tests.integration/scenarios/UpgradeScenarios.cs
@@ -86,25 +86,15 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_contain_a_message_that_a_new_version_is_available()
             {
-                bool expectedMessage = false;
-                foreach (var message in MockLogger.MessagesFor(LogLevel.Warn).OrEmpty())
-                {
-                    if (message.Contains("You have upgradepackage v1.0.0 installed. Version 1.1.0 is available based on your source(s)")) expectedMessage = true;
-                }
-
-                expectedMessage.Should().BeTrue();
+                MockLogger.Messages.Should().ContainKey(LogLevel.Warn.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains("You have upgradepackage v1.0.0 installed. Version 1.1.0 is available based on your source(s)"));
             }
 
             [Fact]
             public void Should_contain_a_message_that_a_package_can_be_upgraded()
             {
-                bool expectedMessage = false;
-                foreach (var message in MockLogger.MessagesFor(LogLevel.Warn).OrEmpty())
-                {
-                    if (message.Contains("can upgrade 1/1")) expectedMessage = true;
-                }
-
-                expectedMessage.Should().BeTrue();
+                MockLogger.Messages.Should().ContainKey(LogLevel.Warn.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains("can upgrade 1/1"));
             }
 
             [Fact]
@@ -133,25 +123,15 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_contain_a_message_that_you_have_the_latest_version_available()
             {
-                bool expectedMessage = false;
-                foreach (var message in MockLogger.MessagesFor(LogLevel.Info).OrEmpty())
-                {
-                    if (message.Contains("installpackage v1.0.0 is the latest version available based on your source(s)")) expectedMessage = true;
-                }
-
-                expectedMessage.Should().BeTrue();
+                MockLogger.Messages.Should().ContainKey(LogLevel.Info.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains("installpackage v1.0.0 is the latest version available based on your source(s)"));
             }
 
             [Fact]
             public void Should_contain_a_message_that_no_packages_can_be_upgraded()
             {
-                bool expectedMessage = false;
-                foreach (var message in MockLogger.MessagesFor(LogLevel.Warn).OrEmpty())
-                {
-                    if (message.Contains("can upgrade 0/1")) expectedMessage = true;
-                }
-
-                expectedMessage.Should().BeTrue();
+                MockLogger.Messages.Should().ContainKey(LogLevel.Warn.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains("can upgrade 0/1"));
             }
 
             [Fact]
@@ -180,25 +160,15 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_contain_a_message_the_package_was_not_found()
             {
-                bool expectedMessage = false;
-                foreach (var message in MockLogger.MessagesFor(LogLevel.Error).OrEmpty())
-                {
-                    if (message.Contains("nonexistentpackage not installed. The package was not found with the source(s) listed")) expectedMessage = true;
-                }
-
-                expectedMessage.Should().BeTrue();
+                MockLogger.Messages.Should().ContainKey(LogLevel.Error.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains("nonexistentpackage not installed. The package was not found with the source(s) listed"));
             }
 
             [Fact]
             public void Should_contain_a_message_that_no_packages_can_be_upgraded()
             {
-                bool expectedMessage = false;
-                foreach (var message in MockLogger.MessagesFor(LogLevel.Warn).OrEmpty())
-                {
-                    if (message.Contains("can upgrade 0/0")) expectedMessage = true;
-                }
-
-                expectedMessage.Should().BeTrue();
+                MockLogger.Messages.Should().ContainKey(LogLevel.Warn.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains("can upgrade 0/0"));
             }
         }
 
@@ -248,32 +218,22 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, Configuration.PackageNames +  NuGetConstants.PackageExtension);
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToStringSafe().Should().Be("1.1.0");
+                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().Should().Be("1.1.0");
                 }
             }
 
             [Fact]
             public void Should_contain_a_warning_message_that_it_upgraded_successfully()
             {
-                bool upgradedSuccessMessage = false;
-                foreach (var message in MockLogger.MessagesFor(LogLevel.Warn).OrEmpty())
-                {
-                    if (message.Contains("upgraded 1/1")) upgradedSuccessMessage = true;
-                }
-
-                upgradedSuccessMessage.Should().BeTrue();
+                MockLogger.Messages.Should().ContainKey(LogLevel.Warn.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains("upgraded 1/1"));
             }
 
             [Fact]
             public void Should_contain_a_warning_message_with_old_and_new_versions()
             {
-                bool upgradeMessage = false;
-                foreach (var message in MockLogger.MessagesFor(LogLevel.Warn).OrEmpty())
-                {
-                    if (message.Contains("You have upgradepackage v1.0.0 installed. Version 1.1.0 is available based on your source")) upgradeMessage = true;
-                }
-
-                upgradeMessage.Should().BeTrue();
+                MockLogger.Messages.Should().ContainKey(LogLevel.Warn.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains("You have upgradepackage v1.0.0 installed. Version 1.1.0 is available based on your source"));
             }
 
             [Fact]
@@ -314,7 +274,8 @@ namespace chocolatey.tests.integration.scenarios
             [Platform(Exclude = "Mono")]
             public void Should_have_executed_chocolateyBeforeModify_script_for_original_package()
             {
-                MockLogger.ContainsMessage("upgradepackage 1.0.0 Before Modification", LogLevel.Info).Should().BeTrue();
+                MockLogger.Messages.Should().ContainKey(LogLevel.Info.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains("upgradepackage 1.0.0 Before Modification"));
             }
 
             [Fact]
@@ -324,20 +285,21 @@ namespace chocolatey.tests.integration.scenarios
             {
                 MockLogger.MessagesFor(LogLevel.Info).OrEmpty()
                     .SkipWhile(p => !p.Contains("upgradepackage 1.0.0 Before Modification"))
-                    .Any(p => p.EndsWith("upgradepackage 1.1.0 Installed"))
-                    .Should().BeTrue();
+                    .Should().Contain(p => p.EndsWith("upgradepackage 1.1.0 Installed"));
             }
 
             [Fact]
             public void Should_not_have_executed_chocolateyUninstall_script_for_original_package()
             {
-                MockLogger.ContainsMessage("upgradepackage 1.0.0 Uninstalled", LogLevel.Info).Should().BeFalse();
+                MockLogger.Messages.Should().ContainKey(LogLevel.Info.ToStringSafe())
+                    .WhoseValue.Should().NotContain(m => m.Contains("upgradepackage 1.0.0 Uninstalled"));
             }
 
             [Fact]
             public void Should_not_have_executed_chocolateyBeforeModify_script_for_new_package()
             {
-                MockLogger.ContainsMessage("upgradepackage 1.1.0 Before Modification", LogLevel.Info).Should().BeFalse();
+                MockLogger.Messages.Should().ContainKey(LogLevel.Info.ToStringSafe())
+                    .WhoseValue.Should().NotContain(m => m.Contains("upgradepackage 1.1.0 Before Modification"));
             }
 
             [Fact]
@@ -345,7 +307,8 @@ namespace chocolatey.tests.integration.scenarios
             [Platform(Exclude = "Mono")]
             public void Should_have_executed_chocolateyInstall_script_for_new_package()
             {
-                MockLogger.ContainsMessage("upgradepackage 1.1.0 Installed", LogLevel.Info).Should().BeTrue();
+                MockLogger.Messages.Should().ContainKey(LogLevel.Info.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains("upgradepackage 1.1.0 Installed"));
             }
         }
 
@@ -372,25 +335,15 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_contain_a_message_that_you_have_the_latest_version_available()
             {
-                bool expectedMessage = false;
-                foreach (var message in MockLogger.MessagesFor(LogLevel.Info).OrEmpty())
-                {
-                    if (message.Contains("upgradepackage v1.0.0 is the latest version available based on your source(s)")) expectedMessage = true;
-                }
-
-                expectedMessage.Should().BeTrue();
+                MockLogger.Messages.Should().ContainKey(LogLevel.Info.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains("upgradepackage v1.0.0 is the latest version available based on your source(s)"));
             }
 
             [Fact]
             public void Should_contain_a_message_that_no_packages_were_upgraded()
             {
-                bool expectedMessage = false;
-                foreach (var message in MockLogger.MessagesFor(LogLevel.Warn).OrEmpty())
-                {
-                    if (message.Contains("upgraded 0/1 ")) expectedMessage = true;
-                }
-
-                expectedMessage.Should().BeTrue();
+                MockLogger.Messages.Should().ContainKey(LogLevel.Warn.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains("upgraded 0/1 "));
             }
 
             [Fact]
@@ -464,25 +417,15 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_contain_a_message_that_you_have_the_latest_version_available()
             {
-                bool expectedMessage = false;
-                foreach (var message in MockLogger.MessagesFor(LogLevel.Info).OrEmpty())
-                {
-                    if (message.Contains("upgradepackage v1.1.0 is the latest version available based on your source(s)")) expectedMessage = true;
-                }
-
-                expectedMessage.Should().BeTrue();
+                MockLogger.Messages.Should().ContainKey(LogLevel.Info.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains("upgradepackage v1.1.0 is the latest version available based on your source(s)"));
             }
 
             [Fact]
             public void Should_contain_a_message_that_no_packages_were_upgraded()
             {
-                bool expectedMessage = false;
-                foreach (var message in MockLogger.MessagesFor(LogLevel.Warn).OrEmpty())
-                {
-                    if (message.Contains("upgraded 0/1 ")) expectedMessage = true;
-                }
-
-                expectedMessage.Should().BeTrue();
+                MockLogger.Messages.Should().ContainKey(LogLevel.Warn.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains("upgraded 0/1 "));
             }
 
             [Fact]
@@ -507,7 +450,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, Configuration.PackageNames +  NuGetConstants.PackageExtension);
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToStringSafe().Should().Be("1.1.0");
+                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().Should().Be("1.1.0");
                 }
             }
 
@@ -598,25 +541,15 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_contain_a_warning_message_that_it_upgraded_successfully()
             {
-                bool upgradedSuccessMessage = false;
-                foreach (var message in MockLogger.MessagesFor(LogLevel.Warn).OrEmpty())
-                {
-                    if (message.Contains("upgraded 1/1")) upgradedSuccessMessage = true;
-                }
-
-                upgradedSuccessMessage.Should().BeTrue();
+                MockLogger.Messages.Should().ContainKey(LogLevel.Warn.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains("upgraded 1/1"));
             }
 
             [Fact]
             public void Should_contain_a_warning_message_with_old_and_new_versions()
             {
-                bool upgradeMessage = false;
-                foreach (var message in MockLogger.MessagesFor(LogLevel.Warn).OrEmpty())
-                {
-                    if (message.Contains("You have upgradepackage v1.0.0 installed. Version 1.1.1-beta2 is available based on your source")) upgradeMessage = true;
-                }
-
-                upgradeMessage.Should().BeTrue();
+                MockLogger.Messages.Should().ContainKey(LogLevel.Warn.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains("You have upgradepackage v1.0.0 installed. Version 1.1.1-beta2 is available based on your source"));
             }
 
             [Fact]
@@ -657,7 +590,8 @@ namespace chocolatey.tests.integration.scenarios
             [Platform(Exclude = "Mono")]
             public void Should_have_executed_chocolateyBeforeModify_script_for_original_package()
             {
-                MockLogger.ContainsMessage("upgradepackage 1.0.0 Before Modification", LogLevel.Info).Should().BeTrue();
+                MockLogger.Messages.Should().ContainKey(LogLevel.Info.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains("upgradepackage 1.0.0 Before Modification"));
             }
 
             [Fact]
@@ -667,20 +601,21 @@ namespace chocolatey.tests.integration.scenarios
             {
                 MockLogger.MessagesFor(LogLevel.Info).OrEmpty()
                     .SkipWhile(p => !p.Contains("upgradepackage 1.0.0 Before Modification"))
-                    .Any(p => p.EndsWith("upgradepackage 1.1.1-beta2 Installed"))
-                    .Should().BeTrue();
+                    .Should().Contain(p => p.EndsWith("upgradepackage 1.1.1-beta2 Installed"));
             }
 
             [Fact]
             public void Should_not_have_executed_chocolateyUninstall_script_for_original_package()
             {
-                MockLogger.ContainsMessage("upgradepackage 1.0.0 Uninstalled", LogLevel.Info).Should().BeFalse();
+                MockLogger.Messages.Should().ContainKey(LogLevel.Info.ToStringSafe())
+                    .WhoseValue.Should().NotContain(m => m.Contains("upgradepackage 1.0.0 Uninstalled"));
             }
 
             [Fact]
             public void Should_not_have_executed_chocolateyBeforeModify_script_for_new_package()
             {
-                MockLogger.ContainsMessage("upgradepackage 1.1.1-beta2 Before Modification", LogLevel.Info).Should().BeFalse();
+                MockLogger.Messages.Should().ContainKey(LogLevel.Info.ToStringSafe())
+                    .WhoseValue.Should().NotContain(m => m.Contains("upgradepackage 1.1.1-beta2 Before Modification"));
             }
 
             [Fact]
@@ -688,7 +623,8 @@ namespace chocolatey.tests.integration.scenarios
             [Platform(Exclude = "Mono")]
             public void Should_have_executed_chocolateyInstall_script_for_new_package()
             {
-                MockLogger.ContainsMessage("upgradepackage 1.1.1-beta2 Installed", LogLevel.Info).Should().BeTrue();
+                MockLogger.Messages.Should().ContainKey(LogLevel.Info.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains("upgradepackage 1.1.1-beta2 Installed"));
             }
         }
 
@@ -756,25 +692,15 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_contain_a_warning_message_that_it_upgraded_successfully()
             {
-                bool upgradedSuccessMessage = false;
-                foreach (var message in MockLogger.MessagesFor(LogLevel.Warn).OrEmpty())
-                {
-                    if (message.Contains("upgraded 1/1")) upgradedSuccessMessage = true;
-                }
-
-                upgradedSuccessMessage.Should().BeTrue();
+                MockLogger.Messages.Should().ContainKey(LogLevel.Warn.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains("upgraded 1/1"));
             }
 
             [Fact]
             public void Should_contain_a_warning_message_with_old_and_new_versions()
             {
-                bool upgradeMessage = false;
-                foreach (var message in MockLogger.MessagesFor(LogLevel.Warn).OrEmpty())
-                {
-                    if (message.Contains("You have upgradepackage v1.0.0 installed. Version 1.1.1-beta.1 is available based on your source")) upgradeMessage = true;
-                }
-
-                upgradeMessage.Should().BeTrue();
+                MockLogger.Messages.Should().ContainKey(LogLevel.Warn.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains("You have upgradepackage v1.0.0 installed. Version 1.1.1-beta.1 is available based on your source"));
             }
 
             [Fact]
@@ -815,7 +741,8 @@ namespace chocolatey.tests.integration.scenarios
             [Platform(Exclude = "Mono")]
             public void Should_have_executed_chocolateyBeforeModify_script_for_original_package()
             {
-                MockLogger.ContainsMessage("upgradepackage 1.0.0 Before Modification", LogLevel.Info).Should().BeTrue();
+                MockLogger.Messages.Should().ContainKey(LogLevel.Info.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains("upgradepackage 1.0.0 Before Modification"));
             }
 
             [Fact]
@@ -825,20 +752,21 @@ namespace chocolatey.tests.integration.scenarios
             {
                 MockLogger.MessagesFor(LogLevel.Info).OrEmpty()
                     .SkipWhile(p => !p.Contains("upgradepackage 1.0.0 Before Modification"))
-                    .Any(p => p.EndsWith("upgradepackage 1.1.1-beta.1 Installed"))
-                    .Should().BeTrue();
+                    .Should().Contain(p => p.EndsWith("upgradepackage 1.1.1-beta.1 Installed"));
             }
 
             [Fact]
             public void Should_not_have_executed_chocolateyUninstall_script_for_original_package()
             {
-                MockLogger.ContainsMessage("upgradepackage 1.0.0 Uninstalled", LogLevel.Info).Should().BeFalse();
+                MockLogger.Messages.Should().ContainKey(LogLevel.Info.ToStringSafe())
+                    .WhoseValue.Should().NotContain(m => m.Contains("upgradepackage 1.0.0 Uninstalled"));
             }
 
             [Fact]
             public void Should_not_have_executed_chocolateyBeforeModify_script_for_new_package()
             {
-                MockLogger.ContainsMessage("upgradepackage 1.1.1-beta.1 Before Modification", LogLevel.Info).Should().BeFalse();
+                MockLogger.Messages.Should().ContainKey(LogLevel.Info.ToStringSafe())
+                    .WhoseValue.Should().NotContain(m => m.Contains("upgradepackage 1.1.1-beta.1 Before Modification"));
             }
 
             [Fact]
@@ -846,7 +774,8 @@ namespace chocolatey.tests.integration.scenarios
             [Platform(Exclude = "Mono")]
             public void Should_have_executed_chocolateyInstall_script_for_new_package()
             {
-                MockLogger.ContainsMessage("upgradepackage 1.1.1-beta.1 Installed", LogLevel.Info).Should().BeTrue();
+                MockLogger.Messages.Should().ContainKey(LogLevel.Info.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains("upgradepackage 1.1.1-beta.1 Installed"));
             }
         }
 
@@ -908,32 +837,22 @@ namespace chocolatey.tests.integration.scenarios
 
                     version.Version.ToStringSafe().Should().Be("1.1.1.0");
                     version.OriginalVersion.ToStringSafe().Should().Be("1.1.1-beta2");
-                    version.ToStringSafe().Should().Be("1.1.1-beta2");
+                    version.ToNormalizedStringChecked().Should().Be("1.1.1-beta2");
                 }
             }
 
             [Fact]
             public void Should_contain_a_warning_message_that_it_upgraded_successfully()
             {
-                bool upgradedSuccessMessage = false;
-                foreach (var message in MockLogger.MessagesFor(LogLevel.Warn).OrEmpty())
-                {
-                    if (message.Contains("upgraded 1/1")) upgradedSuccessMessage = true;
-                }
-
-                upgradedSuccessMessage.Should().BeTrue();
+                MockLogger.Messages.Should().ContainKey(LogLevel.Warn.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains("upgraded 1/1"));
             }
 
             [Fact]
             public void Should_contain_a_warning_message_with_old_and_new_versions()
             {
-                bool upgradeMessage = false;
-                foreach (var message in MockLogger.MessagesFor(LogLevel.Warn).OrEmpty())
-                {
-                    if (message.Contains("You have upgradepackage v1.1.1-beta installed. Version 1.1.1-beta2 is available based on your source")) upgradeMessage = true;
-                }
-
-                upgradeMessage.Should().BeTrue();
+                MockLogger.Messages.Should().ContainKey(LogLevel.Warn.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains("You have upgradepackage v1.1.1-beta installed. Version 1.1.1-beta2 is available based on your source"));
             }
 
             [Fact]
@@ -971,7 +890,8 @@ namespace chocolatey.tests.integration.scenarios
             [Platform(Exclude = "Mono")]
             public void Should_have_executed_chocolateyBeforeModify_script_for_original_package()
             {
-                MockLogger.ContainsMessage("upgradepackage 1.1.1-beta Before Modification", LogLevel.Info).Should().BeTrue();
+                MockLogger.Messages.Should().ContainKey(LogLevel.Info.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains("upgradepackage 1.1.1-beta Before Modification"));
             }
 
             [Fact]
@@ -981,20 +901,21 @@ namespace chocolatey.tests.integration.scenarios
             {
                 MockLogger.MessagesFor(LogLevel.Info).OrEmpty()
                     .SkipWhile(p => !p.Contains("upgradepackage 1.1.1-beta Before Modification"))
-                    .Any(p => p.EndsWith("upgradepackage 1.1.1-beta2 Installed"))
-                    .Should().BeTrue();
+                    .Should().Contain(p => p.EndsWith("upgradepackage 1.1.1-beta2 Installed"));
             }
 
             [Fact]
             public void Should_not_have_executed_chocolateyUninstall_script_for_original_package()
             {
-                MockLogger.ContainsMessage("upgradepackage 1.1.1-beta Uninstalled", LogLevel.Info).Should().BeFalse();
+                MockLogger.Messages.Should().ContainKey(LogLevel.Info.ToStringSafe())
+                    .WhoseValue.Should().NotContain(m => m.Contains("upgradepackage 1.1.1-beta Uninstalled"));
             }
 
             [Fact]
             public void Should_not_have_executed_chocolateyBeforeModify_script_for_new_package()
             {
-                MockLogger.ContainsMessage("upgradepackage 1.1.1-beta2 Before Modification", LogLevel.Info).Should().BeFalse();
+                MockLogger.Messages.Should().ContainKey(LogLevel.Info.ToStringSafe())
+                    .WhoseValue.Should().NotContain(m => m.Contains("upgradepackage 1.1.1-beta2 Before Modification"));
             }
 
             [Fact]
@@ -1002,7 +923,8 @@ namespace chocolatey.tests.integration.scenarios
             [Platform(Exclude = "Mono")]
             public void Should_have_executed_chocolateyInstall_script_for_new_package()
             {
-                MockLogger.ContainsMessage("upgradepackage 1.1.1-beta2 Installed", LogLevel.Info).Should().BeTrue();
+                MockLogger.Messages.Should().ContainKey(LogLevel.Info.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains("upgradepackage 1.1.1-beta2 Installed"));
             }
         }
 
@@ -1066,32 +988,22 @@ namespace chocolatey.tests.integration.scenarios
 
                     version.Version.ToStringSafe().Should().Be("1.1.1.0");
                     version.OriginalVersion.ToStringSafe().Should().Be("1.1.1-beta.1");
-                    version.ToStringSafe().Should().Be("1.1.1-beta.1");
+                    version.ToNormalizedStringChecked().Should().Be("1.1.1-beta.1");
                 }
             }
 
             [Fact]
             public void Should_contain_a_warning_message_that_it_upgraded_successfully()
             {
-                bool upgradedSuccessMessage = false;
-                foreach (var message in MockLogger.MessagesFor(LogLevel.Warn).OrEmpty())
-                {
-                    if (message.Contains("upgraded 1/1")) upgradedSuccessMessage = true;
-                }
-
-                upgradedSuccessMessage.Should().BeTrue();
+                MockLogger.Messages.Should().ContainKey(LogLevel.Warn.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains("upgraded 1/1"));
             }
 
             [Fact]
             public void Should_contain_a_warning_message_with_old_and_new_versions()
             {
-                bool upgradeMessage = false;
-                foreach (var message in MockLogger.MessagesFor(LogLevel.Warn).OrEmpty())
-                {
-                    if (message.Contains("You have upgradepackage v1.1.1-beta installed. Version 1.1.1-beta.1 is available based on your source")) upgradeMessage = true;
-                }
-
-                upgradeMessage.Should().BeTrue();
+                MockLogger.Messages.Should().ContainKey(LogLevel.Warn.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains("You have upgradepackage v1.1.1-beta installed. Version 1.1.1-beta.1 is available based on your source"));
             }
 
             [Fact]
@@ -1129,7 +1041,8 @@ namespace chocolatey.tests.integration.scenarios
             [Platform(Exclude = "Mono")]
             public void Should_have_executed_chocolateyBeforeModify_script_for_original_package()
             {
-                MockLogger.ContainsMessage("upgradepackage 1.1.1-beta Before Modification", LogLevel.Info).Should().BeTrue();
+                MockLogger.Messages.Should().ContainKey(LogLevel.Info.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains("upgradepackage 1.1.1-beta Before Modification"));
             }
 
             [Fact]
@@ -1139,20 +1052,21 @@ namespace chocolatey.tests.integration.scenarios
             {
                 MockLogger.MessagesFor(LogLevel.Info).OrEmpty()
                     .SkipWhile(p => !p.Contains("upgradepackage 1.1.1-beta Before Modification"))
-                    .Any(p => p.EndsWith("upgradepackage 1.1.1-beta.1 Installed"))
-                    .Should().BeTrue();
+                    .Should().Contain(p => p.EndsWith("upgradepackage 1.1.1-beta.1 Installed"));
             }
 
             [Fact]
             public void Should_not_have_executed_chocolateyUninstall_script_for_original_package()
             {
-                MockLogger.ContainsMessage("upgradepackage 1.1.1-beta Uninstalled", LogLevel.Info).Should().BeFalse();
+                MockLogger.Messages.Should().ContainKey(LogLevel.Info.ToStringSafe())
+                    .WhoseValue.Should().NotContain(m => m.Contains("upgradepackage 1.1.1-beta Uninstalled"));
             }
 
             [Fact]
             public void Should_not_have_executed_chocolateyBeforeModify_script_for_new_package()
             {
-                MockLogger.ContainsMessage("upgradepackage 1.1.1-beta.1 Before Modification", LogLevel.Info).Should().BeFalse();
+                MockLogger.Messages.Should().ContainKey(LogLevel.Info.ToStringSafe())
+                    .WhoseValue.Should().NotContain(m => m.Contains("upgradepackage 1.1.1-beta.1 Before Modification"));
             }
 
             [Fact]
@@ -1160,7 +1074,8 @@ namespace chocolatey.tests.integration.scenarios
             [Platform(Exclude = "Mono")]
             public void Should_have_executed_chocolateyInstall_script_for_new_package()
             {
-                MockLogger.ContainsMessage("upgradepackage 1.1.1-beta.1 Installed", LogLevel.Info).Should().BeTrue();
+                MockLogger.Messages.Should().ContainKey(LogLevel.Info.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains("upgradepackage 1.1.1-beta.1 Installed"));
             }
         }
 
@@ -1223,32 +1138,22 @@ namespace chocolatey.tests.integration.scenarios
 
                     version.Version.ToStringSafe().Should().Be("1.1.1.0");
                     version.OriginalVersion.ToStringSafe().Should().Be("1.1.1-beta2");
-                    version.ToStringSafe().Should().Be("1.1.1-beta2");
+                    version.ToNormalizedStringChecked().Should().Be("1.1.1-beta2");
                 }
             }
 
             [Fact]
             public void Should_contain_a_warning_message_that_it_upgraded_successfully()
             {
-                bool upgradedSuccessMessage = false;
-                foreach (var message in MockLogger.MessagesFor(LogLevel.Warn).OrEmpty())
-                {
-                    if (message.Contains("upgraded 1/1")) upgradedSuccessMessage = true;
-                }
-
-                upgradedSuccessMessage.Should().BeTrue();
+                MockLogger.Messages.Should().ContainKey(LogLevel.Warn.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains("upgraded 1/1"));
             }
 
             [Fact]
             public void Should_contain_a_warning_message_with_old_and_new_versions()
             {
-                bool upgradeMessage = false;
-                foreach (var message in MockLogger.MessagesFor(LogLevel.Warn).OrEmpty())
-                {
-                    if (message.Contains("You have upgradepackage v1.1.1-beta.1 installed. Version 1.1.1-beta2 is available based on your source")) upgradeMessage = true;
-                }
-
-                upgradeMessage.Should().BeTrue();
+                MockLogger.Messages.Should().ContainKey(LogLevel.Warn.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains("You have upgradepackage v1.1.1-beta.1 installed. Version 1.1.1-beta2 is available based on your source"));
             }
 
             [Fact]
@@ -1286,7 +1191,8 @@ namespace chocolatey.tests.integration.scenarios
             [Platform(Exclude = "Mono")]
             public void Should_have_executed_chocolateyBeforeModify_script_for_original_package()
             {
-                MockLogger.ContainsMessage("upgradepackage 1.1.1-beta.1 Before Modification", LogLevel.Info).Should().BeTrue();
+                MockLogger.Messages.Should().ContainKey(LogLevel.Info.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains("upgradepackage 1.1.1-beta.1 Before Modification"));
             }
 
             [Fact]
@@ -1296,20 +1202,21 @@ namespace chocolatey.tests.integration.scenarios
             {
                 MockLogger.MessagesFor(LogLevel.Info).OrEmpty()
                     .SkipWhile(p => !p.Contains("upgradepackage 1.1.1-beta.1 Before Modification"))
-                    .Any(p => p.EndsWith("upgradepackage 1.1.1-beta2 Installed"))
-                    .Should().BeTrue();
+                    .Should().Contain(p => p.EndsWith("upgradepackage 1.1.1-beta2 Installed"));
             }
 
             [Fact]
             public void Should_not_have_executed_chocolateyUninstall_script_for_original_package()
             {
-                MockLogger.ContainsMessage("upgradepackage 1.1.1-beta.1 Uninstalled", LogLevel.Info).Should().BeFalse();
+                MockLogger.Messages.Should().ContainKey(LogLevel.Info.ToStringSafe())
+                    .WhoseValue.Should().NotContain(m => m.Contains("upgradepackage 1.1.1-beta.1 Uninstalled"));
             }
 
             [Fact]
             public void Should_not_have_executed_chocolateyBeforeModify_script_for_new_package()
             {
-                MockLogger.ContainsMessage("upgradepackage 1.1.1-beta2 Before Modification", LogLevel.Info).Should().BeFalse();
+                MockLogger.Messages.Should().ContainKey(LogLevel.Info.ToStringSafe())
+                    .WhoseValue.Should().NotContain(m => m.Contains("upgradepackage 1.1.1-beta2 Before Modification"));
             }
 
             [Fact]
@@ -1317,7 +1224,8 @@ namespace chocolatey.tests.integration.scenarios
             [Platform(Exclude = "Mono")]
             public void Should_have_executed_chocolateyInstall_script_for_new_package()
             {
-                MockLogger.ContainsMessage("upgradepackage 1.1.1-beta2 Installed", LogLevel.Info).Should().BeTrue();
+                MockLogger.Messages.Should().ContainKey(LogLevel.Info.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains("upgradepackage 1.1.1-beta2 Installed"));
             }
         }
 
@@ -1343,25 +1251,15 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_contain_a_message_that_you_have_the_latest_version_available()
             {
-                bool expectedMessage = false;
-                foreach (var message in MockLogger.MessagesFor(LogLevel.Info).OrEmpty())
-                {
-                    if (message.Contains("upgradepackage v1.1.1-beta is newer")) expectedMessage = true;
-                }
-
-                expectedMessage.Should().BeTrue();
+                MockLogger.Messages.Should().ContainKey(LogLevel.Info.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains("upgradepackage v1.1.1-beta is newer"));
             }
 
             [Fact]
             public void Should_contain_a_message_that_no_packages_were_upgraded()
             {
-                bool expectedMessage = false;
-                foreach (var message in MockLogger.MessagesFor(LogLevel.Warn).OrEmpty())
-                {
-                    if (message.Contains("upgraded 0/1 ")) expectedMessage = true;
-                }
-
-                expectedMessage.Should().BeTrue();
+                MockLogger.Messages.Should().ContainKey(LogLevel.Warn.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains("upgraded 0/1 "));
             }
 
             [Fact]
@@ -1389,7 +1287,7 @@ namespace chocolatey.tests.integration.scenarios
                     var version = packageReader.NuspecReader.GetVersion();
                     version.Version.ToStringSafe().Should().Be("1.1.1.0");
                     version.OriginalVersion.Should().Be("1.1.1-beta");
-                    version.ToStringSafe().Should().Be("1.1.1-beta");
+                    version.ToNormalizedStringChecked().Should().Be("1.1.1-beta");
                 }
             }
 
@@ -1441,25 +1339,15 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_contain_a_message_that_you_have_the_latest_version_available()
             {
-                bool expectedMessage = false;
-                foreach (var message in MockLogger.MessagesFor(LogLevel.Info).OrEmpty())
-                {
-                    if (message.Contains("upgradepackage v1.1.1-beta is newer")) expectedMessage = true;
-                }
-
-                expectedMessage.Should().BeTrue();
+                MockLogger.Messages.Should().ContainKey(LogLevel.Info.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains("upgradepackage v1.1.1-beta is newer"));
             }
 
             [Fact]
             public void Should_contain_a_message_that_no_packages_were_upgraded()
             {
-                bool expectedMessage = false;
-                foreach (var message in MockLogger.MessagesFor(LogLevel.Warn).OrEmpty())
-                {
-                    if (message.Contains("upgraded 0/1 ")) expectedMessage = true;
-                }
-
-                expectedMessage.Should().BeTrue();
+                MockLogger.Messages.Should().ContainKey(LogLevel.Warn.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains("upgraded 0/1 "));
             }
 
             [Fact]
@@ -1487,7 +1375,7 @@ namespace chocolatey.tests.integration.scenarios
                     var version = packageReader.NuspecReader.GetVersion();
                     version.Version.ToStringSafe().Should().Be("1.1.1.0");
                     version.OriginalVersion.Should().Be("1.1.1-beta");
-                    version.ToStringSafe().Should().Be("1.1.1-beta");
+                    version.ToNormalizedStringChecked().Should().Be("1.1.1-beta");
                 }
             }
 
@@ -1552,7 +1440,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, Configuration.PackageNames +  NuGetConstants.PackageExtension);
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToStringSafe().Should().Be("1.1.0");
+                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().Should().Be("1.1.0");
                 }
             }
 
@@ -1575,25 +1463,15 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_contain_a_warning_message_that_it_upgraded_successfully()
             {
-                bool upgradedSuccessMessage = false;
-                foreach (var message in MockLogger.MessagesFor(LogLevel.Warn).OrEmpty())
-                {
-                    if (message.Contains("upgraded 1/1")) upgradedSuccessMessage = true;
-                }
-
-                upgradedSuccessMessage.Should().BeTrue();
+                MockLogger.Messages.Should().ContainKey(LogLevel.Warn.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains("upgraded 1/1"));
             }
 
             [Fact]
             public void Should_contain_a_warning_message_with_old_and_new_versions()
             {
-                bool upgradeMessage = false;
-                foreach (var message in MockLogger.MessagesFor(LogLevel.Warn).OrEmpty())
-                {
-                    if (message.Contains("You have upgradepackage v1.0.0 installed. Version 1.1.0 is available based on your source")) upgradeMessage = true;
-                }
-
-                upgradeMessage.Should().BeTrue();
+                MockLogger.Messages.Should().ContainKey(LogLevel.Warn.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains("You have upgradepackage v1.0.0 installed. Version 1.1.0 is available based on your source"));
             }
 
             [Fact]
@@ -1649,25 +1527,15 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_contain_a_message_that_you_have_the_latest_version_available()
             {
-                bool expectedMessage = false;
-                foreach (var message in MockLogger.MessagesFor(LogLevel.Info).OrEmpty())
-                {
-                    if (message.Contains("installpackage v1.0.0 is the latest version available based on your source(s)")) expectedMessage = true;
-                }
-
-                expectedMessage.Should().BeTrue();
+                MockLogger.Messages.Should().ContainKey(LogLevel.Info.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains("installpackage v1.0.0 is the latest version available based on your source(s)"));
             }
 
             [Fact]
             public void Should_contain_a_message_that_no_packages_were_upgraded()
             {
-                bool expectedMessage = false;
-                foreach (var message in MockLogger.MessagesFor(LogLevel.Warn).OrEmpty())
-                {
-                    if (message.Contains("upgraded 0/1 ")) expectedMessage = true;
-                }
-
-                expectedMessage.Should().BeTrue();
+                MockLogger.Messages.Should().ContainKey(LogLevel.Warn.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains("upgraded 0/1 "));
             }
 
             [Fact]
@@ -1692,7 +1560,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, Configuration.PackageNames +  NuGetConstants.PackageExtension);
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToStringSafe().Should().Be("1.0.0");
+                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().Should().Be("1.0.0");
                 }
             }
 
@@ -1741,25 +1609,15 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_contain_a_message_that_you_have_the_latest_version_available()
             {
-                bool expectedMessage = false;
-                foreach (var message in MockLogger.MessagesFor(LogLevel.Info).OrEmpty())
-                {
-                    if (message.Contains("installpackage v1.0.0 is the latest version available based on your source(s)")) expectedMessage = true;
-                }
-
-                expectedMessage.Should().BeTrue();
+                MockLogger.Messages.Should().ContainKey(LogLevel.Info.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains("installpackage v1.0.0 is the latest version available based on your source(s)"));
             }
 
             [Fact]
             public void Should_contain_a_message_that_the_package_was_upgraded()
             {
-                bool expectedMessage = false;
-                foreach (var message in MockLogger.MessagesFor(LogLevel.Warn).OrEmpty())
-                {
-                    if (message.Contains("upgraded 1/1")) expectedMessage = true;
-                }
-
-                expectedMessage.Should().BeTrue();
+                MockLogger.Messages.Should().ContainKey(LogLevel.Warn.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains("upgraded 1/1"));
             }
 
             [Fact]
@@ -1784,7 +1642,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, Configuration.PackageNames +  NuGetConstants.PackageExtension);
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToStringSafe().Should().Be("1.0.0");
+                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().Should().Be("1.0.0");
                 }
             }
 
@@ -1875,7 +1733,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, Configuration.PackageNames +  NuGetConstants.PackageExtension);
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToStringSafe().Should().Be("1.1.0");
+                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().Should().Be("1.1.0");
                 }
             }
 
@@ -1898,25 +1756,15 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_contain_a_warning_message_that_it_upgraded_successfully()
             {
-                bool upgradedSuccessMessage = false;
-                foreach (var message in MockLogger.MessagesFor(LogLevel.Warn).OrEmpty())
-                {
-                    if (message.Contains("upgraded 1/1")) upgradedSuccessMessage = true;
-                }
-
-                upgradedSuccessMessage.Should().BeTrue();
+                MockLogger.Messages.Should().ContainKey(LogLevel.Warn.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains("upgraded 1/1"));
             }
 
             [Fact]
             public void Should_contain_a_warning_message_with_old_and_new_versions()
             {
-                bool upgradeMessage = false;
-                foreach (var message in MockLogger.MessagesFor(LogLevel.Warn).OrEmpty())
-                {
-                    if (message.Contains("You have upgradepackage v1.0.0 installed. Version 1.1.0 is available based on your source")) upgradeMessage = true;
-                }
-
-                upgradeMessage.Should().BeTrue();
+                MockLogger.Messages.Should().ContainKey(LogLevel.Warn.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains("You have upgradepackage v1.0.0 installed. Version 1.1.0 is available based on your source"));
             }
 
             [Fact]
@@ -1989,7 +1837,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, Configuration.PackageNames +  NuGetConstants.PackageExtension);
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToStringSafe().Should().Be("1.1.0");
+                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().Should().Be("1.1.0");
                 }
             }
 
@@ -2024,25 +1872,15 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_contain_a_warning_message_that_it_upgraded_successfully()
             {
-                bool upgradedSuccessMessage = false;
-                foreach (var message in MockLogger.MessagesFor(LogLevel.Warn).OrEmpty())
-                {
-                    if (message.Contains("upgraded 1/1")) upgradedSuccessMessage = true;
-                }
-
-                upgradedSuccessMessage.Should().BeTrue();
+                MockLogger.Messages.Should().ContainKey(LogLevel.Warn.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains("upgraded 1/1"));
             }
 
             [Fact]
             public void Should_contain_a_warning_message_with_old_and_new_versions()
             {
-                bool upgradeMessage = false;
-                foreach (var message in MockLogger.MessagesFor(LogLevel.Warn).OrEmpty())
-                {
-                    if (message.Contains("You have upgradepackage v1.0.0 installed. Version 1.1.0 is available based on your source")) upgradeMessage = true;
-                }
-
-                upgradeMessage.Should().BeTrue();
+                MockLogger.Messages.Should().ContainKey(LogLevel.Warn.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains("You have upgradepackage v1.0.0 installed. Version 1.1.0 is available based on your source"));
             }
 
             [Fact]
@@ -2125,32 +1963,22 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, Configuration.PackageNames +  NuGetConstants.PackageExtension);
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToStringSafe().Should().Be("1.0.0");
+                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().Should().Be("1.0.0");
                 }
             }
 
             [Fact]
             public void Should_contain_a_warning_message_that_it_was_not_able_to_upgrade()
             {
-                bool upgradedSuccessMessage = false;
-                foreach (var message in MockLogger.MessagesFor(LogLevel.Warn).OrEmpty())
-                {
-                    if (message.Contains("upgraded 0/1")) upgradedSuccessMessage = true;
-                }
-
-                upgradedSuccessMessage.Should().BeTrue();
+                MockLogger.Messages.Should().ContainKey(LogLevel.Warn.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains("upgraded 0/1"));
             }
 
             [Fact]
             public void Should_contain_a_warning_message_with_old_and_new_versions()
             {
-                bool upgradeMessage = false;
-                foreach (var message in MockLogger.MessagesFor(LogLevel.Warn).OrEmpty())
-                {
-                    if (message.Contains("You have upgradepackage v1.0.0 installed. Version 1.1.0 is available based on your source")) upgradeMessage = true;
-                }
-
-                upgradeMessage.Should().BeTrue();
+                MockLogger.Messages.Should().ContainKey(LogLevel.Warn.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains("You have upgradepackage v1.0.0 installed. Version 1.1.0 is available based on your source"));
             }
 
             [Fact]
@@ -2211,20 +2039,15 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, Configuration.PackageNames +  NuGetConstants.PackageExtension);
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToStringSafe().Should().Be("1.1.0");
+                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().Should().Be("1.1.0");
                 }
             }
 
             [Fact]
             public void Should_contain_a_warning_message_that_it_upgraded_successfully()
             {
-                bool upgradedSuccessMessage = false;
-                foreach (var message in MockLogger.MessagesFor(LogLevel.Warn).OrEmpty())
-                {
-                    if (message.Contains("upgraded 1/1")) upgradedSuccessMessage = true;
-                }
-
-                upgradedSuccessMessage.Should().BeTrue();
+                MockLogger.Messages.Should().ContainKey(LogLevel.Warn.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains("upgraded 1/1"));
             }
 
             [Fact]
@@ -2294,20 +2117,15 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, Configuration.PackageNames +  NuGetConstants.PackageExtension);
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToStringSafe().Should().Be("1.1.0");
+                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().Should().Be("1.1.0");
                 }
             }
 
             [Fact]
             public void Should_contain_a_warning_message_that_it_upgraded_successfully()
             {
-                bool upgradedSuccessMessage = false;
-                foreach (var message in MockLogger.MessagesFor(LogLevel.Warn).OrEmpty())
-                {
-                    if (message.Contains("upgraded 1/1")) upgradedSuccessMessage = true;
-                }
-
-                upgradedSuccessMessage.Should().BeTrue();
+                MockLogger.Messages.Should().ContainKey(LogLevel.Warn.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains("upgraded 1/1"));
             }
 
             [Fact]
@@ -2365,25 +2183,15 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_contain_a_message_the_package_was_not_found()
             {
-                bool expectedMessage = false;
-                foreach (var message in MockLogger.MessagesFor(LogLevel.Error).OrEmpty())
-                {
-                    if (message.Contains("nonexistentpackage not installed. The package was not found with the source(s) listed")) expectedMessage = true;
-                }
-
-                expectedMessage.Should().BeTrue();
+                MockLogger.Messages.Should().ContainKey(LogLevel.Error.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains("nonexistentpackage not installed. The package was not found with the source(s) listed"));
             }
 
             [Fact]
             public void Should_contain_a_message_that_no_packages_were_upgraded()
             {
-                bool expectedMessage = false;
-                foreach (var message in MockLogger.MessagesFor(LogLevel.Warn).OrEmpty())
-                {
-                    if (message.Contains("upgraded 0/1")) expectedMessage = true;
-                }
-
-                expectedMessage.Should().BeTrue();
+                MockLogger.Messages.Should().ContainKey(LogLevel.Warn.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains("upgraded 0/1"));
             }
 
             [Fact]
@@ -2407,31 +2215,16 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_have_an_error_package_result()
             {
-                bool errorFound = false;
-                foreach (var message in _packageResult.Messages)
-                {
-                    if (message.MessageType == ResultType.Error)
-                    {
-                        errorFound = true;
-                    }
-                }
-
-                errorFound.Should().BeTrue();
+                _packageResult.Messages.Should().Contain(m => m.MessageType == ResultType.Error);
             }
 
             [Fact]
             public void Should_have_expected_error_in_package_result()
             {
-                bool errorFound = false;
-                foreach (var message in _packageResult.Messages)
-                {
-                    if (message.MessageType == ResultType.Error)
-                    {
-                        if (message.Message.Contains("The package was not found")) errorFound = true;
-                    }
-                }
-
-                errorFound.Should().BeTrue();
+                Results.Should().AllSatisfy(r =>
+                    r.Value.Messages.Should().Contain(m =>
+                        m.MessageType == ResultType.Error &&
+                        m.Message.Contains("The package was not found")));
             }
         }
 
@@ -2477,13 +2270,8 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_contain_a_warning_message_that_it_upgraded_successfully()
             {
-                bool upgradedSuccessMessage = false;
-                foreach (var message in MockLogger.MessagesFor(LogLevel.Warn).OrEmpty())
-                {
-                    if (message.Contains("upgraded 1/1")) upgradedSuccessMessage = true;
-                }
-
-                upgradedSuccessMessage.Should().BeTrue();
+                MockLogger.Messages.Should().ContainKey(LogLevel.Warn.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains("upgraded 1/1"));
             }
 
             [Fact]
@@ -2536,13 +2324,8 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_contain_a_warning_message_that_it_was_unable_to_upgrade_a_package()
             {
-                bool notInstalled = false;
-                foreach (var message in MockLogger.MessagesFor(LogLevel.Warn).OrEmpty())
-                {
-                    if (message.Contains("0/1")) notInstalled = true;
-                }
-
-                notInstalled.Should().BeTrue();
+                MockLogger.Messages.Should().ContainKey(LogLevel.Warn.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains("0/1"));
             }
 
             [Fact]
@@ -2566,31 +2349,16 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_have_an_error_package_result()
             {
-                bool errorFound = false;
-                foreach (var message in _packageResult.Messages)
-                {
-                    if (message.MessageType == ResultType.Error)
-                    {
-                        errorFound = true;
-                    }
-                }
-
-                errorFound.Should().BeTrue();
+                _packageResult.Messages.Should().Contain(m => m.MessageType == ResultType.Error);
             }
 
             [Fact]
             public void Should_have_expected_error_in_package_result()
             {
-                bool errorFound = false;
-                foreach (var message in _packageResult.Messages)
-                {
-                    if (message.MessageType == ResultType.Error)
-                    {
-                        if (message.Message.Contains("Cannot upgrade a non-existent package")) errorFound = true;
-                    }
-                }
-
-                errorFound.Should().BeTrue();
+                Results.Should().AllSatisfy(r =>
+                    r.Value.Messages.Should().Contain(m =>
+                        m.MessageType == ResultType.Error &&
+                        m.Message.Contains("Cannot upgrade a non-existent package")));
             }
         }
 
@@ -2626,7 +2394,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, Configuration.PackageNames +  NuGetConstants.PackageExtension);
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToStringSafe().Should().Be("1.0.0");
+                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().Should().Be("1.0.0");
                 }
             }
 
@@ -2644,7 +2412,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib-bad", Configuration.PackageNames, "2.0.0", Configuration.PackageNames +  NuGetConstants.PackageExtension);
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToStringSafe().Should().Be("2.0.0");
+                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().Should().Be("2.0.0");
                 }
             }
 
@@ -2659,13 +2427,8 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_contain_a_warning_message_that_it_was_unable_to_upgrade_a_package()
             {
-                bool installedSuccessfully = false;
-                foreach (var message in MockLogger.MessagesFor(LogLevel.Warn).OrEmpty())
-                {
-                    if (message.Contains("0/1")) installedSuccessfully = true;
-                }
-
-                installedSuccessfully.Should().BeTrue();
+                MockLogger.Messages.Should().ContainKey(LogLevel.Warn.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains("0/1"));
             }
 
             [Fact]
@@ -2689,31 +2452,16 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_have_an_error_package_result()
             {
-                bool errorFound = false;
-                foreach (var message in _packageResult.Messages)
-                {
-                    if (message.MessageType == ResultType.Error)
-                    {
-                        errorFound = true;
-                    }
-                }
-
-                errorFound.Should().BeTrue();
+                _packageResult.Messages.Should().Contain(m => m.MessageType == ResultType.Error);
             }
 
             [Fact]
             public void Should_have_expected_error_in_package_result()
             {
-                bool errorFound = false;
-                foreach (var message in _packageResult.Messages)
-                {
-                    if (message.MessageType == ResultType.Error)
-                    {
-                        if (message.Message.Contains("chocolateyInstall.ps1")) errorFound = true;
-                    }
-                }
-
-                errorFound.Should().BeTrue();
+                Results.Should().AllSatisfy(r =>
+                    r.Value.Messages.Should().Contain(m =>
+                        m.MessageType == ResultType.Error &&
+                        m.Message.Contains("chocolateyInstall.ps1")));
             }
         }
 
@@ -2741,7 +2489,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", "hasdependency", "hasdependency.nupkg");
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToStringSafe().Should().Be("2.1.0");
+                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().Should().Be("2.1.0");
                 }
             }
 
@@ -2751,7 +2499,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", "isdependency", "isdependency.nupkg");
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToStringSafe().Should().Be("2.1.0");
+                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().Should().Be("2.1.0");
                 }
             }
 
@@ -2761,47 +2509,33 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", "isexactversiondependency", "isexactversiondependency.nupkg");
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToStringSafe().Should().Be("2.0.0");
+                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().Should().Be("2.0.0");
                 }
             }
 
             [Fact]
             public void Should_contain_a_message_that_everything_upgraded_successfully()
             {
-                bool expectedMessage = false;
-                foreach (var message in MockLogger.MessagesFor(LogLevel.Warn).OrEmpty())
-                {
-                    if (message.Contains("upgraded 3/3")) expectedMessage = true;
-                }
-
-                expectedMessage.Should().BeTrue();
+                MockLogger.Messages.Should().ContainKey(LogLevel.Warn.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains("upgraded 3/3"));
             }
 
             [Fact]
             public void Should_have_a_successful_package_result()
             {
-                foreach (var packageResult in Results)
-                {
-                    packageResult.Value.Success.Should().BeTrue();
-                }
+                Results.Should().AllSatisfy(r => r.Value.Success.Should().BeTrue());
             }
 
             [Fact]
             public void Should_not_have_inconclusive_package_result()
             {
-                foreach (var packageResult in Results)
-                {
-                    packageResult.Value.Inconclusive.Should().BeFalse();
-                }
+                Results.Should().AllSatisfy(r => r.Value.Inconclusive.Should().BeFalse());
             }
 
             [Fact]
             public void Should_not_have_warning_package_result()
             {
-                foreach (var packageResult in Results)
-                {
-                    packageResult.Value.Warning.Should().BeFalse();
-                }
+                Results.Should().AllSatisfy(r => r.Value.Warning.Should().BeFalse());
             }
         }
 
@@ -2829,7 +2563,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", "hasdependency", "hasdependency.nupkg");
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToStringSafe().Should().Be("1.0.0");
+                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().Should().Be("1.0.0");
                 }
             }
 
@@ -2839,7 +2573,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", "isdependency", "isdependency.nupkg");
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToStringSafe().Should().Be("1.0.0");
+                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().Should().Be("1.0.0");
                 }
             }
 
@@ -2849,85 +2583,49 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", "isexactversiondependency", "isexactversiondependency.nupkg");
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToStringSafe().Should().Be("1.0.0");
+                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().Should().Be("1.0.0");
                 }
             }
 
             [Fact]
             public void Should_contain_a_message_that_it_was_unable_to_upgrade_anything()
             {
-                bool expectedMessage = false;
-                foreach (var message in MockLogger.MessagesFor(LogLevel.Warn).OrEmpty())
-                {
-                    if (message.Contains("upgraded 0/1")) expectedMessage = true;
-                }
-
-                expectedMessage.Should().BeTrue();
+                MockLogger.Messages.Should().ContainKey(LogLevel.Warn.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains("upgraded 0/1"));
             }
 
             [Fact]
             public void Should_not_have_a_successful_package_result()
             {
-                foreach (var packageResult in Results)
-                {
-                    packageResult.Value.Success.Should().BeFalse();
-                }
+                Results.Should().AllSatisfy(r => r.Value.Success.Should().BeFalse());
             }
 
             [Fact]
             public void Should_not_have_inconclusive_package_result()
             {
-                foreach (var packageResult in Results)
-                {
-                    packageResult.Value.Inconclusive.Should().BeFalse();
-                }
+                Results.Should().AllSatisfy(r => r.Value.Inconclusive.Should().BeFalse());
             }
 
             [Fact]
             public void Should_not_have_warning_package_result()
             {
-                foreach (var packageResult in Results)
-                {
-                    packageResult.Value.Warning.Should().BeFalse();
-                }
+                Results.Should().AllSatisfy(r => r.Value.Warning.Should().BeFalse());
             }
 
             [Fact]
             public void Should_have_an_error_package_result()
             {
-                bool errorFound = false;
-
-                foreach (var packageResult in Results)
-                {
-                    foreach (var message in packageResult.Value.Messages)
-                    {
-                        if (message.MessageType == ResultType.Error)
-                        {
-                            errorFound = true;
-                        }
-                    }
-                }
-
-                errorFound.Should().BeTrue();
+                Results.Should().AllSatisfy(r =>
+                    r.Value.Messages.Should().Contain(m => m.MessageType == ResultType.Error));
             }
 
             [Fact]
             public void Should_have_expected_error_in_package_result()
             {
-                bool errorFound = false;
-
-                foreach (var packageResult in Results)
-                {
-                    foreach (var message in packageResult.Value.Messages)
-                    {
-                        if (message.MessageType == ResultType.Error)
-                        {
-                            if (message.Message.Contains("Unable to resolve dependency 'isexactversiondependency")) errorFound = true;
-                        }
-                    }
-                }
-
-                errorFound.Should().BeTrue();
+                Results.Should().AllSatisfy(r =>
+                    r.Value.Messages.Should().Contain(m =>
+                        m.MessageType == ResultType.Error &&
+                        m.Message.Contains("Unable to resolve dependency 'isexactversiondependency")));
             }
         }
 
@@ -2956,7 +2654,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", "hasdependency", "hasdependency.nupkg");
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToStringSafe().Should().Be("2.1.0");
+                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().Should().Be("2.1.0");
                 }
             }
 
@@ -2966,7 +2664,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", "isdependency", "isdependency.nupkg");
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToStringSafe().Should().Be("1.0.0");
+                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().Should().Be("1.0.0");
                 }
             }
 
@@ -2976,47 +2674,33 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", "isexactversiondependency", "isexactversiondependency.nupkg");
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToStringSafe().Should().Be("1.0.0");
+                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().Should().Be("1.0.0");
                 }
             }
 
             [Fact]
             public void Should_contain_a_message_that_it_upgraded_only_the_package_successfully()
             {
-                bool expectedMessage = false;
-                foreach (var message in MockLogger.MessagesFor(LogLevel.Warn).OrEmpty())
-                {
-                    if (message.Contains("upgraded 1/1")) expectedMessage = true;
-                }
-
-                expectedMessage.Should().BeTrue();
+                MockLogger.Messages.Should().ContainKey(LogLevel.Warn.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains("upgraded 1/1"));
             }
 
             [Fact]
             public void Should_have_a_successful_package_result()
             {
-                foreach (var packageResult in Results)
-                {
-                    packageResult.Value.Success.Should().BeTrue();
-                }
+                Results.Should().AllSatisfy(r => r.Value.Success.Should().BeTrue());
             }
 
             [Fact]
             public void Should_not_have_inconclusive_package_result()
             {
-                foreach (var packageResult in Results)
-                {
-                    packageResult.Value.Inconclusive.Should().BeFalse();
-                }
+                Results.Should().AllSatisfy(r => r.Value.Inconclusive.Should().BeFalse());
             }
 
             [Fact]
             public void Should_not_have_warning_package_result()
             {
-                foreach (var packageResult in Results)
-                {
-                    packageResult.Value.Warning.Should().BeFalse();
-                }
+                Results.Should().AllSatisfy(r => r.Value.Warning.Should().BeFalse());
             }
         }
 
@@ -3044,7 +2728,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", "isdependency", "isdependency.nupkg");
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToStringSafe().Should().Be("1.1.0");
+                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().Should().Be("1.1.0");
                 }
             }
 
@@ -3054,7 +2738,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", "hasdependency", "hasdependency.nupkg");
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToStringSafe().Should().Be("1.0.0");
+                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().Should().Be("1.0.0");
                 }
             }
 
@@ -3064,47 +2748,33 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", "isexactversiondependency", "isexactversiondependency.nupkg");
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToStringSafe().Should().Be("1.0.0");
+                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().Should().Be("1.0.0");
                 }
             }
 
             [Fact]
             public void Should_contain_a_message_the_dependency_upgraded_successfully()
             {
-                bool expectedMessage = false;
-                foreach (var message in MockLogger.MessagesFor(LogLevel.Warn).OrEmpty())
-                {
-                    if (message.Contains("upgraded 1/1")) expectedMessage = true;
-                }
-
-                expectedMessage.Should().BeTrue();
+                MockLogger.Messages.Should().ContainKey(LogLevel.Warn.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains("upgraded 1/1"));
             }
 
             [Fact]
             public void Should_have_a_successful_package_result()
             {
-                foreach (var packageResult in Results)
-                {
-                    packageResult.Value.Success.Should().BeTrue();
-                }
+                Results.Should().AllSatisfy(r => r.Value.Success.Should().BeTrue());
             }
 
             [Fact]
             public void Should_not_have_inconclusive_package_result()
             {
-                foreach (var packageResult in Results)
-                {
-                    packageResult.Value.Inconclusive.Should().BeFalse();
-                }
+                Results.Should().AllSatisfy(r => r.Value.Inconclusive.Should().BeFalse());
             }
 
             [Fact]
             public void Should_not_have_warning_package_result()
             {
-                foreach (var packageResult in Results)
-                {
-                    packageResult.Value.Warning.Should().BeFalse();
-                }
+                Results.Should().AllSatisfy(r => r.Value.Warning.Should().BeFalse());
             }
         }
 
@@ -3132,7 +2802,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", "isdependency", "isdependency.nupkg");
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToStringSafe().Should().Be("2.1.0");
+                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().Should().Be("2.1.0");
                 }
             }
 
@@ -3142,7 +2812,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", "hasdependency", "hasdependency.nupkg");
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToStringSafe().Should().Be("2.1.0");
+                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().Should().Be("2.1.0");
                 }
             }
 
@@ -3152,47 +2822,33 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", "isexactversiondependency", "isexactversiondependency.nupkg");
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToStringSafe().Should().Be("2.0.0");
+                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().Should().Be("2.0.0");
                 }
             }
 
             [Fact]
             public void Should_contain_a_message_that_everything_upgraded_successfully()
             {
-                bool expectedMessage = false;
-                foreach (var message in MockLogger.MessagesFor(LogLevel.Warn).OrEmpty())
-                {
-                    if (message.Contains("upgraded 3/3")) expectedMessage = true;
-                }
-
-                expectedMessage.Should().BeTrue();
+                MockLogger.Messages.Should().ContainKey(LogLevel.Warn.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains("upgraded 3/3"));
             }
 
             [Fact]
             public void Should_have_a_successful_package_result()
             {
-                foreach (var packageResult in Results)
-                {
-                    packageResult.Value.Success.Should().BeTrue();
-                }
+                Results.Should().AllSatisfy(r => r.Value.Success.Should().BeTrue());
             }
 
             [Fact]
             public void Should_not_have_inconclusive_package_result()
             {
-                foreach (var packageResult in Results)
-                {
-                    packageResult.Value.Inconclusive.Should().BeFalse();
-                }
+                Results.Should().AllSatisfy(r => r.Value.Inconclusive.Should().BeFalse());
             }
 
             [Fact]
             public void Should_not_have_warning_package_result()
             {
-                foreach (var packageResult in Results)
-                {
-                    packageResult.Value.Warning.Should().BeFalse();
-                }
+                Results.Should().AllSatisfy(r => r.Value.Warning.Should().BeFalse());
             }
         }
 
@@ -3222,7 +2878,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", "isdependency", "isdependency.nupkg");
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToStringSafe().Should().Be("2.1.0");
+                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().Should().Be("2.1.0");
                 }
             }
 
@@ -3232,7 +2888,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", "hasdependency", "hasdependency.nupkg");
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToStringSafe().Should().Be("2.1.0");
+                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().Should().Be("2.1.0");
                 }
             }
 
@@ -3242,47 +2898,33 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", "isexactversiondependency", "isexactversiondependency.nupkg");
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToStringSafe().Should().Be("2.0.0");
+                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().Should().Be("2.0.0");
                 }
             }
 
             [Fact]
             public void Should_contain_a_message_that_everything_upgraded_successfully()
             {
-                bool expectedMessage = false;
-                foreach (var message in MockLogger.MessagesFor(LogLevel.Warn).OrEmpty())
-                {
-                    if (message.Contains("upgraded 3/3")) expectedMessage = true;
-                }
-
-                expectedMessage.Should().BeTrue();
+                MockLogger.Messages.Should().ContainKey(LogLevel.Warn.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains("upgraded 3/3"));
             }
 
             [Fact]
             public void Should_have_a_successful_package_result()
             {
-                foreach (var packageResult in Results)
-                {
-                    packageResult.Value.Success.Should().BeTrue();
-                }
+                Results.Should().AllSatisfy(r => r.Value.Success.Should().BeTrue());
             }
 
             [Fact]
             public void Should_not_have_inconclusive_package_result()
             {
-                foreach (var packageResult in Results)
-                {
-                    packageResult.Value.Inconclusive.Should().BeFalse();
-                }
+                Results.Should().AllSatisfy(r => r.Value.Inconclusive.Should().BeFalse());
             }
 
             [Fact]
             public void Should_not_have_warning_package_result()
             {
-                foreach (var packageResult in Results)
-                {
-                    packageResult.Value.Warning.Should().BeFalse();
-                }
+                Results.Should().AllSatisfy(r => r.Value.Warning.Should().BeFalse());
             }
         }
 
@@ -3312,7 +2954,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", "isdependency", "isdependency.nupkg");
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToStringSafe().Should().Be("1.1.0");
+                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().Should().Be("1.1.0");
                 }
             }
 
@@ -3322,7 +2964,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", "hasdependency", "hasdependency.nupkg");
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToStringSafe().Should().Be("1.0.0");
+                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().Should().Be("1.0.0");
                 }
             }
 
@@ -3332,63 +2974,42 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", "isexactversiondependency", "isexactversiondependency.nupkg");
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToStringSafe().Should().Be("1.0.0");
+                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().Should().Be("1.0.0");
                 }
             }
 
             [Fact]
             public void Should_contain_a_message_that_everything_upgraded_successfully()
             {
-                bool expectedMessage = false;
-                foreach (var message in MockLogger.MessagesFor(LogLevel.Warn).OrEmpty())
-                {
-                    if (message.Contains("upgraded 1/1")) expectedMessage = true;
-                }
-
-                expectedMessage.Should().BeTrue();
+                MockLogger.Messages.Should().ContainKey(LogLevel.Warn.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains("upgraded 1/1"));
             }
 
             [Fact]
             public void Should_have_a_successful_package_result()
             {
-                foreach (var packageResult in Results)
-                {
-                    packageResult.Value.Success.Should().BeTrue();
-                }
+                Results.Should().AllSatisfy(r => r.Value.Success.Should().BeTrue());
             }
 
             [Fact]
             public void Should_not_have_inconclusive_package_result()
             {
-                foreach (var packageResult in Results)
-                {
-                    packageResult.Value.Inconclusive.Should().BeFalse();
-                }
+                Results.Should().AllSatisfy(r => r.Value.Inconclusive.Should().BeFalse());
             }
 
             [Fact]
             public void Should_not_have_warning_package_result()
             {
-                foreach (var packageResult in Results)
-                {
-                    packageResult.Value.Warning.Should().BeFalse();
-                }
+                Results.Should().AllSatisfy(r => r.Value.Warning.Should().BeFalse());
             }
 
             [Fact]
             public void Should_have_outputted_conflicting_upgrade_message()
             {
-                bool expectedMessage = false;
-                foreach (var message in MockLogger.MessagesFor(LogLevel.Warn).OrEmpty())
-                {
-                    if (message.Contains("One or more unresolved package dependency constraints detected in the Chocolatey lib folder")
-                        && message.Contains("hasdependency 1.0.0 constraint: isdependency (>= 1.0.0 && < 2.0.0)"))
-                    {
-                        expectedMessage = true;
-                    }
-                }
-
-                expectedMessage.Should().BeTrue();
+                MockLogger.Messages.Should().ContainKey(LogLevel.Warn.ToStringSafe())
+                    .WhoseValue.Should().Contain(m =>
+                        m.Contains("One or more unresolved package dependency constraints detected in the Chocolatey lib folder")
+                        && m.Contains("hasdependency 1.0.0 constraint: isdependency (>= 1.0.0 && < 2.0.0)"));
             }
         }
 
@@ -3420,7 +3041,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", "isdependency", "isdependency.nupkg");
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToStringSafe().Should().Be("1.1.0");
+                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().Should().Be("1.1.0");
                 }
             }
 
@@ -3430,7 +3051,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", "hasdependency", "hasdependency.nupkg");
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToStringSafe().Should().Be("1.0.0");
+                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().Should().Be("1.0.0");
                 }
             }
 
@@ -3440,64 +3061,43 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", "isexactversiondependency", "isexactversiondependency.nupkg");
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToStringSafe().Should().Be("1.0.0");
+                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().Should().Be("1.0.0");
                 }
             }
 
             [Fact]
             public void Should_contain_a_message_that_everything_upgraded_successfully()
             {
-                bool expectedMessage = false;
-                foreach (var message in MockLogger.MessagesFor(LogLevel.Warn).OrEmpty())
-                {
-                    if (message.Contains("upgraded 2/2")) expectedMessage = true;
-                }
-
-                expectedMessage.Should().BeTrue();
+                MockLogger.Messages.Should().ContainKey(LogLevel.Warn.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains("upgraded 2/2"));
             }
 
             [Fact]
             public void Should_have_a_successful_package_result()
             {
-                foreach (var packageResult in Results)
-                {
-                    packageResult.Value.Success.Should().BeTrue();
-                }
+                Results.Should().AllSatisfy(r => r.Value.Success.Should().BeTrue());
             }
 
             [Fact]
             public void Should_not_have_inconclusive_package_result()
             {
-                foreach (var packageResult in Results)
-                {
-                    packageResult.Value.Inconclusive.Should().BeFalse();
-                }
+                Results.Should().AllSatisfy(r => r.Value.Inconclusive.Should().BeFalse());
             }
 
             [Fact]
             public void Should_not_have_warning_package_result()
             {
-                foreach (var packageResult in Results)
-                {
-                    packageResult.Value.Warning.Should().BeFalse();
-                }
+                Results.Should().AllSatisfy(r => r.Value.Warning.Should().BeFalse());
             }
 
             [Fact]
             public void Should_have_outputted_conflicting_upgrade_message()
             {
-                bool expectedMessage = false;
-                foreach (var message in MockLogger.MessagesFor(LogLevel.Warn).OrEmpty())
-                {
-                    if (message.Contains("One or more unresolved package dependency constraints detected in the Chocolatey lib folder")
-                        && message.Contains("hasdependency 1.0.0 constraint: isexactversiondependency (= 1.0.0)")
-                        && message.Contains("hasdependency 1.0.0 constraint: isdependency (>= 1.0.0 && < 2.0.0)"))
-                    {
-                        expectedMessage = true;
-                    }
-                }
-
-                expectedMessage.Should().BeTrue();
+                MockLogger.Messages.Should().ContainKey(LogLevel.Warn.ToStringSafe())
+                    .WhoseValue.Should().Contain(m =>
+                        m.Contains("One or more unresolved package dependency constraints detected in the Chocolatey lib folder")
+                        && m.Contains("hasdependency 1.0.0 constraint: isexactversiondependency (= 1.0.0)")
+                        && m.Contains("hasdependency 1.0.0 constraint: isdependency (>= 1.0.0 && < 2.0.0)"));
             }
         }
 
@@ -3529,7 +3129,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", "isdependency", "isdependency.nupkg");
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToStringSafe().Should().Be("1.1.0");
+                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().Should().Be("1.1.0");
                 }
             }
 
@@ -3539,7 +3139,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", "hasdependency", "hasdependency.nupkg");
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToStringSafe().Should().Be("1.0.0");
+                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().Should().Be("1.0.0");
                 }
             }
 
@@ -3549,63 +3149,42 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", "isexactversiondependency", "isexactversiondependency.nupkg");
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToStringSafe().Should().Be("1.0.0");
+                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().Should().Be("1.0.0");
                 }
             }
 
             [Fact]
             public void Should_contain_a_message_that_everything_upgraded_successfully()
             {
-                bool expectedMessage = false;
-                foreach (var message in MockLogger.MessagesFor(LogLevel.Warn).OrEmpty())
-                {
-                    if (message.Contains("upgraded 1/1")) expectedMessage = true;
-                }
-
-                expectedMessage.Should().BeTrue();
+                MockLogger.Messages.Should().ContainKey(LogLevel.Warn.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains("upgraded 1/1"));
             }
 
             [Fact]
             public void Should_have_a_successful_package_result()
             {
-                foreach (var packageResult in Results)
-                {
-                    packageResult.Value.Success.Should().BeTrue();
-                }
+                Results.Should().AllSatisfy(r => r.Value.Success.Should().BeTrue());
             }
 
             [Fact]
             public void Should_not_have_inconclusive_package_result()
             {
-                foreach (var packageResult in Results)
-                {
-                    packageResult.Value.Inconclusive.Should().BeFalse();
-                }
+                Results.Should().AllSatisfy(r => r.Value.Inconclusive.Should().BeFalse());
             }
 
             [Fact]
             public void Should_not_have_warning_package_result()
             {
-                foreach (var packageResult in Results)
-                {
-                    packageResult.Value.Warning.Should().BeFalse();
-                }
+                Results.Should().AllSatisfy(r => r.Value.Warning.Should().BeFalse());
             }
 
             [Fact]
             public void Should_have_outputted_conflicting_upgrade_message()
             {
-                bool expectedMessage = false;
-                foreach (var message in MockLogger.MessagesFor(LogLevel.Warn).OrEmpty())
-                {
-                    if (message.Contains("One or more unresolved package dependency constraints detected in the Chocolatey lib folder")
-                        && message.Contains("hasdependency 1.0.0 constraint: isdependency (>= 1.0.0 && < 2.0.0)"))
-                    {
-                        expectedMessage = true;
-                    }
-                }
-
-                expectedMessage.Should().BeTrue();
+                MockLogger.Messages.Should().ContainKey(LogLevel.Warn.ToStringSafe())
+                    .WhoseValue.Should().Contain(m =>
+                        m.Contains("One or more unresolved package dependency constraints detected in the Chocolatey lib folder")
+                        && m.Contains("hasdependency 1.0.0 constraint: isdependency (>= 1.0.0 && < 2.0.0)"));
             }
         }
 
@@ -3636,7 +3215,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", "isdependency", "isdependency.nupkg");
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToStringSafe().Should().Be("1.0.0");
+                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().Should().Be("1.0.0");
                 }
             }
 
@@ -3646,7 +3225,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", "hasdependency", "hasdependency.nupkg");
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToStringSafe().Should().Be("1.0.0");
+                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().Should().Be("1.0.0");
                 }
             }
 
@@ -3656,59 +3235,40 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", "isexactversiondependency", "isexactversiondependency.nupkg");
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToStringSafe().Should().Be("1.0.0");
+                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().Should().Be("1.0.0");
                 }
             }
 
             [Fact]
             public void Should_contain_a_message_that_nothing_was_upgraded()
             {
-                bool expectedMessage = false;
-                foreach (var message in MockLogger.MessagesFor(LogLevel.Warn).OrEmpty())
-                {
-                    if (message.Contains("upgraded 0/1")) expectedMessage = true;
-                }
-
-                expectedMessage.Should().BeTrue();
+                MockLogger.Messages.Should().ContainKey(LogLevel.Warn.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains("upgraded 0/1"));
             }
 
             [Fact]
             public void Should_have_an_error_package_result()
             {
-                foreach (var packageResult in Results)
-                {
-                    packageResult.Value.Success.Should().BeFalse();
-                }
+                Results.Should().AllSatisfy(r => r.Value.Success.Should().BeFalse());
             }
 
             [Fact]
             public void Should_not_have_inconclusive_package_result()
             {
-                foreach (var packageResult in Results)
-                {
-                    packageResult.Value.Inconclusive.Should().BeFalse();
-                }
+                Results.Should().AllSatisfy(r => r.Value.Inconclusive.Should().BeFalse());
             }
 
             [Fact]
             public void Should_not_have_warning_package_result()
             {
-                foreach (var packageResult in Results)
-                {
-                    packageResult.Value.Warning.Should().BeFalse();
-                }
+                Results.Should().AllSatisfy(r => r.Value.Warning.Should().BeFalse());
             }
 
             [Fact]
             public void Should_have_outputted_expected_error_message()
             {
-                bool expectedMessage = false;
-                foreach (var message in MockLogger.MessagesFor(LogLevel.Error).OrEmpty())
-                {
-                    if (message.Contains("Unable to resolve dependency chain. This may be caused by a parent package depending on this package, try specifying a specific version to use or don't ignore any dependencies!")) expectedMessage = true;
-                }
-
-                expectedMessage.Should().BeTrue();
+                MockLogger.Messages.Should().ContainKey(LogLevel.Error.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains("Unable to resolve dependency chain. This may be caused by a parent package depending on this package, try specifying a specific version to use or don't ignore any dependencies!"));
             }
         }
 
@@ -3740,20 +3300,15 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, Configuration.PackageNames +  NuGetConstants.PackageExtension);
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToStringSafe().Should().Be("1.1.0");
+                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().Should().Be("1.1.0");
                 }
             }
 
             [Fact]
             public void Should_contain_a_warning_message_that_it_upgraded_successfully()
             {
-                bool upgradedSuccessMessage = false;
-                foreach (var message in MockLogger.MessagesFor(LogLevel.Warn).OrEmpty())
-                {
-                    if (message.Contains("upgraded 1/1")) upgradedSuccessMessage = true;
-                }
-
-                upgradedSuccessMessage.Should().BeTrue();
+                MockLogger.Messages.Should().ContainKey(LogLevel.Warn.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains("upgraded 1/1"));
             }
 
             [Fact]
@@ -3843,20 +3398,15 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, Configuration.PackageNames +  NuGetConstants.PackageExtension);
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToStringSafe().Should().Be("1.1.0");
+                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().Should().Be("1.1.0");
                 }
             }
 
             [Fact]
             public void Should_contain_a_warning_message_that_it_upgraded_successfully()
             {
-                bool upgradedSuccessMessage = false;
-                foreach (var message in MockLogger.MessagesFor(LogLevel.Warn).OrEmpty())
-                {
-                    if (message.Contains("upgraded 1/1")) upgradedSuccessMessage = true;
-                }
-
-                upgradedSuccessMessage.Should().BeTrue();
+                MockLogger.Messages.Should().ContainKey(LogLevel.Warn.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains("upgraded 1/1"));
             }
 
             [Fact]
@@ -3937,13 +3487,14 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_have_no_sources_enabled_result()
             {
-                MockLogger.ContainsMessage("Upgrading was NOT successful. There are no sources enabled for", LogLevel.Error).Should().BeTrue();
+                MockLogger.Messages.Should().ContainKey(LogLevel.Error.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains("Upgrading was NOT successful. There are no sources enabled for"));
             }
 
             [Fact]
             public void Should_not_have_any_packages_upgraded()
             {
-                Results.Count().Should().Be(0);
+                Results.Should().BeEmpty();
             }
         }
 
@@ -3963,14 +3514,14 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_report_for_all_installed_packages()
             {
-                Results.Count().Should().Be(3);
+                Results.Should().HaveCount(3);
             }
 
             [Fact]
             public void Should_upgrade_packages_with_upgrades()
             {
                 var upgradePackageResult = Results.Where(x => x.Key == "upgradepackage").ToList();
-                upgradePackageResult.Count.Should().Be(1, "upgradepackage must be there once");
+                upgradePackageResult.Should().ContainSingle( "upgradepackage must be there once");
                 upgradePackageResult.First().Value.Version.Should().Be("1.1.0");
             }
 
@@ -3978,7 +3529,7 @@ namespace chocolatey.tests.integration.scenarios
             public void Should_skip_packages_without_upgrades()
             {
                 var installPackageResult = Results.Where(x => x.Key == "installpackage").ToList();
-                installPackageResult.Count.Should().Be(1, "installpackage must be there once");
+                installPackageResult.Should().ContainSingle( "installpackage must be there once");
                 installPackageResult.First().Value.Version.Should().Be("1.0.0");
             }
         }
@@ -4002,14 +3553,14 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_report_for_all_installed_packages()
             {
-                Results.Count().Should().Be(3);
+                Results.Should().HaveCount(3);
             }
 
             [Fact]
             public void Should_upgrade_packages_with_upgrades()
             {
                 var upgradePackageResult = Results.Where(x => x.Key == "upgradepackage").ToList();
-                upgradePackageResult.Count.Should().Be(1, "upgradepackage must be there once");
+                upgradePackageResult.Should().ContainSingle( "upgradepackage must be there once");
                 upgradePackageResult.First().Value.Version.Should().Be("1.1.1-beta2");
             }
 
@@ -4022,7 +3573,7 @@ namespace chocolatey.tests.integration.scenarios
                     var version = packageReader.NuspecReader.GetVersion();
                     version.Version.ToStringSafe().Should().Be("1.1.1.0");
                     version.OriginalVersion.Should().Be("1.1.1-beta2");
-                    version.ToStringSafe().Should().Be("1.1.1-beta2");
+                    version.ToNormalizedStringChecked().Should().Be("1.1.1-beta2");
                 }
             }
 
@@ -4030,7 +3581,7 @@ namespace chocolatey.tests.integration.scenarios
             public void Should_skip_packages_without_upgrades()
             {
                 var installPackageResult = Results.Where(x => x.Key == "installpackage").ToList();
-                installPackageResult.Count.Should().Be(1, "installpackage must be there once");
+                installPackageResult.Should().ContainSingle( "installpackage must be there once");
                 installPackageResult.First().Value.Version.Should().Be("1.0.0");
             }
         }
@@ -4056,14 +3607,14 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_report_for_all_installed_packages()
             {
-                Results.Count().Should().Be(3);
+                Results.Should().HaveCount(3);
             }
 
             [Fact]
             public void Should_upgrade_packages_with_upgrades()
             {
                 var upgradePackageResult = Results.Where(x => x.Key == "upgradepackage").ToList();
-                upgradePackageResult.Count.Should().Be(1, "upgradepackage must be there once");
+                upgradePackageResult.Should().ContainSingle( "upgradepackage must be there once");
                 // available version will show as last stable
                 upgradePackageResult.First().Value.Version.Should().Be("1.1.0");
             }
@@ -4077,7 +3628,7 @@ namespace chocolatey.tests.integration.scenarios
                     var version = packageReader.NuspecReader.GetVersion();
                     version.Version.ToStringSafe().Should().Be("1.1.1.0");
                     version.OriginalVersion.Should().Be("1.1.1-beta");
-                    version.ToStringSafe().Should().Be("1.1.1-beta");
+                    version.ToNormalizedStringChecked().Should().Be("1.1.1-beta");
                 }
             }
 
@@ -4085,7 +3636,7 @@ namespace chocolatey.tests.integration.scenarios
             public void Should_skip_packages_without_upgrades()
             {
                 var installPackageResult = Results.Where(x => x.Key == "installpackage").ToList();
-                installPackageResult.Count.Should().Be(1, "installpackage must be there once");
+                installPackageResult.Should().ContainSingle( "installpackage must be there once");
                 installPackageResult.First().Value.Version.Should().Be("1.0.0");
             }
         }
@@ -4112,7 +3663,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_have_a_single_package_result()
             {
-                Results.Count.Should().Be(1, "The returned package results do not have a single value!");
+                Results.Should().ContainSingle( "The returned package results do not have a single value!");
             }
 
             [Fact]
@@ -4153,32 +3704,22 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, Configuration.PackageNames + NuGetConstants.PackageExtension);
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToStringSafe().Should().Be("1.1.1-beta.1");
+                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().Should().Be("1.1.1-beta.1");
                 }
             }
 
             [Fact]
             public void Should_contain_a_warning_message_that_it_upgraded_successfully()
             {
-                bool upgradedSuccessMessage = false;
-                foreach (var message in MockLogger.MessagesFor(LogLevel.Warn).OrEmpty())
-                {
-                    if (message.Contains("upgraded 1/1")) upgradedSuccessMessage = true;
-                }
-
-                upgradedSuccessMessage.Should().BeTrue();
+                MockLogger.Messages.Should().ContainKey(LogLevel.Warn.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains("upgraded 1/1"));
             }
 
             [Fact]
             public void Should_contain_a_warning_message_with_old_and_new_versions()
             {
-                bool upgradeMessage = false;
-                foreach (var message in MockLogger.MessagesFor(LogLevel.Warn).OrEmpty())
-                {
-                    if (message.Contains("You have upgradepackage v1.0.0 installed. Version 1.1.1-beta.1 is available based on your source")) upgradeMessage = true;
-                }
-
-                upgradeMessage.Should().BeTrue();
+                MockLogger.Messages.Should().ContainKey(LogLevel.Warn.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains("You have upgradepackage v1.0.0 installed. Version 1.1.1-beta.1 is available based on your source"));
             }
 
             [Fact]
@@ -4219,7 +3760,8 @@ namespace chocolatey.tests.integration.scenarios
             [Platform(Exclude = "Mono")]
             public void Should_have_executed_chocolateyBeforeModify_script_for_original_package()
             {
-                MockLogger.ContainsMessage("upgradepackage 1.0.0 Before Modification", LogLevel.Info).Should().BeTrue();
+                MockLogger.Messages.Should().ContainKey(LogLevel.Info.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains("upgradepackage 1.0.0 Before Modification"));
             }
 
             [Fact]
@@ -4229,20 +3771,21 @@ namespace chocolatey.tests.integration.scenarios
             {
                 MockLogger.MessagesFor(LogLevel.Info).OrEmpty()
                     .SkipWhile(p => !p.Contains("upgradepackage 1.0.0 Before Modification"))
-                    .Any(p => p.EndsWith("upgradepackage 1.1.1-beta.1 Installed"))
-                    .Should().BeTrue();
+                    .Should().Contain(p => p.EndsWith("upgradepackage 1.1.1-beta.1 Installed"));
             }
 
             [Fact]
             public void Should_not_have_executed_chocolateyUninstall_script_for_original_package()
             {
-                MockLogger.ContainsMessage("upgradepackage 1.0.0 Uninstalled", LogLevel.Info).Should().BeFalse();
+                MockLogger.Messages.Should().ContainKey(LogLevel.Info.ToStringSafe())
+                    .WhoseValue.Should().NotContain(m => m.Contains("upgradepackage 1.0.0 Uninstalled"));
             }
 
             [Fact]
             public void Should_not_have_executed_chocolateyBeforeModify_script_for_new_package()
             {
-                MockLogger.ContainsMessage("upgradepackage 1.1.0 Before Modification", LogLevel.Info).Should().BeFalse();
+                MockLogger.Messages.Should().ContainKey(LogLevel.Info.ToStringSafe())
+                    .WhoseValue.Should().NotContain(m => m.Contains("upgradepackage 1.1.0 Before Modification"));
             }
 
             [Fact]
@@ -4252,7 +3795,8 @@ namespace chocolatey.tests.integration.scenarios
             {
                 const string expectedMessage = "upgradepackage 1.1.1-beta.1 Installed";
 
-                MockLogger.ContainsMessage(expectedMessage, LogLevel.Info).Should().BeTrue("No log message containing the sentence '{0}' could be found!".FormatWith(expectedMessage));
+                MockLogger.Messages.Should().ContainKey(LogLevel.Info.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains(expectedMessage), "No log message containing the sentence '{0}' could be found!".FormatWith(expectedMessage));
             }
         }
 
@@ -4273,7 +3817,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_report_for_all_non_skipped_packages()
             {
-                Results.Count().Should().Be(1);
+                Results.Should().HaveCount(1);
                 Results.First().Key.Should().Be("installpackage");
             }
 
@@ -4281,7 +3825,7 @@ namespace chocolatey.tests.integration.scenarios
             public void Should_skip_packages_in_except_list()
             {
                 var upgradePackageResult = Results.Where(x => x.Key == "upgradepackage").ToList();
-                upgradePackageResult.Count.Should().Be(0, "upgradepackage should not be in the results list");
+                upgradePackageResult.Should().BeEmpty("upgradepackage should not be in the results list");
             }
         }
 
@@ -4332,32 +3876,22 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, Configuration.PackageNames + NuGetConstants.PackageExtension);
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToStringSafe().Should().Be("2.0.0");
+                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().Should().Be("2.0.0");
                 }
             }
 
             [Fact]
             public void Should_contain_a_warning_message_that_it_upgraded_successfully()
             {
-                bool upgradedSuccessMessage = false;
-                foreach (var message in MockLogger.MessagesFor(LogLevel.Warn).OrEmpty())
-                {
-                    if (message.Contains("upgraded 1/1")) upgradedSuccessMessage = true;
-                }
-
-                upgradedSuccessMessage.Should().BeTrue();
+                MockLogger.Messages.Should().ContainKey(LogLevel.Warn.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains("upgraded 1/1"));
             }
 
             [Fact]
             public void Should_contain_a_warning_message_with_old_and_new_versions()
             {
-                bool upgradeMessage = false;
-                foreach (var message in MockLogger.MessagesFor(LogLevel.Warn).OrEmpty())
-                {
-                    if (message.Contains("You have scriptpackage.hook v1.0.0 installed. Version 2.0.0 is available based on your source")) upgradeMessage = true;
-                }
-
-                upgradeMessage.Should().BeTrue();
+                MockLogger.Messages.Should().ContainKey(LogLevel.Warn.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains("You have scriptpackage.hook v1.0.0 installed. Version 2.0.0 is available based on your source"));
             }
 
             [Fact]
@@ -4478,32 +4012,22 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, Configuration.PackageNames + NuGetConstants.PackageExtension);
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToStringSafe().Should().Be("1.1.0");
+                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().Should().Be("1.1.0");
                 }
             }
 
             [Fact]
             public void Should_contain_a_warning_message_that_it_upgraded_successfully()
             {
-                bool upgradedSuccessMessage = false;
-                foreach (var message in MockLogger.MessagesFor(LogLevel.Warn).OrEmpty())
-                {
-                    if (message.Contains("upgraded 1/1")) upgradedSuccessMessage = true;
-                }
-
-                upgradedSuccessMessage.Should().BeTrue();
+                MockLogger.Messages.Should().ContainKey(LogLevel.Warn.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains("upgraded 1/1"));
             }
 
             [Fact]
             public void Should_contain_a_warning_message_with_old_and_new_versions()
             {
-                bool upgradeMessage = false;
-                foreach (var message in MockLogger.MessagesFor(LogLevel.Warn).OrEmpty())
-                {
-                    if (message.Contains("You have upgradepackage v1.0.0 installed. Version 1.1.0 is available based on your source")) upgradeMessage = true;
-                }
-
-                upgradeMessage.Should().BeTrue();
+                MockLogger.Messages.Should().ContainKey(LogLevel.Warn.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains("You have upgradepackage v1.0.0 installed. Version 1.1.0 is available based on your source"));
             }
 
             [Fact]
@@ -4544,7 +4068,8 @@ namespace chocolatey.tests.integration.scenarios
             [Platform(Exclude = "Mono")]
             public void Should_have_executed_chocolateyBeforeModify_script_for_original_package()
             {
-                MockLogger.ContainsMessage("upgradepackage 1.0.0 Before Modification", LogLevel.Info).Should().BeTrue();
+                MockLogger.Messages.Should().ContainKey(LogLevel.Info.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains("upgradepackage 1.0.0 Before Modification"));
             }
 
             [Fact]
@@ -4554,20 +4079,21 @@ namespace chocolatey.tests.integration.scenarios
             {
                 MockLogger.MessagesFor(LogLevel.Info).OrEmpty()
                     .SkipWhile(p => !p.Contains("upgradepackage 1.0.0 Before Modification"))
-                    .Any(p => p.EndsWith("upgradepackage 1.1.0 Installed"))
-                    .Should().BeTrue();
+                    .Should().Contain(p => p.EndsWith("upgradepackage 1.1.0 Installed"));
             }
 
             [Fact]
             public void Should_not_have_executed_chocolateyUninstall_script_for_original_package()
             {
-                MockLogger.ContainsMessage("upgradepackage 1.0.0 Uninstalled", LogLevel.Info).Should().BeFalse();
+                MockLogger.Messages.Should().ContainKey(LogLevel.Info.ToStringSafe())
+                    .WhoseValue.Should().NotContain(m => m.Contains("upgradepackage 1.0.0 Uninstalled"));
             }
 
             [Fact]
             public void Should_not_have_executed_chocolateyBeforeModify_script_for_new_package()
             {
-                MockLogger.ContainsMessage("upgradepackage 1.1.0 Before Modification", LogLevel.Info).Should().BeFalse();
+                MockLogger.Messages.Should().ContainKey(LogLevel.Info.ToStringSafe())
+                    .WhoseValue.Should().NotContain(m => m.Contains("upgradepackage 1.1.0 Before Modification"));
             }
 
             [Fact]
@@ -4575,7 +4101,8 @@ namespace chocolatey.tests.integration.scenarios
             [Platform(Exclude = "Mono")]
             public void Should_have_executed_chocolateyInstall_script_for_new_package()
             {
-                MockLogger.ContainsMessage("upgradepackage 1.1.0 Installed", LogLevel.Info).Should().BeTrue();
+                MockLogger.Messages.Should().ContainKey(LogLevel.Info.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains("upgradepackage 1.1.0 Installed"));
             }
 
             [Fact]
@@ -4583,7 +4110,8 @@ namespace chocolatey.tests.integration.scenarios
             [Platform(Exclude = "Mono")]
             public void Should_have_executed_pre_all_hook_script()
             {
-                MockLogger.ContainsMessage("pre-install-all.ps1 hook ran for upgradepackage 1.1.0", LogLevel.Info).Should().BeTrue();
+                MockLogger.Messages.Should().ContainKey(LogLevel.Info.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains("pre-install-all.ps1 hook ran for upgradepackage 1.1.0"));
             }
 
             [Fact]
@@ -4591,7 +4119,8 @@ namespace chocolatey.tests.integration.scenarios
             [Platform(Exclude = "Mono")]
             public void Should_have_executed_post_all_hook_script()
             {
-                MockLogger.ContainsMessage("post-install-all.ps1 hook ran for upgradepackage 1.1.0", LogLevel.Info).Should().BeTrue();
+                MockLogger.Messages.Should().ContainKey(LogLevel.Info.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains("post-install-all.ps1 hook ran for upgradepackage 1.1.0"));
             }
 
             [Fact]
@@ -4599,7 +4128,8 @@ namespace chocolatey.tests.integration.scenarios
             [Platform(Exclude = "Mono")]
             public void Should_have_executed_pre_upgradepackage_hook_script()
             {
-                MockLogger.ContainsMessage("pre-install-upgradepackage.ps1 hook ran for upgradepackage 1.1.0", LogLevel.Info).Should().BeTrue();
+                MockLogger.Messages.Should().ContainKey(LogLevel.Info.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains("pre-install-upgradepackage.ps1 hook ran for upgradepackage 1.1.0"));
             }
 
             [Fact]
@@ -4607,7 +4137,8 @@ namespace chocolatey.tests.integration.scenarios
             [Platform(Exclude = "Mono")]
             public void Should_have_executed_post_upgradepackage_hook_script()
             {
-                MockLogger.ContainsMessage("post-install-upgradepackage.ps1 hook ran for upgradepackage 1.1.0", LogLevel.Info).Should().BeTrue();
+                MockLogger.Messages.Should().ContainKey(LogLevel.Info.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains("post-install-upgradepackage.ps1 hook ran for upgradepackage 1.1.0"));
             }
 
             [Fact]
@@ -4615,7 +4146,8 @@ namespace chocolatey.tests.integration.scenarios
             [Platform(Exclude = "Mono")]
             public void Should_not_have_executed_uninstall_hook_script()
             {
-                MockLogger.ContainsMessage("post-uninstall-all.ps1 hook ran for upgradepackage 1.1.0", LogLevel.Info).Should().BeFalse();
+                MockLogger.Messages.Should().ContainKey(LogLevel.Info.ToStringSafe())
+                    .WhoseValue.Should().NotContain(m => m.Contains("post-uninstall-all.ps1 hook ran for upgradepackage 1.1.0"));
             }
 
             [Fact]
@@ -4623,7 +4155,8 @@ namespace chocolatey.tests.integration.scenarios
             [Platform(Exclude = "Mono")]
             public void Should_not_have_executed_installpackage_hook_script()
             {
-                MockLogger.ContainsMessage("pre-install-installpackage.ps1 hook ran for upgradepackage 1.1.0", LogLevel.Info).Should().BeFalse();
+                MockLogger.Messages.Should().ContainKey(LogLevel.Info.ToStringSafe())
+                    .WhoseValue.Should().NotContain(m => m.Contains("pre-install-installpackage.ps1 hook ran for upgradepackage 1.1.0"));
             }
 
             [Fact]
@@ -4631,7 +4164,8 @@ namespace chocolatey.tests.integration.scenarios
             [Platform(Exclude = "Mono")]
             public void Should_have_executed_beforemodify_hook_script_for_previous_version()
             {
-                MockLogger.ContainsMessage("pre-beforemodify-all.ps1 hook ran for upgradepackage 1.0.0", LogLevel.Info).Should().BeTrue();
+                MockLogger.Messages.Should().ContainKey(LogLevel.Info.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains("pre-beforemodify-all.ps1 hook ran for upgradepackage 1.0.0"));
             }
 
             [Fact]
@@ -4639,7 +4173,8 @@ namespace chocolatey.tests.integration.scenarios
             [Platform(Exclude = "Mono")]
             public void Should_not_have_executed_beforemodify_hook_script_for_upgrade_version()
             {
-                MockLogger.ContainsMessage("pre-beforemodify-all.ps1 hook ran for upgradepackage 1.1.0", LogLevel.Info).Should().BeFalse();
+                MockLogger.Messages.Should().ContainKey(LogLevel.Info.ToStringSafe())
+                    .WhoseValue.Should().NotContain(m => m.Contains("pre-beforemodify-all.ps1 hook ran for upgradepackage 1.1.0"));
             }
         }
         public class When_upgrading_an_existing_package_with_uppercase_id : ScenariosBase
@@ -4688,32 +4223,22 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, Configuration.PackageNames + NuGetConstants.PackageExtension);
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToStringSafe().Should().Be("1.1.0");
+                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().Should().Be("1.1.0");
                 }
             }
 
             [Fact]
             public void Should_contain_a_warning_message_that_it_upgraded_successfully()
             {
-                bool upgradedSuccessMessage = false;
-                foreach (var message in MockLogger.MessagesFor(LogLevel.Warn).OrEmpty())
-                {
-                    if (message.Contains("upgraded 1/1")) upgradedSuccessMessage = true;
-                }
-
-                upgradedSuccessMessage.Should().BeTrue();
+                MockLogger.Messages.Should().ContainKey(LogLevel.Warn.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains("upgraded 1/1"));
             }
 
             [Fact]
             public void Should_contain_a_warning_message_with_old_and_new_versions()
             {
-                bool upgradeMessage = false;
-                foreach (var message in MockLogger.MessagesFor(LogLevel.Warn).OrEmpty())
-                {
-                    if (message.Contains("You have UpperCase v1.0.0 installed. Version 1.1.0 is available based on your source")) upgradeMessage = true;
-                }
-
-                upgradeMessage.Should().BeTrue();
+                MockLogger.Messages.Should().ContainKey(LogLevel.Warn.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains("You have UpperCase v1.0.0 installed. Version 1.1.0 is available based on your source"));
             }
 
             [Fact]
@@ -4751,7 +4276,8 @@ namespace chocolatey.tests.integration.scenarios
             [Platform(Exclude = "Mono")]
             public void Should_have_executed_chocolateyBeforeModify_script_for_original_package()
             {
-                MockLogger.ContainsMessage("UpperCase 1.0.0 Before Modification", LogLevel.Info).Should().BeTrue();
+                MockLogger.Messages.Should().ContainKey(LogLevel.Info.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains("UpperCase 1.0.0 Before Modification"));
             }
 
             [Fact]
@@ -4761,20 +4287,21 @@ namespace chocolatey.tests.integration.scenarios
             {
                 MockLogger.MessagesFor(LogLevel.Info).OrEmpty()
                     .SkipWhile(p => !p.Contains("UpperCase 1.0.0 Before Modification"))
-                    .Any(p => p.EndsWith("UpperCase 1.1.0 Installed"))
-                    .Should().BeTrue();
+                    .Should().Contain(p => p.EndsWith("UpperCase 1.1.0 Installed"));
             }
 
             [Fact]
             public void Should_not_have_executed_chocolateyUninstall_script_for_original_package()
             {
-                MockLogger.ContainsMessage("UpperCase 1.0.0 Uninstalled", LogLevel.Info).Should().BeFalse();
+                MockLogger.Messages.Should().ContainKey(LogLevel.Info.ToStringSafe())
+                    .WhoseValue.Should().NotContain(m => m.Contains("UpperCase 1.0.0 Uninstalled"));
             }
 
             [Fact]
             public void Should_not_have_executed_chocolateyBeforeModify_script_for_new_package()
             {
-                MockLogger.ContainsMessage("UpperCase 1.1.0 Before Modification", LogLevel.Info).Should().BeFalse();
+                MockLogger.Messages.Should().ContainKey(LogLevel.Info.ToStringSafe())
+                    .WhoseValue.Should().NotContain(m => m.Contains("UpperCase 1.1.0 Before Modification"));
             }
 
             [Fact]
@@ -4782,7 +4309,8 @@ namespace chocolatey.tests.integration.scenarios
             [Platform(Exclude = "Mono")]
             public void Should_have_executed_chocolateyInstall_script_for_new_package()
             {
-                MockLogger.ContainsMessage("UpperCase 1.1.0 Installed", LogLevel.Info).Should().BeTrue();
+                MockLogger.Messages.Should().ContainKey(LogLevel.Info.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains("UpperCase 1.1.0 Installed"));
             }
         }
 
@@ -4824,43 +4352,29 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, Configuration.PackageNames + NuGetConstants.PackageExtension);
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToStringSafe().Should().Be("1.1.0");
+                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().Should().Be("1.1.0");
                 }
             }
 
             [Fact]
             public void Should_contain_a_warning_message_that_it_upgraded_successfully()
             {
-                bool upgradedSuccessMessage = false;
-                foreach (var message in MockLogger.MessagesFor(LogLevel.Warn).OrEmpty())
-                {
-                    if (message.Contains("upgraded 1/1")) upgradedSuccessMessage = true;
-                }
-
-                upgradedSuccessMessage.Should().BeTrue();
+                MockLogger.Messages.Should().ContainKey(LogLevel.Warn.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains("upgraded 1/1"));
             }
 
             [Fact]
             public void Should_contain_a_warning_message_with_old_and_new_versions()
             {
-                bool upgradeMessage = false;
-                foreach (var message in MockLogger.MessagesFor(LogLevel.Warn).OrEmpty())
-                {
-                    if (message.Contains("You have unsupportedelements v1.0.0 installed. Version 1.1.0 is available based on your source")) upgradeMessage = true;
-                }
-
-                upgradeMessage.Should().BeTrue();
+                MockLogger.Messages.Should().ContainKey(LogLevel.Warn.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains("You have unsupportedelements v1.0.0 installed. Version 1.1.0 is available based on your source"));
             }
 
             [Fact]
             public void Should_contain_a_warning_message_about_unsupported_elements()
             {
-                bool upgradeMessage = false;
-                foreach (var message in MockLogger.MessagesFor(LogLevel.Warn).OrEmpty())
-                {
-                    if (message.Contains("Issues found with nuspec elements")) upgradeMessage = true;
-                }
-                upgradeMessage.Should().BeTrue();
+                MockLogger.Messages.Should().ContainKey(LogLevel.Warn.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains("Issues found with nuspec elements"));
             }
 
             [Fact]
@@ -4898,7 +4412,8 @@ namespace chocolatey.tests.integration.scenarios
             [Platform(Exclude = "Mono")]
             public void Should_have_executed_chocolateyBeforeModify_script_for_original_package()
             {
-                MockLogger.ContainsMessage("unsupportedelements 1.0.0 Before Modification", LogLevel.Info).Should().BeTrue();
+                MockLogger.Messages.Should().ContainKey(LogLevel.Info.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains("unsupportedelements 1.0.0 Before Modification"));
             }
 
             [Fact]
@@ -4908,20 +4423,21 @@ namespace chocolatey.tests.integration.scenarios
             {
                 MockLogger.MessagesFor(LogLevel.Info).OrEmpty()
                     .SkipWhile(p => !p.Contains("unsupportedelements 1.0.0 Before Modification"))
-                    .Any(p => p.EndsWith("unsupportedelements 1.1.0 Installed"))
-                    .Should().BeTrue();
+                    .Should().Contain(p => p.EndsWith("unsupportedelements 1.1.0 Installed"));
             }
 
             [Fact]
             public void Should_not_have_executed_chocolateyUninstall_script_for_original_package()
             {
-                MockLogger.ContainsMessage("unsupportedelements 1.0.0 Uninstalled", LogLevel.Info).Should().BeFalse();
+                MockLogger.Messages.Should().ContainKey(LogLevel.Info.ToStringSafe())
+                    .WhoseValue.Should().NotContain(m => m.Contains("unsupportedelements 1.0.0 Uninstalled"));
             }
 
             [Fact]
             public void Should_not_have_executed_chocolateyBeforeModify_script_for_new_package()
             {
-                MockLogger.ContainsMessage("unsupportedelements 1.1.0 Before Modification", LogLevel.Info).Should().BeFalse();
+                MockLogger.Messages.Should().ContainKey(LogLevel.Info.ToStringSafe())
+                    .WhoseValue.Should().NotContain(m => m.Contains("unsupportedelements 1.1.0 Before Modification"));
             }
 
             [Fact]
@@ -4929,7 +4445,8 @@ namespace chocolatey.tests.integration.scenarios
             [Platform(Exclude = "Mono")]
             public void Should_have_executed_chocolateyInstall_script_for_new_package()
             {
-                MockLogger.ContainsMessage("unsupportedelements 1.1.0 Installed", LogLevel.Info).Should().BeTrue();
+                MockLogger.Messages.Should().ContainKey(LogLevel.Info.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains("unsupportedelements 1.1.0 Installed"));
             }
         }
 
@@ -4988,25 +4505,15 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_contain_a_warning_message_that_it_upgraded_successfully()
             {
-                bool upgradedSuccessMessage = false;
-                foreach (var message in MockLogger.MessagesFor(LogLevel.Warn).OrEmpty())
-                {
-                    if (message.Contains("upgraded 1/1")) upgradedSuccessMessage = true;
-                }
-
-                upgradedSuccessMessage.Should().BeTrue();
+                MockLogger.Messages.Should().ContainKey(LogLevel.Warn.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains("upgraded 1/1"));
             }
 
             [Fact]
             public void Should_contain_a_warning_message_with_old_and_new_versions()
             {
-                bool upgradeMessage = false;
-                foreach (var message in MockLogger.MessagesFor(LogLevel.Warn).OrEmpty())
-                {
-                    if (message.Contains("You have upgradepackage v1.0.0 installed. Version {0} is available based on your source".FormatWith(NonNormalizedVersion))) upgradeMessage = true;
-                }
-
-                upgradeMessage.Should().BeTrue();
+                MockLogger.Messages.Should().ContainKey(LogLevel.Warn.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains("You have upgradepackage v1.0.0 installed. Version {0} is available based on your source".FormatWith(NonNormalizedVersion)));
             }
 
             [Fact]
@@ -5039,7 +4546,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_match_the_upgrade_version()
             {
-                _packageResult.Version.Should().Be(NonNormalizedVersion);
+                _packageResult.Version.Should().Be(NormalizedVersion);
             }
 
             [Fact]
@@ -5047,7 +4554,8 @@ namespace chocolatey.tests.integration.scenarios
             [Platform(Exclude = "Mono")]
             public void Should_have_executed_chocolateyBeforeModify_script_for_original_package()
             {
-                MockLogger.ContainsMessage("upgradepackage 1.0.0 Before Modification", LogLevel.Info).Should().BeTrue();
+                MockLogger.Messages.Should().ContainKey(LogLevel.Info.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains("upgradepackage 1.0.0 Before Modification"));
             }
 
             [Fact]
@@ -5057,20 +4565,22 @@ namespace chocolatey.tests.integration.scenarios
             {
                 MockLogger.MessagesFor(LogLevel.Info).OrEmpty()
                     .SkipWhile(p => !p.Contains("upgradepackage 1.0.0 Before Modification"))
-                    .Any(p => p.EndsWith("upgradepackage {0} Installed".FormatWith(NonNormalizedVersion)))
+                    .Any(p => p.EndsWith("upgradepackage {0} Installed".FormatWith(NormalizedVersion)))
                     .Should().BeTrue();
             }
 
             [Fact]
             public void Should_not_have_executed_chocolateyUninstall_script_for_original_package()
             {
-                MockLogger.ContainsMessage("upgradepackage 1.0.0 Uninstalled", LogLevel.Info).Should().BeFalse();
+                MockLogger.Messages.Should().ContainKey(LogLevel.Info.ToStringSafe())
+                    .WhoseValue.Should().NotContain(m => m.Contains("upgradepackage 1.0.0 Uninstalled"));
             }
 
             [Fact]
             public void Should_not_have_executed_chocolateyBeforeModify_script_for_new_package()
             {
-                MockLogger.ContainsMessage("upgradepackage {0} Before Modification".FormatWith(NonNormalizedVersion), LogLevel.Info).Should().BeFalse();
+                MockLogger.Messages.Should().ContainKey(LogLevel.Info.ToStringSafe())
+                    .WhoseValue.Should().NotContain(m => m.Contains("upgradepackage {0} Before Modification".FormatWith(NormalizedVersion)));
             }
 
             [Fact]
@@ -5078,7 +4588,8 @@ namespace chocolatey.tests.integration.scenarios
             [Platform(Exclude = "Mono")]
             public void Should_have_executed_chocolateyInstall_script_for_new_package()
             {
-                MockLogger.ContainsMessage("upgradepackage {0} Installed".FormatWith(NonNormalizedVersion), LogLevel.Info).Should().BeTrue();
+                MockLogger.Messages.Should().ContainKey(LogLevel.Info.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains("upgradepackage {0} Installed".FormatWith(NormalizedVersion)));
             }
         }
 
@@ -5167,14 +4678,15 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", DependencyName, "{0}.nupkg".FormatWith(DependencyName));
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToStringSafe().Should().Be("2.0.0");
+                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().Should().Be("2.0.0");
                 }
             }
 
             [Fact]
             public void Should_contain_a_message_that_everything_upgraded_successfully()
             {
-                MockLogger.ContainsMessage("upgraded 2/2", LogLevel.Warn).Should().BeTrue();
+                MockLogger.Messages.Should().ContainKey(LogLevel.Warn.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains("upgraded 2/2"));
             }
 
             [Fact]
@@ -5182,7 +4694,8 @@ namespace chocolatey.tests.integration.scenarios
             [Platform(Exclude = "Mono")]
             public void Should_run_beforemodify_hook_script_for_previous_version_of_target()
             {
-                MockLogger.ContainsMessage("pre-beforemodify-all.ps1 hook ran for {0} {1}".FormatWith(TargetPackageName, "1.0.0"), LogLevel.Info).Should().BeTrue();
+                MockLogger.Messages.Should().ContainKey(LogLevel.Info.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains("pre-beforemodify-all.ps1 hook ran for {0} {1}".FormatWith(TargetPackageName, "1.0.0")));
             }
 
             [Fact]
@@ -5190,7 +4703,8 @@ namespace chocolatey.tests.integration.scenarios
             [Platform(Exclude = "Mono")]
             public void Should_run_already_installed_target_package_beforeModify()
             {
-                MockLogger.ContainsMessage("Ran BeforeModify: {0} {1}".FormatWith(TargetPackageName, "1.0.0"), LogLevel.Info).Should().BeTrue();
+                MockLogger.Messages.Should().ContainKey(LogLevel.Info.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains("Ran BeforeModify: {0} {1}".FormatWith(TargetPackageName, "1.0.0")));
             }
 
             [Fact]
@@ -5198,7 +4712,8 @@ namespace chocolatey.tests.integration.scenarios
             [Platform(Exclude = "Mono")]
             public void Should_not_run_beforemodify_hook_script_for_upgrade_version_of_target()
             {
-                MockLogger.ContainsMessage("pre-beforemodify-all.ps1 hook ran for {0} {1}".FormatWith(TargetPackageName, "2.0.0"), LogLevel.Info).Should().BeFalse();
+                MockLogger.Messages.Should().ContainKey(LogLevel.Info.ToStringSafe())
+                    .WhoseValue.Should().NotContain(m => m.Contains("pre-beforemodify-all.ps1 hook ran for {0} {1}".FormatWith(TargetPackageName, "2.0.0")));
             }
 
             [Fact]
@@ -5206,7 +4721,8 @@ namespace chocolatey.tests.integration.scenarios
             [Platform(Exclude = "Mono")]
             public void Should_not_run_target_package_beforeModify_for_upgraded_version()
             {
-                MockLogger.ContainsMessage("Ran BeforeModify: {0} {1}".FormatWith(TargetPackageName, "2.0.0"), LogLevel.Info).Should().BeFalse();
+                MockLogger.Messages.Should().ContainKey(LogLevel.Info.ToStringSafe())
+                    .WhoseValue.Should().NotContain(m => m.Contains("Ran BeforeModify: {0} {1}".FormatWith(TargetPackageName, "2.0.0")));
             }
 
             [Fact]
@@ -5214,7 +4730,8 @@ namespace chocolatey.tests.integration.scenarios
             [Platform(Exclude = "Mono")]
             public void Should_run_pre_all_hook_script_for_upgraded_version_of_target()
             {
-                MockLogger.ContainsMessage("pre-install-all.ps1 hook ran for {0} {1}".FormatWith(TargetPackageName, "2.0.0"), LogLevel.Info).Should().BeTrue();
+                MockLogger.Messages.Should().ContainKey(LogLevel.Info.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains("pre-install-all.ps1 hook ran for {0} {1}".FormatWith(TargetPackageName, "2.0.0")));
             }
 
             [Fact]
@@ -5222,7 +4739,8 @@ namespace chocolatey.tests.integration.scenarios
             [Platform(Exclude = "Mono")]
             public void Should_run_post_all_hook_script_for_upgraded_version_of_target()
             {
-                MockLogger.ContainsMessage("post-install-all.ps1 hook ran for {0} {1}".FormatWith(TargetPackageName, "2.0.0"), LogLevel.Info).Should().BeTrue();
+                MockLogger.Messages.Should().ContainKey(LogLevel.Info.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains("post-install-all.ps1 hook ran for {0} {1}".FormatWith(TargetPackageName, "2.0.0")));
             }
 
             [Fact]
@@ -5230,7 +4748,8 @@ namespace chocolatey.tests.integration.scenarios
             [Platform(Exclude = "Mono")]
             public void Should_run_beforemodify_hook_script_for_previous_version_of_dependency()
             {
-                MockLogger.ContainsMessage("pre-beforemodify-all.ps1 hook ran for {0} {1}".FormatWith(DependencyName, "1.0.0"), LogLevel.Info).Should().BeTrue();
+                MockLogger.Messages.Should().ContainKey(LogLevel.Info.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains("pre-beforemodify-all.ps1 hook ran for {0} {1}".FormatWith(DependencyName, "1.0.0")));
             }
 
             [Fact]
@@ -5238,7 +4757,8 @@ namespace chocolatey.tests.integration.scenarios
             [Platform(Exclude = "Mono")]
             public void Should_run_already_installed_dependency_package_beforeModify()
             {
-                MockLogger.ContainsMessage("Ran BeforeModify: {0} {1}".FormatWith(DependencyName, "1.0.0"), LogLevel.Info).Should().BeTrue();
+                MockLogger.Messages.Should().ContainKey(LogLevel.Info.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains("Ran BeforeModify: {0} {1}".FormatWith(DependencyName, "1.0.0")));
             }
 
             [Fact]
@@ -5246,7 +4766,8 @@ namespace chocolatey.tests.integration.scenarios
             [Platform(Exclude = "Mono")]
             public void Should_not_run_beforemodify_hook_script_for_upgrade_version_of_dependency()
             {
-                MockLogger.ContainsMessage("pre-beforemodify-all.ps1 hook ran for {0} {1}".FormatWith(DependencyName, "2.0.0"), LogLevel.Info).Should().BeFalse();
+                MockLogger.Messages.Should().ContainKey(LogLevel.Info.ToStringSafe())
+                    .WhoseValue.Should().NotContain(m => m.Contains("pre-beforemodify-all.ps1 hook ran for {0} {1}".FormatWith(DependencyName, "2.0.0")));
             }
 
             [Fact]
@@ -5254,7 +4775,8 @@ namespace chocolatey.tests.integration.scenarios
             [Platform(Exclude = "Mono")]
             public void Should_not_run_dependency_package_beforeModify_for_upgraded_version()
             {
-                MockLogger.ContainsMessage("Ran BeforeModify: {0} {1}".FormatWith(DependencyName, "2.0.0"), LogLevel.Info).Should().BeFalse();
+                MockLogger.Messages.Should().ContainKey(LogLevel.Info.ToStringSafe())
+                    .WhoseValue.Should().NotContain(m => m.Contains("Ran BeforeModify: {0} {1}".FormatWith(DependencyName, "2.0.0")));
             }
 
             [Fact]
@@ -5262,7 +4784,8 @@ namespace chocolatey.tests.integration.scenarios
             [Platform(Exclude = "Mono")]
             public void Should_run_pre_all_hook_script_for_upgraded_version_of_dependency()
             {
-                MockLogger.ContainsMessage("pre-install-all.ps1 hook ran for {0} {1}".FormatWith(DependencyName, "2.0.0"), LogLevel.Info).Should().BeTrue();
+                MockLogger.Messages.Should().ContainKey(LogLevel.Info.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains("pre-install-all.ps1 hook ran for {0} {1}".FormatWith(DependencyName, "2.0.0")));
             }
 
             [Fact]
@@ -5270,34 +4793,26 @@ namespace chocolatey.tests.integration.scenarios
             [Platform(Exclude = "Mono")]
             public void Should_run_post_all_hook_script_for_upgraded_version_of_dependency()
             {
-                MockLogger.ContainsMessage("post-install-all.ps1 hook ran for {0} {1}".FormatWith(DependencyName, "2.0.0"), LogLevel.Info).Should().BeTrue();
+                MockLogger.Messages.Should().ContainKey(LogLevel.Info.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains("post-install-all.ps1 hook ran for {0} {1}".FormatWith(DependencyName, "2.0.0")));
             }
 
             [Fact]
             public void Should_have_a_successful_package_result()
             {
-                foreach (var packageResult in Results)
-                {
-                    packageResult.Value.Success.Should().BeTrue();
-                }
+                Results.Should().AllSatisfy(r => r.Value.Success.Should().BeTrue());
             }
 
             [Fact]
             public void Should_not_have_inconclusive_package_result()
             {
-                foreach (var packageResult in Results)
-                {
-                    packageResult.Value.Inconclusive.Should().BeFalse();
-                }
+                Results.Should().AllSatisfy(r => r.Value.Inconclusive.Should().BeFalse());
             }
 
             [Fact]
             public void Should_not_have_warning_package_result()
             {
-                foreach (var packageResult in Results)
-                {
-                    packageResult.Value.Warning.Should().BeFalse();
-                }
+                Results.Should().AllSatisfy(r => r.Value.Warning.Should().BeFalse());
             }
         }
     }

--- a/src/chocolatey.tests/chocolatey.tests.csproj
+++ b/src/chocolatey.tests/chocolatey.tests.csproj
@@ -13,6 +13,7 @@
     <RootNamespace>chocolatey.tests</RootNamespace>
     <AssemblyName>chocolatey.tests</AssemblyName>
     <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
+    <LangVersion>7.3</LangVersion>
     <FileAlignment>512</FileAlignment>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <TargetFrameworkProfile />

--- a/src/chocolatey.tests/chocolatey.tests.csproj
+++ b/src/chocolatey.tests/chocolatey.tests.csproj
@@ -116,6 +116,9 @@
     <Reference Include="Chocolatey.NuGet.Versioning">
       <HintPath>..\packages\Chocolatey.NuGet.Versioning.3.2.0\lib\net472\Chocolatey.NuGet.Versioning.dll</HintPath>
     </Reference>
+    <Reference Include="FluentAssertions, Version=6.11.0.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
+      <HintPath>..\packages\FluentAssertions.6.11.0\lib\net47\FluentAssertions.dll</HintPath>
+    </Reference>
     <Reference Include="log4net, Version=2.0.12.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
       <HintPath>..\packages\log4net.2.0.12\lib\net45\log4net.dll</HintPath>
     </Reference>
@@ -132,9 +135,6 @@
     <Reference Include="nunit.framework, Version=3.13.3.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
       <HintPath>..\packages\NUnit.3.13.3\lib\net40\nunit.framework.dll</HintPath>
     </Reference>
-    <Reference Include="Should, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Should.1.1.20\lib\Should.dll</HintPath>
-    </Reference>
     <Reference Include="SimpleInjector, Version=2.8.3.0, Culture=neutral, PublicKeyToken=984cb50dea722e99, processorArchitecture=MSIL">
       <HintPath>..\packages\SimpleInjector.2.8.3\lib\net45\SimpleInjector.dll</HintPath>
     </Reference>
@@ -146,8 +146,14 @@
     <Reference Include="System.IO.Compression" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Net.Http.WebRequest" />
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=4.0.4.1, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.4.5.3\lib\net461\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    </Reference>
     <Reference Include="System.Security" />
     <Reference Include="System.ServiceModel" />
+    <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Threading.Tasks.Extensions.4.5.4\lib\net461\System.Threading.Tasks.Extensions.dll</HintPath>
+    </Reference>
     <Reference Include="System.Web" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
@@ -226,7 +232,9 @@
       <Name>chocolatey.console</Name>
     </ProjectReference>
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <Analyzer Include="..\packages\FluentAssertions.Analyzers.0.19.1\analyzers\dotnet\cs\FluentAssertions.Analyzers.dll" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>

--- a/src/chocolatey.tests/infrastructure.app/attributes/CommandForAttributeSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/attributes/CommandForAttributeSpecs.cs
@@ -17,7 +17,7 @@
 namespace chocolatey.tests.infrastructure.app.attributes
 {
     using chocolatey.infrastructure.app.attributes;
-    using Should;
+    using FluentAssertions;
 
     public class CommandForAttributeSpecs
     {
@@ -43,7 +43,7 @@ namespace chocolatey.tests.infrastructure.app.attributes
             [Fact]
             public void Should_be_set_to_the_string()
             {
-                result.ShouldEqual("bob");
+                result.Should().Be("bob");
             }
         }
     }

--- a/src/chocolatey.tests/infrastructure.app/commands/ChocolateyApiKeyCommandSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/commands/ChocolateyApiKeyCommandSpecs.cs
@@ -26,7 +26,7 @@ namespace chocolatey.tests.infrastructure.app.commands
     using chocolatey.infrastructure.app.services;
     using chocolatey.infrastructure.commandline;
     using Moq;
-    using Should;
+    using FluentAssertions;
 
     public class ChocolateyApiKeyCommandSpecs
     {
@@ -56,13 +56,13 @@ namespace chocolatey.tests.infrastructure.app.commands
             [Fact]
             public void Should_implement_apikey()
             {
-                results.ShouldContain("apikey");
+                results.Should().Contain("apikey");
             }
 
             [Fact]
             public void Should_implement_setapikey()
             {
-                results.ShouldContain("setapikey");
+                results.Should().Contain("setapikey");
             }
         }
 
@@ -84,31 +84,31 @@ namespace chocolatey.tests.infrastructure.app.commands
             [Fact]
             public void Should_clear_previously_set_Source()
             {
-                configuration.Sources.ShouldBeNull();
+                configuration.Sources.Should().BeNull();
             }
 
             [Fact]
             public void Should_add_source_to_the_option_set()
             {
-                optionSet.Contains("source").ShouldBeTrue();
+                optionSet.Contains("source").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_short_version_of_source_to_the_option_set()
             {
-                optionSet.Contains("s").ShouldBeTrue();
+                optionSet.Contains("s").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_apikey_to_the_option_set()
             {
-                optionSet.Contains("apikey").ShouldBeTrue();
+                optionSet.Contains("apikey").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_short_version_of_apikey_to_the_option_set()
             {
-                optionSet.Contains("k").ShouldBeTrue();
+                optionSet.Contains("k").Should().BeTrue();
             }
         }
 
@@ -136,9 +136,9 @@ namespace chocolatey.tests.infrastructure.app.commands
                     error = ex;
                 }
 
-                errored.ShouldBeTrue();
-                error.ShouldNotBeNull();
-                error.ShouldBeType<ApplicationException>();
+                errored.Should().BeTrue();
+                error.Should().NotBeNull();
+                error.Should().BeOfType<ApplicationException>();
             }
 
             [Fact]
@@ -175,9 +175,9 @@ namespace chocolatey.tests.infrastructure.app.commands
                     error = ex;
                 }
 
-                errored.ShouldBeTrue();
-                error.ShouldNotBeNull();
-                error.ShouldBeType<ApplicationException>();
+                errored.Should().BeTrue();
+                error.Should().NotBeNull();
+                error.Should().BeOfType<ApplicationException>();
             }
 
             [Fact]

--- a/src/chocolatey.tests/infrastructure.app/commands/ChocolateyConfigCommandSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/commands/ChocolateyConfigCommandSpecs.cs
@@ -26,7 +26,7 @@ namespace chocolatey.tests.infrastructure.app.commands
     using chocolatey.infrastructure.app.services;
     using chocolatey.infrastructure.commandline;
     using Moq;
-    using Should;
+    using FluentAssertions;
 
     public class ChocolateyConfigCommandSpecs
     {
@@ -55,7 +55,7 @@ namespace chocolatey.tests.infrastructure.app.commands
             [Fact]
             public void Should_implement_config()
             {
-                _results.ShouldContain("config");
+                _results.Should().Contain("config");
             }
         }
 
@@ -77,13 +77,13 @@ namespace chocolatey.tests.infrastructure.app.commands
             [Fact]
             public void Should_add_name_to_the_option_set()
             {
-                _optionSet.Contains("name").ShouldBeTrue();
+                _optionSet.Contains("name").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_value_to_the_option_set()
             {
-                _optionSet.Contains("value").ShouldBeTrue();
+                _optionSet.Contains("value").Should().BeTrue();
             }
         }
 

--- a/src/chocolatey.tests/infrastructure.app/commands/ChocolateyExportCommandSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/commands/ChocolateyExportCommandSpecs.cs
@@ -161,8 +161,7 @@ namespace chocolatey.tests.infrastructure.app.commands
             public void Should_log_the_message_we_expect()
             {
                 var messages = MockLogger.MessagesFor(LogLevel.Info);
-                messages.Should().NotBeEmpty();
-                messages.Count.Should().Be(1);
+                messages.Should().ContainSingle();
                 messages[0].Should().Contain("Export would have been with options");
             }
         }

--- a/src/chocolatey.tests/infrastructure.app/commands/ChocolateyExportCommandSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/commands/ChocolateyExportCommandSpecs.cs
@@ -26,7 +26,7 @@ namespace chocolatey.tests.infrastructure.app.commands
     using chocolatey.infrastructure.commandline;
     using chocolatey.infrastructure.filesystem;
     using Moq;
-    using Should;
+    using FluentAssertions;
 
     public class ChocolateyExportCommandSpecs
     {
@@ -62,7 +62,7 @@ namespace chocolatey.tests.infrastructure.app.commands
             [Fact]
             public void Should_implement_help()
             {
-                results.ShouldContain("export");
+                results.Should().Contain("export");
             }
         }
 
@@ -84,25 +84,25 @@ namespace chocolatey.tests.infrastructure.app.commands
             [Fact]
             public void Should_add_output_file_path_to_the_option_set()
             {
-                optionSet.Contains("output-file-path").ShouldBeTrue();
+                optionSet.Contains("output-file-path").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_short_version_of_output_file_path_to_the_option_set()
             {
-                optionSet.Contains("o").ShouldBeTrue();
+                optionSet.Contains("o").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_include_version_numbers_to_the_option_set()
             {
-                optionSet.Contains("include-version-numbers").ShouldBeTrue();
+                optionSet.Contains("include-version-numbers").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_include_version_to_the_option_set()
             {
-                optionSet.Contains("include-version").ShouldBeTrue();
+                optionSet.Contains("include-version").Should().BeTrue();
             }
         }
 
@@ -130,7 +130,7 @@ namespace chocolatey.tests.infrastructure.app.commands
                 unparsedArgs.Add(" ");
                 because();
 
-                configuration.ExportCommand.OutputFilePath.ShouldEqual("packages.config");
+                configuration.ExportCommand.OutputFilePath.Should().Be("packages.config");
             }
 
             [Fact]
@@ -140,7 +140,7 @@ namespace chocolatey.tests.infrastructure.app.commands
                 unparsedArgs.Add("custompackages.config");
                 because();
 
-                configuration.ExportCommand.OutputFilePath.ShouldEqual("custompackages.config");
+                configuration.ExportCommand.OutputFilePath.Should().Be("custompackages.config");
             }
         }
 
@@ -161,9 +161,9 @@ namespace chocolatey.tests.infrastructure.app.commands
             public void Should_log_the_message_we_expect()
             {
                 var messages = MockLogger.MessagesFor(LogLevel.Info);
-                messages.ShouldNotBeEmpty();
-                messages.Count.ShouldEqual(1);
-                messages[0].ShouldContain("Export would have been with options");
+                messages.Should().NotBeEmpty();
+                messages.Count.Should().Be(1);
+                messages[0].Should().Contain("Export would have been with options");
             }
         }
 

--- a/src/chocolatey.tests/infrastructure.app/commands/ChocolateyFeatureCommandSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/commands/ChocolateyFeatureCommandSpecs.cs
@@ -26,7 +26,7 @@ namespace chocolatey.tests.infrastructure.app.commands
     using chocolatey.infrastructure.app.services;
     using chocolatey.infrastructure.commandline;
     using Moq;
-    using Should;
+    using FluentAssertions;
 
     public class ChocolateyFeatureCommandSpecs
     {
@@ -56,13 +56,13 @@ namespace chocolatey.tests.infrastructure.app.commands
             [Fact]
             public void Should_implement_feature()
             {
-                _results.ShouldContain("feature");
+                _results.Should().Contain("feature");
             }
 
             [Fact]
             public void Should_implement_features()
             {
-                _results.ShouldContain("features");
+                _results.Should().Contain("features");
             }
         }
 
@@ -85,13 +85,13 @@ namespace chocolatey.tests.infrastructure.app.commands
             [Fact]
             public void Should_add_name_to_the_option_set()
             {
-                _optionSet.Contains("name").ShouldBeTrue();
+                _optionSet.Contains("name").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_short_version_of_name_to_the_option_set()
             {
-                _optionSet.Contains("n").ShouldBeTrue();
+                _optionSet.Contains("n").Should().BeTrue();
             }
         }
 
@@ -118,7 +118,7 @@ namespace chocolatey.tests.infrastructure.app.commands
                 _unparsedArgs.Add("list");
                 _because();
 
-                Configuration.FeatureCommand.Command.ShouldEqual(FeatureCommandType.List);
+                Configuration.FeatureCommand.Command.Should().Be(FeatureCommandType.List);
             }
 
             [Fact]
@@ -140,10 +140,10 @@ namespace chocolatey.tests.infrastructure.app.commands
                     error = ex;
                 }
 
-                errored.ShouldBeTrue();
-                error.ShouldNotBeNull();
-                error.ShouldBeType<ApplicationException>();
-                error.Message.ShouldContain("A single features command must be listed");
+                errored.Should().BeTrue();
+                error.Should().NotBeNull();
+                error.Should().BeOfType<ApplicationException>();
+                error.Message.Should().Contain("A single features command must be listed");
             }
 
             [Fact]
@@ -153,7 +153,7 @@ namespace chocolatey.tests.infrastructure.app.commands
                 _unparsedArgs.Add("enable");
                 _because();
 
-                Configuration.FeatureCommand.Command.ShouldEqual(FeatureCommandType.Enable);
+                Configuration.FeatureCommand.Command.Should().Be(FeatureCommandType.Enable);
             }
 
             [Fact]
@@ -163,7 +163,7 @@ namespace chocolatey.tests.infrastructure.app.commands
                 _unparsedArgs.Add("disable");
                 _because();
 
-                Configuration.FeatureCommand.Command.ShouldEqual(FeatureCommandType.Disable);
+                Configuration.FeatureCommand.Command.Should().Be(FeatureCommandType.Disable);
             }
 
             [Fact]
@@ -173,7 +173,7 @@ namespace chocolatey.tests.infrastructure.app.commands
                 _unparsedArgs.Add("wtf");
                 _because();
 
-                Configuration.FeatureCommand.Command.ShouldEqual(FeatureCommandType.List);
+                Configuration.FeatureCommand.Command.Should().Be(FeatureCommandType.List);
             }
 
             [Fact]
@@ -182,7 +182,7 @@ namespace chocolatey.tests.infrastructure.app.commands
                 Reset();
                 _because();
 
-                Configuration.FeatureCommand.Command.ShouldEqual(FeatureCommandType.List);
+                Configuration.FeatureCommand.Command.Should().Be(FeatureCommandType.List);
             }
 
             [Fact]
@@ -192,7 +192,7 @@ namespace chocolatey.tests.infrastructure.app.commands
                 _unparsedArgs.Add(" ");
                 _because();
 
-                Configuration.FeatureCommand.Command.ShouldEqual(FeatureCommandType.List);
+                Configuration.FeatureCommand.Command.Should().Be(FeatureCommandType.List);
             }
         }
 
@@ -223,10 +223,10 @@ namespace chocolatey.tests.infrastructure.app.commands
                     error = ex;
                 }
 
-                errored.ShouldBeTrue();
-                error.ShouldNotBeNull();
-                error.ShouldBeType<ApplicationException>();
-                error.Message.ShouldEqual("When specifying the subcommand '{0}', you must also specify --name.".FormatWith(Configuration.FeatureCommand.Command.ToStringSafe().ToLower()));
+                errored.Should().BeTrue();
+                error.Should().NotBeNull();
+                error.Should().BeOfType<ApplicationException>();
+                error.Message.Should().Be("When specifying the subcommand '{0}', you must also specify --name.".FormatWith(Configuration.FeatureCommand.Command.ToStringSafe().ToLower()));
             }
 
             [Fact]

--- a/src/chocolatey.tests/infrastructure.app/commands/ChocolateyHelpCommandSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/commands/ChocolateyHelpCommandSpecs.cs
@@ -21,7 +21,7 @@ namespace chocolatey.tests.infrastructure.app.commands
     using chocolatey.infrastructure.app.attributes;
     using chocolatey.infrastructure.app.commands;
     using chocolatey.infrastructure.app.configuration;
-    using Should;
+    using FluentAssertions;
 
     public class ChocolateyHelpCommandSpecs
     {
@@ -49,7 +49,7 @@ namespace chocolatey.tests.infrastructure.app.commands
             [Fact]
             public void Should_implement_help()
             {
-                results.ShouldContain("help");
+                results.Should().Contain("help");
             }
         }
     }

--- a/src/chocolatey.tests/infrastructure.app/commands/ChocolateyInfoCommandSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/commands/ChocolateyInfoCommandSpecs.cs
@@ -25,7 +25,7 @@ namespace chocolatey.tests.infrastructure.app.commands
     using chocolatey.infrastructure.app.services;
     using chocolatey.infrastructure.commandline;
     using Moq;
-    using Should;
+    using FluentAssertions;
 
     public class ChocolateyInfoCommandSpecs
     {
@@ -55,7 +55,7 @@ namespace chocolatey.tests.infrastructure.app.commands
             [Fact]
             public void Should_implement_info()
             {
-                _results.ShouldContain("info");
+                _results.Should().Contain("info");
             }
         }
 
@@ -77,61 +77,61 @@ namespace chocolatey.tests.infrastructure.app.commands
             [Fact]
             public void Should_add_source_to_the_option_set()
             {
-                _optionSet.Contains("source").ShouldBeTrue();
+                _optionSet.Contains("source").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_short_version_of_source_to_the_option_set()
             {
-                _optionSet.Contains("s").ShouldBeTrue();
+                _optionSet.Contains("s").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_localonly_to_the_option_set()
             {
-                _optionSet.Contains("localonly").ShouldBeTrue();
+                _optionSet.Contains("localonly").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_short_version_of_localonly_to_the_option_set()
             {
-                _optionSet.Contains("l").ShouldBeTrue();
+                _optionSet.Contains("l").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_prerelease_to_the_option_set()
             {
-                _optionSet.Contains("prerelease").ShouldBeTrue();
+                _optionSet.Contains("prerelease").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_short_version_of_prerelease_to_the_option_set()
             {
-                _optionSet.Contains("pre").ShouldBeTrue();
+                _optionSet.Contains("pre").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_user_to_the_option_set()
             {
-                _optionSet.Contains("user").ShouldBeTrue();
+                _optionSet.Contains("user").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_short_version_of_user_to_the_option_set()
             {
-                _optionSet.Contains("u").ShouldBeTrue();
+                _optionSet.Contains("u").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_password_to_the_option_set()
             {
-                _optionSet.Contains("password").ShouldBeTrue();
+                _optionSet.Contains("password").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_short_version_of_password_to_the_option_set()
             {
-                _optionSet.Contains("p").ShouldBeTrue();
+                _optionSet.Contains("p").Should().BeTrue();
             }
         }
 
@@ -165,9 +165,9 @@ namespace chocolatey.tests.infrastructure.app.commands
                     _error = ex;
                 }
 
-                _error.ShouldNotBeNull();
-                _error.ShouldBeType<ApplicationException>();
-                _error.Message.ShouldContain("A single package name is required to run the choco info command.");
+                _error.Should().NotBeNull();
+                _error.Should().BeOfType<ApplicationException>();
+                _error.Message.Should().Contain("A single package name is required to run the choco info command.");
             }
 
             [Fact]
@@ -185,9 +185,9 @@ namespace chocolatey.tests.infrastructure.app.commands
                     _error = ex;
                 }
 
-                _error.ShouldNotBeNull();
-                _error.ShouldBeType<ApplicationException>();
-                _error.Message.ShouldContain("Only a single package name can be passed to the choco info command.");
+                _error.Should().NotBeNull();
+                _error.Should().BeOfType<ApplicationException>();
+                _error.Message.Should().Contain("Only a single package name can be passed to the choco info command.");
             }
         }
         public class When_handling_additional_argument_parsing : ChocolateyInfoCommandSpecsBase
@@ -213,7 +213,7 @@ namespace chocolatey.tests.infrastructure.app.commands
             public void Should_set_unparsed_arguments_to_configuration_input()
             {
                 _because();
-                Configuration.Input.ShouldEqual("pkg1 pkg2");
+                Configuration.Input.Should().Be("pkg1 pkg2");
             }
 
             [Fact]
@@ -221,7 +221,7 @@ namespace chocolatey.tests.infrastructure.app.commands
             {
                 Configuration.ListCommand.LocalOnly = false;
                 _because();
-                Configuration.Sources.ShouldEqual(_source);
+                Configuration.Sources.Should().Be(_source);
             }
 
             [Fact]
@@ -229,7 +229,7 @@ namespace chocolatey.tests.infrastructure.app.commands
             {
                 Configuration.ListCommand.Exact = false;
                 _because();
-                Configuration.ListCommand.Exact.ShouldBeTrue();
+                Configuration.ListCommand.Exact.Should().BeTrue();
             }
 
             [Fact]
@@ -237,7 +237,7 @@ namespace chocolatey.tests.infrastructure.app.commands
             {
                 Configuration.Verbose = false;
                 _because();
-                Configuration.Verbose.ShouldBeTrue();
+                Configuration.Verbose.Should().BeTrue();
             }
         }
 

--- a/src/chocolatey.tests/infrastructure.app/commands/ChocolateyInstallCommandSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/commands/ChocolateyInstallCommandSpecs.cs
@@ -26,7 +26,7 @@ namespace chocolatey.tests.infrastructure.app.commands
     using chocolatey.infrastructure.app.services;
     using chocolatey.infrastructure.commandline;
     using Moq;
-    using Should;
+    using FluentAssertions;
 
     public class ChocolateyInstallCommandSpecs
     {
@@ -56,7 +56,7 @@ namespace chocolatey.tests.infrastructure.app.commands
             [Fact]
             public void Should_implement_install()
             {
-                results.ShouldContain("install");
+                results.Should().Contain("install");
             }
         }
 
@@ -78,181 +78,181 @@ namespace chocolatey.tests.infrastructure.app.commands
             [Fact]
             public void Should_add_source_to_the_option_set()
             {
-                optionSet.Contains("source").ShouldBeTrue();
+                optionSet.Contains("source").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_short_version_of_source_to_the_option_set()
             {
-                optionSet.Contains("s").ShouldBeTrue();
+                optionSet.Contains("s").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_version_to_the_option_set()
             {
-                optionSet.Contains("version").ShouldBeTrue();
+                optionSet.Contains("version").Should().BeTrue();
             }
 
             [Fact]
             public void Should_allow_insensitive_case_Version_to_the_option_set()
             {
-                optionSet.Contains("Version").ShouldBeTrue();
+                optionSet.Contains("Version").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_prerelease_to_the_option_set()
             {
-                optionSet.Contains("prerelease").ShouldBeTrue();
+                optionSet.Contains("prerelease").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_short_version_of_prerelease_to_the_option_set()
             {
-                optionSet.Contains("pre").ShouldBeTrue();
+                optionSet.Contains("pre").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_installargs_to_the_option_set()
             {
-                optionSet.Contains("installarguments").ShouldBeTrue();
+                optionSet.Contains("installarguments").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_short_version_of_installargs_to_the_option_set()
             {
-                optionSet.Contains("ia").ShouldBeTrue();
+                optionSet.Contains("ia").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_overrideargs_to_the_option_set()
             {
-                optionSet.Contains("overridearguments").ShouldBeTrue();
+                optionSet.Contains("overridearguments").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_short_version_of_overrideargs_to_the_option_set()
             {
-                optionSet.Contains("o").ShouldBeTrue();
+                optionSet.Contains("o").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_notsilent_to_the_option_set()
             {
-                optionSet.Contains("notsilent").ShouldBeTrue();
+                optionSet.Contains("notsilent").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_packageparameters_to_the_option_set()
             {
-                optionSet.Contains("packageparameters").ShouldBeTrue();
+                optionSet.Contains("packageparameters").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_short_version_of_packageparameters_to_the_option_set()
             {
-                optionSet.Contains("params").ShouldBeTrue();
+                optionSet.Contains("params").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_applyPackageParametersToDependencies_to_the_option_set()
             {
-                optionSet.Contains("apply-package-parameters-to-dependencies").ShouldBeTrue();
+                optionSet.Contains("apply-package-parameters-to-dependencies").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_applyInstallArgumentsToDependencies_to_the_option_set()
             {
-                optionSet.Contains("apply-install-arguments-to-dependencies").ShouldBeTrue();
+                optionSet.Contains("apply-install-arguments-to-dependencies").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_ignoredependencies_to_the_option_set()
             {
-                optionSet.Contains("ignoredependencies").ShouldBeTrue();
+                optionSet.Contains("ignoredependencies").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_short_version_of_ignoredependencies_to_the_option_set()
             {
-                optionSet.Contains("i").ShouldBeTrue();
+                optionSet.Contains("i").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_forcedependencies_to_the_option_set()
             {
-                optionSet.Contains("forcedependencies").ShouldBeTrue();
+                optionSet.Contains("forcedependencies").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_short_version_of_forcedependencies_to_the_option_set()
             {
-                optionSet.Contains("x").ShouldBeTrue();
+                optionSet.Contains("x").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_skippowershell_to_the_option_set()
             {
-                optionSet.Contains("skippowershell").ShouldBeTrue();
+                optionSet.Contains("skippowershell").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_short_version_of_skippowershell_to_the_option_set()
             {
-                optionSet.Contains("n").ShouldBeTrue();
+                optionSet.Contains("n").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_user_to_the_option_set()
             {
-                optionSet.Contains("user").ShouldBeTrue();
+                optionSet.Contains("user").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_short_version_of_user_to_the_option_set()
             {
-                optionSet.Contains("u").ShouldBeTrue();
+                optionSet.Contains("u").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_password_to_the_option_set()
             {
-                optionSet.Contains("password").ShouldBeTrue();
+                optionSet.Contains("password").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_short_version_of_password_to_the_option_set()
             {
-                optionSet.Contains("p").ShouldBeTrue();
+                optionSet.Contains("p").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_pin_to_the_option_set()
             {
-                optionSet.Contains("pinpackage").ShouldBeTrue();
+                optionSet.Contains("pinpackage").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_long_version_of_pin_to_the_option_set()
             {
-                optionSet.Contains("pin-package").ShouldBeTrue();
+                optionSet.Contains("pin-package").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_short_version_of_pin_to_the_option_set()
             {
-                optionSet.Contains("pin").ShouldBeTrue();
+                optionSet.Contains("pin").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_skip_hooks_to_the_option_set()
             {
-                optionSet.Contains("skip-hooks").ShouldBeTrue();
+                optionSet.Contains("skip-hooks").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_short_version_of_skip_hooks_to_the_option_set()
             {
-                optionSet.Contains("skiphooks").ShouldBeTrue();
+                optionSet.Contains("skiphooks").Should().BeTrue();
             }
         }
 
@@ -275,7 +275,7 @@ namespace chocolatey.tests.infrastructure.app.commands
             [Fact]
             public void Should_set_unparsed_arguments_to_the_package_names()
             {
-                configuration.PackageNames.ShouldEqual("pkg1;pkg2");
+                configuration.PackageNames.Should().Be("pkg1;pkg2");
             }
         }
 
@@ -302,9 +302,9 @@ namespace chocolatey.tests.infrastructure.app.commands
                     error = ex;
                 }
 
-                errored.ShouldBeTrue();
-                error.ShouldNotBeNull();
-                error.ShouldBeType<ApplicationException>();
+                errored.Should().BeTrue();
+                error.Should().NotBeNull();
+                error.Should().BeOfType<ApplicationException>();
             }
 
             [Fact]

--- a/src/chocolatey.tests/infrastructure.app/commands/ChocolateyListCommandSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/commands/ChocolateyListCommandSpecs.cs
@@ -24,7 +24,7 @@ namespace chocolatey.tests.infrastructure.app.commands
     using chocolatey.infrastructure.app.services;
     using chocolatey.infrastructure.commandline;
     using Moq;
-    using Should;
+    using FluentAssertions;
 
     public static class ChocolateyListCommandSpecs
     {
@@ -53,19 +53,19 @@ namespace chocolatey.tests.infrastructure.app.commands
             [Fact]
             public void Should_implement_list()
             {
-                _results.ShouldContain("list");
+                _results.Should().Contain("list");
             }
 
             [Fact]
             public void Should_not_implement_search()
             {
-                _results.ShouldNotContain("search");
+                _results.Should().NotContain("search");
             }
 
             [Fact]
             public void Should_not_implement_find()
             {
-                _results.ShouldNotContain("find");
+                _results.Should().NotContain("find");
             }
 
             public class When_configurating_the_argument_parser : ChocolateyListCommandSpecsBase
@@ -91,7 +91,7 @@ namespace chocolatey.tests.infrastructure.app.commands
                 [NUnit.Framework.TestCase("i")]
                 public void Should_add_to_option_set(string option)
                 {
-                    _optionSet.Contains(option).ShouldBeTrue();
+                    _optionSet.Contains(option).Should().BeTrue();
                 }
 
                 [NUnit.Framework.TestCase("localonly")]
@@ -104,7 +104,7 @@ namespace chocolatey.tests.infrastructure.app.commands
                 [NUnit.Framework.TestCase("a")]
                 public void Should_not_add_to_option_set(string option)
                 {
-                    _optionSet.Contains(option).ShouldBeFalse();
+                    _optionSet.Contains(option).Should().BeFalse();
                 }
             }
 
@@ -154,9 +154,9 @@ namespace chocolatey.tests.infrastructure.app.commands
                         error = ex;
                     }
 
-                    errored.ShouldBeTrue();
-                    error.ShouldNotBeNull();
-                    error.ShouldBeType<ApplicationException>();
+                    errored.Should().BeTrue();
+                    error.Should().NotBeNull();
+                    error.Should().BeOfType<ApplicationException>();
                 }
 
                 [Fact]
@@ -164,7 +164,7 @@ namespace chocolatey.tests.infrastructure.app.commands
                 {
                     Configuration.RegularOutput = false;
                     _because();
-                    Configuration.Input.ShouldEqual("pkg1 pkg2");
+                    Configuration.Input.Should().Be("pkg1 pkg2");
                 }
 
                 [NUnit.Framework.TestCase("-l")]
@@ -175,8 +175,8 @@ namespace chocolatey.tests.infrastructure.app.commands
                 {
                     Configuration.RegularOutput = false;
                     _because();
-                    MockLogger.Messages.Keys.ShouldContain("Warn");
-                    MockLogger.Messages["Warn"].ShouldContain("Ignoring the argument {0}. This argument is unsupported for locally installed packages.".FormatWith(argument));
+                    MockLogger.Messages.Keys.Should().Contain("Warn");
+                    MockLogger.Messages["Warn"].Should().Contain("Ignoring the argument {0}. This argument is unsupported for locally installed packages.".FormatWith(argument));
                 }
 
                 [NUnit.Framework.TestCase("-li")]
@@ -185,9 +185,9 @@ namespace chocolatey.tests.infrastructure.app.commands
                 {
                     Configuration.RegularOutput = false;
                     _because();
-                    MockLogger.Messages.Keys.ShouldContain("Warn");
-                    MockLogger.Messages["Warn"].ShouldContain("Ignoring the argument {0}. This argument is unsupported for locally installed packages.".FormatWith(argument));
-                    Configuration.ListCommand.IncludeRegistryPrograms.ShouldBeTrue();
+                    MockLogger.Messages.Keys.Should().Contain("Warn");
+                    MockLogger.Messages["Warn"].Should().Contain("Ignoring the argument {0}. This argument is unsupported for locally installed packages.".FormatWith(argument));
+                    Configuration.ListCommand.IncludeRegistryPrograms.Should().BeTrue();
                 }
             }
 
@@ -214,7 +214,7 @@ namespace chocolatey.tests.infrastructure.app.commands
                 [Fact]
                 public void Should_not_report_any_warning_messages()
                 {
-                    MockLogger.Messages.Keys.ShouldNotContain("Warn");
+                    MockLogger.Messages.Keys.Should().NotContain("Warn");
                 }
             }
 
@@ -240,7 +240,7 @@ namespace chocolatey.tests.infrastructure.app.commands
                 [Fact]
                 public void Should_not_report_any_warning_messages()
                 {
-                    MockLogger.Messages.Keys.ShouldNotContain("Warn");
+                    MockLogger.Messages.Keys.Should().NotContain("Warn");
                 }
             }
         }

--- a/src/chocolatey.tests/infrastructure.app/commands/ChocolateyNewCommandSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/commands/ChocolateyNewCommandSpecs.cs
@@ -133,7 +133,7 @@ namespace chocolatey.tests.infrastructure.app.commands
             {
                 reset();
                 because();
-                configuration.NewCommand.TemplateProperties.Count.Should().Be(0);
+                configuration.NewCommand.TemplateProperties.Should().HaveCount(0);
             }
 
             [Fact]
@@ -144,7 +144,7 @@ namespace chocolatey.tests.infrastructure.app.commands
                 because();
 
                 var properties = configuration.NewCommand.TemplateProperties;
-                properties.Count.Should().Be(1);
+                properties.Should().HaveCount(1);
                 var templateProperty = properties.FirstOrDefault();
                 templateProperty.Key.Should().Be("bob");
                 templateProperty.Value.Should().Be("new");
@@ -159,7 +159,7 @@ namespace chocolatey.tests.infrastructure.app.commands
                 because();
 
                 var properties = configuration.NewCommand.TemplateProperties;
-                properties.Count.Should().Be(1);
+                properties.Should().HaveCount(1);
                 var templateProperty = properties.FirstOrDefault();
                 templateProperty.Key.Should().Be("bob");
                 templateProperty.Value.Should().Be("one");
@@ -174,7 +174,7 @@ namespace chocolatey.tests.infrastructure.app.commands
                 because();
 
                 var properties = configuration.NewCommand.TemplateProperties;
-                properties.Count.Should().Be(1);
+                properties.Should().HaveCount(1);
                 var templateProperty = properties.FirstOrDefault();
                 templateProperty.Key.Should().Be("bob");
                 templateProperty.Value.Should().Be("one");
@@ -190,7 +190,7 @@ namespace chocolatey.tests.infrastructure.app.commands
                 because();
 
                 var properties = configuration.NewCommand.TemplateProperties;
-                properties.Count.Should().Be(1);
+                properties.Should().HaveCount(1);
                 var templateProperty = properties.FirstOrDefault();
                 templateProperty.Key.Should().Be("PackageName");
                 templateProperty.Value.Should().Be("bill");
@@ -206,7 +206,7 @@ namespace chocolatey.tests.infrastructure.app.commands
                 because();
 
                 var properties = configuration.NewCommand.TemplateProperties;
-                properties.Count.Should().Be(1);
+                properties.Should().HaveCount(1);
                 var templateProperty = properties.FirstOrDefault();
                 templateProperty.Key.Should().Be("PackageName");
                 templateProperty.Value.Should().Be("bill");
@@ -235,7 +235,7 @@ namespace chocolatey.tests.infrastructure.app.commands
                 because();
 
                 var properties = configuration.NewCommand.TemplateProperties;
-                properties.Count.Should().Be(1);
+                properties.Should().HaveCount(1);
                 var templateProperty = properties.FirstOrDefault();
                 templateProperty.Key.Should().Be("bob");
                 templateProperty.Value.Should().Be("new");
@@ -249,7 +249,7 @@ namespace chocolatey.tests.infrastructure.app.commands
                 because();
 
                 var properties = configuration.NewCommand.TemplateProperties;
-                properties.Count.Should().Be(1);
+                properties.Should().HaveCount(1);
                 var templateProperty = properties.FirstOrDefault();
                 templateProperty.Key.Should().Be("bob");
                 templateProperty.Value.Should().Be("new this");
@@ -263,7 +263,7 @@ namespace chocolatey.tests.infrastructure.app.commands
                 because();
                 var properties = configuration.NewCommand.TemplateProperties;
 
-                properties.Count.Should().Be(1);
+                properties.Should().HaveCount(1);
                 var templateProperty = properties.FirstOrDefault();
                 templateProperty.Key.Should().Be("bob");
                 templateProperty.Value.Should().Be("new \"this");
@@ -277,7 +277,7 @@ namespace chocolatey.tests.infrastructure.app.commands
                 because();
                 var properties = configuration.NewCommand.TemplateProperties;
 
-                properties.Count.Should().Be(1);
+                properties.Should().HaveCount(1);
                 var templateProperty = properties.FirstOrDefault();
                 templateProperty.Key.Should().Be("bob");
                 templateProperty.Value.Should().Be("new this");
@@ -291,7 +291,7 @@ namespace chocolatey.tests.infrastructure.app.commands
                 because();
                 var properties = configuration.NewCommand.TemplateProperties;
 
-                properties.Count.Should().Be(1);
+                properties.Should().HaveCount(1);
                 var templateProperty = properties.FirstOrDefault();
                 templateProperty.Key.Should().Be("bob");
                 templateProperty.Value.Should().Be("new 'this");

--- a/src/chocolatey.tests/infrastructure.app/commands/ChocolateyNewCommandSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/commands/ChocolateyNewCommandSpecs.cs
@@ -26,7 +26,7 @@ namespace chocolatey.tests.infrastructure.app.commands
     using chocolatey.infrastructure.app.templates;
     using chocolatey.infrastructure.commandline;
     using Moq;
-    using Should;
+    using FluentAssertions;
 
     public class ChocolateyNewCommandSpecs
     {
@@ -55,7 +55,7 @@ namespace chocolatey.tests.infrastructure.app.commands
             [Fact]
             public void Should_implement_new()
             {
-                results.ShouldContain("new");
+                results.Should().Contain("new");
             }
         }
 
@@ -77,37 +77,37 @@ namespace chocolatey.tests.infrastructure.app.commands
             [Fact]
             public void Should_add_automaticpackage_to_the_option_set()
             {
-                optionSet.Contains("automaticpackage").ShouldBeTrue();
+                optionSet.Contains("automaticpackage").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_short_version_of_automaticpackage_to_the_option_set()
             {
-                optionSet.Contains("a").ShouldBeTrue();
+                optionSet.Contains("a").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_name_to_the_option_set()
             {
-                optionSet.Contains("name").ShouldBeTrue();
+                optionSet.Contains("name").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_version_to_the_option_set()
             {
-                optionSet.Contains("version").ShouldBeTrue();
+                optionSet.Contains("version").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_maintainer_to_the_option_set()
             {
-                optionSet.Contains("maintainer").ShouldBeTrue();
+                optionSet.Contains("maintainer").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_outputdirectory_to_the_option_set()
             {
-                optionSet.Contains("outputdirectory").ShouldBeTrue();
+                optionSet.Contains("outputdirectory").Should().BeTrue();
             }
         }
 
@@ -133,7 +133,7 @@ namespace chocolatey.tests.infrastructure.app.commands
             {
                 reset();
                 because();
-                configuration.NewCommand.TemplateProperties.Count.ShouldEqual(0);
+                configuration.NewCommand.TemplateProperties.Count.Should().Be(0);
             }
 
             [Fact]
@@ -144,10 +144,10 @@ namespace chocolatey.tests.infrastructure.app.commands
                 because();
 
                 var properties = configuration.NewCommand.TemplateProperties;
-                properties.Count.ShouldEqual(1);
+                properties.Count.Should().Be(1);
                 var templateProperty = properties.FirstOrDefault();
-                templateProperty.Key.ShouldEqual("bob");
-                templateProperty.Value.ShouldEqual("new");
+                templateProperty.Key.Should().Be("bob");
+                templateProperty.Value.Should().Be("new");
             }
 
             [Fact]
@@ -159,10 +159,10 @@ namespace chocolatey.tests.infrastructure.app.commands
                 because();
 
                 var properties = configuration.NewCommand.TemplateProperties;
-                properties.Count.ShouldEqual(1);
+                properties.Count.Should().Be(1);
                 var templateProperty = properties.FirstOrDefault();
-                templateProperty.Key.ShouldEqual("bob");
-                templateProperty.Value.ShouldEqual("one");
+                templateProperty.Key.Should().Be("bob");
+                templateProperty.Value.Should().Be("one");
             }
 
             [Fact]
@@ -174,10 +174,10 @@ namespace chocolatey.tests.infrastructure.app.commands
                 because();
 
                 var properties = configuration.NewCommand.TemplateProperties;
-                properties.Count.ShouldEqual(1);
+                properties.Count.Should().Be(1);
                 var templateProperty = properties.FirstOrDefault();
-                templateProperty.Key.ShouldEqual("bob");
-                templateProperty.Value.ShouldEqual("one");
+                templateProperty.Key.Should().Be("bob");
+                templateProperty.Value.Should().Be("one");
             }
 
             [Fact]
@@ -190,10 +190,10 @@ namespace chocolatey.tests.infrastructure.app.commands
                 because();
 
                 var properties = configuration.NewCommand.TemplateProperties;
-                properties.Count.ShouldEqual(1);
+                properties.Count.Should().Be(1);
                 var templateProperty = properties.FirstOrDefault();
-                templateProperty.Key.ShouldEqual("PackageName");
-                templateProperty.Value.ShouldEqual("bill");
+                templateProperty.Key.Should().Be("PackageName");
+                templateProperty.Value.Should().Be("bill");
             }
 
             [Fact]
@@ -206,10 +206,10 @@ namespace chocolatey.tests.infrastructure.app.commands
                 because();
 
                 var properties = configuration.NewCommand.TemplateProperties;
-                properties.Count.ShouldEqual(1);
+                properties.Count.Should().Be(1);
                 var templateProperty = properties.FirstOrDefault();
-                templateProperty.Key.ShouldEqual("PackageName");
-                templateProperty.Value.ShouldEqual("bill");
+                templateProperty.Key.Should().Be("PackageName");
+                templateProperty.Value.Should().Be("bill");
             }
 
             [Fact]
@@ -223,8 +223,8 @@ namespace chocolatey.tests.infrastructure.app.commands
 
                 var properties = configuration.NewCommand.TemplateProperties;
                 var templateProperty = properties.FirstOrDefault();
-                templateProperty.Key.ShouldEqual("PackageName");
-                templateProperty.Value.ShouldEqual("bill");
+                templateProperty.Key.Should().Be("PackageName");
+                templateProperty.Value.Should().Be("bill");
             }
 
             [Fact]
@@ -235,10 +235,10 @@ namespace chocolatey.tests.infrastructure.app.commands
                 because();
 
                 var properties = configuration.NewCommand.TemplateProperties;
-                properties.Count.ShouldEqual(1);
+                properties.Count.Should().Be(1);
                 var templateProperty = properties.FirstOrDefault();
-                templateProperty.Key.ShouldEqual("bob");
-                templateProperty.Value.ShouldEqual("new");
+                templateProperty.Key.Should().Be("bob");
+                templateProperty.Value.Should().Be("new");
             }
 
             [Fact]
@@ -249,10 +249,10 @@ namespace chocolatey.tests.infrastructure.app.commands
                 because();
 
                 var properties = configuration.NewCommand.TemplateProperties;
-                properties.Count.ShouldEqual(1);
+                properties.Count.Should().Be(1);
                 var templateProperty = properties.FirstOrDefault();
-                templateProperty.Key.ShouldEqual("bob");
-                templateProperty.Value.ShouldEqual("new this");
+                templateProperty.Key.Should().Be("bob");
+                templateProperty.Value.Should().Be("new this");
             }
 
             [Fact]
@@ -263,10 +263,10 @@ namespace chocolatey.tests.infrastructure.app.commands
                 because();
                 var properties = configuration.NewCommand.TemplateProperties;
 
-                properties.Count.ShouldEqual(1);
+                properties.Count.Should().Be(1);
                 var templateProperty = properties.FirstOrDefault();
-                templateProperty.Key.ShouldEqual("bob");
-                templateProperty.Value.ShouldEqual("new \"this");
+                templateProperty.Key.Should().Be("bob");
+                templateProperty.Value.Should().Be("new \"this");
             }
 
             [Fact]
@@ -277,10 +277,10 @@ namespace chocolatey.tests.infrastructure.app.commands
                 because();
                 var properties = configuration.NewCommand.TemplateProperties;
 
-                properties.Count.ShouldEqual(1);
+                properties.Count.Should().Be(1);
                 var templateProperty = properties.FirstOrDefault();
-                templateProperty.Key.ShouldEqual("bob");
-                templateProperty.Value.ShouldEqual("new this");
+                templateProperty.Key.Should().Be("bob");
+                templateProperty.Value.Should().Be("new this");
             }
 
             [Fact]
@@ -291,10 +291,10 @@ namespace chocolatey.tests.infrastructure.app.commands
                 because();
                 var properties = configuration.NewCommand.TemplateProperties;
 
-                properties.Count.ShouldEqual(1);
+                properties.Count.Should().Be(1);
                 var templateProperty = properties.FirstOrDefault();
-                templateProperty.Key.ShouldEqual("bob");
-                templateProperty.Value.ShouldEqual("new 'this");
+                templateProperty.Key.Should().Be("bob");
+                templateProperty.Value.Should().Be("new 'this");
             }
         }
 
@@ -321,9 +321,9 @@ namespace chocolatey.tests.infrastructure.app.commands
                     error = ex;
                 }
 
-                errored.ShouldBeTrue();
-                error.ShouldNotBeNull();
-                error.ShouldBeType<ApplicationException>();
+                errored.Should().BeTrue();
+                error.Should().NotBeNull();
+                error.Should().BeOfType<ApplicationException>();
             }
 
             [Fact]
@@ -381,38 +381,38 @@ namespace chocolatey.tests.infrastructure.app.commands
             [Fact]
             public void Should_name_equal_to_Bob()
             {
-                configuration.NewCommand.Name.ShouldEqual("Bob");
-                configuration.NewCommand.TemplateProperties[TemplateValues.NamePropertyName].ShouldEqual("Bob");
+                configuration.NewCommand.Name.Should().Be("Bob");
+                configuration.NewCommand.TemplateProperties[TemplateValues.NamePropertyName].Should().Be("Bob");
             }
 
             [Fact]
             public void Should_automaticpackage_equal_to_true()
             {
-                configuration.NewCommand.AutomaticPackage.ShouldBeTrue();
+                configuration.NewCommand.AutomaticPackage.Should().BeTrue();
             }
 
             [Fact]
             public void Should_templatename_equal_to_custom()
             {
-                configuration.NewCommand.TemplateName.ShouldEqual("custom");
+                configuration.NewCommand.TemplateName.Should().Be("custom");
             }
 
             [Fact]
             public void Should_version_equal_to_42()
             {
-                configuration.NewCommand.TemplateProperties[TemplateValues.VersionPropertyName].ShouldEqual("0.42.0");
+                configuration.NewCommand.TemplateProperties[TemplateValues.VersionPropertyName].Should().Be("0.42.0");
             }
 
             [Fact]
             public void Should_maintainer_equal_to_Loyd()
             {
-                configuration.NewCommand.TemplateProperties[TemplateValues.MaintainerPropertyName].ShouldEqual("Loyd");
+                configuration.NewCommand.TemplateProperties[TemplateValues.MaintainerPropertyName].Should().Be("Loyd");
             }
 
             [Fact]
             public void Should_outputdirectory_equal_packages()
             {
-                configuration.OutputDirectory.ShouldEqual("c:\\packages");
+                configuration.OutputDirectory.Should().Be("c:\\packages");
             }
         }
     }

--- a/src/chocolatey.tests/infrastructure.app/commands/ChocolateyOutdatedCommandSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/commands/ChocolateyOutdatedCommandSpecs.cs
@@ -24,7 +24,7 @@ namespace chocolatey.tests.infrastructure.app.commands
     using chocolatey.infrastructure.app.services;
     using chocolatey.infrastructure.commandline;
     using Moq;
-    using Should;
+    using FluentAssertions;
 
     public class ChocolateyOutdatedCommandSpecs
     {
@@ -54,7 +54,7 @@ namespace chocolatey.tests.infrastructure.app.commands
             [Fact]
             public void Should_implement_outdated()
             {
-                results.ShouldContain("outdated");
+                results.Should().Contain("outdated");
             }
         }
 
@@ -76,43 +76,43 @@ namespace chocolatey.tests.infrastructure.app.commands
             [Fact]
             public void Should_add_source_to_the_option_set()
             {
-                optionSet.Contains("source").ShouldBeTrue();
+                optionSet.Contains("source").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_short_version_of_source_to_the_option_set()
             {
-                optionSet.Contains("s").ShouldBeTrue();
+                optionSet.Contains("s").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_user_to_the_option_set()
             {
-                optionSet.Contains("user").ShouldBeTrue();
+                optionSet.Contains("user").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_short_version_of_user_to_the_option_set()
             {
-                optionSet.Contains("u").ShouldBeTrue();
+                optionSet.Contains("u").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_password_to_the_option_set()
             {
-                optionSet.Contains("password").ShouldBeTrue();
+                optionSet.Contains("password").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_short_version_of_password_to_the_option_set()
             {
-                optionSet.Contains("p").ShouldBeTrue();
+                optionSet.Contains("p").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_ignore_pinned_to_the_option_set()
             {
-                optionSet.Contains("ignore-pinned").ShouldBeTrue();
+                optionSet.Contains("ignore-pinned").Should().BeTrue();
             }
         }
 

--- a/src/chocolatey.tests/infrastructure.app/commands/ChocolateyPackCommandSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/commands/ChocolateyPackCommandSpecs.cs
@@ -24,7 +24,7 @@ namespace chocolatey.tests.infrastructure.app.commands
     using chocolatey.infrastructure.app.services;
     using chocolatey.infrastructure.commandline;
     using Moq;
-    using Should;
+    using FluentAssertions;
     using System;
 
     public class ChocolateyPackCommandSpecs
@@ -54,7 +54,7 @@ namespace chocolatey.tests.infrastructure.app.commands
             [Fact]
             public void Should_implement_pack()
             {
-                results.ShouldContain("pack");
+                results.Should().Contain("pack");
             }
         }
 
@@ -76,13 +76,13 @@ namespace chocolatey.tests.infrastructure.app.commands
             [Fact]
             public void Should_add_version_to_the_option_set()
             {
-                optionSet.Contains("version").ShouldBeTrue();
+                optionSet.Contains("version").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_outputdirectory_to_the_option_set()
             {
-                optionSet.Contains("outputdirectory").ShouldBeTrue();
+                optionSet.Contains("outputdirectory").Should().BeTrue();
             }
         }
 
@@ -110,27 +110,27 @@ namespace chocolatey.tests.infrastructure.app.commands
             [Fact]
             public void Should_allow_a_path_to_the_nuspec_to_be_passed_in()
             {
-                configuration.Input.ShouldEqual(nuspecPath);
+                configuration.Input.Should().Be(nuspecPath);
             }
 
             [Fact]
             public void Should_property_foo_equal_1()
             {
-                configuration.PackCommand.Properties["foo"].ShouldEqual("1");
+                configuration.PackCommand.Properties["foo"].Should().Be("1");
             }
 
             [Fact]
             public void Should_property_bar_equal_baz()
             {
-                configuration.PackCommand.Properties["bar"].ShouldEqual("baz");
+                configuration.PackCommand.Properties["bar"].Should().Be("baz");
             }
 
             [Fact]
             public void Should_log_warning_on_duplicate_foo()
             {
                 var warnings = MockLogger.MessagesFor(LogLevel.Warn);
-                warnings.Count.ShouldEqual(1);
-                warnings[0].ShouldEqual("A value for 'foo' has already been added with the value '1'. Ignoring foo='2'.", StringComparer.OrdinalIgnoreCase);
+                warnings.Count.Should().Be(1);
+                warnings[0].Should().BeEquivalentTo("A value for 'foo' has already been added with the value '1'. Ignoring foo='2'.");
             }
         }
 
@@ -181,13 +181,13 @@ namespace chocolatey.tests.infrastructure.app.commands
             [Fact]
             public void Should_version_equal_to_42()
             {
-                configuration.Version.ShouldEqual("0.42.0");
+                configuration.Version.Should().Be("0.42.0");
             }
 
             [Fact]
             public void Should_outputdirectory_equal_packages()
             {
-                configuration.OutputDirectory.ShouldEqual("c:\\packages");
+                configuration.OutputDirectory.Should().Be("c:\\packages");
             }
         }
     }

--- a/src/chocolatey.tests/infrastructure.app/commands/ChocolateyPackCommandSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/commands/ChocolateyPackCommandSpecs.cs
@@ -129,7 +129,7 @@ namespace chocolatey.tests.infrastructure.app.commands
             public void Should_log_warning_on_duplicate_foo()
             {
                 var warnings = MockLogger.MessagesFor(LogLevel.Warn);
-                warnings.Count.Should().Be(1);
+                warnings.Should().HaveCount(1);
                 warnings[0].Should().BeEquivalentTo("A value for 'foo' has already been added with the value '1'. Ignoring foo='2'.");
             }
         }

--- a/src/chocolatey.tests/infrastructure.app/commands/ChocolateyPinCommandSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/commands/ChocolateyPinCommandSpecs.cs
@@ -34,7 +34,7 @@ namespace chocolatey.tests.infrastructure.app.commands
 
     using NUnit.Framework;
 
-    using Should;
+    using FluentAssertions;
 
     public class ChocolateyPinCommandSpecs
     {
@@ -93,7 +93,7 @@ namespace chocolatey.tests.infrastructure.app.commands
             [Fact]
             public void Should_implement_source()
             {
-                results.ShouldContain("pin");
+                results.Should().Contain("pin");
             }
         }
 
@@ -115,19 +115,19 @@ namespace chocolatey.tests.infrastructure.app.commands
             [Fact]
             public void Should_add_name_to_the_option_set()
             {
-                optionSet.Contains("name").ShouldBeTrue();
+                optionSet.Contains("name").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_short_version_of_name_to_the_option_set()
             {
-                optionSet.Contains("n").ShouldBeTrue();
+                optionSet.Contains("n").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_version_to_the_option_set()
             {
-                optionSet.Contains("version").ShouldBeTrue();
+                optionSet.Contains("version").Should().BeTrue();
             }
         }
 
@@ -154,7 +154,7 @@ namespace chocolatey.tests.infrastructure.app.commands
                 unparsedArgs.Add("list");
                 because();
 
-                configuration.PinCommand.Command.ShouldEqual(PinCommandType.List);
+                configuration.PinCommand.Command.Should().Be(PinCommandType.List);
             }
 
             [Fact]
@@ -176,10 +176,10 @@ namespace chocolatey.tests.infrastructure.app.commands
                     error = ex;
                 }
 
-                errored.ShouldBeTrue();
-                error.ShouldNotBeNull();
-                error.ShouldBeType<ApplicationException>();
-                error.Message.ShouldContain("A single pin command must be listed");
+                errored.Should().BeTrue();
+                error.Should().NotBeNull();
+                error.Should().BeOfType<ApplicationException>();
+                error.Message.Should().Contain("A single pin command must be listed");
             }
 
             [Fact]
@@ -189,7 +189,7 @@ namespace chocolatey.tests.infrastructure.app.commands
                 unparsedArgs.Add("add");
                 because();
 
-                configuration.PinCommand.Command.ShouldEqual(PinCommandType.Add);
+                configuration.PinCommand.Command.Should().Be(PinCommandType.Add);
             }
 
             [Fact]
@@ -199,7 +199,7 @@ namespace chocolatey.tests.infrastructure.app.commands
                 unparsedArgs.Add("ADD");
                 because();
 
-                configuration.PinCommand.Command.ShouldEqual(PinCommandType.Add);
+                configuration.PinCommand.Command.Should().Be(PinCommandType.Add);
             }
 
             [Fact]
@@ -209,7 +209,7 @@ namespace chocolatey.tests.infrastructure.app.commands
                 unparsedArgs.Add("remove");
                 because();
 
-                configuration.PinCommand.Command.ShouldEqual(PinCommandType.Remove);
+                configuration.PinCommand.Command.Should().Be(PinCommandType.Remove);
             }
 
             [Fact]
@@ -219,7 +219,7 @@ namespace chocolatey.tests.infrastructure.app.commands
                 unparsedArgs.Add("wtf");
                 because();
 
-                configuration.PinCommand.Command.ShouldEqual(PinCommandType.List);
+                configuration.PinCommand.Command.Should().Be(PinCommandType.List);
             }
 
             [Fact]
@@ -228,7 +228,7 @@ namespace chocolatey.tests.infrastructure.app.commands
                 Reset();
                 because();
 
-                configuration.PinCommand.Command.ShouldEqual(PinCommandType.List);
+                configuration.PinCommand.Command.Should().Be(PinCommandType.List);
             }
 
             [Fact]
@@ -238,7 +238,7 @@ namespace chocolatey.tests.infrastructure.app.commands
                 unparsedArgs.Add(" ");
                 because();
 
-                configuration.PinCommand.Command.ShouldEqual(PinCommandType.List);
+                configuration.PinCommand.Command.Should().Be(PinCommandType.List);
             }
 
             [Fact]
@@ -247,7 +247,7 @@ namespace chocolatey.tests.infrastructure.app.commands
                 Reset();
                 because();
 
-                configuration.Sources.ShouldEqual(ApplicationParameters.PackagesLocation);
+                configuration.Sources.Should().Be(ApplicationParameters.PackagesLocation);
             }
 
             [Fact]
@@ -256,7 +256,7 @@ namespace chocolatey.tests.infrastructure.app.commands
                 Reset();
                 because();
 
-                configuration.ListCommand.LocalOnly.ShouldBeTrue();
+                configuration.ListCommand.LocalOnly.Should().BeTrue();
             }
 
             [Fact]
@@ -265,7 +265,7 @@ namespace chocolatey.tests.infrastructure.app.commands
                 Reset();
                 because();
 
-                configuration.AllVersions.ShouldBeTrue();
+                configuration.AllVersions.Should().BeTrue();
             }
         }
 
@@ -296,10 +296,10 @@ namespace chocolatey.tests.infrastructure.app.commands
                     error = ex;
                 }
 
-                errored.ShouldBeTrue();
-                error.ShouldNotBeNull();
-                error.ShouldBeType<ApplicationException>();
-                error.Message.ShouldEqual("When specifying the subcommand '{0}', you must also specify --name.".FormatWith(configuration.PinCommand.Command.ToStringSafe().ToLower()));
+                errored.Should().BeTrue();
+                error.Should().NotBeNull();
+                error.Should().BeOfType<ApplicationException>();
+                error.Message.Should().Be("When specifying the subcommand '{0}', you must also specify --name.".FormatWith(configuration.PinCommand.Command.ToStringSafe().ToLower()));
             }
 
             [Fact]
@@ -336,9 +336,9 @@ namespace chocolatey.tests.infrastructure.app.commands
             public void Should_log_the_message_we_expect()
             {
                 var messages = MockLogger.MessagesFor(tests.LogLevel.Info);
-                messages.ShouldNotBeEmpty();
-                messages.Count.ShouldEqual(1);
-                messages[0].ShouldContain("Pin would have called");
+                messages.Should().NotBeEmpty();
+                messages.Count.Should().Be(1);
+                messages[0].Should().Contain("Pin would have called");
             }
         }
 
@@ -385,7 +385,7 @@ namespace chocolatey.tests.infrastructure.app.commands
             [Fact]
             public void Should_log_one_message()
             {
-                MockLogger.Messages.Count.ShouldEqual(1);
+                MockLogger.Messages.Count.Should().Be(1);
             }
         }
 

--- a/src/chocolatey.tests/infrastructure.app/commands/ChocolateyPinCommandSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/commands/ChocolateyPinCommandSpecs.cs
@@ -336,8 +336,8 @@ namespace chocolatey.tests.infrastructure.app.commands
             public void Should_log_the_message_we_expect()
             {
                 var messages = MockLogger.MessagesFor(tests.LogLevel.Info);
-                messages.Should().NotBeEmpty();
-                messages.Count.Should().Be(1);
+                messages.Should().NotBeEmpty()
+                    .And.ContainSingle();
                 messages[0].Should().Contain("Pin would have called");
             }
         }
@@ -385,7 +385,7 @@ namespace chocolatey.tests.infrastructure.app.commands
             [Fact]
             public void Should_log_one_message()
             {
-                MockLogger.Messages.Count.Should().Be(1);
+                MockLogger.Messages.Should().ContainSingle();
             }
         }
 

--- a/src/chocolatey.tests/infrastructure.app/commands/ChocolateyPushCommandSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/commands/ChocolateyPushCommandSpecs.cs
@@ -27,7 +27,7 @@ namespace chocolatey.tests.infrastructure.app.commands
     using chocolatey.infrastructure.commandline;
     using Moq;
     using NUnit.Framework;
-    using Should;
+    using FluentAssertions;
 
     public class ChocolateyPushCommandSpecs
     {
@@ -58,7 +58,7 @@ namespace chocolatey.tests.infrastructure.app.commands
             [Fact]
             public void Should_implement_push()
             {
-                _results.ShouldContain("push");
+                _results.Should().Contain("push");
             }
         }
 
@@ -81,37 +81,37 @@ namespace chocolatey.tests.infrastructure.app.commands
             [Fact]
             public void Should_clear_previously_set_Source()
             {
-                Configuration.Sources.ShouldBeNull();
+                Configuration.Sources.Should().BeNull();
             }
 
             [Fact]
             public void Should_add_source_to_the_option_set()
             {
-                _optionSet.Contains("source").ShouldBeTrue();
+                _optionSet.Contains("source").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_short_version_of_source_to_the_option_set()
             {
-                _optionSet.Contains("s").ShouldBeTrue();
+                _optionSet.Contains("s").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_apikey_to_the_option_set()
             {
-                _optionSet.Contains("apikey").ShouldBeTrue();
+                _optionSet.Contains("apikey").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_short_version_of_apikey_to_the_option_set()
             {
-                _optionSet.Contains("k").ShouldBeTrue();
+                _optionSet.Contains("k").Should().BeTrue();
             }
 
             [Fact]
             public void Should_not_add_short_version_of_timeout_to_the_option_set()
             {
-                _optionSet.Contains("t").ShouldBeFalse();
+                _optionSet.Contains("t").Should().BeFalse();
             }
         }
 
@@ -138,7 +138,7 @@ namespace chocolatey.tests.infrastructure.app.commands
                 string nupkgPath = "./some/path/to.nupkg";
                 _unparsedArgs.Add(nupkgPath);
                 _because();
-                Configuration.Input.ShouldEqual(nupkgPath);
+                Configuration.Input.Should().Be(nupkgPath);
             }
         }
 
@@ -160,7 +160,7 @@ namespace chocolatey.tests.infrastructure.app.commands
                 Configuration.PushCommand.DefaultSource = "https://localhost/default/source";
                 _because();
 
-                Configuration.Sources.ShouldEqual("https://localhost/somewhere/out/there");
+                Configuration.Sources.Should().Be("https://localhost/somewhere/out/there");
             }
 
 
@@ -174,7 +174,7 @@ namespace chocolatey.tests.infrastructure.app.commands
 
                 _because();
 
-                Configuration.Sources.ShouldEqual("https://localhost/default/source");
+                Configuration.Sources.Should().Be("https://localhost/default/source");
             }
 
             [Fact]
@@ -196,10 +196,10 @@ namespace chocolatey.tests.infrastructure.app.commands
                     error = ex;
                 }
 
-                errorred.ShouldBeTrue();
-                error.ShouldNotBeNull();
-                error.ShouldBeType<ApplicationException>();
-                error.Message.ShouldContain("Default push source configuration is not set.");
+                errorred.Should().BeTrue();
+                error.Should().NotBeNull();
+                error.Should().BeOfType<ApplicationException>();
+                error.Message.Should().Contain("Default push source configuration is not set.");
             }
 
             [Fact]
@@ -231,10 +231,10 @@ namespace chocolatey.tests.infrastructure.app.commands
                     error = ex;
                 }
 
-                errorred.ShouldBeTrue();
-                error.ShouldNotBeNull();
-                error.ShouldBeType<ApplicationException>();
-                error.Message.ShouldContain($"An API key was not found for '{Configuration.Sources}'");
+                errorred.Should().BeTrue();
+                error.Should().NotBeNull();
+                error.Should().BeOfType<ApplicationException>();
+                error.Message.Should().Contain($"An API key was not found for '{Configuration.Sources}'");
             }
 
             [Fact]
@@ -245,7 +245,7 @@ namespace chocolatey.tests.infrastructure.app.commands
                 Configuration.Sources = "https://localhost/somewhere/out/there";
                 _because();
 
-                Configuration.PushCommand.Key.ShouldEqual(_apiKey);
+                Configuration.PushCommand.Key.Should().Be(_apiKey);
                 ConfigSettingsService.Verify(c => c.GetApiKey(It.IsAny<ChocolateyConfiguration>(), It.IsAny<Action<ConfigFileApiKeySetting>>()), Times.Never);
             }
 
@@ -292,7 +292,7 @@ namespace chocolatey.tests.infrastructure.app.commands
                  };
                 _because();
 
-                Configuration.Sources.ShouldEqual("https://localhost/somewhere/out/there");
+                Configuration.Sources.Should().Be("https://localhost/somewhere/out/there");
             }
 
             [Fact]
@@ -311,7 +311,7 @@ namespace chocolatey.tests.infrastructure.app.commands
                 };
                 _because();
 
-                Configuration.Sources.ShouldEqual("https://localhost/somewhere/out/there");
+                Configuration.Sources.Should().Be("https://localhost/somewhere/out/there");
             }
 
             [Fact]
@@ -332,10 +332,10 @@ namespace chocolatey.tests.infrastructure.app.commands
                     error = ex;
                 }
 
-                errored.ShouldBeTrue();
-                error.ShouldNotBeNull();
-                error.ShouldBeType<ApplicationException>();
-                error.Message.ShouldContain("API key was not found");
+                errored.Should().BeTrue();
+                error.Should().NotBeNull();
+                error.Should().BeOfType<ApplicationException>();
+                error.Message.Should().Contain("API key was not found");
             }
 
             [Fact]
@@ -381,10 +381,10 @@ namespace chocolatey.tests.infrastructure.app.commands
                     error = ex;
                 }
 
-                errored.ShouldBeTrue();
-                error.ShouldNotBeNull();
-                error.ShouldBeType<ApplicationException>();
-                error.Message.ShouldContain("WARNING! The specified source '{0}' is not secure".FormatWith(Configuration.Sources));
+                errored.Should().BeTrue();
+                error.Should().NotBeNull();
+                error.Should().BeOfType<ApplicationException>();
+                error.Message.Should().Contain("WARNING! The specified source '{0}' is not secure".FormatWith(Configuration.Sources));
             }
 
             [Fact]

--- a/src/chocolatey.tests/infrastructure.app/commands/ChocolateySearchCommandSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/commands/ChocolateySearchCommandSpecs.cs
@@ -25,7 +25,7 @@ namespace chocolatey.tests.infrastructure.app.commands
     using chocolatey.infrastructure.app.services;
     using chocolatey.infrastructure.commandline;
     using Moq;
-    using Should;
+    using FluentAssertions;
 
     public class ChocolateySearchCommandSpecs
     {
@@ -55,19 +55,19 @@ namespace chocolatey.tests.infrastructure.app.commands
             [Fact]
             public void Should_not_implement_list()
             {
-                results.ShouldNotContain("list");
+                results.Should().NotContain("list");
             }
 
             [Fact]
             public void Should_implement_search()
             {
-                results.ShouldContain("search");
+                results.Should().Contain("search");
             }
 
             [Fact]
             public void Should_implement_find()
             {
-                results.ShouldContain("find");
+                results.Should().Contain("find");
             }
         }
 
@@ -90,73 +90,73 @@ namespace chocolatey.tests.infrastructure.app.commands
             [Fact]
             public void Should_add_source_to_the_option_set()
             {
-                optionSet.Contains("source").ShouldBeTrue();
+                optionSet.Contains("source").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_short_version_of_source_to_the_option_set()
             {
-                optionSet.Contains("s").ShouldBeTrue();
+                optionSet.Contains("s").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_prerelease_to_the_option_set()
             {
-                optionSet.Contains("prerelease").ShouldBeTrue();
+                optionSet.Contains("prerelease").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_short_version_of_prerelease_to_the_option_set()
             {
-                optionSet.Contains("pre").ShouldBeTrue();
+                optionSet.Contains("pre").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_includeprograms_to_the_option_set()
             {
-                optionSet.Contains("includeprograms").ShouldBeTrue();
+                optionSet.Contains("includeprograms").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_short_version_of_includeprograms_to_the_option_set()
             {
-                optionSet.Contains("i").ShouldBeTrue();
+                optionSet.Contains("i").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_allversions_to_the_option_set()
             {
-                optionSet.Contains("allversions").ShouldBeTrue();
+                optionSet.Contains("allversions").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_short_version_of_allversions_to_the_option_set()
             {
-                optionSet.Contains("a").ShouldBeTrue();
+                optionSet.Contains("a").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_user_to_the_option_set()
             {
-                optionSet.Contains("user").ShouldBeTrue();
+                optionSet.Contains("user").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_short_version_of_user_to_the_option_set()
             {
-                optionSet.Contains("u").ShouldBeTrue();
+                optionSet.Contains("u").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_password_to_the_option_set()
             {
-                optionSet.Contains("password").ShouldBeTrue();
+                optionSet.Contains("password").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_short_version_of_password_to_the_option_set()
             {
-                optionSet.Contains("p").ShouldBeTrue();
+                optionSet.Contains("p").Should().BeTrue();
             }
         }
 
@@ -185,73 +185,73 @@ namespace chocolatey.tests.infrastructure.app.commands
             [Fact]
             public void Should_add_source_to_the_option_set()
             {
-                optionSet.Contains("source").ShouldBeTrue();
+                optionSet.Contains("source").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_short_version_of_source_to_the_option_set()
             {
-                optionSet.Contains("s").ShouldBeTrue();
+                optionSet.Contains("s").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_prerelease_to_the_option_set()
             {
-                optionSet.Contains("prerelease").ShouldBeTrue();
+                optionSet.Contains("prerelease").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_short_version_of_prerelease_to_the_option_set()
             {
-                optionSet.Contains("pre").ShouldBeTrue();
+                optionSet.Contains("pre").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_includeprograms_to_the_option_set()
             {
-                optionSet.Contains("includeprograms").ShouldBeTrue();
+                optionSet.Contains("includeprograms").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_short_version_of_includeprograms_to_the_option_set()
             {
-                optionSet.Contains("i").ShouldBeTrue();
+                optionSet.Contains("i").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_allversions_to_the_option_set()
             {
-                optionSet.Contains("allversions").ShouldBeTrue();
+                optionSet.Contains("allversions").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_short_version_of_allversions_to_the_option_set()
             {
-                optionSet.Contains("a").ShouldBeTrue();
+                optionSet.Contains("a").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_user_to_the_option_set()
             {
-                optionSet.Contains("user").ShouldBeTrue();
+                optionSet.Contains("user").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_short_version_of_user_to_the_option_set()
             {
-                optionSet.Contains("u").ShouldBeTrue();
+                optionSet.Contains("u").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_password_to_the_option_set()
             {
-                optionSet.Contains("password").ShouldBeTrue();
+                optionSet.Contains("password").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_short_version_of_password_to_the_option_set()
             {
-                optionSet.Contains("p").ShouldBeTrue();
+                optionSet.Contains("p").Should().BeTrue();
             }
         }
 
@@ -278,7 +278,7 @@ namespace chocolatey.tests.infrastructure.app.commands
             public void Should_set_unparsed_arguments_to_configuration_input()
             {
                 because();
-                configuration.Input.ShouldEqual("pkg1 pkg2");
+                configuration.Input.Should().Be("pkg1 pkg2");
             }
 
             [Fact]
@@ -286,7 +286,7 @@ namespace chocolatey.tests.infrastructure.app.commands
             {
                 configuration.ListCommand.LocalOnly = false;
                 because();
-                configuration.Sources.ShouldEqual(source);
+                configuration.Sources.Should().Be(source);
             }
         }
 
@@ -326,7 +326,7 @@ namespace chocolatey.tests.infrastructure.app.commands
             [Fact]
             public void Should_not_report_any_warning_messages()
             {
-                MockLogger.Messages.Keys.ShouldNotContain("Warn");
+                MockLogger.Messages.Keys.Should().NotContain("Warn");
             }
         }
 
@@ -366,7 +366,7 @@ namespace chocolatey.tests.infrastructure.app.commands
             [Fact]
             public void Should_not_report_any_warning_messages()
             {
-                MockLogger.Messages.Keys.ShouldNotContain("Warn");
+                MockLogger.Messages.Keys.Should().NotContain("Warn");
             }
         }
 

--- a/src/chocolatey.tests/infrastructure.app/commands/ChocolateySourceCommandSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/commands/ChocolateySourceCommandSpecs.cs
@@ -26,7 +26,7 @@ namespace chocolatey.tests.infrastructure.app.commands
     using chocolatey.infrastructure.app.services;
     using chocolatey.infrastructure.commandline;
     using Moq;
-    using Should;
+    using FluentAssertions;
 
     public class ChocolateySourceCommandSpecs
     {
@@ -56,13 +56,13 @@ namespace chocolatey.tests.infrastructure.app.commands
             [Fact]
             public void Should_implement_source()
             {
-                results.ShouldContain("source");
+                results.Should().Contain("source");
             }
 
             [Fact]
             public void Should_implement_sources()
             {
-                results.ShouldContain("sources");
+                results.Should().Contain("sources");
             }
         }
 
@@ -85,55 +85,55 @@ namespace chocolatey.tests.infrastructure.app.commands
             [Fact]
             public void Should_clear_previously_set_Source()
             {
-                configuration.Sources.ShouldBeEmpty();
+                configuration.Sources.Should().BeEmpty();
             }
 
             [Fact]
             public void Should_add_name_to_the_option_set()
             {
-                optionSet.Contains("name").ShouldBeTrue();
+                optionSet.Contains("name").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_short_version_of_name_to_the_option_set()
             {
-                optionSet.Contains("n").ShouldBeTrue();
+                optionSet.Contains("n").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_source_to_the_option_set()
             {
-                optionSet.Contains("source").ShouldBeTrue();
+                optionSet.Contains("source").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_short_version_of_source_to_the_option_set()
             {
-                optionSet.Contains("s").ShouldBeTrue();
+                optionSet.Contains("s").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_user_to_the_option_set()
             {
-                optionSet.Contains("user").ShouldBeTrue();
+                optionSet.Contains("user").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_short_version_of_user_to_the_option_set()
             {
-                optionSet.Contains("u").ShouldBeTrue();
+                optionSet.Contains("u").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_password_to_the_option_set()
             {
-                optionSet.Contains("password").ShouldBeTrue();
+                optionSet.Contains("password").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_short_version_of_password_to_the_option_set()
             {
-                optionSet.Contains("p").ShouldBeTrue();
+                optionSet.Contains("p").Should().BeTrue();
             }
         }
 
@@ -160,7 +160,7 @@ namespace chocolatey.tests.infrastructure.app.commands
                 unparsedArgs.Add("list");
                 because();
 
-                configuration.SourceCommand.Command.ShouldEqual(SourceCommandType.List);
+                configuration.SourceCommand.Command.Should().Be(SourceCommandType.List);
             }
 
             [Fact]
@@ -182,10 +182,10 @@ namespace chocolatey.tests.infrastructure.app.commands
                     error = ex;
                 }
 
-                errored.ShouldBeTrue();
-                error.ShouldNotBeNull();
-                error.ShouldBeType<ApplicationException>();
-                error.Message.ShouldContain("A single sources command must be listed");
+                errored.Should().BeTrue();
+                error.Should().NotBeNull();
+                error.Should().BeOfType<ApplicationException>();
+                error.Message.Should().Contain("A single sources command must be listed");
             }
 
             [Fact]
@@ -195,7 +195,7 @@ namespace chocolatey.tests.infrastructure.app.commands
                 unparsedArgs.Add("add");
                 because();
 
-                configuration.SourceCommand.Command.ShouldEqual(SourceCommandType.Add);
+                configuration.SourceCommand.Command.Should().Be(SourceCommandType.Add);
             }
 
             [Fact]
@@ -205,7 +205,7 @@ namespace chocolatey.tests.infrastructure.app.commands
                 unparsedArgs.Add("ADD");
                 because();
 
-                configuration.SourceCommand.Command.ShouldEqual(SourceCommandType.Add);
+                configuration.SourceCommand.Command.Should().Be(SourceCommandType.Add);
             }
 
             [Fact]
@@ -215,7 +215,7 @@ namespace chocolatey.tests.infrastructure.app.commands
                 unparsedArgs.Add("remove");
                 because();
 
-                configuration.SourceCommand.Command.ShouldEqual(SourceCommandType.Remove);
+                configuration.SourceCommand.Command.Should().Be(SourceCommandType.Remove);
             }
 
             [Fact]
@@ -225,7 +225,7 @@ namespace chocolatey.tests.infrastructure.app.commands
                 unparsedArgs.Add("enable");
                 because();
 
-                configuration.SourceCommand.Command.ShouldEqual(SourceCommandType.Enable);
+                configuration.SourceCommand.Command.Should().Be(SourceCommandType.Enable);
             }
 
             [Fact]
@@ -235,7 +235,7 @@ namespace chocolatey.tests.infrastructure.app.commands
                 unparsedArgs.Add("disable");
                 because();
 
-                configuration.SourceCommand.Command.ShouldEqual(SourceCommandType.Disable);
+                configuration.SourceCommand.Command.Should().Be(SourceCommandType.Disable);
             }
 
             [Fact]
@@ -245,7 +245,7 @@ namespace chocolatey.tests.infrastructure.app.commands
                 unparsedArgs.Add("wtf");
                 because();
 
-                configuration.SourceCommand.Command.ShouldEqual(SourceCommandType.List);
+                configuration.SourceCommand.Command.Should().Be(SourceCommandType.List);
             }
 
             [Fact]
@@ -254,7 +254,7 @@ namespace chocolatey.tests.infrastructure.app.commands
                 Reset();
                 because();
 
-                configuration.SourceCommand.Command.ShouldEqual(SourceCommandType.List);
+                configuration.SourceCommand.Command.Should().Be(SourceCommandType.List);
             }
 
             [Fact]
@@ -264,7 +264,7 @@ namespace chocolatey.tests.infrastructure.app.commands
                 unparsedArgs.Add(" ");
                 because();
 
-                configuration.SourceCommand.Command.ShouldEqual(SourceCommandType.List);
+                configuration.SourceCommand.Command.Should().Be(SourceCommandType.List);
             }
         }
 
@@ -311,11 +311,11 @@ namespace chocolatey.tests.infrastructure.app.commands
                     error = ex;
                 }
 
-                errored.ShouldBeTrue();
-                error.ShouldNotBeNull();
-                error.ShouldBeType<ApplicationException>();
+                errored.Should().BeTrue();
+                error.Should().NotBeNull();
+                error.Should().BeOfType<ApplicationException>();
                 var commandName = configuration.SourceCommand.Command.ToStringSafe().ToLower();
-                error.Message.ShouldEqual(expectedMessage.FormatWith(commandName));
+                error.Message.Should().Be(expectedMessage.FormatWith(commandName));
             }
 
             [Fact]

--- a/src/chocolatey.tests/infrastructure.app/commands/ChocolateyTemplateCommandSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/commands/ChocolateyTemplateCommandSpecs.cs
@@ -27,7 +27,7 @@ namespace chocolatey.tests.infrastructure.app.commands
     using chocolatey.infrastructure.commandline;
     using chocolatey.infrastructure.filesystem;
     using Moq;
-    using Should;
+    using FluentAssertions;
 
     public class ChocolateyTemplateCommandSpecs
     {
@@ -61,8 +61,8 @@ namespace chocolatey.tests.infrastructure.app.commands
             [Fact]
             public void Should_implement_help()
             {
-                results.ShouldContain("template");
-                results.ShouldContain("templates");
+                results.Should().Contain("template");
+                results.Should().Contain("templates");
             }
         }
 
@@ -84,13 +84,13 @@ namespace chocolatey.tests.infrastructure.app.commands
             [Fact]
             public void Should_add_name_to_the_option_set()
             {
-                optionSet.Contains("name").ShouldBeTrue();
+                optionSet.Contains("name").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_short_version_of_name_to_the_option_set()
             {
-                optionSet.Contains("n").ShouldBeTrue();
+                optionSet.Contains("n").Should().BeTrue();
             }
         }
 
@@ -120,7 +120,7 @@ namespace chocolatey.tests.infrastructure.app.commands
                 unparsedArgs.Add("list");
                 because();
 
-                configuration.TemplateCommand.Command.ShouldEqual(TemplateCommandType.List);
+                configuration.TemplateCommand.Command.Should().Be(TemplateCommandType.List);
             }
 
             [Fact]
@@ -142,10 +142,10 @@ namespace chocolatey.tests.infrastructure.app.commands
                     error = ex;
                 }
 
-                errorred.ShouldBeTrue();
-                error.ShouldNotBeNull();
-                error.ShouldBeType<ApplicationException>();
-                error.Message.ShouldContain("A single template command must be listed");
+                errorred.Should().BeTrue();
+                error.Should().NotBeNull();
+                error.Should().BeOfType<ApplicationException>();
+                error.Message.Should().Contain("A single template command must be listed");
             }
 
             [Fact]
@@ -155,7 +155,7 @@ namespace chocolatey.tests.infrastructure.app.commands
                 unparsedArgs.Add("list");
                 because();
 
-                configuration.TemplateCommand.Command.ShouldEqual(TemplateCommandType.List);
+                configuration.TemplateCommand.Command.Should().Be(TemplateCommandType.List);
             }
 
             [Fact]
@@ -165,7 +165,7 @@ namespace chocolatey.tests.infrastructure.app.commands
                 unparsedArgs.Add("LIST");
                 because();
 
-                configuration.TemplateCommand.Command.ShouldEqual(TemplateCommandType.List);
+                configuration.TemplateCommand.Command.Should().Be(TemplateCommandType.List);
             }
 
             [Fact]
@@ -175,7 +175,7 @@ namespace chocolatey.tests.infrastructure.app.commands
                 unparsedArgs.Add("info");
                 because();
 
-                configuration.TemplateCommand.Command.ShouldEqual(TemplateCommandType.Info);
+                configuration.TemplateCommand.Command.Should().Be(TemplateCommandType.Info);
             }
 
             [Fact]
@@ -185,7 +185,7 @@ namespace chocolatey.tests.infrastructure.app.commands
                 unparsedArgs.Add("INFO");
                 because();
 
-                configuration.TemplateCommand.Command.ShouldEqual(TemplateCommandType.Info);
+                configuration.TemplateCommand.Command.Should().Be(TemplateCommandType.Info);
             }
 
             [Fact]
@@ -195,7 +195,7 @@ namespace chocolatey.tests.infrastructure.app.commands
                 unparsedArgs.Add("badcommand");
                 because();
 
-                configuration.TemplateCommand.Command.ShouldEqual(TemplateCommandType.List);
+                configuration.TemplateCommand.Command.Should().Be(TemplateCommandType.List);
             }
 
             [Fact]
@@ -204,7 +204,7 @@ namespace chocolatey.tests.infrastructure.app.commands
                 Reset();
                 because();
 
-                configuration.TemplateCommand.Command.ShouldEqual(TemplateCommandType.List);
+                configuration.TemplateCommand.Command.Should().Be(TemplateCommandType.List);
             }
 
             [Fact]
@@ -214,7 +214,7 @@ namespace chocolatey.tests.infrastructure.app.commands
                 unparsedArgs.Add(" ");
                 because();
 
-                configuration.TemplateCommand.Command.ShouldEqual(TemplateCommandType.List);
+                configuration.TemplateCommand.Command.Should().Be(TemplateCommandType.List);
             }
         }
 
@@ -261,10 +261,10 @@ namespace chocolatey.tests.infrastructure.app.commands
                     error = ex;
                 }
 
-                errorred.ShouldBeTrue();
-                error.ShouldNotBeNull();
-                error.ShouldBeType<ApplicationException>();
-                error.Message.ShouldEqual("When specifying the subcommand '{0}', you must also specify --name.".FormatWith(configuration.TemplateCommand.Command.ToStringSafe().ToLower()));
+                errorred.Should().BeTrue();
+                error.Should().NotBeNull();
+                error.Should().BeOfType<ApplicationException>();
+                error.Message.Should().Be("When specifying the subcommand '{0}', you must also specify --name.".FormatWith(configuration.TemplateCommand.Command.ToStringSafe().ToLower()));
             }
 
             [Fact]

--- a/src/chocolatey.tests/infrastructure.app/commands/ChocolateyUninstallCommandSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/commands/ChocolateyUninstallCommandSpecs.cs
@@ -26,7 +26,7 @@ namespace chocolatey.tests.infrastructure.app.commands
     using chocolatey.infrastructure.app.services;
     using chocolatey.infrastructure.commandline;
     using Moq;
-    using Should;
+    using FluentAssertions;
 
     public class ChocolateyUninstallCommandSpecs
     {
@@ -56,7 +56,7 @@ namespace chocolatey.tests.infrastructure.app.commands
             [Fact]
             public void Should_implement_uninstall()
             {
-                results.ShouldContain("uninstall");
+                results.Should().Contain("uninstall");
             }
         }
 
@@ -78,109 +78,109 @@ namespace chocolatey.tests.infrastructure.app.commands
             [Fact]
             public void Should_add_version_to_the_option_set()
             {
-                optionSet.Contains("version").ShouldBeTrue();
+                optionSet.Contains("version").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_allversions_to_the_option_set()
             {
-                optionSet.Contains("allversions").ShouldBeTrue();
+                optionSet.Contains("allversions").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_short_version_of_allversions_to_the_option_set()
             {
-                optionSet.Contains("a").ShouldBeTrue();
+                optionSet.Contains("a").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_uninstallargs_to_the_option_set()
             {
-                optionSet.Contains("uninstallarguments").ShouldBeTrue();
+                optionSet.Contains("uninstallarguments").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_short_version_of_uninstallargs_to_the_option_set()
             {
-                optionSet.Contains("ua").ShouldBeTrue();
+                optionSet.Contains("ua").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_overrideargs_to_the_option_set()
             {
-                optionSet.Contains("overridearguments").ShouldBeTrue();
+                optionSet.Contains("overridearguments").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_short_version_of_overrideargs_to_the_option_set()
             {
-                optionSet.Contains("o").ShouldBeTrue();
+                optionSet.Contains("o").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_notsilent_to_the_option_set()
             {
-                optionSet.Contains("notsilent").ShouldBeTrue();
+                optionSet.Contains("notsilent").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_packageparameters_to_the_option_set()
             {
-                optionSet.Contains("packageparameters").ShouldBeTrue();
+                optionSet.Contains("packageparameters").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_short_version_of_packageparameters_to_the_option_set()
             {
-                optionSet.Contains("params").ShouldBeTrue();
+                optionSet.Contains("params").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_applyPackageParametersToDependencies_to_the_option_set()
             {
-                optionSet.Contains("apply-package-parameters-to-dependencies").ShouldBeTrue();
+                optionSet.Contains("apply-package-parameters-to-dependencies").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_applyInstallArgumentsToDependencies_to_the_option_set()
             {
-                optionSet.Contains("apply-install-arguments-to-dependencies").ShouldBeTrue();
+                optionSet.Contains("apply-install-arguments-to-dependencies").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_forcedependencies_to_the_option_set()
             {
-                optionSet.Contains("forcedependencies").ShouldBeTrue();
+                optionSet.Contains("forcedependencies").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_short_version_of_forcedependencies_to_the_option_set()
             {
-                optionSet.Contains("x").ShouldBeTrue();
+                optionSet.Contains("x").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_skippowershell_to_the_option_set()
             {
-                optionSet.Contains("skippowershell").ShouldBeTrue();
+                optionSet.Contains("skippowershell").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_short_version_of_skippowershell_to_the_option_set()
             {
-                optionSet.Contains("n").ShouldBeTrue();
+                optionSet.Contains("n").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_skip_hooks_to_the_option_set()
             {
-                optionSet.Contains("skip-hooks").ShouldBeTrue();
+                optionSet.Contains("skip-hooks").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_short_version_of_skip_hooks_to_the_option_set()
             {
-                optionSet.Contains("skiphooks").ShouldBeTrue();
+                optionSet.Contains("skiphooks").Should().BeTrue();
             }
         }
 
@@ -203,7 +203,7 @@ namespace chocolatey.tests.infrastructure.app.commands
             [Fact]
             public void Should_set_unparsed_arguments_to_the_package_names()
             {
-                configuration.PackageNames.ShouldEqual("pkg1;pkg2");
+                configuration.PackageNames.Should().Be("pkg1;pkg2");
             }
         }
 
@@ -230,9 +230,9 @@ namespace chocolatey.tests.infrastructure.app.commands
                     error = ex;
                 }
 
-                errored.ShouldBeTrue();
-                error.ShouldNotBeNull();
-                error.ShouldBeType<ApplicationException>();
+                errored.Should().BeTrue();
+                error.Should().NotBeNull();
+                error.Should().BeOfType<ApplicationException>();
             }
 
             [Fact]

--- a/src/chocolatey.tests/infrastructure.app/commands/ChocolateyUnpackSelfCommandSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/commands/ChocolateyUnpackSelfCommandSpecs.cs
@@ -25,7 +25,7 @@ namespace chocolatey.tests.infrastructure.app.commands
     using chocolatey.infrastructure.app.configuration;
     using chocolatey.infrastructure.filesystem;
     using Moq;
-    using Should;
+    using FluentAssertions;
 
     public class ChocolateyUnpackSelfCommandSpecs
     {
@@ -56,7 +56,7 @@ namespace chocolatey.tests.infrastructure.app.commands
             [Fact]
             public void Should_implement_unpackself()
             {
-                results.ShouldContain("unpackself");
+                results.Should().Contain("unpackself");
             }
         }
 
@@ -76,13 +76,13 @@ namespace chocolatey.tests.infrastructure.app.commands
             [Fact]
             public void Should_log_one_message()
             {
-                MockLogger.Messages.Count.ShouldEqual(1);
+                MockLogger.Messages.Count.Should().Be(1);
             }
 
             [Fact]
             public void Should_log_a_message_about_what_it_would_have_done()
             {
-                MockLogger.MessagesFor(LogLevel.Info).FirstOrDefault().ShouldContain("This would have unpacked");
+                MockLogger.MessagesFor(LogLevel.Info).FirstOrDefault().Should().Contain("This would have unpacked");
             }
         }
 

--- a/src/chocolatey.tests/infrastructure.app/commands/ChocolateyUnpackSelfCommandSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/commands/ChocolateyUnpackSelfCommandSpecs.cs
@@ -76,7 +76,7 @@ namespace chocolatey.tests.infrastructure.app.commands
             [Fact]
             public void Should_log_one_message()
             {
-                MockLogger.Messages.Count.Should().Be(1);
+                MockLogger.Messages.Should().HaveCount(1);
             }
 
             [Fact]

--- a/src/chocolatey.tests/infrastructure.app/commands/ChocolateyUpgradeCommandSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/commands/ChocolateyUpgradeCommandSpecs.cs
@@ -26,7 +26,7 @@ namespace chocolatey.tests.infrastructure.app.commands
     using chocolatey.infrastructure.app.services;
     using chocolatey.infrastructure.commandline;
     using Moq;
-    using Should;
+    using FluentAssertions;
 
     public class ChocolateyUpgradeCommandSpecs
     {
@@ -56,7 +56,7 @@ namespace chocolatey.tests.infrastructure.app.commands
             [Fact]
             public void Should_implement_upgrade()
             {
-                results.ShouldContain("upgrade");
+                results.Should().Contain("upgrade");
             }
         }
 
@@ -78,163 +78,163 @@ namespace chocolatey.tests.infrastructure.app.commands
             [Fact]
             public void Should_add_source_to_the_option_set()
             {
-                optionSet.Contains("source").ShouldBeTrue();
+                optionSet.Contains("source").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_short_version_of_source_to_the_option_set()
             {
-                optionSet.Contains("s").ShouldBeTrue();
+                optionSet.Contains("s").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_version_to_the_option_set()
             {
-                optionSet.Contains("version").ShouldBeTrue();
+                optionSet.Contains("version").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_prerelease_to_the_option_set()
             {
-                optionSet.Contains("prerelease").ShouldBeTrue();
+                optionSet.Contains("prerelease").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_short_version_of_prerelease_to_the_option_set()
             {
-                optionSet.Contains("pre").ShouldBeTrue();
+                optionSet.Contains("pre").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_installargs_to_the_option_set()
             {
-                optionSet.Contains("installarguments").ShouldBeTrue();
+                optionSet.Contains("installarguments").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_short_version_of_installargs_to_the_option_set()
             {
-                optionSet.Contains("ia").ShouldBeTrue();
+                optionSet.Contains("ia").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_overrideargs_to_the_option_set()
             {
-                optionSet.Contains("overridearguments").ShouldBeTrue();
+                optionSet.Contains("overridearguments").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_short_version_of_overrideargs_to_the_option_set()
             {
-                optionSet.Contains("o").ShouldBeTrue();
+                optionSet.Contains("o").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_notsilent_to_the_option_set()
             {
-                optionSet.Contains("notsilent").ShouldBeTrue();
+                optionSet.Contains("notsilent").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_packageparameters_to_the_option_set()
             {
-                optionSet.Contains("packageparameters").ShouldBeTrue();
+                optionSet.Contains("packageparameters").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_short_version_of_packageparameters_to_the_option_set()
             {
-                optionSet.Contains("params").ShouldBeTrue();
+                optionSet.Contains("params").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_applyPackageParametersToDependencies_to_the_option_set()
             {
-                optionSet.Contains("apply-package-parameters-to-dependencies").ShouldBeTrue();
+                optionSet.Contains("apply-package-parameters-to-dependencies").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_applyInstallArgumentsToDependencies_to_the_option_set()
             {
-                optionSet.Contains("apply-install-arguments-to-dependencies").ShouldBeTrue();
+                optionSet.Contains("apply-install-arguments-to-dependencies").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_ignoredependencies_to_the_option_set()
             {
-                optionSet.Contains("ignoredependencies").ShouldBeTrue();
+                optionSet.Contains("ignoredependencies").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_short_version_of_ignoredependencies_to_the_option_set()
             {
-                optionSet.Contains("i").ShouldBeTrue();
+                optionSet.Contains("i").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_skippowershell_to_the_option_set()
             {
-                optionSet.Contains("skippowershell").ShouldBeTrue();
+                optionSet.Contains("skippowershell").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_short_version_of_skippowershell_to_the_option_set()
             {
-                optionSet.Contains("n").ShouldBeTrue();
+                optionSet.Contains("n").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_user_to_the_option_set()
             {
-                optionSet.Contains("user").ShouldBeTrue();
+                optionSet.Contains("user").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_short_version_of_user_to_the_option_set()
             {
-                optionSet.Contains("u").ShouldBeTrue();
+                optionSet.Contains("u").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_password_to_the_option_set()
             {
-                optionSet.Contains("password").ShouldBeTrue();
+                optionSet.Contains("password").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_short_version_of_password_to_the_option_set()
             {
-                optionSet.Contains("p").ShouldBeTrue();
+                optionSet.Contains("p").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_pin_to_the_option_set()
             {
-                optionSet.Contains("pinpackage").ShouldBeTrue();
+                optionSet.Contains("pinpackage").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_long_version_of_pin_to_the_option_set()
             {
-                optionSet.Contains("pin-package").ShouldBeTrue();
+                optionSet.Contains("pin-package").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_short_version_of_pin_to_the_option_set()
             {
-                optionSet.Contains("pin").ShouldBeTrue();
+                optionSet.Contains("pin").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_skip_hooks_to_the_option_set()
             {
-                optionSet.Contains("skip-hooks").ShouldBeTrue();
+                optionSet.Contains("skip-hooks").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_short_version_of_skip_hooks_to_the_option_set()
             {
-                optionSet.Contains("skiphooks").ShouldBeTrue();
+                optionSet.Contains("skiphooks").Should().BeTrue();
             }
         }
 
@@ -257,7 +257,7 @@ namespace chocolatey.tests.infrastructure.app.commands
             [Fact]
             public void Should_set_unparsed_arguments_to_the_package_names()
             {
-                configuration.PackageNames.ShouldEqual("pkg1;pkg2");
+                configuration.PackageNames.Should().Be("pkg1;pkg2");
             }
         }
 
@@ -284,9 +284,9 @@ namespace chocolatey.tests.infrastructure.app.commands
                     error = ex;
                 }
 
-                errored.ShouldBeTrue();
-                error.ShouldNotBeNull();
-                error.ShouldBeType<ApplicationException>();
+                errored.Should().BeTrue();
+                error.Should().NotBeNull();
+                error.Should().BeOfType<ApplicationException>();
             }
 
             [Fact]

--- a/src/chocolatey.tests/infrastructure.app/configuration/ConfigurationOptionsSpec.cs
+++ b/src/chocolatey.tests/infrastructure.app/configuration/ConfigurationOptionsSpec.cs
@@ -25,7 +25,7 @@ namespace chocolatey.tests.infrastructure.app.configuration
     using chocolatey.infrastructure.app.configuration;
     using chocolatey.infrastructure.commandline;
     using Moq;
-    using Should;
+    using FluentAssertions;
 
     public class ConfigurationOptionsSpec
     {
@@ -78,9 +78,9 @@ namespace chocolatey.tests.infrastructure.app.configuration
             {
                 setOptions = set =>
                 {
-                    set.Contains("h").ShouldBeTrue();
-                    set.Contains("help").ShouldBeTrue();
-                    set.Contains("?").ShouldBeTrue();
+                    set.Contains("h").Should().BeTrue();
+                    set.Contains("help").Should().BeTrue();
+                    set.Contains("?").Should().BeTrue();
                 };
                 because();
             }
@@ -88,7 +88,7 @@ namespace chocolatey.tests.infrastructure.app.configuration
             [Fact]
             public void Should_not_have_set_other_options_by_default()
             {
-                setOptions = set => { set.Contains("dude").ShouldBeFalse(); };
+                setOptions = set => { set.Contains("dude").Should().BeFalse(); };
                 because();
             }
 
@@ -99,8 +99,8 @@ namespace chocolatey.tests.infrastructure.app.configuration
 
                 because();
 
-                config.HelpRequested.ShouldBeTrue();
-                config.ShowOnlineHelp.ShouldBeFalse();
+                config.HelpRequested.Should().BeTrue();
+                config.ShowOnlineHelp.Should().BeFalse();
             }
 
             [Fact]
@@ -111,8 +111,8 @@ namespace chocolatey.tests.infrastructure.app.configuration
 
                 because();
 
-                config.HelpRequested.ShouldBeTrue();
-                config.ShowOnlineHelp.ShouldBeTrue();
+                config.HelpRequested.Should().BeTrue();
+                config.ShowOnlineHelp.Should().BeTrue();
             }
 
             [Fact]
@@ -122,14 +122,14 @@ namespace chocolatey.tests.infrastructure.app.configuration
 
                 because();
 
-                helpMessageContents.ToString().ShouldNotBeEmpty();
+                helpMessageContents.ToString().Should().NotBeEmpty();
             }
 
             [Fact]
             public void Should_not_run_validate_configuration_when_help_is_requested()
             {
                 args.Add("-h");
-                validateConfiguration = () => { "should".ShouldEqual("not be reached"); };
+                validateConfiguration = () => { "should".Should().Be("not be reached"); };
 
                 because();
             }
@@ -142,7 +142,7 @@ namespace chocolatey.tests.infrastructure.app.configuration
 
                 because();
 
-                wasCalled.ShouldBeTrue();
+                wasCalled.Should().BeTrue();
             }
 
             [Fact]
@@ -152,12 +152,12 @@ namespace chocolatey.tests.infrastructure.app.configuration
                 afterParse = list =>
                 {
                     wasCalled = true;
-                    list.ShouldBeEmpty();
+                    list.Should().BeEmpty();
                 };
 
                 because();
 
-                wasCalled.ShouldBeTrue();
+                wasCalled.Should().BeTrue();
             }
 
             [Fact]
@@ -168,12 +168,12 @@ namespace chocolatey.tests.infrastructure.app.configuration
                 afterParse = list =>
                 {
                     wasCalled = true;
-                    list.ShouldBeEmpty();
+                    list.Should().BeEmpty();
                 };
 
                 because();
 
-                wasCalled.ShouldBeTrue();
+                wasCalled.Should().BeTrue();
             }
 
             [Fact]
@@ -184,12 +184,12 @@ namespace chocolatey.tests.infrastructure.app.configuration
                 afterParse = list =>
                 {
                     wasCalled = true;
-                    list.ShouldContain(args.First());
+                    list.Should().Contain(args.First());
                 };
 
                 because();
 
-                wasCalled.ShouldBeTrue();
+                wasCalled.Should().BeTrue();
             }
 
             [Fact]
@@ -200,13 +200,13 @@ namespace chocolatey.tests.infrastructure.app.configuration
                 afterParse = list =>
                 {
                     wasCalled = true;
-                    list.ShouldContain(args.First());
+                    list.Should().Contain(args.First());
                 };
 
                 because();
 
-                config.CommandName.ShouldEqual("dude");
-                wasCalled.ShouldBeTrue();
+                config.CommandName.Should().Be("dude");
+                wasCalled.Should().BeTrue();
             }
 
             [Fact]
@@ -217,14 +217,14 @@ namespace chocolatey.tests.infrastructure.app.configuration
                 afterParse = list =>
                 {
                     wasCalled = true;
-                    list.ShouldContain(args.First());
+                    list.Should().Contain(args.First());
                 };
 
                 because();
 
-                config.CommandName.ShouldNotEqual("dude");
-                config.HelpRequested.ShouldBeTrue();
-                wasCalled.ShouldBeTrue();
+                config.CommandName.Should().NotBe("dude");
+                config.HelpRequested.Should().BeTrue();
+                wasCalled.Should().BeTrue();
             }
 
             [Fact]
@@ -233,7 +233,7 @@ namespace chocolatey.tests.infrastructure.app.configuration
                 setOptions = set => { set.Add("bob", "sets the bob switch", option => config.Verbose = option != null); };
                 because();
 
-                config.Verbose.ShouldBeFalse();
+                config.Verbose.Should().BeFalse();
             }
 
             [Fact]
@@ -244,7 +244,7 @@ namespace chocolatey.tests.infrastructure.app.configuration
 
                 because();
 
-                config.Verbose.ShouldBeTrue();
+                config.Verbose.Should().BeTrue();
             }
 
             [Fact]
@@ -254,7 +254,7 @@ namespace chocolatey.tests.infrastructure.app.configuration
                 args.Add("--tina");
                 because();
 
-                config.Verbose.ShouldBeTrue();
+                config.Verbose.Should().BeTrue();
             }
 
             [Fact]
@@ -265,7 +265,7 @@ namespace chocolatey.tests.infrastructure.app.configuration
 
                 because();
 
-                config.Verbose.ShouldBeTrue();
+                config.Verbose.Should().BeTrue();
             }
 
             [Fact]
@@ -282,9 +282,9 @@ namespace chocolatey.tests.infrastructure.app.configuration
 
                 because();
 
-                config.SkipPackageInstallProvider.ShouldBeTrue();
-                config.Debug.ShouldBeTrue();
-                config.Verbose.ShouldBeTrue();
+                config.SkipPackageInstallProvider.Should().BeTrue();
+                config.Debug.Should().BeTrue();
+                config.Verbose.Should().BeTrue();
             }
 
             [Fact]
@@ -301,10 +301,10 @@ namespace chocolatey.tests.infrastructure.app.configuration
 
                 because();
 
-                config.SkipPackageInstallProvider.ShouldBeTrue();
-                config.Debug.ShouldBeTrue();
-                config.ListCommand.LocalOnly.ShouldBeTrue();
-                helpMessageContents.ToString().ShouldBeEmpty();
+                config.SkipPackageInstallProvider.Should().BeTrue();
+                config.Debug.Should().BeTrue();
+                config.ListCommand.LocalOnly.Should().BeTrue();
+                helpMessageContents.ToString().Should().BeEmpty();
             }
 
             [Fact]
@@ -315,8 +315,8 @@ namespace chocolatey.tests.infrastructure.app.configuration
 
                 because();
 
-                config.Debug.ShouldBeFalse();
-                helpMessageContents.ToString().ShouldNotBeEmpty();
+                config.Debug.Should().BeFalse();
+                helpMessageContents.ToString().Should().NotBeEmpty();
             }
 
             [Fact]
@@ -326,7 +326,7 @@ namespace chocolatey.tests.infrastructure.app.configuration
 
                 because();
 
-                config.UnsuccessfulParsing.ShouldBeFalse();
+                config.UnsuccessfulParsing.Should().BeFalse();
             }
 
             [Fact]
@@ -336,7 +336,7 @@ namespace chocolatey.tests.infrastructure.app.configuration
 
                 because();
 
-                config.UnsuccessfulParsing.ShouldBeTrue();
+                config.UnsuccessfulParsing.Should().BeTrue();
             }
         }
     }

--- a/src/chocolatey.tests/infrastructure.app/nuget/ChocolateyNuGetProjectContextSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/nuget/ChocolateyNuGetProjectContextSpecs.cs
@@ -21,7 +21,7 @@ namespace chocolatey.tests.infrastructure.app.nuget
     using NuGet.Common;
     using NuGet.ProjectManagement;
     using NUnit.Framework;
-    using Should;
+    using FluentAssertions;
 
     public class ChocolateyNuGetProjectContextSpecs
     {
@@ -139,7 +139,7 @@ namespace chocolatey.tests.infrastructure.app.nuget
 
                 var result = Service.ResolveFileConflict(message);
 
-                result.ShouldEqual(FileConflictAction.OverwriteAll);
+                result.Should().Be(FileConflictAction.OverwriteAll);
 
                 Logger.Verify(l => l.LogWarning("File conflict, overwriting all: Some kind of message"), Times.Once);
 

--- a/src/chocolatey.tests/infrastructure.app/nuget/ChocolateyNugetLoggerSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/nuget/ChocolateyNugetLoggerSpecs.cs
@@ -56,7 +56,7 @@ namespace chocolatey.tests.infrastructure.app.nuget
                 _logger.LogDebug(testMessage);
 
                 var loggerName = LogLevel.Debug.ToStringSafe();
-                MockLogger.LoggerNames.Count.Should().Be(1);
+                MockLogger.LoggerNames.Should().ContainSingle();
                 MockLogger.LoggerNames.Should().Contain(typeof(ChocolateyNugetLogger).FullName);
                 MockLogger.Messages.Keys.Should().Contain(loggerName);
                 MockLogger.Messages[loggerName].Should().Contain(expectedMessage);
@@ -71,7 +71,7 @@ namespace chocolatey.tests.infrastructure.app.nuget
                 _logger.LogDebug(testMessage);
 
                 var loggerName = LogLevel.Debug.ToStringSafe();
-                MockLogger.LoggerNames.Count.Should().Be(1);
+                MockLogger.LoggerNames.Should().ContainSingle();
                 MockLogger.LoggerNames.Should().Contain(typeof(ChocolateyNugetLogger).FullName);
                 MockLogger.Messages.Keys.Should().Contain(loggerName);
                 MockLogger.Messages[loggerName].Should().Contain(expectedMessage);
@@ -86,7 +86,7 @@ namespace chocolatey.tests.infrastructure.app.nuget
                 _logger.LogError(testMessage);
 
                 var loggerName = LogLevel.Error.ToStringSafe();
-                MockLogger.LoggerNames.Count.Should().Be(1);
+                MockLogger.LoggerNames.Should().ContainSingle();
                 MockLogger.LoggerNames.Should().Contain(typeof(ChocolateyNugetLogger).FullName);
                 MockLogger.Messages.Keys.Should().Contain(loggerName);
                 MockLogger.Messages[loggerName].Should().Contain(expectedMessage);
@@ -101,7 +101,7 @@ namespace chocolatey.tests.infrastructure.app.nuget
                 _logger.LogError(testMessage);
 
                 var loggerName = LogLevel.Error.ToStringSafe();
-                MockLogger.LoggerNames.Count.Should().Be(1);
+                MockLogger.LoggerNames.Should().ContainSingle();
                 MockLogger.LoggerNames.Should().Contain(typeof(ChocolateyNugetLogger).FullName);
                 MockLogger.Messages.Keys.Should().Contain(loggerName);
                 MockLogger.Messages[loggerName].Should().Contain(expectedMessage);
@@ -114,7 +114,7 @@ namespace chocolatey.tests.infrastructure.app.nuget
             public void Should_log_expected_log_level_when_calling_Log_with_log_message(NuGetLogLevel nugetLogLevel, LogLevel logLevel, string testMessage, string expectedMessage)
             {
                 _logger.Log(new LogMessage(nugetLogLevel, testMessage));
-                MockLogger.LoggerNames.Count.Should().Be(1);
+                MockLogger.LoggerNames.Should().ContainSingle();
                 MockLogger.LoggerNames.Should().Contain(typeof(ChocolateyNugetLogger).FullName);
                 MockLogger.Messages.Keys.Should().Contain(logLevel.ToStringSafe());
                 MockLogger.Messages[logLevel.ToStringSafe()].Should().Contain(expectedMessage);
@@ -127,7 +127,7 @@ namespace chocolatey.tests.infrastructure.app.nuget
             public void Should_log_expected_log_level_when_calling_Log_with_nuget_log_level(NuGetLogLevel nugetLogLevel, LogLevel logLevel, string testMessage, string expectedMessage)
             {
                 _logger.Log(nugetLogLevel, testMessage);
-                MockLogger.LoggerNames.Count.Should().Be(1);
+                MockLogger.LoggerNames.Should().ContainSingle();
                 MockLogger.LoggerNames.Should().Contain(typeof(ChocolateyNugetLogger).FullName);
                 MockLogger.Messages.Keys.Should().Contain(logLevel.ToStringSafe());
                 MockLogger.Messages[logLevel.ToStringSafe()].Should().Contain(expectedMessage);
@@ -140,7 +140,7 @@ namespace chocolatey.tests.infrastructure.app.nuget
             public async Task Should_log_expected_log_level_when_calling_LogAsync_with_nuget_log_level(NuGetLogLevel nugetLogLevel, LogLevel logLevel, string testMessage, string expectedMessage)
             {
                 await _logger.LogAsync(nugetLogLevel, testMessage);
-                MockLogger.LoggerNames.Count.Should().Be(1);
+                MockLogger.LoggerNames.Should().ContainSingle();
                 MockLogger.LoggerNames.Should().Contain(typeof(ChocolateyNugetLogger).FullName);
                 MockLogger.Messages.Keys.Should().Contain(logLevel.ToStringSafe());
                 MockLogger.Messages[logLevel.ToStringSafe()].Should().Contain(expectedMessage);
@@ -153,7 +153,7 @@ namespace chocolatey.tests.infrastructure.app.nuget
             public async Task Should_log_expected_log_level_when_calling_LogAsync_with_nuget_log_message(NuGetLogLevel nugetLogLevel, LogLevel logLevel, string testMessage, string expectedMessage)
             {
                 await _logger.LogAsync(new LogMessage(nugetLogLevel, testMessage));
-                MockLogger.LoggerNames.Count.Should().Be(1);
+                MockLogger.LoggerNames.Should().ContainSingle();
                 MockLogger.LoggerNames.Should().Contain(typeof(ChocolateyNugetLogger).FullName);
                 MockLogger.Messages.Keys.Should().Contain(logLevel.ToStringSafe());
                 MockLogger.Messages[logLevel.ToStringSafe()].Should().Contain(expectedMessage);
@@ -168,7 +168,7 @@ namespace chocolatey.tests.infrastructure.app.nuget
                 _logger.LogInformationSummary(testMessage);
 
                 var loggerName = LogLevel.Info.ToStringSafe();
-                MockLogger.LoggerNames.Count.Should().Be(1);
+                MockLogger.LoggerNames.Should().ContainSingle();
                 MockLogger.LoggerNames.Should().Contain(typeof(ChocolateyNugetLogger).FullName);
                 MockLogger.Messages.Keys.Should().Contain(loggerName);
                 MockLogger.Messages[loggerName].Should().Contain(expectedMessage);
@@ -183,7 +183,7 @@ namespace chocolatey.tests.infrastructure.app.nuget
                 _logger.LogInformationSummary(testMessage);
 
                 var loggerName = LogLevel.Info.ToStringSafe();
-                MockLogger.LoggerNames.Count.Should().Be(1);
+                MockLogger.LoggerNames.Should().ContainSingle();
                 MockLogger.LoggerNames.Should().Contain(typeof(ChocolateyNugetLogger).FullName);
                 MockLogger.Messages.Keys.Should().Contain(loggerName);
                 MockLogger.Messages[loggerName].Should().Contain(expectedMessage);
@@ -194,7 +194,7 @@ namespace chocolatey.tests.infrastructure.app.nuget
             public void Should_log_verbose_level_when_calling_Log_with_nuget_log_level(NuGetLogLevel nuGetLogLevel, string testMessage, string expectedMessage)
             {
                 _logger.Log(nuGetLogLevel, testMessage);
-                MockLogger.LoggerNames.Count.Should().Be(2);
+                MockLogger.LoggerNames.Should().HaveCount(2);
                 MockLogger.LoggerNames.Should().Contain("Verbose");
                 MockLogger.Messages.Keys.Should().Contain("Info");
                 MockLogger.Messages["Info"].Should().Contain(expectedMessage);
@@ -205,7 +205,7 @@ namespace chocolatey.tests.infrastructure.app.nuget
             public void Should_log_verbose_level_when_calling_Log_with_nuget_log_message(NuGetLogLevel nuGetLogLevel, string testMessage, string expectedMessage)
             {
                 _logger.Log(new LogMessage(nuGetLogLevel, testMessage));
-                MockLogger.LoggerNames.Count.Should().Be(2);
+                MockLogger.LoggerNames.Should().HaveCount(2);
                 MockLogger.LoggerNames.Should().Contain("Verbose");
                 MockLogger.Messages.Keys.Should().Contain("Info");
                 MockLogger.Messages["Info"].Should().Contain(expectedMessage);
@@ -216,7 +216,7 @@ namespace chocolatey.tests.infrastructure.app.nuget
             public async Task Should_log_verbose_level_when_calling_LogAsync_with_nuget_log_level(NuGetLogLevel nuGetLogLevel, string testMessage, string expectedMessage)
             {
                 await _logger.LogAsync(nuGetLogLevel, testMessage);
-                MockLogger.LoggerNames.Count.Should().Be(2);
+                MockLogger.LoggerNames.Should().HaveCount(2);
                 MockLogger.LoggerNames.Should().Contain("Verbose");
                 MockLogger.Messages.Keys.Should().Contain("Info");
                 MockLogger.Messages["Info"].Should().Contain(expectedMessage);
@@ -227,7 +227,7 @@ namespace chocolatey.tests.infrastructure.app.nuget
             public async Task Should_log_verbose_level_when_calling_LogAsync_with_nuget_log_message(NuGetLogLevel nuGetLogLevel, string testMessage, string expectedMessage)
             {
                 await _logger.LogAsync(new LogMessage(nuGetLogLevel, testMessage));
-                MockLogger.LoggerNames.Count.Should().Be(2);
+                MockLogger.LoggerNames.Should().HaveCount(2);
                 MockLogger.LoggerNames.Should().Contain("Verbose");
                 MockLogger.Messages.Keys.Should().Contain("Info");
                 MockLogger.Messages["Info"].Should().Contain(expectedMessage);
@@ -242,7 +242,7 @@ namespace chocolatey.tests.infrastructure.app.nuget
                 _logger.LogInformation(testMessage);
 
                 var loggerName = LogLevel.Info.ToStringSafe();
-                MockLogger.LoggerNames.Count.Should().Be(2);
+                MockLogger.LoggerNames.Should().HaveCount(2);
                 MockLogger.LoggerNames.Should().Contain("Verbose");
                 MockLogger.Messages.Keys.Should().Contain(loggerName);
                 MockLogger.Messages[loggerName].Should().Contain(expectedMessage);
@@ -257,7 +257,7 @@ namespace chocolatey.tests.infrastructure.app.nuget
                 _logger.LogMinimal(testMessage);
 
                 var loggerName = LogLevel.Info.ToStringSafe();
-                MockLogger.LoggerNames.Count.Should().Be(2);
+                MockLogger.LoggerNames.Should().HaveCount(2);
                 MockLogger.LoggerNames.Should().Contain("Verbose");
                 MockLogger.Messages.Keys.Should().Contain(loggerName);
                 MockLogger.Messages[loggerName].Should().Contain(expectedMessage);
@@ -272,7 +272,7 @@ namespace chocolatey.tests.infrastructure.app.nuget
                 _logger.LogVerbose(testMessage);
 
                 var loggerName = LogLevel.Info.ToStringSafe();
-                MockLogger.LoggerNames.Count.Should().Be(2);
+                MockLogger.LoggerNames.Should().HaveCount(2);
                 MockLogger.LoggerNames.Should().Contain("Verbose");
                 MockLogger.Messages.Keys.Should().Contain(loggerName);
                 MockLogger.Messages[loggerName].Should().Contain(expectedMessage);
@@ -287,7 +287,7 @@ namespace chocolatey.tests.infrastructure.app.nuget
                 _logger.LogInformation(testMessage);
 
                 var loggerName = LogLevel.Info.ToStringSafe();
-                MockLogger.LoggerNames.Count.Should().Be(2);
+                MockLogger.LoggerNames.Should().HaveCount(2);
                 MockLogger.LoggerNames.Should().Contain("Verbose");
                 MockLogger.Messages.Keys.Should().Contain(loggerName);
                 MockLogger.Messages[loggerName].Should().Contain(expectedMessage);
@@ -302,7 +302,7 @@ namespace chocolatey.tests.infrastructure.app.nuget
                 _logger.LogMinimal(testMessage);
 
                 var loggerName = LogLevel.Info.ToStringSafe();
-                MockLogger.LoggerNames.Count.Should().Be(2);
+                MockLogger.LoggerNames.Should().HaveCount(2);
                 MockLogger.LoggerNames.Should().Contain("Verbose");
                 MockLogger.Messages.Keys.Should().Contain(loggerName);
                 MockLogger.Messages[loggerName].Should().Contain(expectedMessage);
@@ -317,7 +317,7 @@ namespace chocolatey.tests.infrastructure.app.nuget
                 _logger.LogVerbose(testMessage);
 
                 var loggerName = LogLevel.Info.ToStringSafe();
-                MockLogger.LoggerNames.Count.Should().Be(2);
+                MockLogger.LoggerNames.Should().HaveCount(2);
                 MockLogger.LoggerNames.Should().Contain("Verbose");
                 MockLogger.Messages.Keys.Should().Contain(loggerName);
                 MockLogger.Messages[loggerName].Should().Contain(expectedMessage);
@@ -332,7 +332,7 @@ namespace chocolatey.tests.infrastructure.app.nuget
                 _logger.LogWarning(testMessage);
 
                 var loggerName = LogLevel.Warn.ToStringSafe();
-                MockLogger.LoggerNames.Count.Should().Be(1);
+                MockLogger.LoggerNames.Should().ContainSingle();
                 MockLogger.LoggerNames.Should().Contain(typeof(ChocolateyNugetLogger).FullName);
                 MockLogger.Messages.Keys.Should().Contain(loggerName);
                 MockLogger.Messages[loggerName].Should().Contain(expectedMessage);
@@ -347,7 +347,7 @@ namespace chocolatey.tests.infrastructure.app.nuget
                 _logger.LogWarning(testMessage);
 
                 var loggerName = LogLevel.Warn.ToStringSafe();
-                MockLogger.LoggerNames.Count.Should().Be(1);
+                MockLogger.LoggerNames.Should().ContainSingle();
                 MockLogger.LoggerNames.Should().Contain(typeof(ChocolateyNugetLogger).FullName);
                 MockLogger.Messages.Keys.Should().Contain(loggerName);
                 MockLogger.Messages[loggerName].Should().Contain(expectedMessage);

--- a/src/chocolatey.tests/infrastructure.app/nuget/ChocolateyNugetLoggerSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/nuget/ChocolateyNugetLoggerSpecs.cs
@@ -20,7 +20,7 @@ namespace chocolatey.tests.infrastructure.app.nuget
     using chocolatey.infrastructure.app.nuget;
     using NuGet.Common;
     using NUnit.Framework;
-    using Should;
+    using FluentAssertions;
 
     using LogLevel = chocolatey.tests.LogLevel;
     using NuGetLogLevel = NuGet.Common.LogLevel;
@@ -56,10 +56,10 @@ namespace chocolatey.tests.infrastructure.app.nuget
                 _logger.LogDebug(testMessage);
 
                 var loggerName = LogLevel.Debug.ToStringSafe();
-                MockLogger.LoggerNames.Count.ShouldEqual(1);
-                MockLogger.LoggerNames.ShouldContain(typeof(ChocolateyNugetLogger).FullName);
-                MockLogger.Messages.Keys.ShouldContain(loggerName);
-                MockLogger.Messages[loggerName].ShouldContain(expectedMessage);
+                MockLogger.LoggerNames.Count.Should().Be(1);
+                MockLogger.LoggerNames.Should().Contain(typeof(ChocolateyNugetLogger).FullName);
+                MockLogger.Messages.Keys.Should().Contain(loggerName);
+                MockLogger.Messages[loggerName].Should().Contain(expectedMessage);
             }
 
             [Fact]
@@ -71,10 +71,10 @@ namespace chocolatey.tests.infrastructure.app.nuget
                 _logger.LogDebug(testMessage);
 
                 var loggerName = LogLevel.Debug.ToStringSafe();
-                MockLogger.LoggerNames.Count.ShouldEqual(1);
-                MockLogger.LoggerNames.ShouldContain(typeof(ChocolateyNugetLogger).FullName);
-                MockLogger.Messages.Keys.ShouldContain(loggerName);
-                MockLogger.Messages[loggerName].ShouldContain(expectedMessage);
+                MockLogger.LoggerNames.Count.Should().Be(1);
+                MockLogger.LoggerNames.Should().Contain(typeof(ChocolateyNugetLogger).FullName);
+                MockLogger.Messages.Keys.Should().Contain(loggerName);
+                MockLogger.Messages[loggerName].Should().Contain(expectedMessage);
             }
 
             [Fact]
@@ -86,10 +86,10 @@ namespace chocolatey.tests.infrastructure.app.nuget
                 _logger.LogError(testMessage);
 
                 var loggerName = LogLevel.Error.ToStringSafe();
-                MockLogger.LoggerNames.Count.ShouldEqual(1);
-                MockLogger.LoggerNames.ShouldContain(typeof(ChocolateyNugetLogger).FullName);
-                MockLogger.Messages.Keys.ShouldContain(loggerName);
-                MockLogger.Messages[loggerName].ShouldContain(expectedMessage);
+                MockLogger.LoggerNames.Count.Should().Be(1);
+                MockLogger.LoggerNames.Should().Contain(typeof(ChocolateyNugetLogger).FullName);
+                MockLogger.Messages.Keys.Should().Contain(loggerName);
+                MockLogger.Messages[loggerName].Should().Contain(expectedMessage);
             }
 
             [Fact]
@@ -101,10 +101,10 @@ namespace chocolatey.tests.infrastructure.app.nuget
                 _logger.LogError(testMessage);
 
                 var loggerName = LogLevel.Error.ToStringSafe();
-                MockLogger.LoggerNames.Count.ShouldEqual(1);
-                MockLogger.LoggerNames.ShouldContain(typeof(ChocolateyNugetLogger).FullName);
-                MockLogger.Messages.Keys.ShouldContain(loggerName);
-                MockLogger.Messages[loggerName].ShouldContain(expectedMessage);
+                MockLogger.LoggerNames.Count.Should().Be(1);
+                MockLogger.LoggerNames.Should().Contain(typeof(ChocolateyNugetLogger).FullName);
+                MockLogger.Messages.Keys.Should().Contain(loggerName);
+                MockLogger.Messages[loggerName].Should().Contain(expectedMessage);
             }
 
             [TestCase(NuGetLogLevel.Debug, LogLevel.Debug, "Test debug message", "[NuGet] Test debug message")]
@@ -114,10 +114,10 @@ namespace chocolatey.tests.infrastructure.app.nuget
             public void Should_log_expected_log_level_when_calling_Log_with_log_message(NuGetLogLevel nugetLogLevel, LogLevel logLevel, string testMessage, string expectedMessage)
             {
                 _logger.Log(new LogMessage(nugetLogLevel, testMessage));
-                MockLogger.LoggerNames.Count.ShouldEqual(1);
-                MockLogger.LoggerNames.ShouldContain(typeof(ChocolateyNugetLogger).FullName);
-                MockLogger.Messages.Keys.ShouldContain(logLevel.ToStringSafe());
-                MockLogger.Messages[logLevel.ToStringSafe()].ShouldContain(expectedMessage);
+                MockLogger.LoggerNames.Count.Should().Be(1);
+                MockLogger.LoggerNames.Should().Contain(typeof(ChocolateyNugetLogger).FullName);
+                MockLogger.Messages.Keys.Should().Contain(logLevel.ToStringSafe());
+                MockLogger.Messages[logLevel.ToStringSafe()].Should().Contain(expectedMessage);
             }
 
             [TestCase(NuGetLogLevel.Debug, LogLevel.Debug, "Test debug message", "[NuGet] Test debug message")]
@@ -127,10 +127,10 @@ namespace chocolatey.tests.infrastructure.app.nuget
             public void Should_log_expected_log_level_when_calling_Log_with_nuget_log_level(NuGetLogLevel nugetLogLevel, LogLevel logLevel, string testMessage, string expectedMessage)
             {
                 _logger.Log(nugetLogLevel, testMessage);
-                MockLogger.LoggerNames.Count.ShouldEqual(1);
-                MockLogger.LoggerNames.ShouldContain(typeof(ChocolateyNugetLogger).FullName);
-                MockLogger.Messages.Keys.ShouldContain(logLevel.ToStringSafe());
-                MockLogger.Messages[logLevel.ToStringSafe()].ShouldContain(expectedMessage);
+                MockLogger.LoggerNames.Count.Should().Be(1);
+                MockLogger.LoggerNames.Should().Contain(typeof(ChocolateyNugetLogger).FullName);
+                MockLogger.Messages.Keys.Should().Contain(logLevel.ToStringSafe());
+                MockLogger.Messages[logLevel.ToStringSafe()].Should().Contain(expectedMessage);
             }
 
             [TestCase(NuGetLogLevel.Debug, LogLevel.Debug, "Test debug message", "[NuGet] Test debug message")]
@@ -140,10 +140,10 @@ namespace chocolatey.tests.infrastructure.app.nuget
             public async Task Should_log_expected_log_level_when_calling_LogAsync_with_nuget_log_level(NuGetLogLevel nugetLogLevel, LogLevel logLevel, string testMessage, string expectedMessage)
             {
                 await _logger.LogAsync(nugetLogLevel, testMessage);
-                MockLogger.LoggerNames.Count.ShouldEqual(1);
-                MockLogger.LoggerNames.ShouldContain(typeof(ChocolateyNugetLogger).FullName);
-                MockLogger.Messages.Keys.ShouldContain(logLevel.ToStringSafe());
-                MockLogger.Messages[logLevel.ToStringSafe()].ShouldContain(expectedMessage);
+                MockLogger.LoggerNames.Count.Should().Be(1);
+                MockLogger.LoggerNames.Should().Contain(typeof(ChocolateyNugetLogger).FullName);
+                MockLogger.Messages.Keys.Should().Contain(logLevel.ToStringSafe());
+                MockLogger.Messages[logLevel.ToStringSafe()].Should().Contain(expectedMessage);
             }
 
             [TestCase(NuGetLogLevel.Debug, LogLevel.Debug, "Test debug message", "[NuGet] Test debug message")]
@@ -153,10 +153,10 @@ namespace chocolatey.tests.infrastructure.app.nuget
             public async Task Should_log_expected_log_level_when_calling_LogAsync_with_nuget_log_message(NuGetLogLevel nugetLogLevel, LogLevel logLevel, string testMessage, string expectedMessage)
             {
                 await _logger.LogAsync(new LogMessage(nugetLogLevel, testMessage));
-                MockLogger.LoggerNames.Count.ShouldEqual(1);
-                MockLogger.LoggerNames.ShouldContain(typeof(ChocolateyNugetLogger).FullName);
-                MockLogger.Messages.Keys.ShouldContain(logLevel.ToStringSafe());
-                MockLogger.Messages[logLevel.ToStringSafe()].ShouldContain(expectedMessage);
+                MockLogger.LoggerNames.Count.Should().Be(1);
+                MockLogger.LoggerNames.Should().Contain(typeof(ChocolateyNugetLogger).FullName);
+                MockLogger.Messages.Keys.Should().Contain(logLevel.ToStringSafe());
+                MockLogger.Messages[logLevel.ToStringSafe()].Should().Contain(expectedMessage);
             }
 
             [Fact]
@@ -168,10 +168,10 @@ namespace chocolatey.tests.infrastructure.app.nuget
                 _logger.LogInformationSummary(testMessage);
 
                 var loggerName = LogLevel.Info.ToStringSafe();
-                MockLogger.LoggerNames.Count.ShouldEqual(1);
-                MockLogger.LoggerNames.ShouldContain(typeof(ChocolateyNugetLogger).FullName);
-                MockLogger.Messages.Keys.ShouldContain(loggerName);
-                MockLogger.Messages[loggerName].ShouldContain(expectedMessage);
+                MockLogger.LoggerNames.Count.Should().Be(1);
+                MockLogger.LoggerNames.Should().Contain(typeof(ChocolateyNugetLogger).FullName);
+                MockLogger.Messages.Keys.Should().Contain(loggerName);
+                MockLogger.Messages[loggerName].Should().Contain(expectedMessage);
             }
 
             [Fact]
@@ -183,10 +183,10 @@ namespace chocolatey.tests.infrastructure.app.nuget
                 _logger.LogInformationSummary(testMessage);
 
                 var loggerName = LogLevel.Info.ToStringSafe();
-                MockLogger.LoggerNames.Count.ShouldEqual(1);
-                MockLogger.LoggerNames.ShouldContain(typeof(ChocolateyNugetLogger).FullName);
-                MockLogger.Messages.Keys.ShouldContain(loggerName);
-                MockLogger.Messages[loggerName].ShouldContain(expectedMessage);
+                MockLogger.LoggerNames.Count.Should().Be(1);
+                MockLogger.LoggerNames.Should().Contain(typeof(ChocolateyNugetLogger).FullName);
+                MockLogger.Messages.Keys.Should().Contain(loggerName);
+                MockLogger.Messages[loggerName].Should().Contain(expectedMessage);
             }
 
             [TestCase(NuGetLogLevel.Verbose, "Test verbose message", "[NuGet] Test verbose message")]
@@ -194,10 +194,10 @@ namespace chocolatey.tests.infrastructure.app.nuget
             public void Should_log_verbose_level_when_calling_Log_with_nuget_log_level(NuGetLogLevel nuGetLogLevel, string testMessage, string expectedMessage)
             {
                 _logger.Log(nuGetLogLevel, testMessage);
-                MockLogger.LoggerNames.Count.ShouldEqual(2);
-                MockLogger.LoggerNames.ShouldContain("Verbose");
-                MockLogger.Messages.Keys.ShouldContain("Info");
-                MockLogger.Messages["Info"].ShouldContain(expectedMessage);
+                MockLogger.LoggerNames.Count.Should().Be(2);
+                MockLogger.LoggerNames.Should().Contain("Verbose");
+                MockLogger.Messages.Keys.Should().Contain("Info");
+                MockLogger.Messages["Info"].Should().Contain(expectedMessage);
             }
 
             [TestCase(NuGetLogLevel.Verbose, "Test verbose message", "[NuGet] Test verbose message")]
@@ -205,10 +205,10 @@ namespace chocolatey.tests.infrastructure.app.nuget
             public void Should_log_verbose_level_when_calling_Log_with_nuget_log_message(NuGetLogLevel nuGetLogLevel, string testMessage, string expectedMessage)
             {
                 _logger.Log(new LogMessage(nuGetLogLevel, testMessage));
-                MockLogger.LoggerNames.Count.ShouldEqual(2);
-                MockLogger.LoggerNames.ShouldContain("Verbose");
-                MockLogger.Messages.Keys.ShouldContain("Info");
-                MockLogger.Messages["Info"].ShouldContain(expectedMessage);
+                MockLogger.LoggerNames.Count.Should().Be(2);
+                MockLogger.LoggerNames.Should().Contain("Verbose");
+                MockLogger.Messages.Keys.Should().Contain("Info");
+                MockLogger.Messages["Info"].Should().Contain(expectedMessage);
             }
 
             [TestCase(NuGetLogLevel.Verbose, "Test verbose message", "[NuGet] Test verbose message")]
@@ -216,10 +216,10 @@ namespace chocolatey.tests.infrastructure.app.nuget
             public async Task Should_log_verbose_level_when_calling_LogAsync_with_nuget_log_level(NuGetLogLevel nuGetLogLevel, string testMessage, string expectedMessage)
             {
                 await _logger.LogAsync(nuGetLogLevel, testMessage);
-                MockLogger.LoggerNames.Count.ShouldEqual(2);
-                MockLogger.LoggerNames.ShouldContain("Verbose");
-                MockLogger.Messages.Keys.ShouldContain("Info");
-                MockLogger.Messages["Info"].ShouldContain(expectedMessage);
+                MockLogger.LoggerNames.Count.Should().Be(2);
+                MockLogger.LoggerNames.Should().Contain("Verbose");
+                MockLogger.Messages.Keys.Should().Contain("Info");
+                MockLogger.Messages["Info"].Should().Contain(expectedMessage);
             }
 
             [TestCase(NuGetLogLevel.Verbose, "Test verbose message", "[NuGet] Test verbose message")]
@@ -227,10 +227,10 @@ namespace chocolatey.tests.infrastructure.app.nuget
             public async Task Should_log_verbose_level_when_calling_LogAsync_with_nuget_log_message(NuGetLogLevel nuGetLogLevel, string testMessage, string expectedMessage)
             {
                 await _logger.LogAsync(new LogMessage(nuGetLogLevel, testMessage));
-                MockLogger.LoggerNames.Count.ShouldEqual(2);
-                MockLogger.LoggerNames.ShouldContain("Verbose");
-                MockLogger.Messages.Keys.ShouldContain("Info");
-                MockLogger.Messages["Info"].ShouldContain(expectedMessage);
+                MockLogger.LoggerNames.Count.Should().Be(2);
+                MockLogger.LoggerNames.Should().Contain("Verbose");
+                MockLogger.Messages.Keys.Should().Contain("Info");
+                MockLogger.Messages["Info"].Should().Contain(expectedMessage);
             }
 
             [Fact]
@@ -242,10 +242,10 @@ namespace chocolatey.tests.infrastructure.app.nuget
                 _logger.LogInformation(testMessage);
 
                 var loggerName = LogLevel.Info.ToStringSafe();
-                MockLogger.LoggerNames.Count.ShouldEqual(2);
-                MockLogger.LoggerNames.ShouldContain("Verbose");
-                MockLogger.Messages.Keys.ShouldContain(loggerName);
-                MockLogger.Messages[loggerName].ShouldContain(expectedMessage);
+                MockLogger.LoggerNames.Count.Should().Be(2);
+                MockLogger.LoggerNames.Should().Contain("Verbose");
+                MockLogger.Messages.Keys.Should().Contain(loggerName);
+                MockLogger.Messages[loggerName].Should().Contain(expectedMessage);
             }
 
             [Fact]
@@ -257,10 +257,10 @@ namespace chocolatey.tests.infrastructure.app.nuget
                 _logger.LogMinimal(testMessage);
 
                 var loggerName = LogLevel.Info.ToStringSafe();
-                MockLogger.LoggerNames.Count.ShouldEqual(2);
-                MockLogger.LoggerNames.ShouldContain("Verbose");
-                MockLogger.Messages.Keys.ShouldContain(loggerName);
-                MockLogger.Messages[loggerName].ShouldContain(expectedMessage);
+                MockLogger.LoggerNames.Count.Should().Be(2);
+                MockLogger.LoggerNames.Should().Contain("Verbose");
+                MockLogger.Messages.Keys.Should().Contain(loggerName);
+                MockLogger.Messages[loggerName].Should().Contain(expectedMessage);
             }
 
             [Fact]
@@ -272,10 +272,10 @@ namespace chocolatey.tests.infrastructure.app.nuget
                 _logger.LogVerbose(testMessage);
 
                 var loggerName = LogLevel.Info.ToStringSafe();
-                MockLogger.LoggerNames.Count.ShouldEqual(2);
-                MockLogger.LoggerNames.ShouldContain("Verbose");
-                MockLogger.Messages.Keys.ShouldContain(loggerName);
-                MockLogger.Messages[loggerName].ShouldContain(expectedMessage);
+                MockLogger.LoggerNames.Count.Should().Be(2);
+                MockLogger.LoggerNames.Should().Contain("Verbose");
+                MockLogger.Messages.Keys.Should().Contain(loggerName);
+                MockLogger.Messages[loggerName].Should().Contain(expectedMessage);
             }
 
             [Fact]
@@ -287,10 +287,10 @@ namespace chocolatey.tests.infrastructure.app.nuget
                 _logger.LogInformation(testMessage);
 
                 var loggerName = LogLevel.Info.ToStringSafe();
-                MockLogger.LoggerNames.Count.ShouldEqual(2);
-                MockLogger.LoggerNames.ShouldContain("Verbose");
-                MockLogger.Messages.Keys.ShouldContain(loggerName);
-                MockLogger.Messages[loggerName].ShouldContain(expectedMessage);
+                MockLogger.LoggerNames.Count.Should().Be(2);
+                MockLogger.LoggerNames.Should().Contain("Verbose");
+                MockLogger.Messages.Keys.Should().Contain(loggerName);
+                MockLogger.Messages[loggerName].Should().Contain(expectedMessage);
             }
 
             [Fact]
@@ -302,10 +302,10 @@ namespace chocolatey.tests.infrastructure.app.nuget
                 _logger.LogMinimal(testMessage);
 
                 var loggerName = LogLevel.Info.ToStringSafe();
-                MockLogger.LoggerNames.Count.ShouldEqual(2);
-                MockLogger.LoggerNames.ShouldContain("Verbose");
-                MockLogger.Messages.Keys.ShouldContain(loggerName);
-                MockLogger.Messages[loggerName].ShouldContain(expectedMessage);
+                MockLogger.LoggerNames.Count.Should().Be(2);
+                MockLogger.LoggerNames.Should().Contain("Verbose");
+                MockLogger.Messages.Keys.Should().Contain(loggerName);
+                MockLogger.Messages[loggerName].Should().Contain(expectedMessage);
             }
 
             [Fact]
@@ -317,10 +317,10 @@ namespace chocolatey.tests.infrastructure.app.nuget
                 _logger.LogVerbose(testMessage);
 
                 var loggerName = LogLevel.Info.ToStringSafe();
-                MockLogger.LoggerNames.Count.ShouldEqual(2);
-                MockLogger.LoggerNames.ShouldContain("Verbose");
-                MockLogger.Messages.Keys.ShouldContain(loggerName);
-                MockLogger.Messages[loggerName].ShouldContain(expectedMessage);
+                MockLogger.LoggerNames.Count.Should().Be(2);
+                MockLogger.LoggerNames.Should().Contain("Verbose");
+                MockLogger.Messages.Keys.Should().Contain(loggerName);
+                MockLogger.Messages[loggerName].Should().Contain(expectedMessage);
             }
 
             [Fact]
@@ -332,10 +332,10 @@ namespace chocolatey.tests.infrastructure.app.nuget
                 _logger.LogWarning(testMessage);
 
                 var loggerName = LogLevel.Warn.ToStringSafe();
-                MockLogger.LoggerNames.Count.ShouldEqual(1);
-                MockLogger.LoggerNames.ShouldContain(typeof(ChocolateyNugetLogger).FullName);
-                MockLogger.Messages.Keys.ShouldContain(loggerName);
-                MockLogger.Messages[loggerName].ShouldContain(expectedMessage);
+                MockLogger.LoggerNames.Count.Should().Be(1);
+                MockLogger.LoggerNames.Should().Contain(typeof(ChocolateyNugetLogger).FullName);
+                MockLogger.Messages.Keys.Should().Contain(loggerName);
+                MockLogger.Messages[loggerName].Should().Contain(expectedMessage);
             }
 
             [Fact]
@@ -347,10 +347,10 @@ namespace chocolatey.tests.infrastructure.app.nuget
                 _logger.LogWarning(testMessage);
 
                 var loggerName = LogLevel.Warn.ToStringSafe();
-                MockLogger.LoggerNames.Count.ShouldEqual(1);
-                MockLogger.LoggerNames.ShouldContain(typeof(ChocolateyNugetLogger).FullName);
-                MockLogger.Messages.Keys.ShouldContain(loggerName);
-                MockLogger.Messages[loggerName].ShouldContain(expectedMessage);
+                MockLogger.LoggerNames.Count.Should().Be(1);
+                MockLogger.LoggerNames.Should().Contain(typeof(ChocolateyNugetLogger).FullName);
+                MockLogger.Messages.Keys.Should().Contain(loggerName);
+                MockLogger.Messages[loggerName].Should().Contain(expectedMessage);
             }
 
             [TestCase("")]
@@ -361,8 +361,8 @@ namespace chocolatey.tests.infrastructure.app.nuget
                 var expectedValue = "[NuGet] I will be containing{0}[NuGet]{0}[NuGet] some whitespace".FormatWith(Environment.NewLine);
 
                 _logger.Log(NuGetLogLevel.Minimal, testValue);
-                MockLogger.Messages.Keys.ShouldContain("Info");
-                MockLogger.Messages["Info"].ShouldContain(expectedValue);
+                MockLogger.Messages.Keys.Should().Contain("Info");
+                MockLogger.Messages["Info"].Should().Contain(expectedValue);
             }
 
             [TestCase(null)]
@@ -372,8 +372,8 @@ namespace chocolatey.tests.infrastructure.app.nuget
             {
                 _logger.Log(NuGetLogLevel.Minimal, testValue);
 
-                MockLogger.Messages.Keys.ShouldContain("Info");
-                MockLogger.Messages["Info"].ShouldContain("[NuGet]");
+                MockLogger.Messages.Keys.Should().Contain("Info");
+                MockLogger.Messages["Info"].Should().Contain("[NuGet]");
             }
 
             [TestCase("\n\n\n\n\n")]
@@ -383,8 +383,8 @@ namespace chocolatey.tests.infrastructure.app.nuget
                 var expectedValue = "[NuGet]{0}[NuGet]{0}[NuGet]{0}[NuGet]{0}[NuGet]".FormatWith(Environment.NewLine);
 
                 _logger.Log(NuGetLogLevel.Information, testValue);
-                MockLogger.Messages.Keys.ShouldContain("Info");
-                MockLogger.Messages["Info"].ShouldContain(expectedValue);
+                MockLogger.Messages.Keys.Should().Contain("Info");
+                MockLogger.Messages["Info"].Should().Contain(expectedValue);
             }
         }
     }

--- a/src/chocolatey.tests/infrastructure.app/nuget/NugetCommonSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/nuget/NugetCommonSpecs.cs
@@ -67,7 +67,7 @@ namespace chocolatey.tests.infrastructure.app.nuget
 
                 because();
 
-                packageRepositories.Count().Should().Be(0);
+                packageRepositories.Should().BeEmpty();
             }
 
             [Fact]

--- a/src/chocolatey.tests/infrastructure.app/nuget/NugetCommonSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/nuget/NugetCommonSpecs.cs
@@ -28,7 +28,7 @@ namespace chocolatey.tests.infrastructure.app.nuget
     using NuGet.Packaging;
     using NuGet.Protocol;
     using NuGet.Protocol.Core.Types;
-    using Should;
+    using FluentAssertions;
 
     public class NugetCommonSpecs
     {
@@ -67,7 +67,7 @@ namespace chocolatey.tests.infrastructure.app.nuget
 
                 because();
 
-                packageRepositories.Count().ShouldEqual(0);
+                packageRepositories.Count().Should().Be(0);
             }
 
             [Fact]
@@ -80,9 +80,9 @@ namespace chocolatey.tests.infrastructure.app.nuget
 
                 because();
 
-                packageRepositories.First().PackageSource.TrySourceAsUri.ShouldNotBeNull();
-                packageRepositories.First().PackageSource.SourceUri.ToStringSafe().ShouldEqual(source);
-                packageRepositories.First().PackageSource.IsHttp.ShouldBeTrue();
+                packageRepositories.First().PackageSource.TrySourceAsUri.Should().NotBeNull();
+                packageRepositories.First().PackageSource.SourceUri.ToStringSafe().Should().Be(source);
+                packageRepositories.First().PackageSource.IsHttp.Should().BeTrue();
             }
 
             [Fact]
@@ -95,9 +95,9 @@ namespace chocolatey.tests.infrastructure.app.nuget
 
                 because();
 
-                packageRepositories.First().PackageSource.TrySourceAsUri.ShouldNotBeNull();
-                packageRepositories.First().PackageSource.SourceUri.ToStringSafe().ShouldEqual(source);
-                packageRepositories.First().PackageSource.IsHttps.ShouldBeTrue();
+                packageRepositories.First().PackageSource.TrySourceAsUri.Should().NotBeNull();
+                packageRepositories.First().PackageSource.SourceUri.ToStringSafe().Should().Be(source);
+                packageRepositories.First().PackageSource.IsHttps.Should().BeTrue();
             }
 
             [Fact]
@@ -109,10 +109,10 @@ namespace chocolatey.tests.infrastructure.app.nuget
 
                 because();
 
-                packageRepositories.First().PackageSource.TrySourceAsUri.ShouldNotBeNull();
+                packageRepositories.First().PackageSource.TrySourceAsUri.Should().NotBeNull();
                 packageRepositories.First().PackageSource.SourceUri.ToStringSafe()
-                    .ShouldEqual(("file:///" + source).Replace("\\","/"));
-                packageRepositories.First().PackageSource.IsLocal.ShouldBeTrue();
+                    .Should().Be(("file:///" + source).Replace("\\","/"));
+                packageRepositories.First().PackageSource.IsLocal.Should().BeTrue();
             }
 
             [Fact]
@@ -125,10 +125,10 @@ namespace chocolatey.tests.infrastructure.app.nuget
 
                 because();
 
-                packageRepositories.First().PackageSource.TrySourceAsUri.ShouldNotBeNull();
+                packageRepositories.First().PackageSource.TrySourceAsUri.Should().NotBeNull();
                 packageRepositories.First().PackageSource.SourceUri.ToStringSafe()
-                    .ShouldEqual(("file:///" + fullsource).Replace("\\", "/"));
-                packageRepositories.First().PackageSource.IsLocal.ShouldBeTrue();
+                    .Should().Be(("file:///" + fullsource).Replace("\\", "/"));
+                packageRepositories.First().PackageSource.IsLocal.Should().BeTrue();
             }
 
             [Fact]
@@ -141,10 +141,10 @@ namespace chocolatey.tests.infrastructure.app.nuget
 
                 because();
 
-                packageRepositories.First().PackageSource.TrySourceAsUri.ShouldNotBeNull();
+                packageRepositories.First().PackageSource.TrySourceAsUri.Should().NotBeNull();
                 packageRepositories.First().PackageSource.SourceUri.ToStringSafe()
-                    .ShouldEqual(("file:///" + fullsource + "/").Replace("\\", "/"));
-                packageRepositories.First().PackageSource.IsLocal.ShouldBeTrue();
+                    .Should().Be(("file:///" + fullsource + "/").Replace("\\", "/"));
+                packageRepositories.First().PackageSource.IsLocal.Should().BeTrue();
             }
 
             [Fact]
@@ -156,11 +156,11 @@ namespace chocolatey.tests.infrastructure.app.nuget
 
                 because();
 
-                packageRepositories.First().PackageSource.TrySourceAsUri.ShouldNotBeNull();
+                packageRepositories.First().PackageSource.TrySourceAsUri.Should().NotBeNull();
                 packageRepositories.First().PackageSource.SourceUri.ToStringSafe()
-                    .ShouldEqual(("file:" + source).Replace("\\", "/"));
-                packageRepositories.First().PackageSource.IsLocal.ShouldBeTrue();
-                packageRepositories.First().PackageSource.SourceUri.IsUnc.ShouldBeTrue();
+                    .Should().Be(("file:" + source).Replace("\\", "/"));
+                packageRepositories.First().PackageSource.IsLocal.Should().BeTrue();
+                packageRepositories.First().PackageSource.SourceUri.IsUnc.Should().BeTrue();
             }
 
             [Fact]
@@ -176,7 +176,7 @@ namespace chocolatey.tests.infrastructure.app.nuget
                 // Change this when the NuGet version is updated.
                 string nugetClientVersion = "6.4.1";
                 string expectedUserAgentString = "{0}/{1} via NuGet Client/{2}".FormatWith(ApplicationParameters.UserAgent, configuration.Information.ChocolateyProductVersion, nugetClientVersion);
-                UserAgent.UserAgentString.ShouldStartWith(expectedUserAgentString);
+                UserAgent.UserAgentString.Should().StartWith(expectedUserAgentString);
             }
         }
     }

--- a/src/chocolatey.tests/infrastructure.app/services/ChocolateyConfigSettingsServiceSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/services/ChocolateyConfigSettingsServiceSpecs.cs
@@ -8,8 +8,7 @@
     using chocolatey.infrastructure.app.services;
     using chocolatey.infrastructure.services;
     using Moq;
-    using Should;
-    using Assert = Should.Core.Assertions.Assert;
+    using FluentAssertions;
 
     public class ChocolateyConfigSettingsServiceSpecs
     {
@@ -61,14 +60,14 @@
             [Fact]
             public void Should_not_report_feature_being_unsupported()
             {
-                MockLogger.Messages["Warn"].ShouldNotContain("Feature '{0}' is not supported. Any change have no effect on running Chocolatey.".FormatWith(ApplicationParameters.Features.ChecksumFiles));
+                MockLogger.Messages["Warn"].Should().NotContain("Feature '{0}' is not supported. Any change have no effect on running Chocolatey.".FormatWith(ApplicationParameters.Features.ChecksumFiles));
             }
 
             [Fact]
             public void Should_report_feature_being_disabled()
             {
-                MockLogger.Messages.Keys.ShouldContain("Warn");
-                MockLogger.Messages["Warn"].ShouldContain("Disabled {0}".FormatWith(ApplicationParameters.Features.ChecksumFiles));
+                MockLogger.Messages.Keys.Should().Contain("Warn");
+                MockLogger.Messages["Warn"].Should().Contain("Disabled {0}".FormatWith(ApplicationParameters.Features.ChecksumFiles));
             }
 
             [Fact]
@@ -102,13 +101,13 @@
             [Fact]
             public void Should_not_contain_any_warnings()
             {
-                MockLogger.Messages.Keys.ShouldNotContain("Warn");
+                MockLogger.Messages.Keys.Should().NotContain("Warn");
             }
 
             [Fact]
             public void Should_throw_exception_on_unknown_feature()
             {
-                Assert.ThrowsDelegate action = () =>
+                Action action = () =>
                 {
                     var config = new ChocolateyConfiguration()
                     {
@@ -121,8 +120,8 @@
                     Service.DisableFeature(config);
                 };
 
-                Assert.Throws<ApplicationException>(action)
-                    .Message.ShouldEqual("Feature 'unknown' not found");
+                action.Should().Throw<ApplicationException>()
+                    .WithMessage("Feature 'unknown' not found");
             }
         }
 
@@ -156,7 +155,7 @@
             [Fact]
             public void Should_throw_exception_on_unsupported_feature()
             {
-                Assert.Throws<ApplicationException>(() =>
+                Action action = () =>
                 {
                     var config = new ChocolateyConfiguration()
                     {
@@ -167,7 +166,9 @@
                     };
 
                     Service.DisableFeature(config);
-                }).Message.ShouldEqual("Feature '{0}' is not supported.".FormatWith(FeatureName));
+                };
+                    action.Should().Throw<ApplicationException>()
+                        .WithMessage("Feature '{0}' is not supported.".FormatWith(FeatureName));
             }
         }
 
@@ -208,14 +209,14 @@
             [Fact]
             public void Should_not_report_feature_being_unsupported()
             {
-                MockLogger.Messages["Warn"].ShouldNotContain("Feature '{0}' is not supported. Any change have no effect on running Chocolatey.".FormatWith(ApplicationParameters.Features.ChecksumFiles));
+                MockLogger.Messages["Warn"].Should().NotContain("Feature '{0}' is not supported. Any change have no effect on running Chocolatey.".FormatWith(ApplicationParameters.Features.ChecksumFiles));
             }
 
             [Fact]
             public void Should_report_feature_being_enabled()
             {
-                MockLogger.Messages.Keys.ShouldContain("Warn");
-                MockLogger.Messages["Warn"].ShouldContain("Enabled {0}".FormatWith(ApplicationParameters.Features.ChecksumFiles));
+                MockLogger.Messages.Keys.Should().Contain("Warn");
+                MockLogger.Messages["Warn"].Should().Contain("Enabled {0}".FormatWith(ApplicationParameters.Features.ChecksumFiles));
             }
 
             [Fact]
@@ -249,13 +250,13 @@
             [Fact]
             public void Should_not_contain_any_warnings()
             {
-                MockLogger.Messages.Keys.ShouldNotContain("Warn");
+                MockLogger.Messages.Keys.Should().NotContain("Warn");
             }
 
             [Fact]
             public void Should_throw_exception_on_unknown_feature()
             {
-                Assert.ThrowsDelegate action = () =>
+                Action action = () =>
                 {
                     var config = new ChocolateyConfiguration()
                     {
@@ -268,8 +269,8 @@
                     Service.EnableFeature(config);
                 };
 
-                Assert.Throws<ApplicationException>(action)
-                    .Message.ShouldEqual("Feature 'unknown' not found");
+                action.Should().Throw<ApplicationException>()
+                    .WithMessage("Feature 'unknown' not found");
             }
         }
 
@@ -303,7 +304,7 @@
             [Fact]
             public void Should_throw_exception_on_unsupported_feature()
             {
-                Assert.Throws<ApplicationException>(() =>
+                Action action = () =>
                 {
                     var config = new ChocolateyConfiguration()
                     {
@@ -314,7 +315,10 @@
                     };
 
                     Service.EnableFeature(config);
-                }).Message.ShouldEqual("Feature '{0}' is not supported.".FormatWith(FeatureName));
+                }
+                ;
+                action.Should().Throw<ApplicationException>()
+                    .WithMessage("Feature '{0}' is not supported.".FormatWith(FeatureName));
             }
         }
 
@@ -356,12 +360,12 @@
             [Fact]
             public void Should_output_features_in_alphabetical_order()
             {
-                MockLogger.Messages.Keys.ShouldContain("Info");
+                MockLogger.Messages.Keys.Should().Contain("Info");
 
                 var infoMessages = MockLogger.Messages["Info"];
-                infoMessages.Count.ShouldEqual(2);
-                infoMessages[0].ShouldContain("allowEmptyChecksums");
-                infoMessages[1].ShouldContain("virusCheck");
+                infoMessages.Count.Should().Be(2);
+                infoMessages[0].Should().Contain("allowEmptyChecksums");
+                infoMessages[1].Should().Contain("virusCheck");
             }
         }
 
@@ -403,12 +407,12 @@
             [Fact]
             public void Should_output_config_in_alphabetical_order()
             {
-                MockLogger.Messages.Keys.ShouldContain("Info");
+                MockLogger.Messages.Keys.Should().Contain("Info");
 
                 var infoMessages = MockLogger.Messages["Info"];
-                infoMessages.Count.ShouldEqual(2);
-                infoMessages[0].ShouldContain("cacheLocation");
-                infoMessages[1].ShouldContain("webRequestTimeoutSeconds");
+                infoMessages.Count.Should().Be(2);
+                infoMessages[0].Should().Contain("cacheLocation");
+                infoMessages[1].Should().Contain("webRequestTimeoutSeconds");
             }
         }
 
@@ -450,12 +454,12 @@
             [Fact]
             public void Should_output_sources_in_alphabetical_order()
             {
-                MockLogger.Messages.Keys.ShouldContain("Info");
+                MockLogger.Messages.Keys.Should().Contain("Info");
 
                 var infoMessages = MockLogger.Messages["Info"];
-                infoMessages.Count.ShouldEqual(2);
-                infoMessages[0].ShouldContain("alpha");
-                infoMessages[1].ShouldContain("beta");
+                infoMessages.Count.Should().Be(2);
+                infoMessages[0].Should().Contain("alpha");
+                infoMessages[1].Should().Contain("beta");
             }
         }
 
@@ -516,9 +520,9 @@
                     _error = ex;
                 }
 
-                _error.ShouldNotBeNull();
-                _error.ShouldBeType<ApplicationException>();
-                _error.Message.ShouldContain("No feature value by the name 'unknown'");
+                _error.Should().NotBeNull();
+                _error.Should().BeOfType<ApplicationException>();
+                _error.Message.Should().Contain("No feature value by the name 'unknown'");
             }
         }
 
@@ -562,10 +566,10 @@
             [Fact]
             public void Should_return_feature_status()
             {
-                MockLogger.Messages.Keys.ShouldContain("Info");
+                MockLogger.Messages.Keys.Should().Contain("Info");
                 var infoMessages = MockLogger.Messages["Info"];
-                infoMessages.Count.ShouldEqual(1);
-                infoMessages[0].ShouldContain("Enabled");
+                infoMessages.Count.Should().Be(1);
+                infoMessages[0].Should().Contain("Enabled");
             }
         }
     }

--- a/src/chocolatey.tests/infrastructure.app/services/ChocolateyConfigSettingsServiceSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/services/ChocolateyConfigSettingsServiceSpecs.cs
@@ -363,7 +363,7 @@
                 MockLogger.Messages.Keys.Should().Contain("Info");
 
                 var infoMessages = MockLogger.Messages["Info"];
-                infoMessages.Count.Should().Be(2);
+                infoMessages.Should().HaveCount(2);
                 infoMessages[0].Should().Contain("allowEmptyChecksums");
                 infoMessages[1].Should().Contain("virusCheck");
             }
@@ -410,7 +410,7 @@
                 MockLogger.Messages.Keys.Should().Contain("Info");
 
                 var infoMessages = MockLogger.Messages["Info"];
-                infoMessages.Count.Should().Be(2);
+                infoMessages.Should().HaveCount(2);
                 infoMessages[0].Should().Contain("cacheLocation");
                 infoMessages[1].Should().Contain("webRequestTimeoutSeconds");
             }
@@ -457,7 +457,7 @@
                 MockLogger.Messages.Keys.Should().Contain("Info");
 
                 var infoMessages = MockLogger.Messages["Info"];
-                infoMessages.Count.Should().Be(2);
+                infoMessages.Should().HaveCount(2);
                 infoMessages[0].Should().Contain("alpha");
                 infoMessages[1].Should().Contain("beta");
             }
@@ -568,7 +568,7 @@
             {
                 MockLogger.Messages.Keys.Should().Contain("Info");
                 var infoMessages = MockLogger.Messages["Info"];
-                infoMessages.Count.Should().Be(1);
+                infoMessages.Should().ContainSingle();
                 infoMessages[0].Should().Contain("Enabled");
             }
         }

--- a/src/chocolatey.tests/infrastructure.app/services/ChocolateyPackageServiceSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/services/ChocolateyPackageServiceSpecs.cs
@@ -27,7 +27,7 @@ using chocolatey.infrastructure.results;
 using chocolatey.infrastructure.services;
 using Moq;
 using NUnit.Framework;
-using Should;
+using FluentAssertions;
 using IFileSystem = chocolatey.infrastructure.filesystem.IFileSystem;
 
 namespace chocolatey.tests.infrastructure.app.services
@@ -134,7 +134,7 @@ namespace chocolatey.tests.infrastructure.app.services
             [Test]
             public void Should_return_package_that_should_have_been_installed()
             {
-                _result.Keys.ShouldContain("test-feature");
+                _result.Keys.Should().Contain("test-feature");
             }
 
             [Test]
@@ -191,7 +191,7 @@ namespace chocolatey.tests.infrastructure.app.services
                 var ex = TryRun(Action);
                 var message = GetExpectedLocalValue(directory, "my-package");
 
-                ex.Message.ShouldEqual(message);
+                ex.Message.Should().Be(message);
             }
 
             [Fact]
@@ -209,7 +209,7 @@ namespace chocolatey.tests.infrastructure.app.services
 
                 var ex = TryRun(Action);
                 var message = GetExpectedLocalValue(directory, "my-package");
-                ex.Message.ShouldEqual(message);
+                ex.Message.Should().Be(message);
             }
 
             [Fact, Categories.Unc]
@@ -227,7 +227,7 @@ namespace chocolatey.tests.infrastructure.app.services
 
                 var ex = TryRun(Action);
                 var message = GetExpectedUncValue(directory, "my-package");
-                ex.Message.ShouldEqual(message);
+                ex.Message.Should().Be(message);
             }
 
             [Fact]
@@ -236,7 +236,7 @@ namespace chocolatey.tests.infrastructure.app.services
                 Configuration.PackageNames = "https://test.com/repository/awesome-package.nupkg";
 
                 var ex = TryRun(Action);
-                ex.Message.ShouldEqual("Package name cannot point directly to a local, or remote file. Please use the --source argument and point it to a local file directory, UNC directory path or a NuGet feed instead.");
+                ex.Message.Should().Be("Package name cannot point directly to a local, or remote file. Please use the --source argument and point it to a local file directory, UNC directory path or a NuGet feed instead.");
             }
 
             [Fact]
@@ -253,7 +253,7 @@ namespace chocolatey.tests.infrastructure.app.services
 
                 var ex = TryRun(Action);
                 var expectedMessage = GetExpectedLocalValue(Environment.CurrentDirectory, "test", "1.5.0");
-                ex.Message.ShouldEqual(expectedMessage);
+                ex.Message.Should().Be(expectedMessage);
             }
 
             [Fact]
@@ -270,7 +270,7 @@ namespace chocolatey.tests.infrastructure.app.services
 
                 var ex = TryRun(Action);
                 var expectedMessage = GetExpectedLocalValue(Environment.CurrentDirectory, "test", "2.0.0-alpha", prerelease: true);
-                ex.Message.ShouldEqual(expectedMessage);
+                ex.Message.Should().Be(expectedMessage);
             }
 
             [Fact]
@@ -284,7 +284,7 @@ namespace chocolatey.tests.infrastructure.app.services
 
                 var ex = TryRun(Action);
                 var expectedMessage = GetExpectedLocalValue(string.Empty, "test", "2.0.0", prerelease: false);
-                ex.Message.ShouldEqual(expectedMessage);
+                ex.Message.Should().Be(expectedMessage);
             }
 
             [Fact]
@@ -294,7 +294,7 @@ namespace chocolatey.tests.infrastructure.app.services
 
                 var ex = TryRun(Action);
 
-                ex.Message.ShouldEqual("Package name cannot point directly to a local, or remote file. Please use the --source argument and point it to a local file directory, UNC directory path or a NuGet feed instead.");
+                ex.Message.Should().Be("Package name cannot point directly to a local, or remote file. Please use the --source argument and point it to a local file directory, UNC directory path or a NuGet feed instead.");
             }
 
             [Fact]
@@ -303,7 +303,7 @@ namespace chocolatey.tests.infrastructure.app.services
                 Configuration.PackageNames = "test-package.nuspec";
 
                 var ex = TryRun(Action);
-                ex.Message.ShouldEqual("Package name cannot point directly to a package manifest file. Please create a package by running 'choco pack' on the .nuspec file first.");
+                ex.Message.Should().Be("Package name cannot point directly to a package manifest file. Please create a package by running 'choco pack' on the .nuspec file first.");
             }
 
             private string GetExpectedUncValue(string path, string name, string version = null, bool prerelease = false)
@@ -373,7 +373,7 @@ namespace chocolatey.tests.infrastructure.app.services
                 }
                 catch (Exception ex)
                 {
-                    ex.ShouldBeType<ApplicationException>();
+                    ex.Should().BeOfType<ApplicationException>();
                     return ex;
                 }
             }

--- a/src/chocolatey.tests/infrastructure.app/services/FilesServiceSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/services/FilesServiceSpecs.cs
@@ -28,7 +28,7 @@ namespace chocolatey.tests.infrastructure.app.services
     using chocolatey.infrastructure.results;
     using chocolatey.infrastructure.services;
     using Moq;
-    using Should;
+    using FluentAssertions;
 
     public class FilesServiceSpecs
     {
@@ -138,13 +138,13 @@ namespace chocolatey.tests.infrastructure.app.services
             [Fact]
             public void Should_return_a_warning_if_the_install_directory_matches_choco_install_location()
             {
-                packageResult.Warning.ShouldBeTrue();
+                packageResult.Warning.Should().BeTrue();
             }
 
             [Fact]
             public void Should_return_null()
             {
-                result.ShouldBeNull();
+                result.Should().BeNull();
             }
         }
 
@@ -174,13 +174,13 @@ namespace chocolatey.tests.infrastructure.app.services
             [Fact]
             public void Should_return_a_warning_if_the_install_directory_matches_choco_install_location()
             {
-                packageResult.Warning.ShouldBeTrue();
+                packageResult.Warning.Should().BeTrue();
             }
 
             [Fact]
             public void Should_return_null()
             {
-                result.ShouldBeNull();
+                result.Should().BeNull();
             }
         }
 
@@ -210,13 +210,13 @@ namespace chocolatey.tests.infrastructure.app.services
             [Fact]
             public void Should_return_a_non_null_object()
             {
-                result.ShouldNotBeNull();
+                result.Should().NotBeNull();
             }
 
             [Fact]
             public void Should_return_empty_package_files()
             {
-                result.Files.ShouldBeEmpty();
+                result.Files.Should().BeEmpty();
             }
         }
 
@@ -249,19 +249,19 @@ namespace chocolatey.tests.infrastructure.app.services
             [Fact]
             public void Should_return_a_PackageFiles_object()
             {
-                result.ShouldNotBeNull();
+                result.Should().NotBeNull();
             }
 
             [Fact]
             public void Should_contain_package_files()
             {
-                result.Files.ShouldNotBeEmpty();
+                result.Files.Should().NotBeEmpty();
             }
 
             [Fact]
             public void Should_contain_the_correct_number_of_package_files()
             {
-                result.Files.Count.ShouldEqual(files.Count);
+                result.Files.Count.Should().Be(files.Count);
             }
 
             [Fact]

--- a/src/chocolatey.tests/infrastructure.app/services/FilesServiceSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/services/FilesServiceSpecs.cs
@@ -261,7 +261,7 @@ namespace chocolatey.tests.infrastructure.app.services
             [Fact]
             public void Should_contain_the_correct_number_of_package_files()
             {
-                result.Files.Count.Should().Be(files.Count);
+                result.Files.Should().HaveCount(files.Count);
             }
 
             [Fact]

--- a/src/chocolatey.tests/infrastructure.app/services/NugetServiceSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/services/NugetServiceSpecs.cs
@@ -310,8 +310,8 @@ namespace chocolatey.tests.infrastructure.app.services
                 because();
 
                 var infos = MockLogger.MessagesFor(tests.LogLevel.Info);
-                infos.Count.Should().Be(1);
-                infos[0].Should().Be("Chocolatey would have searched for a nuspec file in \"c:\\projects\\chocolatey\" and attempted to compile it.");
+                infos.Should().ContainSingle();
+                infos.Should().HaveElementAt(0,"Chocolatey would have searched for a nuspec file in \"c:\\projects\\chocolatey\" and attempted to compile it.");
             }
 
             [Fact]
@@ -324,8 +324,8 @@ namespace chocolatey.tests.infrastructure.app.services
                 because();
 
                 var infos = MockLogger.MessagesFor(tests.LogLevel.Info);
-                infos.Count.Should().Be(1);
-                infos[0].Should().Be("Chocolatey would have searched for a nuspec file in \"c:\\packages\" and attempted to compile it.");
+                infos.Should().ContainSingle();
+                infos.Should().HaveElementAt(0,"Chocolatey would have searched for a nuspec file in \"c:\\packages\" and attempted to compile it.");
             }
         }
     }

--- a/src/chocolatey.tests/infrastructure.app/services/NugetServiceSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/services/NugetServiceSpecs.cs
@@ -27,7 +27,7 @@ namespace chocolatey.tests.infrastructure.app.services
     using Moq;
     using NuGet.Common;
     using NuGet.Packaging;
-    using Should;
+    using FluentAssertions;
     using IFileSystem = chocolatey.infrastructure.filesystem.IFileSystem;
 
     public class NugetServiceSpecs
@@ -310,8 +310,8 @@ namespace chocolatey.tests.infrastructure.app.services
                 because();
 
                 var infos = MockLogger.MessagesFor(tests.LogLevel.Info);
-                infos.Count.ShouldEqual(1);
-                infos[0].ShouldEqual("Chocolatey would have searched for a nuspec file in \"c:\\projects\\chocolatey\" and attempted to compile it.");
+                infos.Count.Should().Be(1);
+                infos[0].Should().Be("Chocolatey would have searched for a nuspec file in \"c:\\projects\\chocolatey\" and attempted to compile it.");
             }
 
             [Fact]
@@ -324,8 +324,8 @@ namespace chocolatey.tests.infrastructure.app.services
                 because();
 
                 var infos = MockLogger.MessagesFor(tests.LogLevel.Info);
-                infos.Count.ShouldEqual(1);
-                infos[0].ShouldEqual("Chocolatey would have searched for a nuspec file in \"c:\\packages\" and attempted to compile it.");
+                infos.Count.Should().Be(1);
+                infos[0].Should().Be("Chocolatey would have searched for a nuspec file in \"c:\\packages\" and attempted to compile it.");
             }
         }
     }

--- a/src/chocolatey.tests/infrastructure.app/services/RegistryServiceSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/services/RegistryServiceSpecs.cs
@@ -22,7 +22,7 @@ namespace chocolatey.tests.infrastructure.app.services
     using Microsoft.Win32;
     using Moq;
     using NUnit.Framework;
-    using Should;
+    using FluentAssertions;
     using Registry = chocolatey.infrastructure.app.domain.Registry;
 
     public class RegistryServiceSpecs
@@ -66,7 +66,7 @@ namespace chocolatey.tests.infrastructure.app.services
             [Fact]
             public void Should_not_be_null()
             {
-                _result.ShouldNotBeNull();
+                _result.Should().NotBeNull();
             }
         }
 
@@ -91,25 +91,25 @@ namespace chocolatey.tests.infrastructure.app.services
             [Fact]
             public void Should_return_a_non_null_value()
             {
-                _result.ShouldNotBeNull();
+                _result.Should().NotBeNull();
             }
 
             [Fact]
             public void Should_return_a_value_of_type_RegistryKey()
             {
-                _result.ShouldBeType<RegistryKey>();
+                _result.Should().BeOfType<RegistryKey>();
             }
 
             [Fact]
             public void Should_contain_keys()
             {
-                _result.GetSubKeyNames().ShouldNotBeEmpty();
+                _result.GetSubKeyNames().Should().NotBeEmpty();
             }
 
             [Fact]
             public void Should_contain_values()
             {
-                Service.GetKey(_hive, "Environment").GetValueNames().ShouldNotBeEmpty();
+                Service.GetKey(_hive, "Environment").GetValueNames().Should().NotBeEmpty();
             }
         }
 
@@ -140,7 +140,7 @@ namespace chocolatey.tests.infrastructure.app.services
             [Fact]
             public void Should_return_null_key()
             {
-                _result.ShouldBeNull();
+                _result.Should().BeNull();
             }
         }
 

--- a/src/chocolatey.tests/infrastructure.app/services/RulesServiceSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/services/RulesServiceSpecs.cs
@@ -62,12 +62,16 @@ namespace chocolatey.tests.infrastructure.app.services
         [Fact]
         public void GetsRulesFromService()
         {
-            _detectedRules.Count().Should().Be(4);
+            _detectedRules.Should().HaveCount(4);
             IEnumerable<string> ruleIds = _detectedRules.Select(t => t.Id);
-            ruleIds.Should().Contain(UnsupportedElementUsed);
-            ruleIds.Should().Contain(EmptyRequiredElement);
-            ruleIds.Should().Contain(InvalidTypeElement);
-            ruleIds.Should().Contain(MissingElementOnRequiringLicenseAcceptance);
+
+            ruleIds.Should().Contain(new[]
+            {
+                UnsupportedElementUsed,
+                EmptyRequiredElement,
+                InvalidTypeElement,
+                MissingElementOnRequiringLicenseAcceptance
+            });
         }
     }
 }

--- a/src/chocolatey.tests/infrastructure.app/services/RulesServiceSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/services/RulesServiceSpecs.cs
@@ -24,7 +24,7 @@ namespace chocolatey.tests.infrastructure.app.services
     using chocolatey.infrastructure.app.services;
     using chocolatey.infrastructure.rules;
     using chocolatey.infrastructure.services;
-    using Should;
+    using FluentAssertions;
 
     public class RulesServiceSpecs : TinySpec
     {
@@ -62,12 +62,12 @@ namespace chocolatey.tests.infrastructure.app.services
         [Fact]
         public void GetsRulesFromService()
         {
-            _detectedRules.Count().ShouldEqual(4);
+            _detectedRules.Count().Should().Be(4);
             IEnumerable<string> ruleIds = _detectedRules.Select(t => t.Id);
-            ruleIds.ShouldContain(UnsupportedElementUsed);
-            ruleIds.ShouldContain(EmptyRequiredElement);
-            ruleIds.ShouldContain(InvalidTypeElement);
-            ruleIds.ShouldContain(MissingElementOnRequiringLicenseAcceptance);
+            ruleIds.Should().Contain(UnsupportedElementUsed);
+            ruleIds.Should().Contain(EmptyRequiredElement);
+            ruleIds.Should().Contain(InvalidTypeElement);
+            ruleIds.Should().Contain(MissingElementOnRequiringLicenseAcceptance);
         }
     }
 }

--- a/src/chocolatey.tests/infrastructure.app/services/TemplateServiceSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/services/TemplateServiceSpecs.cs
@@ -80,8 +80,8 @@ namespace chocolatey.tests.infrastructure.app.services
                 because();
 
                 var infos = MockLogger.MessagesFor(LogLevel.Info);
-                infos.Count.Should().Be(1);
-                infos[0].Should().Be("Would have generated a new package specification at c:\\chocolatey\\Bob");
+                infos.Should().ContainSingle();
+                infos.Should().HaveElementAt(0,"Would have generated a new package specification at c:\\chocolatey\\Bob");
             }
 
             [Fact]
@@ -92,8 +92,8 @@ namespace chocolatey.tests.infrastructure.app.services
                 because();
 
                 var infos = MockLogger.MessagesFor(LogLevel.Info);
-                infos.Count.Should().Be(1);
-                infos[0].Should().Be("Would have generated a new package specification at c:\\packages\\Bob");
+                infos.Should().ContainSingle();
+                infos.Should().HaveElementAt(0,"Would have generated a new package specification at c:\\packages\\Bob");
             }
         }
 
@@ -132,8 +132,8 @@ namespace chocolatey.tests.infrastructure.app.services
                 because();
 
                 var debugs = MockLogger.MessagesFor(LogLevel.Debug);
-                debugs.Count.Should().Be(1);
-                debugs[0].Should().Be("Bob");
+                debugs.Should().ContainSingle();
+                debugs.Should().HaveElementAt(0,"Bob");
             }
 
             [Fact]
@@ -144,12 +144,12 @@ namespace chocolatey.tests.infrastructure.app.services
                 because();
 
                 var debugs = MockLogger.MessagesFor(LogLevel.Debug);
-                debugs.Count.Should().Be(1);
-                debugs[0].Should().Be("Bob");
+                debugs.Should().ContainSingle();
+                debugs.Should().HaveElementAt(0,"Bob");
 
                 var infos = MockLogger.MessagesFor(LogLevel.Info);
-                infos.Count.Should().Be(1);
-                infos[0].Should().Be(string.Format(@"Generating template to a file{0} at 'c:\packages\bob.nuspec'", Environment.NewLine));
+                infos.Should().ContainSingle();
+                infos.Should().HaveElementAt(0,string.Format(@"Generating template to a file{0} at 'c:\packages\bob.nuspec'", Environment.NewLine));
             }
         }
 
@@ -294,13 +294,13 @@ namespace chocolatey.tests.infrastructure.app.services
                 because();
 
                 var directories = directoryCreated.ToList();
-                directories.Count.Should().Be(2, "There should be 2 directories, but there was: " + string.Join(", ", directories));
-                directories[0].Should().Be("c:\\chocolatey\\Bob");
-                directories[1].Should().Be("c:\\chocolatey\\Bob\\tools");
+                directories.Should().HaveCount(2, "There should be 2 directories, but there was: " + string.Join(", ", directories));
+                directories.Should().HaveElementAt(0,"c:\\chocolatey\\Bob");
+                directories.Should().HaveElementAt(1,"c:\\chocolatey\\Bob\\tools");
 
-                files.Count.Should().Be(2, "There should be 2 files, but there was: " + string.Join(", ", files));
-                files[0].Should().Be("c:\\chocolatey\\Bob\\__name_replace__.nuspec");
-                files[1].Should().Be("c:\\chocolatey\\Bob\\random.txt");
+                files.Should().HaveCount(2, "There should be 2 files, but there was: " + string.Join(", ", files));
+                files.Should().HaveElementAt(0,"c:\\chocolatey\\Bob\\__name_replace__.nuspec");
+                files.Should().HaveElementAt(1,"c:\\chocolatey\\Bob\\random.txt");
 
                 MockLogger.MessagesFor(LogLevel.Info).Last().Should().Be(string.Format(@"Successfully generated Bob package specification files{0} at 'c:\chocolatey\Bob'", Environment.NewLine));
             }
@@ -313,13 +313,13 @@ namespace chocolatey.tests.infrastructure.app.services
                 because();
 
                 var directories = directoryCreated.ToList();
-                directories.Count.Should().Be(2, "There should be 2 directories, but there was: " + string.Join(", ", directories));
-                directories[0].Should().Be("c:\\packages\\Bob");
-                directories[1].Should().Be("c:\\packages\\Bob\\tools");
+                directories.Should().HaveCount(2, "There should be 2 directories, but there was: " + string.Join(", ", directories));
+                directories.Should().HaveElementAt(0,"c:\\packages\\Bob");
+                directories.Should().HaveElementAt(1,"c:\\packages\\Bob\\tools");
 
-                files.Count.Should().Be(2, "There should be 2 files, but there was: " + string.Join(", ", files));
-                files[0].Should().Be("c:\\packages\\Bob\\__name_replace__.nuspec");
-                files[1].Should().Be("c:\\packages\\Bob\\random.txt");
+                files.Should().HaveCount(2, "There should be 2 files, but there was: " + string.Join(", ", files));
+                files.Should().HaveElementAt(0,"c:\\packages\\Bob\\__name_replace__.nuspec");
+                files.Should().HaveElementAt(1,"c:\\packages\\Bob\\random.txt");
 
                 MockLogger.MessagesFor(LogLevel.Info).Last().Should().Be(string.Format(@"Successfully generated Bob package specification files{0} at 'c:\packages\Bob'", Environment.NewLine));
             }
@@ -392,16 +392,16 @@ namespace chocolatey.tests.infrastructure.app.services
                 because();
 
                 var directories = directoryCreated.ToList();
-                directories.Count.Should().Be(3, "There should be 3 directories, but there was: " + string.Join(", ", directories));
-                directories[0].Should().Be("c:\\chocolatey\\Bob");
-                directories[1].Should().Be("c:\\chocolatey\\Bob\\tools");
-                directories[2].Should().Be("c:\\chocolatey\\Bob\\tools\\lower");
+                directories.Should().HaveCount(3, "There should be 3 directories, but there was: " + string.Join(", ", directories));
+                directories.Should().HaveElementAt(0,"c:\\chocolatey\\Bob");
+                directories.Should().HaveElementAt(1,"c:\\chocolatey\\Bob\\tools");
+                directories.Should().HaveElementAt(2,"c:\\chocolatey\\Bob\\tools\\lower");
 
-                files.Count.Should().Be(4, "There should be 4 files, but there was: " + string.Join(", ", files));
-                files[0].Should().Be("c:\\chocolatey\\Bob\\__name_replace__.nuspec");
-                files[1].Should().Be("c:\\chocolatey\\Bob\\random.txt");
-                files[2].Should().Be("c:\\chocolatey\\Bob\\tools\\chocolateyInstall.ps1");
-                files[3].Should().Be("c:\\chocolatey\\Bob\\tools\\lower\\another.ps1");
+                files.Should().HaveCount(4, "There should be 4 files, but there was: " + string.Join(", ", files));
+                files.Should().HaveElementAt(0,"c:\\chocolatey\\Bob\\__name_replace__.nuspec");
+                files.Should().HaveElementAt(1,"c:\\chocolatey\\Bob\\random.txt");
+                files.Should().HaveElementAt(2,"c:\\chocolatey\\Bob\\tools\\chocolateyInstall.ps1");
+                files.Should().HaveElementAt(3,"c:\\chocolatey\\Bob\\tools\\lower\\another.ps1");
 
                 MockLogger.MessagesFor(LogLevel.Info).Last().Should().Be(string.Format(@"Successfully generated Bob package specification files{0} at 'c:\chocolatey\Bob'", Environment.NewLine));
             }
@@ -414,16 +414,16 @@ namespace chocolatey.tests.infrastructure.app.services
                 because();
 
                 var directories = directoryCreated.ToList();
-                directories.Count.Should().Be(3, "There should be 3 directories, but there was: " + string.Join(", ", directories));
-                directories[0].Should().Be("c:\\packages\\Bob");
-                directories[1].Should().Be("c:\\packages\\Bob\\tools");
-                directories[2].Should().Be("c:\\packages\\Bob\\tools\\lower");
+                directories.Should().HaveCount(3, "There should be 3 directories, but there was: " + string.Join(", ", directories));
+                directories.Should().HaveElementAt(0,"c:\\packages\\Bob");
+                directories.Should().HaveElementAt(1,"c:\\packages\\Bob\\tools");
+                directories.Should().HaveElementAt(2,"c:\\packages\\Bob\\tools\\lower");
 
-                files.Count.Should().Be(4, "There should be 4 files, but there was: " + string.Join(", ", files));
-                files[0].Should().Be("c:\\packages\\Bob\\__name_replace__.nuspec");
-                files[1].Should().Be("c:\\packages\\Bob\\random.txt");
-                files[2].Should().Be("c:\\packages\\Bob\\tools\\chocolateyInstall.ps1");
-                files[3].Should().Be("c:\\packages\\Bob\\tools\\lower\\another.ps1");
+                files.Should().HaveCount(4, "There should be 4 files, but there was: " + string.Join(", ", files));
+                files.Should().HaveElementAt(0,"c:\\packages\\Bob\\__name_replace__.nuspec");
+                files.Should().HaveElementAt(1,"c:\\packages\\Bob\\random.txt");
+                files.Should().HaveElementAt(2,"c:\\packages\\Bob\\tools\\chocolateyInstall.ps1");
+                files.Should().HaveElementAt(3,"c:\\packages\\Bob\\tools\\lower\\another.ps1");
 
                 MockLogger.MessagesFor(LogLevel.Info).Last().Should().Be(string.Format(@"Successfully generated Bob package specification files{0} at 'c:\packages\Bob'", Environment.NewLine));
             }
@@ -496,18 +496,18 @@ namespace chocolatey.tests.infrastructure.app.services
                 because();
 
                 var directories = directoryCreated.ToList();
-                directories.Count.Should().Be(5, "There should be 5 directories, but there was: " + string.Join(", ", directories));
-                directories[0].Should().Be("c:\\chocolatey\\Bob");
-                directories[1].Should().Be("c:\\chocolatey\\Bob\\tools");
-                directories[2].Should().Be("c:\\chocolatey\\Bob\\tools\\lower");
-                directories[3].Should().Be("c:\\chocolatey\\Bob\\empty");
-                directories[4].Should().Be("c:\\chocolatey\\Bob\\empty\\nested");
+                directories.Should().HaveCount(5, "There should be 5 directories, but there was: " + string.Join(", ", directories));
+                directories.Should().HaveElementAt(0,"c:\\chocolatey\\Bob");
+                directories.Should().HaveElementAt(1,"c:\\chocolatey\\Bob\\tools");
+                directories.Should().HaveElementAt(2,"c:\\chocolatey\\Bob\\tools\\lower");
+                directories.Should().HaveElementAt(3,"c:\\chocolatey\\Bob\\empty");
+                directories.Should().HaveElementAt(4,"c:\\chocolatey\\Bob\\empty\\nested");
 
-                files.Count.Should().Be(4, "There should be 4 files, but there was: " + string.Join(", ", files));
-                files[0].Should().Be("c:\\chocolatey\\Bob\\__name_replace__.nuspec");
-                files[1].Should().Be("c:\\chocolatey\\Bob\\random.txt");
-                files[2].Should().Be("c:\\chocolatey\\Bob\\tools\\chocolateyInstall.ps1");
-                files[3].Should().Be("c:\\chocolatey\\Bob\\tools\\lower\\another.ps1");
+                files.Should().HaveCount(4, "There should be 4 files, but there was: " + string.Join(", ", files));
+                files.Should().HaveElementAt(0,"c:\\chocolatey\\Bob\\__name_replace__.nuspec");
+                files.Should().HaveElementAt(1,"c:\\chocolatey\\Bob\\random.txt");
+                files.Should().HaveElementAt(2,"c:\\chocolatey\\Bob\\tools\\chocolateyInstall.ps1");
+                files.Should().HaveElementAt(3,"c:\\chocolatey\\Bob\\tools\\lower\\another.ps1");
 
                 MockLogger.MessagesFor(LogLevel.Info).Last().Should().Be(string.Format(@"Successfully generated Bob package specification files{0} at 'c:\chocolatey\Bob'", Environment.NewLine));
             }
@@ -520,18 +520,18 @@ namespace chocolatey.tests.infrastructure.app.services
                 because();
 
                 var directories = directoryCreated.ToList();
-                directories.Count.Should().Be(5, "There should be 5 directories, but there was: " + string.Join(", ", directories));
-                directories[0].Should().Be("c:\\packages\\Bob");
-                directories[1].Should().Be("c:\\packages\\Bob\\tools");
-                directories[2].Should().Be("c:\\packages\\Bob\\tools\\lower");
-                directories[3].Should().Be("c:\\packages\\Bob\\empty");
-                directories[4].Should().Be("c:\\packages\\Bob\\empty\\nested");
+                directories.Should().HaveCount(5, "There should be 5 directories, but there was: " + string.Join(", ", directories));
+                directories.Should().HaveElementAt(0,"c:\\packages\\Bob");
+                directories.Should().HaveElementAt(1,"c:\\packages\\Bob\\tools");
+                directories.Should().HaveElementAt(2,"c:\\packages\\Bob\\tools\\lower");
+                directories.Should().HaveElementAt(3,"c:\\packages\\Bob\\empty");
+                directories.Should().HaveElementAt(4,"c:\\packages\\Bob\\empty\\nested");
 
-                files.Count.Should().Be(4, "There should be 4 files, but there was: " + string.Join(", ", files));
-                files[0].Should().Be("c:\\packages\\Bob\\__name_replace__.nuspec");
-                files[1].Should().Be("c:\\packages\\Bob\\random.txt");
-                files[2].Should().Be("c:\\packages\\Bob\\tools\\chocolateyInstall.ps1");
-                files[3].Should().Be("c:\\packages\\Bob\\tools\\lower\\another.ps1");
+                files.Should().HaveCount(4, "There should be 4 files, but there was: " + string.Join(", ", files));
+                files.Should().HaveElementAt(0,"c:\\packages\\Bob\\__name_replace__.nuspec");
+                files.Should().HaveElementAt(1,"c:\\packages\\Bob\\random.txt");
+                files.Should().HaveElementAt(2,"c:\\packages\\Bob\\tools\\chocolateyInstall.ps1");
+                files.Should().HaveElementAt(3,"c:\\packages\\Bob\\tools\\lower\\another.ps1");
 
                 MockLogger.MessagesFor(LogLevel.Info).Last().Should().Be(string.Format(@"Successfully generated Bob package specification files{0} at 'c:\packages\Bob'", Environment.NewLine));
             }
@@ -849,8 +849,8 @@ namespace chocolatey.tests.infrastructure.app.services
                 because();
 
                 var infos = MockLogger.MessagesFor(LogLevel.Info);
-                infos.Count.Should().Be(1);
-                infos[0].Should().Be("Would have listed templates in {0}".FormatWith(ApplicationParameters.TemplatesLocation));
+                infos.Should().ContainSingle();
+                infos.Should().HaveElementAt(0,"Would have listed templates in {0}".FormatWith(ApplicationParameters.TemplatesLocation));
             }
 
             [Fact]
@@ -860,8 +860,8 @@ namespace chocolatey.tests.infrastructure.app.services
                 because();
 
                 var infos = MockLogger.MessagesFor(LogLevel.Info);
-                infos.Count.Should().Be(1);
-                infos[0].Should().Be("Would have listed information about {0}".FormatWith(config.TemplateCommand.Name));
+                infos.Should().ContainSingle();
+                infos.Should().HaveElementAt(0,"Would have listed information about {0}".FormatWith(config.TemplateCommand.Name));
             }
         }
     }

--- a/src/chocolatey.tests/infrastructure.app/services/TemplateServiceSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/services/TemplateServiceSpecs.cs
@@ -30,7 +30,7 @@ namespace chocolatey.tests.infrastructure.app.services
     using Moq;
     using NuGet.Common;
     using NUnit.Framework;
-    using Should;
+    using FluentAssertions;
     using LogLevel = tests.LogLevel;
 
     public class TemplateServiceSpecs
@@ -80,8 +80,8 @@ namespace chocolatey.tests.infrastructure.app.services
                 because();
 
                 var infos = MockLogger.MessagesFor(LogLevel.Info);
-                infos.Count.ShouldEqual(1);
-                infos[0].ShouldEqual("Would have generated a new package specification at c:\\chocolatey\\Bob");
+                infos.Count.Should().Be(1);
+                infos[0].Should().Be("Would have generated a new package specification at c:\\chocolatey\\Bob");
             }
 
             [Fact]
@@ -92,8 +92,8 @@ namespace chocolatey.tests.infrastructure.app.services
                 because();
 
                 var infos = MockLogger.MessagesFor(LogLevel.Info);
-                infos.Count.ShouldEqual(1);
-                infos[0].ShouldEqual("Would have generated a new package specification at c:\\packages\\Bob");
+                infos.Count.Should().Be(1);
+                infos[0].Should().Be("Would have generated a new package specification at c:\\packages\\Bob");
             }
         }
 
@@ -132,8 +132,8 @@ namespace chocolatey.tests.infrastructure.app.services
                 because();
 
                 var debugs = MockLogger.MessagesFor(LogLevel.Debug);
-                debugs.Count.ShouldEqual(1);
-                debugs[0].ShouldEqual("Bob");
+                debugs.Count.Should().Be(1);
+                debugs[0].Should().Be("Bob");
             }
 
             [Fact]
@@ -144,12 +144,12 @@ namespace chocolatey.tests.infrastructure.app.services
                 because();
 
                 var debugs = MockLogger.MessagesFor(LogLevel.Debug);
-                debugs.Count.ShouldEqual(1);
-                debugs[0].ShouldEqual("Bob");
+                debugs.Count.Should().Be(1);
+                debugs[0].Should().Be("Bob");
 
                 var infos = MockLogger.MessagesFor(LogLevel.Info);
-                infos.Count.ShouldEqual(1);
-                infos[0].ShouldEqual(string.Format(@"Generating template to a file{0} at 'c:\packages\bob.nuspec'", Environment.NewLine));
+                infos.Count.Should().Be(1);
+                infos[0].Should().Be(string.Format(@"Generating template to a file{0} at 'c:\packages\bob.nuspec'", Environment.NewLine));
             }
         }
 
@@ -202,9 +202,9 @@ namespace chocolatey.tests.infrastructure.app.services
                     errorMessage = ex.Message;
                 }
 
-                errored.ShouldBeTrue();
-                errorMessage.ShouldEqual(string.Format("The location for the template already exists. You can:{0} 1. Remove 'c:\\chocolatey\\Bob'{0} 2. Use --force{0} 3. Specify a different name", Environment.NewLine));
-                verifiedDirectoryPath.ShouldEqual("c:\\chocolatey\\Bob");
+                errored.Should().BeTrue();
+                errorMessage.Should().Be(string.Format("The location for the template already exists. You can:{0} 1. Remove 'c:\\chocolatey\\Bob'{0} 2. Use --force{0} 3. Specify a different name", Environment.NewLine));
+                verifiedDirectoryPath.Should().Be("c:\\chocolatey\\Bob");
             }
 
             [Fact]
@@ -225,9 +225,9 @@ namespace chocolatey.tests.infrastructure.app.services
                     errorMessage = ex.Message;
                 }
 
-                errored.ShouldBeTrue();
-                errorMessage.ShouldEqual(string.Format("The location for the template already exists. You can:{0} 1. Remove 'c:\\packages\\Bob'{0} 2. Use --force{0} 3. Specify a different name", Environment.NewLine));
-                verifiedDirectoryPath.ShouldEqual("c:\\packages\\Bob");
+                errored.Should().BeTrue();
+                errorMessage.Should().Be(string.Format("The location for the template already exists. You can:{0} 1. Remove 'c:\\packages\\Bob'{0} 2. Use --force{0} 3. Specify a different name", Environment.NewLine));
+                verifiedDirectoryPath.Should().Be("c:\\packages\\Bob");
             }
         }
 
@@ -294,15 +294,15 @@ namespace chocolatey.tests.infrastructure.app.services
                 because();
 
                 var directories = directoryCreated.ToList();
-                directories.Count.ShouldEqual(2, "There should be 2 directories, but there was: " + string.Join(", ", directories));
-                directories[0].ShouldEqual("c:\\chocolatey\\Bob");
-                directories[1].ShouldEqual("c:\\chocolatey\\Bob\\tools");
+                directories.Count.Should().Be(2, "There should be 2 directories, but there was: " + string.Join(", ", directories));
+                directories[0].Should().Be("c:\\chocolatey\\Bob");
+                directories[1].Should().Be("c:\\chocolatey\\Bob\\tools");
 
-                files.Count.ShouldEqual(2, "There should be 2 files, but there was: " + string.Join(", ", files));
-                files[0].ShouldEqual("c:\\chocolatey\\Bob\\__name_replace__.nuspec");
-                files[1].ShouldEqual("c:\\chocolatey\\Bob\\random.txt");
+                files.Count.Should().Be(2, "There should be 2 files, but there was: " + string.Join(", ", files));
+                files[0].Should().Be("c:\\chocolatey\\Bob\\__name_replace__.nuspec");
+                files[1].Should().Be("c:\\chocolatey\\Bob\\random.txt");
 
-                MockLogger.MessagesFor(LogLevel.Info).Last().ShouldEqual(string.Format(@"Successfully generated Bob package specification files{0} at 'c:\chocolatey\Bob'", Environment.NewLine));
+                MockLogger.MessagesFor(LogLevel.Info).Last().Should().Be(string.Format(@"Successfully generated Bob package specification files{0} at 'c:\chocolatey\Bob'", Environment.NewLine));
             }
 
             [Fact]
@@ -313,15 +313,15 @@ namespace chocolatey.tests.infrastructure.app.services
                 because();
 
                 var directories = directoryCreated.ToList();
-                directories.Count.ShouldEqual(2, "There should be 2 directories, but there was: " + string.Join(", ", directories));
-                directories[0].ShouldEqual("c:\\packages\\Bob");
-                directories[1].ShouldEqual("c:\\packages\\Bob\\tools");
+                directories.Count.Should().Be(2, "There should be 2 directories, but there was: " + string.Join(", ", directories));
+                directories[0].Should().Be("c:\\packages\\Bob");
+                directories[1].Should().Be("c:\\packages\\Bob\\tools");
 
-                files.Count.ShouldEqual(2, "There should be 2 files, but there was: " + string.Join(", ", files));
-                files[0].ShouldEqual("c:\\packages\\Bob\\__name_replace__.nuspec");
-                files[1].ShouldEqual("c:\\packages\\Bob\\random.txt");
+                files.Count.Should().Be(2, "There should be 2 files, but there was: " + string.Join(", ", files));
+                files[0].Should().Be("c:\\packages\\Bob\\__name_replace__.nuspec");
+                files[1].Should().Be("c:\\packages\\Bob\\random.txt");
 
-                MockLogger.MessagesFor(LogLevel.Info).Last().ShouldEqual(string.Format(@"Successfully generated Bob package specification files{0} at 'c:\packages\Bob'", Environment.NewLine));
+                MockLogger.MessagesFor(LogLevel.Info).Last().Should().Be(string.Format(@"Successfully generated Bob package specification files{0} at 'c:\packages\Bob'", Environment.NewLine));
             }
         }
 
@@ -392,18 +392,18 @@ namespace chocolatey.tests.infrastructure.app.services
                 because();
 
                 var directories = directoryCreated.ToList();
-                directories.Count.ShouldEqual(3, "There should be 3 directories, but there was: " + string.Join(", ", directories));
-                directories[0].ShouldEqual("c:\\chocolatey\\Bob");
-                directories[1].ShouldEqual("c:\\chocolatey\\Bob\\tools");
-                directories[2].ShouldEqual("c:\\chocolatey\\Bob\\tools\\lower");
+                directories.Count.Should().Be(3, "There should be 3 directories, but there was: " + string.Join(", ", directories));
+                directories[0].Should().Be("c:\\chocolatey\\Bob");
+                directories[1].Should().Be("c:\\chocolatey\\Bob\\tools");
+                directories[2].Should().Be("c:\\chocolatey\\Bob\\tools\\lower");
 
-                files.Count.ShouldEqual(4, "There should be 4 files, but there was: " + string.Join(", ", files));
-                files[0].ShouldEqual("c:\\chocolatey\\Bob\\__name_replace__.nuspec");
-                files[1].ShouldEqual("c:\\chocolatey\\Bob\\random.txt");
-                files[2].ShouldEqual("c:\\chocolatey\\Bob\\tools\\chocolateyInstall.ps1");
-                files[3].ShouldEqual("c:\\chocolatey\\Bob\\tools\\lower\\another.ps1");
+                files.Count.Should().Be(4, "There should be 4 files, but there was: " + string.Join(", ", files));
+                files[0].Should().Be("c:\\chocolatey\\Bob\\__name_replace__.nuspec");
+                files[1].Should().Be("c:\\chocolatey\\Bob\\random.txt");
+                files[2].Should().Be("c:\\chocolatey\\Bob\\tools\\chocolateyInstall.ps1");
+                files[3].Should().Be("c:\\chocolatey\\Bob\\tools\\lower\\another.ps1");
 
-                MockLogger.MessagesFor(LogLevel.Info).Last().ShouldEqual(string.Format(@"Successfully generated Bob package specification files{0} at 'c:\chocolatey\Bob'", Environment.NewLine));
+                MockLogger.MessagesFor(LogLevel.Info).Last().Should().Be(string.Format(@"Successfully generated Bob package specification files{0} at 'c:\chocolatey\Bob'", Environment.NewLine));
             }
 
             [Fact]
@@ -414,18 +414,18 @@ namespace chocolatey.tests.infrastructure.app.services
                 because();
 
                 var directories = directoryCreated.ToList();
-                directories.Count.ShouldEqual(3, "There should be 3 directories, but there was: " + string.Join(", ", directories));
-                directories[0].ShouldEqual("c:\\packages\\Bob");
-                directories[1].ShouldEqual("c:\\packages\\Bob\\tools");
-                directories[2].ShouldEqual("c:\\packages\\Bob\\tools\\lower");
+                directories.Count.Should().Be(3, "There should be 3 directories, but there was: " + string.Join(", ", directories));
+                directories[0].Should().Be("c:\\packages\\Bob");
+                directories[1].Should().Be("c:\\packages\\Bob\\tools");
+                directories[2].Should().Be("c:\\packages\\Bob\\tools\\lower");
 
-                files.Count.ShouldEqual(4, "There should be 4 files, but there was: " + string.Join(", ", files));
-                files[0].ShouldEqual("c:\\packages\\Bob\\__name_replace__.nuspec");
-                files[1].ShouldEqual("c:\\packages\\Bob\\random.txt");
-                files[2].ShouldEqual("c:\\packages\\Bob\\tools\\chocolateyInstall.ps1");
-                files[3].ShouldEqual("c:\\packages\\Bob\\tools\\lower\\another.ps1");
+                files.Count.Should().Be(4, "There should be 4 files, but there was: " + string.Join(", ", files));
+                files[0].Should().Be("c:\\packages\\Bob\\__name_replace__.nuspec");
+                files[1].Should().Be("c:\\packages\\Bob\\random.txt");
+                files[2].Should().Be("c:\\packages\\Bob\\tools\\chocolateyInstall.ps1");
+                files[3].Should().Be("c:\\packages\\Bob\\tools\\lower\\another.ps1");
 
-                MockLogger.MessagesFor(LogLevel.Info).Last().ShouldEqual(string.Format(@"Successfully generated Bob package specification files{0} at 'c:\packages\Bob'", Environment.NewLine));
+                MockLogger.MessagesFor(LogLevel.Info).Last().Should().Be(string.Format(@"Successfully generated Bob package specification files{0} at 'c:\packages\Bob'", Environment.NewLine));
             }
         }
 
@@ -496,20 +496,20 @@ namespace chocolatey.tests.infrastructure.app.services
                 because();
 
                 var directories = directoryCreated.ToList();
-                directories.Count.ShouldEqual(5, "There should be 5 directories, but there was: " + string.Join(", ", directories));
-                directories[0].ShouldEqual("c:\\chocolatey\\Bob");
-                directories[1].ShouldEqual("c:\\chocolatey\\Bob\\tools");
-                directories[2].ShouldEqual("c:\\chocolatey\\Bob\\tools\\lower");
-                directories[3].ShouldEqual("c:\\chocolatey\\Bob\\empty");
-                directories[4].ShouldEqual("c:\\chocolatey\\Bob\\empty\\nested");
+                directories.Count.Should().Be(5, "There should be 5 directories, but there was: " + string.Join(", ", directories));
+                directories[0].Should().Be("c:\\chocolatey\\Bob");
+                directories[1].Should().Be("c:\\chocolatey\\Bob\\tools");
+                directories[2].Should().Be("c:\\chocolatey\\Bob\\tools\\lower");
+                directories[3].Should().Be("c:\\chocolatey\\Bob\\empty");
+                directories[4].Should().Be("c:\\chocolatey\\Bob\\empty\\nested");
 
-                files.Count.ShouldEqual(4, "There should be 4 files, but there was: " + string.Join(", ", files));
-                files[0].ShouldEqual("c:\\chocolatey\\Bob\\__name_replace__.nuspec");
-                files[1].ShouldEqual("c:\\chocolatey\\Bob\\random.txt");
-                files[2].ShouldEqual("c:\\chocolatey\\Bob\\tools\\chocolateyInstall.ps1");
-                files[3].ShouldEqual("c:\\chocolatey\\Bob\\tools\\lower\\another.ps1");
+                files.Count.Should().Be(4, "There should be 4 files, but there was: " + string.Join(", ", files));
+                files[0].Should().Be("c:\\chocolatey\\Bob\\__name_replace__.nuspec");
+                files[1].Should().Be("c:\\chocolatey\\Bob\\random.txt");
+                files[2].Should().Be("c:\\chocolatey\\Bob\\tools\\chocolateyInstall.ps1");
+                files[3].Should().Be("c:\\chocolatey\\Bob\\tools\\lower\\another.ps1");
 
-                MockLogger.MessagesFor(LogLevel.Info).Last().ShouldEqual(string.Format(@"Successfully generated Bob package specification files{0} at 'c:\chocolatey\Bob'", Environment.NewLine));
+                MockLogger.MessagesFor(LogLevel.Info).Last().Should().Be(string.Format(@"Successfully generated Bob package specification files{0} at 'c:\chocolatey\Bob'", Environment.NewLine));
             }
 
             [Fact]
@@ -520,20 +520,20 @@ namespace chocolatey.tests.infrastructure.app.services
                 because();
 
                 var directories = directoryCreated.ToList();
-                directories.Count.ShouldEqual(5, "There should be 5 directories, but there was: " + string.Join(", ", directories));
-                directories[0].ShouldEqual("c:\\packages\\Bob");
-                directories[1].ShouldEqual("c:\\packages\\Bob\\tools");
-                directories[2].ShouldEqual("c:\\packages\\Bob\\tools\\lower");
-                directories[3].ShouldEqual("c:\\packages\\Bob\\empty");
-                directories[4].ShouldEqual("c:\\packages\\Bob\\empty\\nested");
+                directories.Count.Should().Be(5, "There should be 5 directories, but there was: " + string.Join(", ", directories));
+                directories[0].Should().Be("c:\\packages\\Bob");
+                directories[1].Should().Be("c:\\packages\\Bob\\tools");
+                directories[2].Should().Be("c:\\packages\\Bob\\tools\\lower");
+                directories[3].Should().Be("c:\\packages\\Bob\\empty");
+                directories[4].Should().Be("c:\\packages\\Bob\\empty\\nested");
 
-                files.Count.ShouldEqual(4, "There should be 4 files, but there was: " + string.Join(", ", files));
-                files[0].ShouldEqual("c:\\packages\\Bob\\__name_replace__.nuspec");
-                files[1].ShouldEqual("c:\\packages\\Bob\\random.txt");
-                files[2].ShouldEqual("c:\\packages\\Bob\\tools\\chocolateyInstall.ps1");
-                files[3].ShouldEqual("c:\\packages\\Bob\\tools\\lower\\another.ps1");
+                files.Count.Should().Be(4, "There should be 4 files, but there was: " + string.Join(", ", files));
+                files[0].Should().Be("c:\\packages\\Bob\\__name_replace__.nuspec");
+                files[1].Should().Be("c:\\packages\\Bob\\random.txt");
+                files[2].Should().Be("c:\\packages\\Bob\\tools\\chocolateyInstall.ps1");
+                files[3].Should().Be("c:\\packages\\Bob\\tools\\lower\\another.ps1");
 
-                MockLogger.MessagesFor(LogLevel.Info).Last().ShouldEqual(string.Format(@"Successfully generated Bob package specification files{0} at 'c:\packages\Bob'", Environment.NewLine));
+                MockLogger.MessagesFor(LogLevel.Info).Last().Should().Be(string.Format(@"Successfully generated Bob package specification files{0} at 'c:\packages\Bob'", Environment.NewLine));
             }
         }
 
@@ -571,7 +571,7 @@ namespace chocolatey.tests.infrastructure.app.services
             {
                 because();
 
-                config.NewCommand.TemplateName.ShouldBeNull();
+                config.NewCommand.TemplateName.Should().BeNull();
             }
         }
 
@@ -616,7 +616,7 @@ namespace chocolatey.tests.infrastructure.app.services
             {
                 because();
 
-                config.NewCommand.TemplateName.ShouldEqual("msi");
+                config.NewCommand.TemplateName.Should().Be("msi");
             }
         }
 
@@ -662,7 +662,7 @@ namespace chocolatey.tests.infrastructure.app.services
             {
                 because();
 
-                config.NewCommand.TemplateName.ShouldEqual("zip");
+                config.NewCommand.TemplateName.Should().Be("zip");
             }
         }
 
@@ -696,7 +696,7 @@ namespace chocolatey.tests.infrastructure.app.services
             {
                 because();
 
-                config.NewCommand.TemplateName.ShouldBeNull();
+                config.NewCommand.TemplateName.Should().BeNull();
             }
         }
 
@@ -731,7 +731,7 @@ namespace chocolatey.tests.infrastructure.app.services
             {
                 because();
 
-                config.NewCommand.TemplateName.ShouldBeNull();
+                config.NewCommand.TemplateName.Should().BeNull();
             }
         }
 
@@ -777,7 +777,7 @@ namespace chocolatey.tests.infrastructure.app.services
             {
                 because();
 
-                config.NewCommand.TemplateName.ShouldEqual("zip");
+                config.NewCommand.TemplateName.Should().Be("zip");
             }
         }
 
@@ -824,7 +824,7 @@ namespace chocolatey.tests.infrastructure.app.services
             {
                 because();
 
-                config.NewCommand.TemplateName.ShouldEqual("zip");
+                config.NewCommand.TemplateName.Should().Be("zip");
             }
         }
 
@@ -849,8 +849,8 @@ namespace chocolatey.tests.infrastructure.app.services
                 because();
 
                 var infos = MockLogger.MessagesFor(LogLevel.Info);
-                infos.Count.ShouldEqual(1);
-                infos[0].ShouldEqual("Would have listed templates in {0}".FormatWith(ApplicationParameters.TemplatesLocation));
+                infos.Count.Should().Be(1);
+                infos[0].Should().Be("Would have listed templates in {0}".FormatWith(ApplicationParameters.TemplatesLocation));
             }
 
             [Fact]
@@ -860,8 +860,8 @@ namespace chocolatey.tests.infrastructure.app.services
                 because();
 
                 var infos = MockLogger.MessagesFor(LogLevel.Info);
-                infos.Count.ShouldEqual(1);
-                infos[0].ShouldEqual("Would have listed information about {0}".FormatWith(config.TemplateCommand.Name));
+                infos.Count.Should().Be(1);
+                infos[0].Should().Be("Would have listed information about {0}".FormatWith(config.TemplateCommand.Name));
             }
         }
     }

--- a/src/chocolatey.tests/infrastructure.app/utility/ArgumentsUtilitySpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/utility/ArgumentsUtilitySpecs.cs
@@ -2,7 +2,7 @@
 {
     using chocolatey.infrastructure.app.utility;
     using NUnit.Framework;
-    using Should;
+    using FluentAssertions;
 
     public class ArgumentsUtilitySpecs
     {
@@ -55,7 +55,7 @@
             [Fact]
             public void Should_return_expected_result()
             {
-                _result.ShouldEqual(_expectedResult);
+                _result.Should().Be(_expectedResult);
             }
         }
     }

--- a/src/chocolatey.tests/infrastructure.app/utility/PackageUtilitySpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/utility/PackageUtilitySpecs.cs
@@ -19,7 +19,7 @@ namespace chocolatey.tests.infrastructure.app.utility
     using chocolatey.infrastructure.app.configuration;
     using chocolatey.infrastructure.platforms;
     using NUnit.Framework;
-    using Should;
+    using FluentAssertions;
 
     public class PackageUtilitySpecs
     {
@@ -67,7 +67,7 @@ namespace chocolatey.tests.infrastructure.app.utility
             [Fact]
             public void Should_return_expected_result()
             {
-                _result.ShouldEqual(_expectedResult);
+                _result.Should().Be(_expectedResult);
             }
         }
     }

--- a/src/chocolatey.tests/infrastructure/commandline/InteractivePromptSpecs.cs
+++ b/src/chocolatey.tests/infrastructure/commandline/InteractivePromptSpecs.cs
@@ -21,7 +21,7 @@ namespace chocolatey.tests.infrastructure.commandline
     using chocolatey.infrastructure.adapters;
     using chocolatey.infrastructure.commandline;
     using Moq;
-    using Should;
+    using FluentAssertions;
 
     public class InteractivePromptSpecs
     {
@@ -73,7 +73,7 @@ namespace chocolatey.tests.infrastructure.commandline
                     errored = true;
                 }
 
-                errored.ShouldBeTrue();
+                errored.Should().BeTrue();
                 console.Verify(c => c.ReadLine(), Times.Never);
             }
 
@@ -94,8 +94,8 @@ namespace chocolatey.tests.infrastructure.commandline
                     errorMessage = ex.Message;
                 }
 
-                errored.ShouldBeTrue();
-                errorMessage.ShouldContain("No choices passed in.");
+                errored.Should().BeTrue();
+                errorMessage.Should().Contain("No choices passed in.");
                 console.Verify(c => c.ReadLine(), Times.Never);
             }
 
@@ -118,7 +118,7 @@ namespace chocolatey.tests.infrastructure.commandline
                     errored = true;
                 }
 
-                errored.ShouldBeTrue();
+                errored.Should().BeTrue();
                 console.Verify(c => c.ReadLine(), Times.Never);
             }
 
@@ -144,9 +144,9 @@ namespace chocolatey.tests.infrastructure.commandline
                     errorMessage = ex.Message;
                 }
 
-                result.ShouldNotEqual("maybe");
-                errored.ShouldBeTrue();
-                errorMessage.ShouldEqual("Default choice value must be one of the given choices.");
+                result.Should().NotBe("maybe");
+                errored.Should().BeTrue();
+                errorMessage.Should().Be("Default choice value must be one of the given choices.");
                 console.Verify(c => c.ReadLine(), Times.Never);
             }
         }
@@ -171,7 +171,7 @@ namespace chocolatey.tests.infrastructure.commandline
             {
                 console.Setup(c => c.ReadLine()).Returns(""); //Enter pressed
                 var result = prompt();
-                result.ShouldBeNull();
+                result.Should().BeNull();
             }
 
             [Fact]
@@ -179,7 +179,7 @@ namespace chocolatey.tests.infrastructure.commandline
             {
                 console.Setup(c => c.ReadLine()).Returns("1");
                 var result = prompt();
-                result.ShouldEqual(choices[0]);
+                result.Should().Be(choices[0]);
             }
 
             [Fact]
@@ -187,7 +187,7 @@ namespace chocolatey.tests.infrastructure.commandline
             {
                 console.Setup(c => c.ReadLine()).Returns("yes");
                 var result = prompt();
-                result.ShouldEqual(choices[0]);
+                result.Should().Be(choices[0]);
             }
 
             [Fact]
@@ -195,7 +195,7 @@ namespace chocolatey.tests.infrastructure.commandline
             {
                 console.Setup(c => c.ReadLine()).Returns("2");
                 var result = prompt();
-                result.ShouldEqual(choices[1]);
+                result.Should().Be(choices[1]);
             }
 
             [Fact]
@@ -203,7 +203,7 @@ namespace chocolatey.tests.infrastructure.commandline
             {
                 console.Setup(c => c.ReadLine()).Returns("3");
                 var result = prompt();
-                result.ShouldBeNull();
+                result.Should().BeNull();
             }
 
             [Fact]
@@ -211,7 +211,7 @@ namespace chocolatey.tests.infrastructure.commandline
             {
                 console.Setup(c => c.ReadLine()).Returns("4");
                 var result = prompt();
-                result.ShouldBeNull();
+                result.Should().BeNull();
             }
 
             [Fact]
@@ -219,7 +219,7 @@ namespace chocolatey.tests.infrastructure.commandline
             {
                 console.Setup(c => c.ReadLine()).Returns("0");
                 var result = prompt();
-                result.ShouldBeNull();
+                result.Should().BeNull();
             }
 
             [Fact]
@@ -227,7 +227,7 @@ namespace chocolatey.tests.infrastructure.commandline
             {
                 console.Setup(c => c.ReadLine()).Returns("-1");
                 var result = prompt();
-                result.ShouldBeNull();
+                result.Should().BeNull();
             }
 
             [Fact]
@@ -235,7 +235,7 @@ namespace chocolatey.tests.infrastructure.commandline
             {
                 console.Setup(c => c.ReadLine()).Returns("abc");
                 var result = prompt();
-                result.ShouldBeNull();
+                result.Should().BeNull();
             }
         }
 
@@ -268,7 +268,7 @@ namespace chocolatey.tests.infrastructure.commandline
                 {
                     errored = true;
                 }
-                errored.ShouldBeTrue();
+                errored.Should().BeTrue();
                 console.Verify(c => c.ReadLine(), Times.AtLeast(8));
             }
 
@@ -277,7 +277,7 @@ namespace chocolatey.tests.infrastructure.commandline
             {
                 console.Setup(c => c.ReadLine()).Returns("1");
                 var result = prompt();
-                result.ShouldEqual(choices[0]);
+                result.Should().Be(choices[0]);
             }
 
             [Fact]
@@ -285,7 +285,7 @@ namespace chocolatey.tests.infrastructure.commandline
             {
                 console.Setup(c => c.ReadLine()).Returns("2");
                 var result = prompt();
-                result.ShouldEqual(choices[1]);
+                result.Should().Be(choices[1]);
             }
 
             [Fact]
@@ -302,7 +302,7 @@ namespace chocolatey.tests.infrastructure.commandline
                 {
                     errored = true;
                 }
-                errored.ShouldBeTrue();
+                errored.Should().BeTrue();
                 console.Verify(c => c.ReadLine(), Times.AtLeast(8));
             }
         }
@@ -327,7 +327,7 @@ namespace chocolatey.tests.infrastructure.commandline
             {
                 console.Setup(c => c.ReadLine()).Returns(""); //Enter pressed
                 var result = prompt();
-                result.ShouldEqual(choices[1]);
+                result.Should().Be(choices[1]);
             }
 
             [Fact]
@@ -335,7 +335,7 @@ namespace chocolatey.tests.infrastructure.commandline
             {
                 console.Setup(c => c.ReadLine()).Returns("1");
                 var result = prompt();
-                result.ShouldEqual(choices[0]);
+                result.Should().Be(choices[0]);
             }
 
             [Fact]
@@ -343,7 +343,7 @@ namespace chocolatey.tests.infrastructure.commandline
             {
                 console.Setup(c => c.ReadLine()).Returns("2");
                 var result = prompt();
-                result.ShouldEqual(choices[1]);
+                result.Should().Be(choices[1]);
             }
 
             [Fact]
@@ -351,7 +351,7 @@ namespace chocolatey.tests.infrastructure.commandline
             {
                 console.Setup(c => c.ReadLine()).Returns("3");
                 var result = prompt();
-                result.ShouldBeNull();
+                result.Should().BeNull();
             }
 
             [Fact]
@@ -359,7 +359,7 @@ namespace chocolatey.tests.infrastructure.commandline
             {
                 console.Setup(c => c.ReadLine()).Returns("4");
                 var result = prompt();
-                result.ShouldBeNull();
+                result.Should().BeNull();
             }
 
             [Fact]
@@ -367,7 +367,7 @@ namespace chocolatey.tests.infrastructure.commandline
             {
                 console.Setup(c => c.ReadLine()).Returns("0");
                 var result = prompt();
-                result.ShouldBeNull();
+                result.Should().BeNull();
             }
 
             [Fact]
@@ -375,7 +375,7 @@ namespace chocolatey.tests.infrastructure.commandline
             {
                 console.Setup(c => c.ReadLine()).Returns("-1");
                 var result = prompt();
-                result.ShouldBeNull();
+                result.Should().BeNull();
             }
 
             [Fact]
@@ -383,7 +383,7 @@ namespace chocolatey.tests.infrastructure.commandline
             {
                 console.Setup(c => c.ReadLine()).Returns("abc");
                 var result = prompt();
-                result.ShouldBeNull();
+                result.Should().BeNull();
             }
         }
 
@@ -407,7 +407,7 @@ namespace chocolatey.tests.infrastructure.commandline
             {
                 console.Setup(c => c.ReadLine()).Returns(""); //Enter pressed
                 var result = prompt();
-                result.ShouldEqual(choices[0]);
+                result.Should().Be(choices[0]);
             }
 
             [Fact]
@@ -415,7 +415,7 @@ namespace chocolatey.tests.infrastructure.commandline
             {
                 console.Setup(c => c.ReadLine()).Returns("1");
                 var result = prompt();
-                result.ShouldEqual(choices[0]);
+                result.Should().Be(choices[0]);
             }
 
             [Fact]
@@ -423,7 +423,7 @@ namespace chocolatey.tests.infrastructure.commandline
             {
                 console.Setup(c => c.ReadLine()).Returns("2");
                 var result = prompt();
-                result.ShouldEqual(choices[1]);
+                result.Should().Be(choices[1]);
             }
 
             [Fact]
@@ -440,7 +440,7 @@ namespace chocolatey.tests.infrastructure.commandline
                 {
                     errored = true;
                 }
-                errored.ShouldBeTrue();
+                errored.Should().BeTrue();
                 console.Verify(c => c.ReadLine(), Times.AtLeast(8));
             }
         }
@@ -470,7 +470,7 @@ namespace chocolatey.tests.infrastructure.commandline
                     errored = true;
                 }
 
-                errored.ShouldBeTrue();
+                errored.Should().BeTrue();
                 console.Verify(c => c.ReadLine(), Times.Never);
             }
 
@@ -491,8 +491,8 @@ namespace chocolatey.tests.infrastructure.commandline
                     errorMessage = ex.Message;
                 }
 
-                errored.ShouldBeTrue();
-                errorMessage.ShouldContain("No choices passed in.");
+                errored.Should().BeTrue();
+                errorMessage.Should().Contain("No choices passed in.");
                 console.Verify(c => c.ReadLine(), Times.Never);
             }
 
@@ -517,8 +517,8 @@ namespace chocolatey.tests.infrastructure.commandline
                     errorMessage = ex.Message;
                 }
 
-                errored.ShouldBeTrue();
-                errorMessage.ShouldContain("Value for prompt cannot be null.");
+                errored.Should().BeTrue();
+                errorMessage.Should().Contain("Value for prompt cannot be null.");
                 console.Verify(c => c.ReadLine(), Times.Never);
             }
 
@@ -543,8 +543,8 @@ namespace chocolatey.tests.infrastructure.commandline
                     errorMessage = ex.Message;
                 }
 
-                errored.ShouldBeTrue();
-                errorMessage.ShouldContain("Some choices are empty.");
+                errored.Should().BeTrue();
+                errorMessage.Should().Contain("Some choices are empty.");
                 console.Verify(c => c.ReadLine(), Times.Never);
             }
 
@@ -569,8 +569,8 @@ namespace chocolatey.tests.infrastructure.commandline
                     errorMessage = ex.Message;
                 }
 
-                errored.ShouldBeTrue();
-                errorMessage.ShouldContain("Multiple choices have the same first letter.");
+                errored.Should().BeTrue();
+                errorMessage.Should().Contain("Multiple choices have the same first letter.");
                 console.Verify(c => c.ReadLine(), Times.Never);
             }
         }
@@ -604,7 +604,7 @@ namespace chocolatey.tests.infrastructure.commandline
                 {
                     errored = true;
                 }
-                errored.ShouldBeTrue();
+                errored.Should().BeTrue();
                 console.Verify(c => c.ReadLine(), Times.AtLeast(8));
             }
 
@@ -613,7 +613,7 @@ namespace chocolatey.tests.infrastructure.commandline
             {
                 console.Setup(c => c.ReadLine()).Returns("yes");
                 var result = prompt();
-                result.ShouldEqual("yes");
+                result.Should().Be("yes");
             }
 
             [Fact]
@@ -621,7 +621,7 @@ namespace chocolatey.tests.infrastructure.commandline
             {
                 console.Setup(c => c.ReadLine()).Returns("y");
                 var result = prompt();
-                result.ShouldEqual("yes");
+                result.Should().Be("yes");
             }
 
             [Fact]
@@ -629,7 +629,7 @@ namespace chocolatey.tests.infrastructure.commandline
             {
                 console.Setup(c => c.ReadLine()).Returns("no");
                 var result = prompt();
-                result.ShouldEqual("no");
+                result.Should().Be("no");
             }
 
             [Fact]
@@ -637,7 +637,7 @@ namespace chocolatey.tests.infrastructure.commandline
             {
                 console.Setup(c => c.ReadLine()).Returns("n");
                 var result = prompt();
-                result.ShouldEqual("no");
+                result.Should().Be("no");
             }
 
             [Fact]
@@ -654,7 +654,7 @@ namespace chocolatey.tests.infrastructure.commandline
                 {
                     errored = true;
                 }
-                errored.ShouldBeTrue();
+                errored.Should().BeTrue();
                 console.Verify(c => c.ReadLine(), Times.AtLeast(8));
             }
         }
@@ -685,7 +685,7 @@ namespace chocolatey.tests.infrastructure.commandline
             {
                 console.Setup(c => c.ReadLine()).Returns("all - yes to all");
                 var result = prompt();
-                result.ShouldEqual("all - yes to all");
+                result.Should().Be("all - yes to all");
             }
 
             [Fact]
@@ -693,7 +693,7 @@ namespace chocolatey.tests.infrastructure.commandline
             {
                 console.Setup(c => c.ReadLine()).Returns("all");
                 var result = prompt();
-                result.ShouldEqual("all - yes to all");
+                result.Should().Be("all - yes to all");
             }
         }
     }

--- a/src/chocolatey.tests/infrastructure/commands/CommandExecutorSpecs.cs
+++ b/src/chocolatey.tests/infrastructure/commands/CommandExecutorSpecs.cs
@@ -22,7 +22,7 @@ namespace chocolatey.tests.infrastructure.commands
     using chocolatey.infrastructure.commands;
     using chocolatey.infrastructure.filesystem;
     using Moq;
-    using Should;
+    using FluentAssertions;
 
     public class CommandExecutorSpecs
     {
@@ -94,7 +94,7 @@ namespace chocolatey.tests.infrastructure.commands
             [Fact]
             public void Should_return_an_exit_code_of_zero_when_finished()
             {
-                result.ShouldEqual(0);
+                result.Should().Be(0);
             }
         }
 
@@ -123,7 +123,7 @@ namespace chocolatey.tests.infrastructure.commands
             [Fact]
             public void Should_return_an_exit_code_of_negative_one_since_it_timed_out()
             {
-                result.ShouldEqual(-1);
+                result.Should().Be(-1);
             }
 
             [Fact]
@@ -145,7 +145,7 @@ namespace chocolatey.tests.infrastructure.commands
             [Fact]
             public void Should_have_an_exit_code_of_negative_one_as_it_didnt_wait_for_finish()
             {
-                result.ShouldEqual(-1);
+                result.Should().Be(-1);
             }
 
             [Fact]

--- a/src/chocolatey.tests/infrastructure/commands/ExternalCommandArgsBuilderSpecs.cs
+++ b/src/chocolatey.tests/infrastructure/commands/ExternalCommandArgsBuilderSpecs.cs
@@ -20,7 +20,7 @@ namespace chocolatey.tests.infrastructure.commands
     using System.Collections.Generic;
     using chocolatey.infrastructure.app.configuration;
     using chocolatey.infrastructure.commands;
-    using Should;
+    using FluentAssertions;
 
     public class ExternalCommandArgsBuilderSpecs
     {
@@ -53,7 +53,7 @@ namespace chocolatey.tests.infrastructure.commands
                     {
                         ArgumentOption = "-source "
                     });
-                buildConfigs().ShouldEqual("-source " + configuration.Sources);
+                buildConfigs().Should().Be("-source " + configuration.Sources);
             }
 
             [Fact]
@@ -66,7 +66,7 @@ namespace chocolatey.tests.infrastructure.commands
                     {
                         ArgumentOption = "-apikey "
                     });
-                buildConfigs().ShouldEqual("-apikey " + configuration.ApiKeyCommand.Key);
+                buildConfigs().Should().Be("-apikey " + configuration.ApiKeyCommand.Key);
             }
 
             [Fact]
@@ -79,7 +79,7 @@ namespace chocolatey.tests.infrastructure.commands
                     {
                         ArgumentOption = "-source "
                     });
-                buildConfigs().ShouldEqual("");
+                buildConfigs().Should().Be("");
             }
 
             [Fact]
@@ -92,7 +92,7 @@ namespace chocolatey.tests.infrastructure.commands
                     {
                         ArgumentOption = "-source "
                     });
-                ExternalCommandArgsBuilder.BuildArguments(configuration, ignoreCaseDictionary).ShouldEqual("-source yo");
+                ExternalCommandArgsBuilder.BuildArguments(configuration, ignoreCaseDictionary).Should().Be("-source yo");
             }
 
             [Fact]
@@ -106,7 +106,7 @@ namespace chocolatey.tests.infrastructure.commands
                         ArgumentOption = "-source ",
                         ArgumentValue = "bob"
                     });
-                buildConfigs().ShouldEqual("-source bob");
+                buildConfigs().Should().Be("-source bob");
             }
 
             [Fact]
@@ -119,7 +119,7 @@ namespace chocolatey.tests.infrastructure.commands
                     {
                         ArgumentOption = "-version "
                     });
-                buildConfigs().ShouldEqual("");
+                buildConfigs().Should().Be("");
             }
 
             [Fact]
@@ -133,7 +133,7 @@ namespace chocolatey.tests.infrastructure.commands
                         ArgumentOption = "install",
                         Required = true
                     });
-                buildConfigs().ShouldEqual("install");
+                buildConfigs().Should().Be("install");
             }
 
             [Fact]
@@ -146,7 +146,7 @@ namespace chocolatey.tests.infrastructure.commands
                     {
                         ArgumentOption = "install"
                     });
-                buildConfigs().ShouldEqual("");
+                buildConfigs().Should().Be("");
             }
 
             [Fact]
@@ -160,7 +160,7 @@ namespace chocolatey.tests.infrastructure.commands
                         ArgumentOption = "install",
                         Required = true
                     });
-                buildConfigs().ShouldEqual("install");
+                buildConfigs().Should().Be("install");
             }
 
             [Fact]
@@ -173,7 +173,7 @@ namespace chocolatey.tests.infrastructure.commands
                     {
                         ArgumentOption = "-verbose"
                     });
-                buildConfigs().ShouldEqual("-verbose");
+                buildConfigs().Should().Be("-verbose");
             }
 
             [Fact]
@@ -186,7 +186,7 @@ namespace chocolatey.tests.infrastructure.commands
                     {
                         ArgumentOption = "-pre"
                     });
-                buildConfigs().ShouldEqual("");
+                buildConfigs().Should().Be("");
             }
 
             [Fact]
@@ -200,7 +200,7 @@ namespace chocolatey.tests.infrastructure.commands
                         ArgumentOption = "-source ",
                         QuoteValue = true
                     });
-                buildConfigs().ShouldEqual("-source \"yo\"");
+                buildConfigs().Should().Be("-source \"yo\"");
             }
 
             [Fact]
@@ -213,7 +213,7 @@ namespace chocolatey.tests.infrastructure.commands
                     {
                         ArgumentOption = "-command "
                     });
-                buildConfigs().ShouldEqual("-command \"{0}\"".FormatWith(configuration.CommandName));
+                buildConfigs().Should().Be("-command \"{0}\"".FormatWith(configuration.CommandName));
             }
 
             [Fact]
@@ -227,7 +227,7 @@ namespace chocolatey.tests.infrastructure.commands
                         ArgumentOption = "-source you know = ",
                         QuoteValue = true
                     });
-                buildConfigs().ShouldEqual("-source you know = \"yo\"");
+                buildConfigs().Should().Be("-source you know = \"yo\"");
             }
 
             [Fact]
@@ -241,7 +241,7 @@ namespace chocolatey.tests.infrastructure.commands
                         ArgumentOption = "-source ",
                         UseValueOnly = true
                     });
-                buildConfigs().ShouldEqual("yo");
+                buildConfigs().Should().Be("yo");
             }
 
             [Fact]
@@ -257,7 +257,7 @@ namespace chocolatey.tests.infrastructure.commands
                         UseValueOnly = true,
                         Required = true
                     });
-                buildConfigs().ShouldEqual("bob");
+                buildConfigs().Should().Be("bob");
             }
 
             [Fact]
@@ -271,7 +271,7 @@ namespace chocolatey.tests.infrastructure.commands
                         ArgumentOption = "-version ",
                         UseValueOnly = true
                     });
-                buildConfigs().ShouldEqual("");
+                buildConfigs().Should().Be("");
             }
 
             [Fact]
@@ -291,7 +291,7 @@ namespace chocolatey.tests.infrastructure.commands
                     {
                         ArgumentOption = "-source "
                     });
-                buildConfigs().ShouldEqual("install -source yo");
+                buildConfigs().Should().Be("install -source yo");
             }
 
             [Fact]
@@ -336,7 +336,7 @@ namespace chocolatey.tests.infrastructure.commands
                         Required = true
                     });
 
-                buildConfigs().ShouldEqual("install -outputdirectory \"bob\" -source \"{0}\" -noninteractive -nocache".FormatWith(configuration.Sources));
+                buildConfigs().Should().Be("install -outputdirectory \"bob\" -source \"{0}\" -noninteractive -nocache".FormatWith(configuration.Sources));
             }
         }
     }

--- a/src/chocolatey.tests/infrastructure/commands/PowershellExecutorSpecs.cs
+++ b/src/chocolatey.tests/infrastructure/commands/PowershellExecutorSpecs.cs
@@ -22,7 +22,7 @@ namespace chocolatey.tests.infrastructure.commands
     using chocolatey.infrastructure.filesystem;
     using Moq;
     using NUnit.Framework;
-    using Should;
+    using FluentAssertions;
 
     public class PowershellExecutorSpecs
     {
@@ -55,19 +55,19 @@ namespace chocolatey.tests.infrastructure.commands
             [Fact]
             public void Should_not_return_null()
             {
-                result.ShouldNotBeNull();
+                result.Should().NotBeNull();
             }
 
             [Fact]
             public void Should_find_powershell()
             {
-                result.ShouldNotBeEmpty();
+                result.Should().NotBeEmpty();
             }
 
             [Fact]
             public void Should_return_the_sysnative_path()
             {
-                result.ShouldEqual(expected);
+                result.Should().Be(expected);
             }
         }
 
@@ -92,7 +92,7 @@ namespace chocolatey.tests.infrastructure.commands
             [Fact]
             public void Should_return_system32_path()
             {
-                result.ShouldEqual(expected);
+                result.Should().Be(expected);
             }
         }
 

--- a/src/chocolatey.tests/infrastructure/configuration/ConfigSpecs.cs
+++ b/src/chocolatey.tests/infrastructure/configuration/ConfigSpecs.cs
@@ -18,7 +18,7 @@ namespace chocolatey.tests.infrastructure.configuration
 {
     using chocolatey.infrastructure.app.configuration;
     using chocolatey.infrastructure.configuration;
-    using Should;
+    using FluentAssertions;
 
     public class ConfigSpecs
     {
@@ -39,7 +39,7 @@ namespace chocolatey.tests.infrastructure.configuration
             [Fact]
             public void Should_be_of_type_ChocolateyConfiguration()
             {
-                Config.GetConfigurationSettings().ShouldBeType<ChocolateyConfiguration>();
+                Config.GetConfigurationSettings().Should().BeOfType<ChocolateyConfiguration>();
             }
         }
 
@@ -57,7 +57,7 @@ namespace chocolatey.tests.infrastructure.configuration
             [Fact]
             public void Should_use_the_overridden_type()
             {
-                Config.GetConfigurationSettings().ShouldBeType<LocalConfig>();
+                Config.GetConfigurationSettings().Should().BeOfType<LocalConfig>();
             }
         }
     }

--- a/src/chocolatey.tests/infrastructure/cryptography/CryptoHashProviderSpecs.cs
+++ b/src/chocolatey.tests/infrastructure/cryptography/CryptoHashProviderSpecs.cs
@@ -24,7 +24,7 @@ namespace chocolatey.tests.infrastructure.cryptography
     using chocolatey.infrastructure.cryptography;
     using chocolatey.infrastructure.filesystem;
     using Moq;
-    using Should;
+    using FluentAssertions;
 
     public class CryptoHashProviderSpecs
     {
@@ -62,7 +62,7 @@ namespace chocolatey.tests.infrastructure.cryptography
             {
                 var expected = BitConverter.ToString(SHA256.Create().ComputeHash(byteArray)).Replace("-", string.Empty);
 
-                result.ShouldEqual(expected);
+                result.Should().Be(expected);
             }
         }
 
@@ -91,7 +91,7 @@ namespace chocolatey.tests.infrastructure.cryptography
             [Fact]
             public void Should_log_a_warning()
             {
-                MockLogger.MessagesFor(LogLevel.Warn).Count.ShouldEqual(1);
+                MockLogger.MessagesFor(LogLevel.Warn).Count.Should().Be(1);
             }
 
             [Fact]
@@ -103,7 +103,7 @@ namespace chocolatey.tests.infrastructure.cryptography
             [Fact]
             public void Should_provide_an_unchanging_hash_for_a_file_too_big_to_hash()
             {
-                result.ShouldEqual(ApplicationParameters.HashProviderFileTooBig);
+                result.Should().Be(ApplicationParameters.HashProviderFileTooBig);
             }
         }
     }

--- a/src/chocolatey.tests/infrastructure/cryptography/CryptoHashProviderSpecs.cs
+++ b/src/chocolatey.tests/infrastructure/cryptography/CryptoHashProviderSpecs.cs
@@ -91,7 +91,7 @@ namespace chocolatey.tests.infrastructure.cryptography
             [Fact]
             public void Should_log_a_warning()
             {
-                MockLogger.MessagesFor(LogLevel.Warn).Count.Should().Be(1);
+                MockLogger.MessagesFor(LogLevel.Warn).Should().HaveCount(1);
             }
 
             [Fact]

--- a/src/chocolatey.tests/infrastructure/events/EventSubscriptionManagerSpecs.cs
+++ b/src/chocolatey.tests/infrastructure/events/EventSubscriptionManagerSpecs.cs
@@ -22,7 +22,7 @@ namespace chocolatey.tests.infrastructure.events
     using chocolatey.infrastructure.services;
     using context;
     using NUnit.Framework;
-    using Should;
+    using FluentAssertions;
 
     public class EventSubscriptionManagerSpecs
     {
@@ -65,25 +65,25 @@ namespace chocolatey.tests.infrastructure.events
             [Fact]
             public void Should_have_called_the_action()
             {
-                _wasCalled.ShouldBeTrue();
+                _wasCalled.Should().BeTrue();
             }
 
             [Fact]
             public void Should_have_passed_the_message()
             {
-                _localFakeEvent.ShouldEqual(Event);
+                _localFakeEvent.Should().Be(Event);
             }
 
             [Fact]
             public void Should_have_passed_the_name_correctly()
             {
-                _localFakeEvent.Name.ShouldEqual("yo");
+                _localFakeEvent.Name.Should().Be("yo");
             }
 
             [Fact]
             public void Should_have_passed_the_digits_correctly()
             {
-                _localFakeEvent.Digits.ShouldEqual(12d);
+                _localFakeEvent.Digits.Should().Be(12d);
             }
         }
 
@@ -117,13 +117,13 @@ namespace chocolatey.tests.infrastructure.events
             public void Should_wait_the_event_to_complete()
             {
                 Console.WriteLine("event complete should be above this");
-                _wasCalled.ShouldBeTrue();
+                _wasCalled.Should().BeTrue();
             }
 
             [Fact]
             public void Should_have_passed_the_message()
             {
-                _localFakeEvent.ShouldEqual(Event);
+                _localFakeEvent.Should().Be(Event);
             }
         }
 
@@ -153,25 +153,25 @@ namespace chocolatey.tests.infrastructure.events
             [Fact]
             public void Should_have_called_the_action()
             {
-                _wasCalled.ShouldBeTrue();
+                _wasCalled.Should().BeTrue();
             }
 
             [Fact]
             public void Should_have_passed_the_message()
             {
-                _localFakeEvent.ShouldEqual(Event);
+                _localFakeEvent.Should().Be(Event);
             }
 
             [Fact]
             public void Should_have_passed_the_name_correctly()
             {
-                _localFakeEvent.Name.ShouldEqual("yo");
+                _localFakeEvent.Name.Should().Be("yo");
             }
 
             [Fact]
             public void Should_have_passed_the_digits_correctly()
             {
-                _localFakeEvent.Digits.ShouldEqual(12d);
+                _localFakeEvent.Digits.Should().Be(12d);
             }
         }
 
@@ -201,13 +201,13 @@ namespace chocolatey.tests.infrastructure.events
             [Fact]
             public void Should_not_have_called_the_action()
             {
-                _wasCalled.ShouldBeFalse();
+                _wasCalled.Should().BeFalse();
             }
 
             [Fact]
             public void Should_not_have_passed_the_message()
             {
-                _localFakeEvent.ShouldNotEqual(Event);
+                _localFakeEvent.Should().NotBe(Event);
             }
         }
 
@@ -253,7 +253,7 @@ namespace chocolatey.tests.infrastructure.events
             public void Should_throw_an_error()
             {
                 Assert.Throws<ArgumentNullException>(() => SubscriptionManager.Publish<FakeEvent>(null));
-                _errored.ShouldBeTrue();
+                _errored.Should().BeTrue();
             }
         }
     }

--- a/src/chocolatey.tests/infrastructure/filesystem/DotNetFileSystemSpecs.cs
+++ b/src/chocolatey.tests/infrastructure/filesystem/DotNetFileSystemSpecs.cs
@@ -24,7 +24,7 @@ namespace chocolatey.tests.infrastructure.filesystem
     using chocolatey.infrastructure.platforms;
     using Moq;
     using NUnit.Framework;
-    using Should;
+    using FluentAssertions;
 
     public class DotNetFileSystemSpecs
     {
@@ -47,37 +47,37 @@ namespace chocolatey.tests.infrastructure.filesystem
             [Fact]
             public void GetFullPath_should_return_the_full_path_to_an_item()
             {
-                FileSystem.GetFullPath("test.txt").ShouldEqual(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "test.txt"));
+                FileSystem.GetFullPath("test.txt").Should().Be(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "test.txt"));
             }
 
             [Fact]
             public void GetFileNameWithoutExtension_should_return_a_file_name_without_an_extension()
             {
-                FileSystem.GetFilenameWithoutExtension("test.txt").ShouldEqual("test");
+                FileSystem.GetFilenameWithoutExtension("test.txt").Should().Be("test");
             }
 
             [Fact]
             public void GetFileNameWithoutExtension_should_return_a_file_name_without_an_extension_even_with_a_full_path()
             {
-                FileSystem.GetFilenameWithoutExtension("C:\\temp\\test.txt").ShouldEqual("test");
+                FileSystem.GetFilenameWithoutExtension("C:\\temp\\test.txt").Should().Be("test");
             }
 
             [Fact]
             public void GetExtension_should_return_the_extension_of_the_filename()
             {
-                FileSystem.GetFileExtension("test.txt").ShouldEqual(".txt");
+                FileSystem.GetFileExtension("test.txt").Should().Be(".txt");
             }
 
             [Fact]
             public void GetExtension_should_return_the_extension_of_the_filename_even_with_a_full_path()
             {
-                FileSystem.GetFileExtension("C:\\temp\\test.txt").ShouldEqual(".txt");
+                FileSystem.GetFileExtension("C:\\temp\\test.txt").Should().Be(".txt");
             }
 
             [Fact]
             public void GetDirectoryName_should_return_the_directory_of_the_path_to_the_file()
             {
-                FileSystem.GetDirectoryName("C:\\temp\\test.txt").ShouldEqual(
+                FileSystem.GetDirectoryName("C:\\temp\\test.txt").Should().Be(
                     Platform.GetPlatform() == PlatformType.Windows
                         ? "C:\\temp"
                         : "C:/temp");
@@ -86,7 +86,7 @@ namespace chocolatey.tests.infrastructure.filesystem
             [Fact]
             public void Combine_should_combine_the_file_paths_of_all_the_included_items_together()
             {
-                FileSystem.CombinePaths("C:\\temp", "yo", "filename.txt").ShouldEqual(
+                FileSystem.CombinePaths("C:\\temp", "yo", "filename.txt").Should().Be(
                     Platform.GetPlatform() == PlatformType.Windows
                         ? "C:\\temp\\yo\\filename.txt"
                         : "C:/temp/yo/filename.txt");
@@ -95,7 +95,7 @@ namespace chocolatey.tests.infrastructure.filesystem
             [Fact]
             public void Combine_should_combine_when_paths_have_backslashes_in_subpaths()
             {
-                FileSystem.CombinePaths("C:\\temp", "yo\\timmy", "filename.txt").ShouldEqual(
+                FileSystem.CombinePaths("C:\\temp", "yo\\timmy", "filename.txt").Should().Be(
                     Platform.GetPlatform() == PlatformType.Windows
                         ? "C:\\temp\\yo\\timmy\\filename.txt"
                         : "C:/temp/yo/timmy/filename.txt");
@@ -104,7 +104,7 @@ namespace chocolatey.tests.infrastructure.filesystem
             [Fact]
             public void Combine_should_combine_when_paths_start_with_backslashes_in_subpaths()
             {
-                FileSystem.CombinePaths("C:\\temp", "\\yo", "filename.txt").ShouldEqual(
+                FileSystem.CombinePaths("C:\\temp", "\\yo", "filename.txt").Should().Be(
                     Platform.GetPlatform() == PlatformType.Windows
                         ? "C:\\temp\\yo\\filename.txt"
                         : "C:/temp/yo/filename.txt");
@@ -113,7 +113,7 @@ namespace chocolatey.tests.infrastructure.filesystem
             [Fact]
             public void Combine_should_combine_when_paths_start_with_forwardslashes_in_subpaths()
             {
-                FileSystem.CombinePaths("C:\\temp", "/yo", "filename.txt").ShouldEqual(
+                FileSystem.CombinePaths("C:\\temp", "/yo", "filename.txt").Should().Be(
                     Platform.GetPlatform() == PlatformType.Windows
                         ? "C:\\temp\\yo\\filename.txt"
                         : "C:/temp/yo/filename.txt");
@@ -155,41 +155,38 @@ namespace chocolatey.tests.infrastructure.filesystem
             [Fact]
             public void GetExecutablePath_should_find_existing_executable()
             {
-                FileSystem.GetExecutablePath("cmd").ToLowerSafe().ShouldEqual(
+                FileSystem.GetExecutablePath("cmd").ToLowerSafe().Should().BeEquivalentTo(
                     Platform.GetPlatform() == PlatformType.Windows
                         ? "c:\\windows\\system32\\cmd.exe"
-                        : "cmd",
-                    StringComparer.OrdinalIgnoreCase
-                );
+                        : "cmd");
             }
 
             [Fact]
             public void GetExecutablePath_should_find_existing_executable_with_extension()
             {
-                FileSystem.GetExecutablePath("cmd.exe").ToLowerSafe().ShouldEqual(
+                FileSystem.GetExecutablePath("cmd.exe").ToLowerSafe().Should().BeEquivalentTo(
                     Platform.GetPlatform() == PlatformType.Windows
                         ? "c:\\windows\\system32\\cmd.exe"
-                        : "cmd.exe",
-                    StringComparer.OrdinalIgnoreCase
+                        : "cmd.exe"
                 );
             }
 
             [Fact]
             public void GetExecutablePath_should_return_same_value_when_executable_is_not_found()
             {
-                FileSystem.GetExecutablePath("daslakjsfdasdfwea").ShouldEqual("daslakjsfdasdfwea");
+                FileSystem.GetExecutablePath("daslakjsfdasdfwea").Should().Be("daslakjsfdasdfwea");
             }
 
             [Fact]
             public void GetExecutablePath_should_return_empty_string_when_value_is_null()
             {
-                FileSystem.GetExecutablePath(null).ShouldEqual(string.Empty);
+                FileSystem.GetExecutablePath(null).Should().Be(string.Empty);
             }
 
             [Fact]
             public void GetExecutablePath_should_return_empty_string_when_value_is_empty_string()
             {
-                FileSystem.GetExecutablePath(string.Empty).ShouldEqual(string.Empty);
+                FileSystem.GetExecutablePath(string.Empty).Should().Be(string.Empty);
             }
         }
 
@@ -217,33 +214,33 @@ namespace chocolatey.tests.infrastructure.filesystem
             {
                 if (Platform.GetPlatform() == PlatformType.Windows)
                 {
-                    FileSystem.GetExecutablePath("ls").ShouldEqual("ls");
+                    FileSystem.GetExecutablePath("ls").Should().Be("ls");
                 }
                 else
                 {
                     new string[]
                     {
                         "/bin/ls", "/usr/bin/ls"
-                    }.ShouldContain(FileSystem.GetExecutablePath("ls"));
+                    }.Should().Contain(FileSystem.GetExecutablePath("ls"));
                 }
             }
 
             [Fact]
             public void GetExecutablePath_should_return_same_value_when_executable_is_not_found()
             {
-                FileSystem.GetExecutablePath("daslakjsfdasdfwea").ShouldEqual("daslakjsfdasdfwea");
+                FileSystem.GetExecutablePath("daslakjsfdasdfwea").Should().Be("daslakjsfdasdfwea");
             }
 
             [Fact]
             public void GetExecutablePath_should_return_empty_string_when_value_is_null()
             {
-                FileSystem.GetExecutablePath(null).ShouldEqual(string.Empty);
+                FileSystem.GetExecutablePath(null).Should().Be(string.Empty);
             }
 
             [Fact]
             public void GetExecutablePath_should_return_empty_string_when_value_is_empty_string()
             {
-                FileSystem.GetExecutablePath(string.Empty).ShouldEqual(string.Empty);
+                FileSystem.GetExecutablePath(string.Empty).Should().Be(string.Empty);
             }
         }
     }

--- a/src/chocolatey.tests/infrastructure/filesystem/DotNetFileSystemSpecs.cs
+++ b/src/chocolatey.tests/infrastructure/filesystem/DotNetFileSystemSpecs.cs
@@ -180,13 +180,13 @@ namespace chocolatey.tests.infrastructure.filesystem
             [Fact]
             public void GetExecutablePath_should_return_empty_string_when_value_is_null()
             {
-                FileSystem.GetExecutablePath(null).Should().Be(string.Empty);
+                FileSystem.GetExecutablePath(null).Should().BeEmpty();
             }
 
             [Fact]
             public void GetExecutablePath_should_return_empty_string_when_value_is_empty_string()
             {
-                FileSystem.GetExecutablePath(string.Empty).Should().Be(string.Empty);
+                FileSystem.GetExecutablePath(string.Empty).Should().BeEmpty();
             }
         }
 
@@ -218,10 +218,10 @@ namespace chocolatey.tests.infrastructure.filesystem
                 }
                 else
                 {
-                    new string[]
+                    FileSystem.GetExecutablePath("ls").Should().BeOneOf(new string[]
                     {
                         "/bin/ls", "/usr/bin/ls"
-                    }.Should().Contain(FileSystem.GetExecutablePath("ls"));
+                    });
                 }
             }
 
@@ -234,13 +234,13 @@ namespace chocolatey.tests.infrastructure.filesystem
             [Fact]
             public void GetExecutablePath_should_return_empty_string_when_value_is_null()
             {
-                FileSystem.GetExecutablePath(null).Should().Be(string.Empty);
+                FileSystem.GetExecutablePath(null).Should().BeEmpty();
             }
 
             [Fact]
             public void GetExecutablePath_should_return_empty_string_when_value_is_empty_string()
             {
-                FileSystem.GetExecutablePath(string.Empty).Should().Be(string.Empty);
+                FileSystem.GetExecutablePath(string.Empty).Should().BeEmpty();
             }
         }
     }

--- a/src/chocolatey.tests/infrastructure/guards/EnsureSpecs.cs
+++ b/src/chocolatey.tests/infrastructure/guards/EnsureSpecs.cs
@@ -20,7 +20,7 @@ namespace chocolatey.tests.infrastructure.guards
     using chocolatey.infrastructure.app.configuration;
     using chocolatey.infrastructure.guards;
     using Moq;
-    using Should;
+    using FluentAssertions;
 
     public class EnsureSpecs
     {
@@ -44,14 +44,14 @@ namespace chocolatey.tests.infrastructure.guards
             [Fact]
             public void Should_return_a_type_of_object_for_ensuring()
             {
-                result.ShouldBeType<Ensure<object>>();
+                result.Should().BeOfType<Ensure<object>>();
             }
 
             [Fact]
             public void Should_have_the_value_specified()
             {
                 var bobEnsure = result as Ensure<object>;
-                bobEnsure.Value.ShouldEqual(bob);
+                bobEnsure.Value.Should().Be(bob);
             }
         }
 
@@ -68,14 +68,14 @@ namespace chocolatey.tests.infrastructure.guards
             [Fact]
             public void Should_return_a_ensure_string_type()
             {
-                result.ShouldBeType<EnsureString>();
+                result.Should().BeOfType<EnsureString>();
             }
 
             [Fact]
             public void Should_have_the_value_specified()
             {
                 var bobEnsure = result as EnsureString;
-                bobEnsure.Value.ShouldEqual(bob);
+                bobEnsure.Value.Should().Be(bob);
             }
         }
 
@@ -92,7 +92,7 @@ namespace chocolatey.tests.infrastructure.guards
 
                 Action a = () => Ensure.That(() => test).NotNullOrWhitespace();
 
-                a.ShouldThrow<ArgumentNullException>();
+                a.Should().Throw<ArgumentNullException>();
             }
 
             [Fact]
@@ -100,7 +100,7 @@ namespace chocolatey.tests.infrastructure.guards
             {
                 Action a = () => Ensure.That(() => string.Empty).NotNullOrWhitespace();
 
-                a.ShouldThrow<ArgumentException>();
+                a.Should().Throw<ArgumentException>();
             }
 
             [Fact]
@@ -110,7 +110,7 @@ namespace chocolatey.tests.infrastructure.guards
 
                 Action a = () => Ensure.That(() => test).NotNullOrWhitespace();
 
-                a.ShouldThrow<ArgumentException>();
+                a.Should().Throw<ArgumentException>();
             }
 
             [Fact]
@@ -128,7 +128,7 @@ namespace chocolatey.tests.infrastructure.guards
 
                 Action a = () => Ensure.That(() => test).HasExtension(".jpg", ".bmp", ".gif");
 
-                a.ShouldThrow<ArgumentException>();
+                a.Should().Throw<ArgumentException>();
             }
 
             [Fact]
@@ -169,8 +169,8 @@ namespace chocolatey.tests.infrastructure.guards
                     exceptionMessage = ex.Message;
                 }
 
-                exceptionType.ShouldBeType<ArgumentNullException>();
-                exceptionMessage.ShouldContain("cannot be null.");
+                exceptionType.Should().BeOfType<ArgumentNullException>();
+                exceptionMessage.Should().Contain("cannot be null.");
             }
 
             [Fact]
@@ -196,8 +196,8 @@ namespace chocolatey.tests.infrastructure.guards
                     exceptionMessage = ex.Message;
                 }
 
-                exceptionType.ShouldBeType<ArgumentNullException>();
-                exceptionMessage.ShouldContain("cannot be null.");
+                exceptionType.Should().BeOfType<ArgumentNullException>();
+                exceptionMessage.Should().Contain("cannot be null.");
             }
 
             [Fact]
@@ -223,8 +223,8 @@ namespace chocolatey.tests.infrastructure.guards
                     exceptionMessage = ex.Message;
                 }
 
-                exceptionType.ShouldBeType<ArgumentNullException>();
-                exceptionMessage.ShouldContain("cannot be null.");
+                exceptionType.Should().BeOfType<ArgumentNullException>();
+                exceptionMessage.Should().Contain("cannot be null.");
             }
 
             [Fact]
@@ -245,8 +245,8 @@ namespace chocolatey.tests.infrastructure.guards
                     exceptionMessage = ex.Message;
                 }
 
-                exceptionType.ShouldBeType<ArgumentNullException>();
-                exceptionMessage.ShouldContain("Value for ensureFunction cannot be null.");
+                exceptionType.Should().BeOfType<ArgumentNullException>();
+                exceptionMessage.Should().Contain("Value for ensureFunction cannot be null.");
             }
 
             [Fact]
@@ -267,9 +267,9 @@ namespace chocolatey.tests.infrastructure.guards
                     exceptionMessage = ex.Message;
                 }
 
-                exceptionType.ShouldBeType<ArgumentNullException>();
-                exceptionMessage.ShouldContain("exceptionAction");
-                exceptionMessage.ShouldContain("cannot be null.");
+                exceptionType.Should().BeOfType<ArgumentNullException>();
+                exceptionMessage.Should().Contain("exceptionAction");
+                exceptionMessage.Should().Contain("cannot be null.");
             }
 
             [Fact]
@@ -290,9 +290,9 @@ namespace chocolatey.tests.infrastructure.guards
                     exceptionMessage = ex.Message;
                 }
 
-                exceptionType.ShouldBeType<ArgumentNullException>();
-                exceptionMessage.ShouldContain("exceptionAction");
-                exceptionMessage.ShouldContain("cannot be null.");
+                exceptionType.Should().BeOfType<ArgumentNullException>();
+                exceptionMessage.Should().Contain("exceptionAction");
+                exceptionMessage.Should().Contain("cannot be null.");
             }
 
             [Fact]
@@ -313,9 +313,9 @@ namespace chocolatey.tests.infrastructure.guards
                     exceptionMessage = ex.Message;
                 }
 
-                exceptionType.ShouldBeType<ArgumentNullException>();
-                exceptionMessage.ShouldContain("ensureFunction");
-                exceptionMessage.ShouldContain("cannot be null.");
+                exceptionType.Should().BeOfType<ArgumentNullException>();
+                exceptionMessage.Should().Contain("ensureFunction");
+                exceptionMessage.Should().Contain("cannot be null.");
             }
 
             [Fact]
@@ -336,9 +336,9 @@ namespace chocolatey.tests.infrastructure.guards
                     exceptionMessage = ex.Message;
                 }
 
-                exceptionType.ShouldBeType<ArgumentNullException>();
-                exceptionMessage.ShouldContain("exceptionAction");
-                exceptionMessage.ShouldContain("cannot be null.");
+                exceptionType.Should().BeOfType<ArgumentNullException>();
+                exceptionMessage.Should().Contain("exceptionAction");
+                exceptionMessage.Should().Contain("cannot be null.");
             }
 
             [Fact]
@@ -359,9 +359,9 @@ namespace chocolatey.tests.infrastructure.guards
                     exceptionMessage = ex.Message;
                 }
 
-                exceptionType.ShouldBeType<ArgumentNullException>();
-                exceptionMessage.ShouldContain("ensureFunction");
-                exceptionMessage.ShouldContain("cannot be null.");
+                exceptionType.Should().BeOfType<ArgumentNullException>();
+                exceptionMessage.Should().Contain("ensureFunction");
+                exceptionMessage.Should().Contain("cannot be null.");
             }
         }
 
@@ -395,19 +395,19 @@ namespace chocolatey.tests.infrastructure.guards
             [Fact]
             public void Should_not_invoke_the_exceptionAction()
             {
-                exceptionActionInvoked.ShouldBeFalse();
+                exceptionActionInvoked.Should().BeFalse();
             }
 
             [Fact]
             public void Should_not_return_a_specified_exception_since_there_was_no_failure()
             {
-                exceptionType.ShouldBeNull();
+                exceptionType.Should().BeNull();
             }
 
             [Fact]
             public void Should_not_return_the_specified_error_message()
             {
-                exceptionMessage.ShouldNotContain("this is what we throw.");
+                exceptionMessage.Should().NotContain("this is what we throw.");
             }
 
             [Fact]
@@ -447,19 +447,19 @@ namespace chocolatey.tests.infrastructure.guards
             [Fact]
             public void Should_invoke_the_exceptionAction()
             {
-                exceptionActionInvoked.ShouldBeTrue();
+                exceptionActionInvoked.Should().BeTrue();
             }
 
             [Fact]
             public void Should_return_the_specified_exception_of_type_ApplicationException()
             {
-                exceptionType.ShouldBeType<ApplicationException>();
+                exceptionType.Should().BeOfType<ApplicationException>();
             }
 
             [Fact]
             public void Should_return_the_specified_error_message()
             {
-                exceptionMessage.ShouldContain("this is what we throw.");
+                exceptionMessage.Should().Contain("this is what we throw.");
             }
 
             [Fact]
@@ -499,25 +499,25 @@ namespace chocolatey.tests.infrastructure.guards
             [Fact]
             public void Should_not_invoke_the_exceptionAction()
             {
-                exceptionActionInvoked.ShouldBeFalse();
+                exceptionActionInvoked.Should().BeFalse();
             }
 
             [Fact]
             public void Should_throw_an_error()
             {
-                exceptionType.ShouldNotBeNull();
+                exceptionType.Should().NotBeNull();
             }
 
             [Fact]
             public void Should_not_return_the_specified_exception_of_type_ApplicationException()
             {
-                exceptionType.ShouldNotBeType<ApplicationException>();
+                exceptionType.Should().NotBeOfType<ApplicationException>();
             }
 
             [Fact]
             public void Should_not_return_the_specified_error_message()
             {
-                exceptionMessage.ShouldNotContain("this is what we throw.");
+                exceptionMessage.Should().NotContain("this is what we throw.");
             }
 
             //[Fact]
@@ -530,9 +530,9 @@ namespace chocolatey.tests.infrastructure.guards
             //    public void Should_log_the_error_we_expect()
             //    {
             //       var messages = MockLogger.MessagesFor(LogLevel.Error);
-            //        messages.ShouldNotBeEmpty();
-            //        messages.Count.ShouldEqual(1);
-            //        messages[0].ShouldContain("Trying to call ensureFunction on");
+            //        messages.Should().NotBeEmpty();
+            //        messages.Count.Should().Be(1);
+            //        messages[0].Should().Contain("Trying to call ensureFunction on");
             //    }
         }
     }

--- a/src/chocolatey.tests/infrastructure/guards/EnsureSpecs.cs
+++ b/src/chocolatey.tests/infrastructure/guards/EnsureSpecs.cs
@@ -531,7 +531,7 @@ namespace chocolatey.tests.infrastructure.guards
             //    {
             //       var messages = MockLogger.MessagesFor(LogLevel.Error);
             //        messages.Should().NotBeEmpty();
-            //        messages.Count.Should().Be(1);
+            //        messages.Should().ContainSingle();
             //        messages[0].Should().Contain("Trying to call ensureFunction on");
             //    }
         }

--- a/src/chocolatey.tests/infrastructure/information/VersionInformationSpecs.cs
+++ b/src/chocolatey.tests/infrastructure/information/VersionInformationSpecs.cs
@@ -18,7 +18,7 @@ namespace chocolatey.tests.infrastructure.information
 {
     using System;
     using chocolatey.infrastructure.information;
-    using Should;
+    using FluentAssertions;
 
     public class VersionInformationSpecs
     {
@@ -41,25 +41,25 @@ namespace chocolatey.tests.infrastructure.information
             [Fact]
             public void Should_not_be_null()
             {
-                result.ShouldNotBeNull();
+                result.Should().NotBeNull();
             }
 
             [Fact]
             public void Should_not_be_empty()
             {
-                result.ShouldNotBeEmpty();
+                result.Should().NotBeEmpty();
             }
 
             [Fact]
             public void Should_be_transferable_to_Version()
             {
-                new Version(result).ShouldNotBeNull();
+                new Version(result).Should().NotBeNull();
             }
 
             [Fact]
             public void Should_not_equal_zero_dot_zero_dot_zero_dot_zero()
             {
-                result.ShouldNotEqual("0.0.0.0");
+                result.Should().NotBe("0.0.0.0");
             }
         }
     }

--- a/src/chocolatey.tests/infrastructure/platforms/PlatformSpecs.cs
+++ b/src/chocolatey.tests/infrastructure/platforms/PlatformSpecs.cs
@@ -21,7 +21,7 @@ namespace chocolatey.tests.infrastructure.platforms
     using chocolatey.infrastructure.filesystem;
     using chocolatey.infrastructure.platforms;
     using Moq;
-    using Should;
+    using FluentAssertions;
     using Environment = System.Environment;
 
     public class PlatformSpecs
@@ -50,7 +50,7 @@ namespace chocolatey.tests.infrastructure.platforms
             [Fact]
             public void Should_not_be_Unknown()
             {
-                result.ShouldNotEqual(PlatformType.Unknown);
+                result.Should().NotBe(PlatformType.Unknown);
             }
         }
 
@@ -72,7 +72,7 @@ namespace chocolatey.tests.infrastructure.platforms
             [Fact]
             public void Should_return_Windows()
             {
-                result.ShouldEqual(PlatformType.Windows);
+                result.Should().Be(PlatformType.Windows);
             }
         }
 
@@ -94,7 +94,7 @@ namespace chocolatey.tests.infrastructure.platforms
             [Fact]
             public void Should_return_Mac()
             {
-                result.ShouldEqual(PlatformType.Mac);
+                result.Should().Be(PlatformType.Mac);
             }
         }
 
@@ -117,7 +117,7 @@ namespace chocolatey.tests.infrastructure.platforms
             [Fact]
             public void Should_return_Linux()
             {
-                result.ShouldEqual(PlatformType.Linux);
+                result.Should().Be(PlatformType.Linux);
             }
         }
 
@@ -140,7 +140,7 @@ namespace chocolatey.tests.infrastructure.platforms
             [Fact]
             public void Should_return_Mac()
             {
-                result.ShouldEqual(PlatformType.Mac);
+                result.Should().Be(PlatformType.Mac);
             }
         }
     }

--- a/src/chocolatey.tests/infrastructure/tokens/TokenReplacerSpecs.cs
+++ b/src/chocolatey.tests/infrastructure/tokens/TokenReplacerSpecs.cs
@@ -19,7 +19,7 @@ namespace chocolatey.tests.infrastructure.tokens
     using System.Collections.Generic;
     using chocolatey.infrastructure.app.configuration;
     using chocolatey.infrastructure.tokens;
-    using Should;
+    using FluentAssertions;
 
     public class TokenReplacerSpecs
     {
@@ -43,67 +43,67 @@ namespace chocolatey.tests.infrastructure.tokens
             [Fact]
             public void When_given_brace_brace_CommandName_brace_brace_should_replace_with_the_Name_from_the_configuration()
             {
-                TokenReplacer.ReplaceTokens(configuration, "Hi! My name is [[CommandName]]").ShouldEqual("Hi! My name is " + name);
+                TokenReplacer.ReplaceTokens(configuration, "Hi! My name is [[CommandName]]").Should().Be("Hi! My name is " + name);
             }
 
             [Fact]
             public void When_given_brace_CommandName_brace_should_NOT_replace_the_value()
             {
-                TokenReplacer.ReplaceTokens(configuration, "Hi! My name is [CommandName]").ShouldEqual("Hi! My name is [CommandName]");
+                TokenReplacer.ReplaceTokens(configuration, "Hi! My name is [CommandName]").Should().Be("Hi! My name is [CommandName]");
             }
 
             [Fact]
             public void When_given_a_value_that_is_the_name_of_a_configuration_item_but_is_not_properly_tokenized_it_should_NOT_replace_the_value()
             {
-                TokenReplacer.ReplaceTokens(configuration, "Hi! My name is CommandName").ShouldEqual("Hi! My name is CommandName");
+                TokenReplacer.ReplaceTokens(configuration, "Hi! My name is CommandName").Should().Be("Hi! My name is CommandName");
             }
 
             [Fact]
             public void When_given_brace_brace_commandname_brace_brace_should_replace_with_the_Name_from_the_configuration()
             {
-                TokenReplacer.ReplaceTokens(configuration, "Hi! My name is [[commandname]]").ShouldEqual("Hi! My name is " + name);
+                TokenReplacer.ReplaceTokens(configuration, "Hi! My name is [[commandname]]").Should().Be("Hi! My name is " + name);
             }
 
             [Fact]
             public void When_given_brace_brace_COMMANDNAME_brace_brace_should_replace_with_the_Name_from_the_configuration()
             {
-                TokenReplacer.ReplaceTokens(configuration, "Hi! My name is [[COMMANDNAME]]").ShouldEqual("Hi! My name is " + name);
+                TokenReplacer.ReplaceTokens(configuration, "Hi! My name is [[COMMANDNAME]]").Should().Be("Hi! My name is " + name);
             }
 
             [Fact]
             public void When_given_brace_brace_cOMmAnDnAMe_brace_brace_should_replace_with_the_Name_from_the_configuration()
             {
-                TokenReplacer.ReplaceTokens(configuration, "Hi! My name is [[cOMmAnDnAMe]]").ShouldEqual("Hi! My name is " + name);
+                TokenReplacer.ReplaceTokens(configuration, "Hi! My name is [[cOMmAnDnAMe]]").Should().Be("Hi! My name is " + name);
             }
 
             [Fact]
             public void If_given_brace_brace_Version_brace_brace_should_NOT_replace_with_the_Name_from_the_configuration()
             {
-                TokenReplacer.ReplaceTokens(configuration, "Go to [[Version]]").ShouldNotContain(name);
+                TokenReplacer.ReplaceTokens(configuration, "Go to [[Version]]").Should().NotContain(name);
             }
 
             [Fact]
             public void If_given_a_value_that_is_not_set_should_return_that_value_as_string_Empty()
             {
-                TokenReplacer.ReplaceTokens(configuration, "Go to [[Version]]").ShouldEqual("Go to " + string.Empty);
+                TokenReplacer.ReplaceTokens(configuration, "Go to [[Version]]").Should().Be("Go to " + string.Empty);
             }
 
             [Fact]
             public void If_given_a_value_that_does_not_exist_should_return_the_original_value_unchanged()
             {
-                TokenReplacer.ReplaceTokens(configuration, "Hi! My name is [[DataBase]]").ShouldEqual("Hi! My name is [[DataBase]]");
+                TokenReplacer.ReplaceTokens(configuration, "Hi! My name is [[DataBase]]").Should().Be("Hi! My name is [[DataBase]]");
             }
 
             [Fact]
             public void If_given_an_empty_value_should_return_the_empty_value()
             {
-                TokenReplacer.ReplaceTokens(configuration, "").ShouldEqual("");
+                TokenReplacer.ReplaceTokens(configuration, "").Should().Be("");
             }
 
             [Fact]
             public void If_given_an_null_value_should_return_the_ll_value()
             {
-                TokenReplacer.ReplaceTokens(configuration, null).ShouldEqual("");
+                TokenReplacer.ReplaceTokens(configuration, null).Should().Be("");
             }
         }
 
@@ -120,7 +120,7 @@ namespace chocolatey.tests.infrastructure.tokens
             [Fact]
             public void When_given_a_proper_token_it_should_replace_with_the_dictionary_value()
             {
-                TokenReplacer.ReplaceTokens(tokens, "Hi! My name is [[dude]]").ShouldEqual("Hi! My name is " + value);
+                TokenReplacer.ReplaceTokens(tokens, "Hi! My name is [[dude]]").Should().Be("Hi! My name is " + value);
             }
         }
     }

--- a/src/chocolatey.tests/infrastructure/tolerance/FaultToleranceSpecs.cs
+++ b/src/chocolatey.tests/infrastructure/tolerance/FaultToleranceSpecs.cs
@@ -79,7 +79,7 @@ namespace chocolatey.tests.infrastructure.tolerance
                     // don't care
                 }
 
-                MockLogger.MessagesFor(LogLevel.Warn).Count.Should().Be(2);
+                MockLogger.MessagesFor(LogLevel.Warn).Should().HaveCount(2);
             }
 
             [Fact]
@@ -117,7 +117,7 @@ namespace chocolatey.tests.infrastructure.tolerance
 
                 i.Should().Be(1);
 
-                MockLogger.MessagesFor(LogLevel.Warn).Count.Should().Be(0);
+                MockLogger.MessagesFor(LogLevel.Warn).Should().BeEmpty();
             }
         }
 
@@ -137,7 +137,7 @@ namespace chocolatey.tests.infrastructure.tolerance
                     "You have an error"
                 );
 
-                MockLogger.MessagesFor(LogLevel.Error).Count.Should().Be(1);
+                MockLogger.MessagesFor(LogLevel.Error).Should().ContainSingle();
             }
 
             [Fact]
@@ -164,7 +164,7 @@ namespace chocolatey.tests.infrastructure.tolerance
                     logWarningInsteadOfError: true
                 );
 
-                MockLogger.MessagesFor(LogLevel.Warn).Count.Should().Be(1);
+                MockLogger.MessagesFor(LogLevel.Warn).Should().ContainSingle();
             }
 
             [Fact]

--- a/src/chocolatey.tests/infrastructure/tolerance/FaultToleranceSpecs.cs
+++ b/src/chocolatey.tests/infrastructure/tolerance/FaultToleranceSpecs.cs
@@ -19,7 +19,7 @@ namespace chocolatey.tests.infrastructure.tolerance
     using System;
     using chocolatey.infrastructure.tolerance;
     using NUnit.Framework;
-    using Should;
+    using FluentAssertions;
 
     public class FaultToleranceSpecs
     {
@@ -52,7 +52,7 @@ namespace chocolatey.tests.infrastructure.tolerance
                     {
                     });
 
-                m.ShouldThrow<ApplicationException>();
+                m.Should().Throw<ApplicationException>();
             }
 
             [Fact]
@@ -62,7 +62,7 @@ namespace chocolatey.tests.infrastructure.tolerance
 
                 Action m = () => FaultTolerance.Retry(2, () => { throw new Exception("YIKES"); }, waitDurationMilliseconds: 0);
 
-                m.ShouldThrow<Exception>();
+                m.Should().Throw<Exception>();
             }
 
             [Fact]
@@ -79,7 +79,7 @@ namespace chocolatey.tests.infrastructure.tolerance
                     // don't care
                 }
 
-                MockLogger.MessagesFor(LogLevel.Warn).Count.ShouldEqual(2);
+                MockLogger.MessagesFor(LogLevel.Warn).Count.Should().Be(2);
             }
 
             [Fact]
@@ -104,7 +104,7 @@ namespace chocolatey.tests.infrastructure.tolerance
                     // don't care
                 }
 
-                i.ShouldEqual(10);
+                i.Should().Be(10);
             }
 
             [Fact]
@@ -115,9 +115,9 @@ namespace chocolatey.tests.infrastructure.tolerance
                 var i = 0;
                 FaultTolerance.Retry(3, () => { i += 1; }, waitDurationMilliseconds: 0);
 
-                i.ShouldEqual(1);
+                i.Should().Be(1);
 
-                MockLogger.MessagesFor(LogLevel.Warn).Count.ShouldEqual(0);
+                MockLogger.MessagesFor(LogLevel.Warn).Count.Should().Be(0);
             }
         }
 
@@ -137,7 +137,7 @@ namespace chocolatey.tests.infrastructure.tolerance
                     "You have an error"
                 );
 
-                MockLogger.MessagesFor(LogLevel.Error).Count.ShouldEqual(1);
+                MockLogger.MessagesFor(LogLevel.Error).Count.Should().Be(1);
             }
 
             [Fact]
@@ -150,7 +150,7 @@ namespace chocolatey.tests.infrastructure.tolerance
                     "You have an error"
                 );
 
-                MockLogger.MessagesFor(LogLevel.Error)[0].ShouldEqual("You have an error:{0} This is the message".FormatWith(Environment.NewLine));
+                MockLogger.MessagesFor(LogLevel.Error)[0].Should().Be("You have an error:{0} This is the message".FormatWith(Environment.NewLine));
             }
 
             [Fact]
@@ -164,7 +164,7 @@ namespace chocolatey.tests.infrastructure.tolerance
                     logWarningInsteadOfError: true
                 );
 
-                MockLogger.MessagesFor(LogLevel.Warn).Count.ShouldEqual(1);
+                MockLogger.MessagesFor(LogLevel.Warn).Count.Should().Be(1);
             }
 
             [Fact]
@@ -178,7 +178,7 @@ namespace chocolatey.tests.infrastructure.tolerance
                     throwError: true
                 );
 
-                m.ShouldThrow<Exception>();
+                m.Should().Throw<Exception>();
             }
 
             [Fact]
@@ -193,7 +193,7 @@ namespace chocolatey.tests.infrastructure.tolerance
                     throwError: true
                 );
 
-                m.ShouldThrow<Exception>();
+                m.Should().Throw<Exception>();
             }
         }
     }

--- a/src/chocolatey.tests/packages.config
+++ b/src/chocolatey.tests/packages.config
@@ -13,6 +13,8 @@
   <package id="Chocolatey.NuGet.Protocol" version="3.2.0" targetFramework="net48" />
   <package id="Chocolatey.NuGet.Resolver" version="3.2.0" targetFramework="net48" />
   <package id="Chocolatey.NuGet.Versioning" version="3.2.0" targetFramework="net48" />
+  <package id="FluentAssertions" version="6.11.0" targetFramework="net48" />
+  <package id="FluentAssertions.Analyzers" version="0.19.1" targetFramework="net48" developmentDependency="true" />
   <package id="log4net" version="2.0.12" targetFramework="net48" />
   <package id="Microsoft.CSharp" version="4.3.0" targetFramework="net48" />
   <package id="Microsoft.Web.Xdt" version="3.1.0" targetFramework="net48" />
@@ -20,6 +22,7 @@
   <package id="Newtonsoft.Json" version="13.0.1" targetFramework="net48" />
   <package id="NUnit" version="3.13.3" targetFramework="net48" />
   <package id="NUnit3TestAdapter" version="4.4.2" targetFramework="net48" />
-  <package id="Should" version="1.1.20" targetFramework="net48" />
   <package id="SimpleInjector" version="2.8.3" targetFramework="net48" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="4.5.3" targetFramework="net48" />
+  <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net48" />
 </packages>

--- a/src/chocolatey/chocolatey.csproj
+++ b/src/chocolatey/chocolatey.csproj
@@ -12,6 +12,7 @@
     <RootNamespace>chocolatey</RootNamespace>
     <AssemblyName>chocolatey</AssemblyName>
     <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
+    <LangVersion>7.3</LangVersion>
     <FileAlignment>512</FileAlignment>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <TargetFrameworkProfile>


### PR DESCRIPTION
## Description Of Changes

This switches chocolatey.tests and chocolatey.tests.integration to use FluentAssertions instead of Should. This is because Should is no longer actively maintained, so it is time to replace it.

As per the FluentAssertions api, various calls needed to be adjusted, mostly in the pattern Shouldxxxx() to Should().xxxx()

## Motivation and Context

See #2893

## Testing

Ran unit and integration tests with `build.ps1` and in Visual Studio

## Change Types Made


* [ ] Bug fix (non-breaking change)
* [x] Feature / Enhancement (non-breaking change)
* [ ] Breaking change (fix or feature that could cause existing functionality to change)
* [ ] PowerShell code changes.

## Related Issue

- Fixes #2893
- Depends on #2927
- https://app.clickup.com/t/20540031/PROJ-427

## Change Checklist

* [ ] Requires a change to the documentation
* [ ] Documentation has been updated
* [ ] Tests to cover my changes, have been added
* [x] All new and existing tests passed.
* [ ] PowerShell v2 compatibility checked.
