### PR TITLE
(#2910) Ensure Pester test file paths don't exceed Test Kitchen maximum lengths.

### DIFF
--- a/Invoke-Tests.ps1
+++ b/Invoke-Tests.ps1
@@ -26,6 +26,17 @@ param(
 )
 $packageRegex = 'chocolatey\.\d.*\.nupkg'
 
+# Check if there are any tests that exceed Test Kitchen maximum lengths
+$TestsLocation = Join-Path $PSScriptRoot tests
+$MaxFileNameLength = 110
+$LongFiles = Get-ChildItem $TestsLocation -Recurse | Where-Object { ($_.FullName.Length - $TestsLocation.Length) -gt $MaxFileNameLength } | ForEach-Object { [pscustomobject]@{ FullName = $_.FullName ; ReductionNeeded = $_.FullName.Length - $TestsLocation.Length - $MaxFileNameLength } }
+
+if ($LongFiles) {
+    Write-Host "File paths too long for Test Kitchen use. Please shorten lengths:"
+    $LongFiles | ForEach-Object { Write-Host "$($_.ReductionNeeded), $($_.FullName)" }
+    throw "Unable to complete tests due to long file paths"
+}
+
 # Use TstPkg as TestPackage has ValidateScript that can't be circumvented
 if (-not $TestPackage) {
     $TstPkg = Get-ChildItem $PSScriptRoot/code_drop/Packages/Chocolatey -Filter *.nupkg | Where-Object Name -Match $packageRegex

--- a/Invoke-Tests.ps1
+++ b/Invoke-Tests.ps1
@@ -29,11 +29,13 @@ $packageRegex = 'chocolatey\.\d.*\.nupkg'
 # Check if there are any tests that exceed Test Kitchen maximum lengths
 $TestsLocation = Join-Path $PSScriptRoot tests
 $MaxFileNameLength = 110
-$LongFiles = Get-ChildItem $TestsLocation -Recurse | Where-Object { ($_.FullName.Length - $TestsLocation.Length) -gt $MaxFileNameLength } | ForEach-Object { [pscustomobject]@{ FullName = $_.FullName ; ReductionNeeded = $_.FullName.Length - $TestsLocation.Length - $MaxFileNameLength } }
+$LongFiles = Get-ChildItem $TestsLocation -Recurse |
+    Where-Object { ($_.FullName.Length - $TestsLocation.Length) -gt $MaxFileNameLength } |
+    Select-Object -Property @{Name = 'RelativePath' ; Expression = { $_.FullName.Replace($TestsLocation, [string]::Empty)}}, @{ Name = 'ReductionNeeded' ; Expression = { $_.FullName.Length - $TestsLocation.Length - $MaxFileNameLength } }
 
 if ($LongFiles) {
-    Write-Host "File paths too long for Test Kitchen use. Please shorten lengths:"
-    $LongFiles | ForEach-Object { Write-Host "$($_.ReductionNeeded), $($_.FullName)" }
+    Write-Host "Tests' file paths may be too long for Test Kitchen use. Please shorten file names or paths:"
+    $LongFiles | Format-List | Out-String | Out-Host
     throw "Unable to complete tests due to long file paths"
 }
 


### PR DESCRIPTION
## Description Of Changes

Add a test to ensure we don't exceed maximum path lengths in Test Kitchen.

## Motivation and Context

When run with some Test Kitchen configurations, files where the path exceeds about 120 characters from the `tests` directory don't get copied to the Test Environment. This results in failing tests due to missing files.


## Testing

1. Set the Max length variable in `Invoke-Tests.ps1` to `50`
2. Ran `vagrant up` from the `tests` directory
3. Confirmed that after building the script errored indicating files to shorten.

## Change Types Made

* [x] Bug fix (non-breaking change)
* [x] Tests update
* [ ] Feature / Enhancement (non-breaking change)
* [ ] Breaking change (fix or feature that could cause existing functionality to change)
* [ ] PowerShell code changes.

## Related Issue

* Fixes #2910 
* ENGTASKS-2346

## Change Checklist

* [ ] Requires a change to the documentation
* [ ] Documentation has been updated
* [ ] Tests to cover my changes, have been added
* [x] All new and existing tests passed.
* [ ] PowerShell v2 compatibility checked.
