### PR TITLE
(#508) Fix unit tests for new dependency handling

### DIFF
--- a/src/chocolatey.tests.integration/scenarios/InstallScenarios.cs
+++ b/src/chocolatey.tests.integration/scenarios/InstallScenarios.cs
@@ -3150,13 +3150,13 @@ namespace chocolatey.tests.integration.scenarios
                 }
             }
 
-            [Fact, Broken]
+            [Fact]
             public void should_contain_a_message_that_it_was_unable_to_install_any_packages()
             {
                 bool expectedMessage = false;
                 foreach (var message in MockLogger.MessagesFor(LogLevel.Warn).or_empty_list_if_null())
                 {
-                    if (message.Contains("installed 0/3")) expectedMessage = true;
+                    if (message.Contains("installed 0/1")) expectedMessage = true;
                 }
 
                 expectedMessage.ShouldBeTrue();
@@ -3252,13 +3252,13 @@ namespace chocolatey.tests.integration.scenarios
                 }
             }
 
-            [Fact, Broken]
+            [Fact]
             public void should_contain_a_message_that_it_was_unable_to_install_any_packages()
             {
                 bool expectedMessage = false;
                 foreach (var message in MockLogger.MessagesFor(LogLevel.Warn).or_empty_list_if_null())
                 {
-                    if (message.Contains("installed 0/3")) expectedMessage = true;
+                    if (message.Contains("installed 0/1")) expectedMessage = true;
                 }
 
                 expectedMessage.ShouldBeTrue();


### PR DESCRIPTION
## Description Of Changes

The underlying framework NuGet.Client has changed how it
resolves dependencies. Because of this we no longer have
information about the dependencies that will be installed
until everything has completed its run successfully.

As such, if a failure happens during the dependency handling
we only show the amount of total packages that was passed
into the executable, instead of the old handling that also included
the dependencies.
For successful runs, even the dependencies will be listed as
the amount of total packages.


## Motivation and Context

To get a working build for Chocolatey CLI.

## Testing

1. Run `.\build.ps1 --testExecutionType=all --shouldRunOpenCover=false`

### Operating Systems Testing

- Windows 10/11

## Change Types Made

* [ ] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.
* [x] Tests

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [x] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue

Related to #508
