### PR TITLE
(#2872) Fix selecting All for interactive prompts

### DIFF
--- a/src/chocolatey/infrastructure.app/configuration/ChocolateyConfiguration.cs
+++ b/src/chocolatey/infrastructure.app/configuration/ChocolateyConfiguration.cs
@@ -119,6 +119,14 @@ namespace chocolatey.infrastructure.app.configuration
 
                 try
                 {
+                    if (property.Name == "PromptForConfirmation")
+                    {
+                        // We do not overwrite this value between backups as it is intended to be a global setting;
+                        // if a user has selected a "[A] yes to all" prompt interactively, this option is
+                        // set and should be retained for the duration of the operations.
+                        continue;
+                    }
+
                     var originalValue = property.GetValue(backup, new object[0]);
 
                     if (removeBackup || property.DeclaringType.IsPrimitive || property.DeclaringType.IsValueType || property.DeclaringType == typeof(string))


### PR DESCRIPTION
## Description Of Changes

- When restoring configuration backups, do not overwrite/change the value of the PromptForConfirmation configuration option.

## Motivation and Context

The configuration that choosing "yes to all" modifies for the run should be remembered, even if we need to take/restore config backups, so that the option works as intended.

## Testing

1. Ensure the allowGlobalConfirmation feature is disabled
1. Run choco with arguments `install curl wget -f`
2. When prompted to run the scripts for `curl`, select "[A] Yes to all"
3. No further prompts should appear and both installations should complete

### Operating Systems Testing

- Windows 11

## Change Types Made

* [x] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [x] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue

Fixes #2872

<!-- PLEASE REMOVE ALL COMMENTS BEFORE SUBMITTING -->
