### PR TITLE
(#2872, #2884) Add automated regression tests for v1.2.1

### DIFF
--- a/tests/chocolatey-tests/commands/choco-upgrade.Tests.ps1
+++ b/tests/chocolatey-tests/commands/choco-upgrade.Tests.ps1
@@ -234,4 +234,26 @@ Describe "choco upgrade" -Tag Chocolatey, UpgradeCommand {
             $line | Should -Not -Match "-forceX86"
         }
     }
+
+
+    Context "Upgrading multiple packages at once" {
+
+        BeforeAll {
+            Restore-ChocolateyInstallSnapshot
+
+            $PackageUnderTest = "installpackage", "packagewithscript"
+
+            $Output = Invoke-Choco upgrade @PackageUnderTest --confirm
+        }
+
+        It "Installs successfully and exits with success (0)" {
+            $Output.ExitCode | Should -Be 0
+        }
+
+        It "Installed the packages to the lib directory" {
+            $PackageUnderTest | ForEach-Object {
+                "$env:ChocolateyInstall\lib\$_" | Should -Exist
+            }
+        }
+    }
 }

--- a/tests/chocolatey-tests/commands/testpackages/packagewithscript/1.0.0/packagewithscript.nuspec
+++ b/tests/chocolatey-tests/commands/testpackages/packagewithscript/1.0.0/packagewithscript.nuspec
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+  <metadata>
+    <id>packagewithscript</id>
+    <version>1.0.0</version>
+    <title>packagewithscript</title>
+    <authors>__REPLACE_AUTHORS_OF_SOFTWARE__</authors>
+    <owners>__REPLACE_YOUR_NAME__</owners>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <description>__REPLACE__</description>
+    <summary>__REPLACE__</summary>
+    <tags>packagewithscript</tags>
+  </metadata>
+  <files>
+    <file src="tools\**" target="tools" />
+  </files>
+</package>

--- a/tests/chocolatey-tests/commands/testpackages/packagewithscript/1.0.0/tools/chocolateyBeforeModify.ps1
+++ b/tests/chocolatey-tests/commands/testpackages/packagewithscript/1.0.0/tools/chocolateyBeforeModify.ps1
@@ -1,0 +1,1 @@
+﻿Write-Output "$env:PackageName $env:PackageVersion Before Modification"

--- a/tests/chocolatey-tests/commands/testpackages/packagewithscript/1.0.0/tools/chocolateyinstall.ps1
+++ b/tests/chocolatey-tests/commands/testpackages/packagewithscript/1.0.0/tools/chocolateyinstall.ps1
@@ -1,0 +1,1 @@
+﻿Write-Output "Installing $env:PackageName $env:PackageVersion"

--- a/tests/chocolatey-tests/commands/testpackages/packagewithscript/1.0.0/tools/chocolateyuninstall.ps1
+++ b/tests/chocolatey-tests/commands/testpackages/packagewithscript/1.0.0/tools/chocolateyuninstall.ps1
@@ -1,0 +1,1 @@
+﻿Write-Output "$env:PackageName $env:PackageVersion Uninstalled"

--- a/tests/helpers/common/Chocolatey/Invoke-Choco.ps1
+++ b/tests/helpers/common/Chocolatey/Invoke-Choco.ps1
@@ -8,19 +8,34 @@
     param(
         # The arguments to use when calling the Choco executable
         [Parameter(Position = 1, ValueFromRemainingArguments)]
-        [string[]]$Arguments
-    )
+        [string[]]$Arguments,
 
-    $chocoPath = Get-ChocoPath
+        # Pipeline input to direct into choco.exe. Used mainly to "respond" to prompts
+        # in a noninteractive context. Provide input as a single string with line-feed
+        # characters ("`n") between input characters in that context.
+        [Parameter(ValueFromPipeline)]
+        [string]$PipelineInput
+    )
+    begin {
+        $chocoPath = Get-ChocoPath
         $firstArgument, [string[]]$remainingArguments = $Arguments
-    $arguments = @($firstArgument; '--allow-unofficial'; $remainingArguments)
-    $output = & $chocoPath @arguments
-    [PSCustomObject]@{
-        # We trim all the lines, so we do not take into account
-        # trimming the lines when asserting, and that extra whitespace
-        # is not considered in our assertions.
-        Lines    = if ($output) { $output.Trim() } else { @() }
-        String   = $output -join "`r`n"
-        ExitCode = $LastExitCode
+        $arguments = @($firstArgument; '--allow-unofficial'; $remainingArguments)
+    }
+    end {
+        $output = if ($PipelineInput) {
+            $PipelineInput | & $chocoPath @arguments
+        }
+        else {
+            & $chocoPath @arguments
+        }
+
+        [PSCustomObject]@{
+            # We trim all the lines, so we do not take into account
+            # trimming the lines when asserting, and that extra whitespace
+            # is not considered in our assertions.
+            Lines    = if ($output) { $output.Trim() } else { @() }
+            String   = $output -join "`r`n"
+            ExitCode = $LastExitCode
+        }
     }
 }


### PR DESCRIPTION
## Description Of Changes

- Add test package and test for functionality of `[A] Yes to all` prompt actions
- Add test for functionality of `choco upgrade` when given multiple packages to upgrade at once.

## Motivation and Context

Keepin' up with the tests.

## Testing

1. Run vagrant image tests for `choco install` and `choco upgrade` command
2. New tests should pass on build from `hotfix/1.2.1` but fail under choco `1.2.0`.

### Operating Systems Testing

N/A

## Change Types Made
<!-- Tick the boxes for the type of changes that have been made -->

* [x] Tests added
* [ ] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [x] Tests to cover my changes, have been added.
* [x] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue

Tests for #2872