### PR TITLE
(#2865) Don't resolve chocolatey for licensed ext

### DIFF
--- a/src/chocolatey/infrastructure/registration/AssemblyResolution.cs
+++ b/src/chocolatey/infrastructure/registration/AssemblyResolution.cs
@@ -369,7 +369,8 @@ namespace chocolatey.infrastructure.registration
 
             // There are things that are ILMerged into Chocolatey. Anything with
             // the right public key except extensions should use the choco/chocolatey assembly
-            if (!requestedAssembly.Name.EndsWith(".resources", StringComparison.OrdinalIgnoreCase))
+            if (!requestedAssembly.Name.EndsWith(".resources", StringComparison.OrdinalIgnoreCase)
+                && !requestedAssembly.Name.is_equal_to(ApplicationParameters.LicensedChocolateyAssemblySimpleName))
             {
                 return typeof(ConsoleApplication).Assembly;
             }


### PR DESCRIPTION
## Description Of Changes

- Fix case in assembly resolver for when it's blindly loading the licensed extension due to finding a valid license.

## Motivation and Context

Previously, the change to the assembly resolver had one edge case; if there is a chocolatey.license.xml that is found, choco will attempt to load the licensed extension specifically. It does not check before that whether the extension is installed or the file is anywhere it should be expected to be, all that is offloaded to the resolver.

This change ensures that if we're looking for that extension due to loading a valid license, we cannot return the base Chocolatey assembly which would be completely incorrect and confuse a lot of choco's built in license assertions and assembly version logic for that extension.

## Testing

1. Install a valid and current `chocolatey.license.xml`, but DO NOT install any extensions
1. Ensure there is _no_ `extensions` folder in Chocolatey's install directory at all
1. Run `choco list -lo` 
1. You should get just the normal error about the licensed assembly not being found (see below)

![image](https://user-images.githubusercontent.com/32407840/205985889-d797968b-2817-417d-9b8e-3dbed9e6094c.png)

### Operating Systems Testing

Windows 11

## Change Types Made

* [x] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [x] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue
<!-- Make sure you have raised an issue for this pull request before
continuing. -->

Fixes the fix for #2865

<!-- PLEASE REMOVE ALL COMMENTS BEFORE SUBMITTING -->
