### PR TITLE
(maint) Update NuGet Libraries to latest version

### DIFF
--- a/src/chocolatey.tests.integration/chocolatey.tests.integration.csproj
+++ b/src/chocolatey.tests.integration/chocolatey.tests.integration.csproj
@@ -69,6 +69,24 @@
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Chocolatey.NuGet.Common, Version=3.0.0.80, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
+      <HintPath>..\packages\Chocolatey.NuGet.Common.3.0.0-alpha-20221213-80\lib\net472\Chocolatey.NuGet.Common.dll</HintPath>
+    </Reference>
+    <Reference Include="Chocolatey.NuGet.Configuration, Version=3.0.0.80, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
+      <HintPath>..\packages\Chocolatey.NuGet.Configuration.3.0.0-alpha-20221213-80\lib\net472\Chocolatey.NuGet.Configuration.dll</HintPath>
+    </Reference>
+    <Reference Include="Chocolatey.NuGet.Frameworks, Version=3.0.0.80, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
+      <HintPath>..\packages\Chocolatey.NuGet.Frameworks.3.0.0-alpha-20221213-80\lib\net472\Chocolatey.NuGet.Frameworks.dll</HintPath>
+    </Reference>
+    <Reference Include="Chocolatey.NuGet.Packaging, Version=3.0.0.80, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
+      <HintPath>..\packages\Chocolatey.NuGet.Packaging.3.0.0-alpha-20221213-80\lib\net472\Chocolatey.NuGet.Packaging.dll</HintPath>
+    </Reference>
+    <Reference Include="Chocolatey.NuGet.Protocol, Version=3.0.0.80, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
+      <HintPath>..\packages\Chocolatey.NuGet.Protocol.3.0.0-alpha-20221213-80\lib\net472\Chocolatey.NuGet.Protocol.dll</HintPath>
+    </Reference>
+    <Reference Include="Chocolatey.NuGet.Versioning, Version=3.0.0.80, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
+      <HintPath>..\packages\Chocolatey.NuGet.Versioning.3.0.0-alpha-20221213-80\lib\net472\Chocolatey.NuGet.Versioning.dll</HintPath>
+    </Reference>
     <Reference Include="log4net, Version=2.0.12.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
       <HintPath>..\packages\log4net.2.0.12\lib\net45\log4net.dll</HintPath>
     </Reference>
@@ -80,24 +98,6 @@
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.13.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
-    </Reference>
-    <Reference Include="NuGet.Common, Version=3.0.0.42, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
-      <HintPath>..\packages\Chocolatey.NuGet.Common.3.0.0-alpha-20221121-42\lib\net472\NuGet.Common.dll</HintPath>
-    </Reference>
-    <Reference Include="NuGet.Configuration, Version=3.0.0.42, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
-      <HintPath>..\packages\Chocolatey.NuGet.Configuration.3.0.0-alpha-20221121-42\lib\net472\NuGet.Configuration.dll</HintPath>
-    </Reference>
-    <Reference Include="NuGet.Frameworks, Version=3.0.0.42, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
-      <HintPath>..\packages\NuGet.Frameworks.3.0.0-alpha-20221121-42\lib\net472\NuGet.Frameworks.dll</HintPath>
-    </Reference>
-    <Reference Include="NuGet.Packaging, Version=3.0.0.42, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
-      <HintPath>..\packages\Chocolatey.NuGet.Packaging.3.0.0-alpha-20221121-42\lib\net472\NuGet.Packaging.dll</HintPath>
-    </Reference>
-    <Reference Include="NuGet.Protocol, Version=3.0.0.42, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
-      <HintPath>..\packages\Chocolatey.NuGet.Protocol.3.0.0-alpha-20221121-42\lib\net472\NuGet.Protocol.dll</HintPath>
-    </Reference>
-    <Reference Include="NuGet.Versioning, Version=3.0.0.42, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
-      <HintPath>..\packages\Chocolatey.NuGet.Versioning.3.0.0-alpha-20221121-42\lib\net472\NuGet.Versioning.dll</HintPath>
     </Reference>
     <Reference Include="nunit.framework, Version=3.13.3.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
       <HintPath>..\packages\NUnit.3.13.3\lib\net40\nunit.framework.dll</HintPath>

--- a/src/chocolatey.tests.integration/packages.config
+++ b/src/chocolatey.tests.integration/packages.config
@@ -1,15 +1,15 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Chocolatey.NuGet.Common" version="3.0.0-alpha-20221121-42" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.Configuration" version="3.0.0-alpha-20221121-42" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.Packaging" version="3.0.0-alpha-20221121-42" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.Protocol" version="3.0.0-alpha-20221121-42" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.Versioning" version="3.0.0-alpha-20221121-42" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.Common" version="3.0.0-alpha-20221213-80" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.Configuration" version="3.0.0-alpha-20221213-80" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.Frameworks" version="3.0.0-alpha-20221213-80" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.Packaging" version="3.0.0-alpha-20221213-80" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.Protocol" version="3.0.0-alpha-20221213-80" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.Versioning" version="3.0.0-alpha-20221213-80" targetFramework="net48" />
   <package id="log4net" version="2.0.12" targetFramework="net48" />
   <package id="Microsoft.Web.Xdt" version="3.1.0" targetFramework="net48" />
   <package id="Moq" version="4.2.1402.2112" targetFramework="net40" />
   <package id="Newtonsoft.Json" version="13.0.1" targetFramework="net48" />
-  <package id="NuGet.Frameworks" version="3.0.0-alpha-20221121-42" targetFramework="net48" />
   <package id="NUnit" version="3.13.3" targetFramework="net48" />
   <package id="NUnit3TestAdapter" version="4.3.0" targetFramework="net48" />
   <package id="Rx-Core" version="2.1.30214.0" targetFramework="net48" />

--- a/src/chocolatey.tests/chocolatey.tests.csproj
+++ b/src/chocolatey.tests/chocolatey.tests.csproj
@@ -68,6 +68,24 @@
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Chocolatey.NuGet.Common, Version=3.0.0.80, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
+      <HintPath>..\packages\Chocolatey.NuGet.Common.3.0.0-alpha-20221213-80\lib\net472\Chocolatey.NuGet.Common.dll</HintPath>
+    </Reference>
+    <Reference Include="Chocolatey.NuGet.Configuration, Version=3.0.0.80, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
+      <HintPath>..\packages\Chocolatey.NuGet.Configuration.3.0.0-alpha-20221213-80\lib\net472\Chocolatey.NuGet.Configuration.dll</HintPath>
+    </Reference>
+    <Reference Include="Chocolatey.NuGet.Frameworks, Version=3.0.0.80, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
+      <HintPath>..\packages\Chocolatey.NuGet.Frameworks.3.0.0-alpha-20221213-80\lib\net472\Chocolatey.NuGet.Frameworks.dll</HintPath>
+    </Reference>
+    <Reference Include="Chocolatey.NuGet.Packaging, Version=3.0.0.80, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
+      <HintPath>..\packages\Chocolatey.NuGet.Packaging.3.0.0-alpha-20221213-80\lib\net472\Chocolatey.NuGet.Packaging.dll</HintPath>
+    </Reference>
+    <Reference Include="Chocolatey.NuGet.Protocol, Version=3.0.0.80, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
+      <HintPath>..\packages\Chocolatey.NuGet.Protocol.3.0.0-alpha-20221213-80\lib\net472\Chocolatey.NuGet.Protocol.dll</HintPath>
+    </Reference>
+    <Reference Include="Chocolatey.NuGet.Versioning, Version=3.0.0.80, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
+      <HintPath>..\packages\Chocolatey.NuGet.Versioning.3.0.0-alpha-20221213-80\lib\net472\Chocolatey.NuGet.Versioning.dll</HintPath>
+    </Reference>
     <Reference Include="log4net, Version=2.0.12.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
       <HintPath>..\packages\log4net.2.0.12\lib\net45\log4net.dll</HintPath>
     </Reference>
@@ -79,24 +97,6 @@
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.13.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
-    </Reference>
-    <Reference Include="NuGet.Common, Version=3.0.0.42, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
-      <HintPath>..\packages\Chocolatey.NuGet.Common.3.0.0-alpha-20221121-42\lib\net472\NuGet.Common.dll</HintPath>
-    </Reference>
-    <Reference Include="NuGet.Configuration, Version=3.0.0.42, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
-      <HintPath>..\packages\Chocolatey.NuGet.Configuration.3.0.0-alpha-20221121-42\lib\net472\NuGet.Configuration.dll</HintPath>
-    </Reference>
-    <Reference Include="NuGet.Frameworks, Version=3.0.0.42, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
-      <HintPath>..\packages\NuGet.Frameworks.3.0.0-alpha-20221121-42\lib\net472\NuGet.Frameworks.dll</HintPath>
-    </Reference>
-    <Reference Include="NuGet.Packaging, Version=3.0.0.42, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
-      <HintPath>..\packages\Chocolatey.NuGet.Packaging.3.0.0-alpha-20221121-42\lib\net472\NuGet.Packaging.dll</HintPath>
-    </Reference>
-    <Reference Include="NuGet.Protocol, Version=3.0.0.42, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
-      <HintPath>..\packages\Chocolatey.NuGet.Protocol.3.0.0-alpha-20221121-42\lib\net472\NuGet.Protocol.dll</HintPath>
-    </Reference>
-    <Reference Include="NuGet.Versioning, Version=3.0.0.42, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
-      <HintPath>..\packages\Chocolatey.NuGet.Versioning.3.0.0-alpha-20221121-42\lib\net472\NuGet.Versioning.dll</HintPath>
     </Reference>
     <Reference Include="nunit.framework, Version=3.13.3.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
       <HintPath>..\packages\NUnit.3.13.3\lib\net40\nunit.framework.dll</HintPath>

--- a/src/chocolatey.tests/packages.config
+++ b/src/chocolatey.tests/packages.config
@@ -1,15 +1,15 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Chocolatey.NuGet.Common" version="3.0.0-alpha-20221121-42" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.Configuration" version="3.0.0-alpha-20221121-42" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.Packaging" version="3.0.0-alpha-20221121-42" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.Protocol" version="3.0.0-alpha-20221121-42" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.Versioning" version="3.0.0-alpha-20221121-42" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.Common" version="3.0.0-alpha-20221213-80" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.Configuration" version="3.0.0-alpha-20221213-80" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.Frameworks" version="3.0.0-alpha-20221213-80" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.Packaging" version="3.0.0-alpha-20221213-80" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.Protocol" version="3.0.0-alpha-20221213-80" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.Versioning" version="3.0.0-alpha-20221213-80" targetFramework="net48" />
   <package id="log4net" version="2.0.12" targetFramework="net48" />
   <package id="Microsoft.Web.Xdt" version="3.1.0" targetFramework="net48" />
   <package id="Moq" version="4.2.1402.2112" targetFramework="net40" />
   <package id="Newtonsoft.Json" version="13.0.1" targetFramework="net48" />
-  <package id="NuGet.Frameworks" version="3.0.0-alpha-20221121-42" targetFramework="net48" />
   <package id="NUnit" version="3.13.3" targetFramework="net48" />
   <package id="NUnit3TestAdapter" version="4.3.0" targetFramework="net48" />
   <package id="Should" version="1.1.20" targetFramework="net48" />

--- a/src/chocolatey/chocolatey.csproj
+++ b/src/chocolatey/chocolatey.csproj
@@ -86,6 +86,45 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\AlphaFS.2.1.3\lib\net40\AlphaFS.dll</HintPath>
     </Reference>
+    <Reference Include="Chocolatey.NuGet.Commands, Version=3.0.0.80, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
+      <HintPath>..\packages\Chocolatey.NuGet.Commands.3.0.0-alpha-20221213-80\lib\net472\Chocolatey.NuGet.Commands.dll</HintPath>
+    </Reference>
+    <Reference Include="Chocolatey.NuGet.Common, Version=3.0.0.80, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
+      <HintPath>..\packages\Chocolatey.NuGet.Common.3.0.0-alpha-20221213-80\lib\net472\Chocolatey.NuGet.Common.dll</HintPath>
+    </Reference>
+    <Reference Include="Chocolatey.NuGet.Configuration, Version=3.0.0.80, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
+      <HintPath>..\packages\Chocolatey.NuGet.Configuration.3.0.0-alpha-20221213-80\lib\net472\Chocolatey.NuGet.Configuration.dll</HintPath>
+    </Reference>
+    <Reference Include="Chocolatey.NuGet.Credentials, Version=3.0.0.80, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
+      <HintPath>..\packages\Chocolatey.NuGet.Credentials.3.0.0-alpha-20221213-80\lib\net472\Chocolatey.NuGet.Credentials.dll</HintPath>
+    </Reference>
+    <Reference Include="Chocolatey.NuGet.DependencyResolver.Core, Version=3.0.0.80, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
+      <HintPath>..\packages\Chocolatey.NuGet.DependencyResolver.Core.3.0.0-alpha-20221213-80\lib\net472\Chocolatey.NuGet.DependencyResolver.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="Chocolatey.NuGet.Frameworks, Version=3.0.0.80, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
+      <HintPath>..\packages\Chocolatey.NuGet.Frameworks.3.0.0-alpha-20221213-80\lib\net472\Chocolatey.NuGet.Frameworks.dll</HintPath>
+    </Reference>
+    <Reference Include="Chocolatey.NuGet.LibraryModel, Version=3.0.0.80, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
+      <HintPath>..\packages\Chocolatey.NuGet.LibraryModel.3.0.0-alpha-20221213-80\lib\net472\Chocolatey.NuGet.LibraryModel.dll</HintPath>
+    </Reference>
+    <Reference Include="Chocolatey.NuGet.PackageManagement, Version=3.0.0.80, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
+      <HintPath>..\packages\Chocolatey.NuGet.PackageManagement.3.0.0-alpha-20221213-80\lib\net472\Chocolatey.NuGet.PackageManagement.dll</HintPath>
+    </Reference>
+    <Reference Include="Chocolatey.NuGet.Packaging, Version=3.0.0.80, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
+      <HintPath>..\packages\Chocolatey.NuGet.Packaging.3.0.0-alpha-20221213-80\lib\net472\Chocolatey.NuGet.Packaging.dll</HintPath>
+    </Reference>
+    <Reference Include="Chocolatey.NuGet.ProjectModel, Version=3.0.0.80, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
+      <HintPath>..\packages\Chocolatey.NuGet.ProjectModel.3.0.0-alpha-20221213-80\lib\net472\Chocolatey.NuGet.ProjectModel.dll</HintPath>
+    </Reference>
+    <Reference Include="Chocolatey.NuGet.Protocol, Version=3.0.0.80, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
+      <HintPath>..\packages\Chocolatey.NuGet.Protocol.3.0.0-alpha-20221213-80\lib\net472\Chocolatey.NuGet.Protocol.dll</HintPath>
+    </Reference>
+    <Reference Include="Chocolatey.NuGet.Resolver, Version=3.0.0.80, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
+      <HintPath>..\packages\Chocolatey.NuGet.Resolver.3.0.0-alpha-20221213-80\lib\net472\Chocolatey.NuGet.Resolver.dll</HintPath>
+    </Reference>
+    <Reference Include="Chocolatey.NuGet.Versioning, Version=3.0.0.80, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
+      <HintPath>..\packages\Chocolatey.NuGet.Versioning.3.0.0-alpha-20221213-80\lib\net472\Chocolatey.NuGet.Versioning.dll</HintPath>
+    </Reference>
     <Reference Include="log4net, Version=2.0.12.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
       <HintPath>..\packages\log4net.2.0.12\lib\net45\log4net.dll</HintPath>
     </Reference>
@@ -95,45 +134,6 @@
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.13.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
-    </Reference>
-    <Reference Include="NuGet.Commands, Version=3.0.0.42, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
-      <HintPath>..\packages\Chocolatey.NuGet.Commands.3.0.0-alpha-20221121-42\lib\net472\NuGet.Commands.dll</HintPath>
-    </Reference>
-    <Reference Include="NuGet.Common, Version=3.0.0.42, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
-      <HintPath>..\packages\Chocolatey.NuGet.Common.3.0.0-alpha-20221121-42\lib\net472\NuGet.Common.dll</HintPath>
-    </Reference>
-    <Reference Include="NuGet.Configuration, Version=3.0.0.42, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
-      <HintPath>..\packages\Chocolatey.NuGet.Configuration.3.0.0-alpha-20221121-42\lib\net472\NuGet.Configuration.dll</HintPath>
-    </Reference>
-    <Reference Include="NuGet.Credentials, Version=3.0.0.42, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
-      <HintPath>..\packages\Chocolatey.Nuget.Credentials.3.0.0-alpha-20221121-42\lib\net472\NuGet.Credentials.dll</HintPath>
-    </Reference>
-    <Reference Include="NuGet.DependencyResolver.Core, Version=3.0.0.42, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
-      <HintPath>..\packages\Chocolatey.NuGet.DependencyResolver.Core.3.0.0-alpha-20221121-42\lib\net472\NuGet.DependencyResolver.Core.dll</HintPath>
-    </Reference>
-    <Reference Include="NuGet.Frameworks, Version=3.0.0.42, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
-      <HintPath>..\packages\NuGet.Frameworks.3.0.0-alpha-20221121-42\lib\net472\NuGet.Frameworks.dll</HintPath>
-    </Reference>
-    <Reference Include="NuGet.LibraryModel, Version=3.0.0.42, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
-      <HintPath>..\packages\Chocolatey.NuGet.LibraryModel.3.0.0-alpha-20221121-42\lib\net472\NuGet.LibraryModel.dll</HintPath>
-    </Reference>
-    <Reference Include="NuGet.PackageManagement, Version=3.0.0.42, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
-      <HintPath>..\packages\Chocolatey.NuGet.PackageManagement.3.0.0-alpha-20221121-42\lib\net472\NuGet.PackageManagement.dll</HintPath>
-    </Reference>
-    <Reference Include="NuGet.Packaging, Version=3.0.0.42, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
-      <HintPath>..\packages\Chocolatey.NuGet.Packaging.3.0.0-alpha-20221121-42\lib\net472\NuGet.Packaging.dll</HintPath>
-    </Reference>
-    <Reference Include="NuGet.ProjectModel, Version=3.0.0.42, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
-      <HintPath>..\packages\Chocolatey.NuGet.ProjectModel.3.0.0-alpha-20221121-42\lib\net472\NuGet.ProjectModel.dll</HintPath>
-    </Reference>
-    <Reference Include="NuGet.Protocol, Version=3.0.0.42, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
-      <HintPath>..\packages\Chocolatey.NuGet.Protocol.3.0.0-alpha-20221121-42\lib\net472\NuGet.Protocol.dll</HintPath>
-    </Reference>
-    <Reference Include="NuGet.Resolver, Version=3.0.0.42, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
-      <HintPath>..\packages\Chocolatey.NuGet.Resolver.3.0.0-alpha-20221121-42\lib\net472\NuGet.Resolver.dll</HintPath>
-    </Reference>
-    <Reference Include="NuGet.Versioning, Version=3.0.0.42, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
-      <HintPath>..\packages\Chocolatey.NuGet.Versioning.3.0.0-alpha-20221121-42\lib\net472\NuGet.Versioning.dll</HintPath>
     </Reference>
     <Reference Include="Rhino.Licensing">
       <HintPath>..\..\lib\Rhino.Licensing.1.4.1\lib\net40\Rhino.Licensing.dll</HintPath>

--- a/src/chocolatey/infrastructure.app/nuget/NugetCommon.cs
+++ b/src/chocolatey/infrastructure.app/nuget/NugetCommon.cs
@@ -29,6 +29,7 @@ namespace chocolatey.infrastructure.app.nuget
     using System.Threading.Tasks;
     using adapters;
     using Alphaleonis.Win32.Filesystem;
+    using Chocolatey.NuGet.Frameworks;
     using infrastructure.configuration;
     using configuration;
     using domain;
@@ -38,7 +39,6 @@ namespace chocolatey.infrastructure.app.nuget
     using NuGet.Common;
     using NuGet.Configuration;
     using NuGet.Credentials;
-    using NuGet.Frameworks;
     using NuGet.PackageManagement;
     using NuGet.Packaging;
     using NuGet.Packaging.Core;

--- a/src/chocolatey/infrastructure.app/services/NugetService.cs
+++ b/src/chocolatey/infrastructure.app/services/NugetService.cs
@@ -24,6 +24,7 @@ namespace chocolatey.infrastructure.app.services
     using System.Net;
     using System.Text.RegularExpressions;
     using System.Threading;
+    using Chocolatey.NuGet.Frameworks;
     using adapters;
     using chocolatey.infrastructure.app.utility;
     using commandline;
@@ -41,7 +42,6 @@ namespace chocolatey.infrastructure.app.services
     using chocolatey.infrastructure.app.utility;
     using NuGet.Common;
     using NuGet.Configuration;
-    using NuGet.Frameworks;
     using NuGet.PackageManagement;
     using NuGet.Packaging;
     using NuGet.Packaging.Core;

--- a/src/chocolatey/packages.config
+++ b/src/chocolatey/packages.config
@@ -1,23 +1,23 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="AlphaFS" version="2.1.3" targetFramework="net40-Client" />
-  <package id="Chocolatey.NuGet.Commands" version="3.0.0-alpha-20221121-42" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.Common" version="3.0.0-alpha-20221121-42" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.Configuration" version="3.0.0-alpha-20221121-42" targetFramework="net48" />
-  <package id="Chocolatey.Nuget.Credentials" version="3.0.0-alpha-20221121-42" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.DependencyResolver.Core" version="3.0.0-alpha-20221121-42" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.LibraryModel" version="3.0.0-alpha-20221121-42" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.PackageManagement" version="3.0.0-alpha-20221121-42" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.Packaging" version="3.0.0-alpha-20221121-42" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.ProjectModel" version="3.0.0-alpha-20221121-42" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.Protocol" version="3.0.0-alpha-20221121-42" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.Resolver" version="3.0.0-alpha-20221121-42" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.Versioning" version="3.0.0-alpha-20221121-42" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.Commands" version="3.0.0-alpha-20221213-80" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.Common" version="3.0.0-alpha-20221213-80" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.Configuration" version="3.0.0-alpha-20221213-80" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.Credentials" version="3.0.0-alpha-20221213-80" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.DependencyResolver.Core" version="3.0.0-alpha-20221213-80" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.Frameworks" version="3.0.0-alpha-20221213-80" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.LibraryModel" version="3.0.0-alpha-20221213-80" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.PackageManagement" version="3.0.0-alpha-20221213-80" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.Packaging" version="3.0.0-alpha-20221213-80" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.ProjectModel" version="3.0.0-alpha-20221213-80" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.Protocol" version="3.0.0-alpha-20221213-80" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.Resolver" version="3.0.0-alpha-20221213-80" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.Versioning" version="3.0.0-alpha-20221213-80" targetFramework="net48" />
   <package id="log4net" version="2.0.12" targetFramework="net48" />
   <package id="Microsoft.CSharp" version="4.3.0" targetFramework="net48" />
   <package id="Microsoft.Web.Xdt" version="3.1.0" targetFramework="net48" />
   <package id="Newtonsoft.Json" version="13.0.1" targetFramework="net48" />
-  <package id="NuGet.Frameworks" version="3.0.0-alpha-20221121-42" targetFramework="net48" />
   <package id="Rx-Core" version="2.1.30214.0" targetFramework="net48" />
   <package id="Rx-Interfaces" version="2.1.30214.0" targetFramework="net48" />
   <package id="Rx-Linq" version="2.1.30214.0" targetFramework="net48" />


### PR DESCRIPTION
## Description Of Changes

This pull request updates all of the NuGet.Client libraries
that we need for Chocolatey CLI to the latest version
we have available on nuget.org. As part of this update, the package
name and assembly name was changed for the packages as well.


## Motivation and Context

To be kept up to date, and to allow people outside of the team to be able to build the project.

## Testing

1. Ran unit and integration tests through `build.ps1`

### Operating Systems Testing

- Windows 11/10

## Change Types Made

* [ ] Bug fix (non-breaking change).
* [x] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [x] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue

N/A
