### PR TITLE
(maint) Resolve a number of warnings

### DIFF
--- a/src/chocolatey.tests/infrastructure.app/commands/ChocolateyPinCommandSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/commands/ChocolateyPinCommandSpecs.cs
@@ -436,7 +436,7 @@ namespace chocolatey.tests.infrastructure.app.commands
 
                 configuration.PinCommand.Name = "regular";
                 //packageManager.Setup(pm => pm.LocalRepository).Returns(localRepository.Object);
-                NuGetVersion nugetVersion = null;
+                //NuGetVersion nugetVersion = null;
                 //nuget woes
                 //localRepository.Setup(r => r.FindPackage(configuration.PinCommand.Name, nugetVersion)).Returns(package.Object);
                 configuration.PinCommand.Command = PinCommandType.add;

--- a/src/chocolatey.tests/infrastructure.app/services/TemplateServiceSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/services/TemplateServiceSpecs.cs
@@ -670,7 +670,6 @@ namespace chocolatey.tests.infrastructure.app.services
         {
             private Action because;
             private readonly ChocolateyConfiguration config = new ChocolateyConfiguration();
-            private string verifiedDirectoryPath;
 
             public override void Context()
             {
@@ -705,7 +704,6 @@ namespace chocolatey.tests.infrastructure.app.services
         {
             private Action because;
             private readonly ChocolateyConfiguration config = new ChocolateyConfiguration();
-            private string verifiedDirectoryPath;
 
             public override void Context()
             {

--- a/src/chocolatey/EnumerableExtensions.cs
+++ b/src/chocolatey/EnumerableExtensions.cs
@@ -31,7 +31,7 @@ namespace chocolatey
         /// <typeparam name="T"></typeparam>
         /// <param name="source">The source.</param>
         /// <returns>
-        ///   Source if not null; otherwise Enumerable.Empty&lt;<see cref="T" />&gt;
+        ///   Source if not null; otherwise Enumerable.Empty&lt;<see cref="or_empty_list_if_null{T}" />&gt;
         /// </returns>
         public static IEnumerable<T> or_empty_list_if_null<T>(this IEnumerable<T> source)
         {

--- a/src/chocolatey/LogExtensions.cs
+++ b/src/chocolatey/LogExtensions.cs
@@ -52,7 +52,7 @@ namespace chocolatey
         }
 
         /// <summary>
-        ///   Gets the logger for <see cref="T" />.
+        ///   Gets the logger for <see cref="Log{T}" />.
         /// </summary>
         /// <typeparam name="T"></typeparam>
         /// <param name="type">The type to get the logger for.</param>

--- a/src/chocolatey/infrastructure.app/configuration/ConfigurationOptions.cs
+++ b/src/chocolatey/infrastructure.app/configuration/ConfigurationOptions.cs
@@ -135,6 +135,7 @@ namespace chocolatey.infrastructure.app.configuration
         ///   Shows the help menu and prints the options
         /// </summary>
         /// <param name="optionSet">The option_set.</param>
+        /// <param name="helpMessage">The action that displays the message</param>
         private static void show_help(OptionSet optionSet, Action helpMessage)
         {
             if (helpMessage != null)

--- a/src/chocolatey/infrastructure.app/nuget/ChocolateyNuGetSettings.cs
+++ b/src/chocolatey/infrastructure.app/nuget/ChocolateyNuGetSettings.cs
@@ -14,7 +14,7 @@ namespace chocolatey.infrastructure.app.nuget
     {
         //private ClientPolicyContext
         private const string CONFIG_SECTION_NAME = "config";
-        private SettingSection _configSettingSection;
+        //private SettingSection _configSettingSection;
 
         public ChocolateyNuGetSettings(ChocolateyConfiguration config)
         {
@@ -40,7 +40,7 @@ namespace chocolatey.infrastructure.app.nuget
                 case CONFIG_SECTION_NAME:
                     //TODO fix
                     return null;
-                    break;
+                    //break;
                 default:
                     return null;
             }

--- a/src/chocolatey/infrastructure.app/nuget/NugetCommon.cs
+++ b/src/chocolatey/infrastructure.app/nuget/NugetCommon.cs
@@ -348,7 +348,10 @@ namespace chocolatey.infrastructure.app.nuget
                         () => GetCredentialProvidersAsync(configuration)), false, true));
         }
 
+#pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously.
+        // We don't care about this method being synchronous because this is just used to pass in the credential provider to Lazy<ICredentialService>
         private static async Task<IEnumerable<ICredentialProvider>> GetCredentialProvidersAsync(ChocolateyConfiguration configuration)
+#pragma warning restore CS1998 // Async method lacks 'await' operators and will run synchronously
         {
             return new List<ICredentialProvider>() { new ChocolateyNugetCredentialProvider(configuration) };
         }

--- a/src/chocolatey/infrastructure.app/services/IPendingRebootService.cs
+++ b/src/chocolatey/infrastructure.app/services/IPendingRebootService.cs
@@ -22,7 +22,6 @@ namespace chocolatey.infrastructure.app.services
     ///   Test to see if there are any known situations that require
     ///   a System reboot.
     /// </summary>
-    /// <param name="config">The current Chocolatey Configuration</param>
     /// <returns><c>true</c> if reboot is required; otherwise <c>false</c>.</returns>
     public interface IPendingRebootService
     {

--- a/src/chocolatey/infrastructure.app/services/NugetService.cs
+++ b/src/chocolatey/infrastructure.app/services/NugetService.cs
@@ -39,7 +39,6 @@ namespace chocolatey.infrastructure.app.services
     using DateTime = adapters.DateTime;
     using Environment = System.Environment;
     using IFileSystem = filesystem.IFileSystem;
-    using chocolatey.infrastructure.app.utility;
     using NuGet.Common;
     using NuGet.Configuration;
     using NuGet.PackageManagement;

--- a/src/chocolatey/infrastructure.app/services/NugetService.cs
+++ b/src/chocolatey/infrastructure.app/services/NugetService.cs
@@ -75,7 +75,6 @@ namespace chocolatey.infrastructure.app.services
         /// <param name="nugetLogger">The nuget logger</param>
         /// <param name="packageInfoService">Package information service</param>
         /// <param name="filesService">The files service</param>
-        /// <param name="packageDownloader">The downloader used to download packages</param>
         public NugetService(IFileSystem fileSystem, ILogger nugetLogger, IChocolateyPackageInformationService packageInfoService, IFilesService filesService)
         {
             _fileSystem = fileSystem;

--- a/src/chocolatey/infrastructure.app/services/WindowsFeatureService.cs
+++ b/src/chocolatey/infrastructure.app/services/WindowsFeatureService.cs
@@ -33,7 +33,7 @@ namespace chocolatey.infrastructure.app.services
     ///   Alternative Source for Enabling Windows Features
     /// </summary>
     /// <remarks>
-    ///   https://technet.microsoft.com/en-us/library/hh825265.aspx?f=255&MSPPError=-2147217396
+    ///   <![CDATA[https://technet.microsoft.com/en-us/library/hh825265.aspx?f=255&MSPPError=-2147217396]]>
     ///   Win 7 - https://technet.microsoft.com/en-us/library/dd744311.aspx
     ///   Maybe Win2003/2008 - http://www.wincert.net/forum/files/file/8-deployment-image-servicing-and-management-dism/ | http://wincert.net/leli55PK/DISM/
     /// </remarks>

--- a/src/chocolatey/infrastructure/adapters/IEnvironment.cs
+++ b/src/chocolatey/infrastructure/adapters/IEnvironment.cs
@@ -132,8 +132,7 @@ namespace chocolatey.infrastructure.adapters
         /// An <see cref="T:System.Collections.IDictionary"/> object that contains all environment variable names and their values from the source specified by the <paramref name="target"/> parameter; otherwise, an empty dictionary if no environment variables are found.
         ///
         /// </returns>
-        /// <param name="target">One of the <see cref="T:System.EnvironmentVariableTarget"/> values.
-        ///                 </param><exception cref="T:System.Security.SecurityException">The caller does not have the required permission to perform this operation for the specified value of <paramref name="target"/>.
+        /// <exception cref="T:System.Security.SecurityException">The caller does not have the required permission to perform this operation for the specified value of <paramref name="target"/>.
         ///                 </exception><exception cref="T:System.NotSupportedException">This method cannot be used on Windows 95 or Windows 98 platforms.
         ///                 </exception><exception cref="T:System.ArgumentException"><paramref name="target"/> contains an illegal value.
         ///                 </exception><filterpriority>1</filterpriority><PermissionSet><IPermission class="System.Security.Permissions.EnvironmentPermission, mscorlib, Version=2.0.3600.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" version="1" Unrestricted="true"/><IPermission class="System.Security.Permissions.RegistryPermission, mscorlib, Version=2.0.3600.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" version="1" Unrestricted="true"/><IPermission class="System.Security.Permissions.SecurityPermission, mscorlib, Version=2.0.3600.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" version="1" Flags="UnmanagedCode"/></PermissionSet>

--- a/src/chocolatey/infrastructure/adapters/IProcess.cs
+++ b/src/chocolatey/infrastructure/adapters/IProcess.cs
@@ -27,7 +27,7 @@ namespace chocolatey.infrastructure.adapters
         event EventHandler<DataReceivedEventArgs> ErrorDataReceived;
 
         /// <summary>
-        ///   Gets or sets the properties to pass into the <see cref='System.Diagnostics.Process.Start' /> method for the
+        ///   Gets or sets the properties to pass into the <see cref='System.Diagnostics.Process.Start()' /> method for the
         ///   <see
         ///     cref='System.Diagnostics.Process' />
         ///   .

--- a/src/chocolatey/infrastructure/registration/AssemblyResolution.cs
+++ b/src/chocolatey/infrastructure/registration/AssemblyResolution.cs
@@ -351,7 +351,7 @@ namespace chocolatey.infrastructure.registration
                             return resolvedAssembly.UnderlyingType;
                         }
                     }
-                    catch (Exception ex)
+                    catch (Exception)
                     {
                         // This catch statement is empty on purpose, we do
                         // not want to do anything if it fails to load.

--- a/src/chocolatey/infrastructure/registration/SimpleInjectorContainer.cs
+++ b/src/chocolatey/infrastructure/registration/SimpleInjectorContainer.cs
@@ -95,6 +95,7 @@ namespace chocolatey.infrastructure.registration
         /// </summary>
         /// <param name="componentRegistry">The component registry.</param>
         /// <param name="container">The container.</param>
+        /// <param name="extensions">Any extension libraries</param>
         private static void load_component_registry(Type componentRegistry, Container container, IEnumerable<ExtensionInformation> extensions)
         {
             if (componentRegistry == null)

--- a/src/chocolatey/infrastructure/results/IResult.cs
+++ b/src/chocolatey/infrastructure/results/IResult.cs
@@ -24,7 +24,7 @@ namespace chocolatey.infrastructure.results
     public interface IResult
     {
         /// <summary>
-        ///   Gets a value indicating whether this <see cref="IResults" /> is successful.
+        ///   Gets a value indicating whether this <see cref="IResult" /> is successful.
         /// </summary>
         /// <value>
         ///   <c>true</c> if success; otherwise, <c>false</c>.


### PR DESCRIPTION
## Description Of Changes

This fixes the xml comments that had warnings, and resolves a number of other warnings in Visual Studio

## Motivation and Context

Reducing the number of warnings in Visual Studio and during the command line build is ideal, as it allows for easier identification of any new warnings that show up, and starts on the path to allow enabling treat warnings as errors.

## Testing

Look at warnings in Visual Studio, and saw the number greatly reduced. 
Built and ensured that there were no compilation issues.

### Operating Systems Testing

- Windows 10 22H2

## Change Types Made

* [x] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [x] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [x] Requires a change to the documentation.
* [x] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [x] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue

Depends on #2927
Helps prepare for #13

