### PR TITLE
(#1541) Add tests for future implementation of source priority

### DIFF
--- a/src/chocolatey.tests.integration/Scenario.cs
+++ b/src/chocolatey.tests.integration/Scenario.cs
@@ -19,12 +19,15 @@ namespace chocolatey.tests.integration
     using System;
     using System.Collections.Generic;
     using System.IO;
+    using System.Linq;
+
     using chocolatey.infrastructure.app;
     using chocolatey.infrastructure.app.configuration;
     using chocolatey.infrastructure.app.domain;
     using chocolatey.infrastructure.app.services;
     using chocolatey.infrastructure.commands;
     using chocolatey.infrastructure.filesystem;
+    using chocolatey.infrastructure.guards;
     using chocolatey.infrastructure.platforms;
 
     public class Scenario
@@ -85,6 +88,71 @@ namespace chocolatey.tests.integration
             }
         }
 
+        public static void add_machine_source(ChocolateyConfiguration config, string name, string path = null, int priority = 0, bool createDirectory = true)
+        {
+            if (string.IsNullOrEmpty(path))
+            {
+                path = _fileSystem.combine_paths(get_top_level(), "PrioritySources", name);
+            }
+
+            if (createDirectory)
+            {
+                _fileSystem.create_directory_if_not_exists(path);
+            }
+
+            var newSource = new MachineSourceConfiguration
+            {
+                Name = name,
+                Key = path,
+                Priority = priority
+            };
+            config.MachineSources.Add(newSource);
+        }
+
+        public static string add_packages_to_priority_source_location(ChocolateyConfiguration config, string pattern, int priority = 0, string name = null)
+        {
+            if (name == null)
+            {
+                name = "Priority" + priority;
+            }
+
+            var prioritySourceDirectory = _fileSystem.combine_paths(get_top_level(), "PrioritySources", name);
+
+            var machineSource = config.MachineSources.FirstOrDefault(m => m.Name.is_equal_to(name));
+
+            if (machineSource == null)
+            {
+                machineSource = new MachineSourceConfiguration
+                {
+                    Name = name,
+                    Key = prioritySourceDirectory,
+                    Priority = priority
+                };
+                config.MachineSources.Add(machineSource);
+            }
+            else
+            {
+                prioritySourceDirectory = machineSource.Key;
+            }
+
+            _fileSystem.create_directory_if_not_exists(prioritySourceDirectory);
+
+            var contextDir = _fileSystem.combine_paths(get_top_level(), "context");
+            var files = _fileSystem.get_files(contextDir, pattern, SearchOption.AllDirectories).or_empty_list_if_null().ToList();
+
+            if (files.Count == 0)
+            {
+                throw new ApplicationException("No files matching the pattern {0} could be found!".format_with(pattern));
+            }
+
+            foreach (var file in files)
+            {
+                _fileSystem.copy_file(_fileSystem.get_full_path(file), _fileSystem.combine_paths(prioritySourceDirectory, _fileSystem.get_file_name(file)), overwriteExisting: true);
+            }
+
+            return machineSource.Name;
+        }
+
         public static void remove_packages_from_destination_location(ChocolateyConfiguration config, string pattern)
         {
             if (!_fileSystem.directory_exists(config.Sources))
@@ -135,6 +203,8 @@ namespace chocolatey.tests.integration
 
         private static ChocolateyConfiguration baseline_configuration()
         {
+            delete_test_package_directories();
+
             // note that this does not mean an empty configuration. It does get influenced by
             // prior commands, so ensure that all items go back to the default values here
             var config = NUnitSetup.Container.GetInstance<ChocolateyConfiguration>();
@@ -195,6 +265,7 @@ namespace chocolatey.tests.integration
             config.PinCommand.Name = string.Empty;
             config.PinCommand.Command = PinCommandType.unknown;
             config.ListCommand.IdOnly = false;
+            config.MachineSources.Clear();
 
             return config;
         }
@@ -231,6 +302,16 @@ namespace chocolatey.tests.integration
             return config;
         }
 
+        public static ChocolateyConfiguration info()
+        {
+            var config = baseline_configuration();
+            config.CommandName = "info";
+            config.Verbose = true;
+            config.ListCommand.Exact = true;
+
+            return config;
+        }
+
         public static ChocolateyConfiguration pin()
         {
             var config = baseline_configuration();
@@ -245,6 +326,22 @@ namespace chocolatey.tests.integration
             config.CommandName = "pack";
 
             return config;
+        }
+
+        private static void delete_test_package_directories()
+        {
+            var topDirectory = get_top_level();
+
+            var directoriesToClean = new[]
+            {
+                Path.Combine(topDirectory, "PackageOutput"),
+                Path.Combine(topDirectory, "PrioritySources")
+            };
+
+            foreach (var directory in directoriesToClean)
+            {
+                _fileSystem.delete_directory_if_exists(directory, recursive: true);
+            }
         }
     }
 }

--- a/src/chocolatey.tests.integration/chocolatey.tests.integration.csproj
+++ b/src/chocolatey.tests.integration/chocolatey.tests.integration.csproj
@@ -151,6 +151,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="NUnitSetup.cs" />
     <Compile Include="Scenario.cs" />
+    <Compile Include="scenarios\InfoScenarios.cs" />
     <Compile Include="scenarios\InstallScenarios.cs" />
     <Compile Include="scenarios\ListScenarios.cs" />
     <Compile Include="scenarios\PackScenarios.cs" />

--- a/src/chocolatey.tests.integration/scenarios/InfoScenarios.cs
+++ b/src/chocolatey.tests.integration/scenarios/InfoScenarios.cs
@@ -1,0 +1,311 @@
+﻿namespace chocolatey.tests.integration.scenarios
+{
+    using System;
+    using System.Collections.Generic;
+    using System.IO;
+    using System.Linq;
+    using System.Reflection;
+    using System.Text;
+    using chocolatey.infrastructure.app.commands;
+    using chocolatey.infrastructure.app.configuration;
+    using chocolatey.infrastructure.app.services;
+    using chocolatey.infrastructure.commands;
+    using chocolatey.infrastructure.results;
+
+    using NuGet;
+
+    using NUnit.Framework;
+
+    using Should;
+
+    public class InfoScenarios
+    {
+        [ConcernFor("info")]
+        public abstract class ScenariosBase : TinySpec
+        {
+            protected IList<PackageResult> Results;
+            protected ChocolateyConfiguration Configuration;
+            protected IChocolateyPackageService Service;
+
+            public override void Context()
+            {
+                Configuration = Scenario.info();
+                Scenario.reset(Configuration);
+
+                Service = NUnitSetup.Container.GetInstance<IChocolateyPackageService>();
+            }
+
+            public override void Because()
+            {
+                MockLogger.reset();
+                // There is no info run. It is purely listing with verbose and exact set to true
+                Results = Service.list_run(Configuration).ToList();
+            }
+        }
+
+        [ConcernFor("info")]
+        public abstract class CommandScenariosBase : TinySpec
+        {
+            protected ChocolateyConfiguration Configuration;
+            protected ICommand Command;
+
+            public override void Context()
+            {
+                Configuration = Scenario.info();
+                Scenario.reset(Configuration);
+
+                Command = NUnitSetup.Container.GetAllInstances<ICommand>()
+                    .Where(c => c.GetType() == typeof(ChocolateyInfoCommand)).First();
+            }
+
+            public override void Because()
+            {
+                MockLogger.reset();
+
+                Command.run(Configuration);
+            }
+        }
+
+        public class when_searching_for_exact_package_through_command : CommandScenariosBase
+        {
+            public override void Context()
+            {
+                base.Context();
+
+                Configuration.PackageNames = Configuration.Input = "installpackage";
+
+                Configuration.Sources = "PackageOutput";
+                Scenario.add_packages_to_source_location(Configuration, "installpackage.*" + Constants.PackageExtension);
+            }
+
+            [Fact]
+            public void should_log_standalone_header_with_package_name_and_version()
+            {
+                MockLogger.Messages.Keys.ShouldContain(LogLevel.Info.to_string());
+                MockLogger.Messages[LogLevel.Info.to_string()].ShouldContain("installpackage 1.0.0");
+            }
+
+            [Fact]
+            public void should_log_package_information()
+            {
+                var lastWriteDate = File.GetLastWriteTimeUtc(Path.Combine("PackageOutput", "installpackage.1.0.0" + Constants.PackageExtension))
+                    .ToShortDateString();
+
+                MockLogger.Messages.Keys.ShouldContain(LogLevel.Info.to_string());
+                MockLogger.Messages[LogLevel.Info.to_string()].ShouldContain(" Title: installpackage | Published: 14.12.2022\r\n Number of Downloads: n/a | Downloads for this version: n/a\r\n Package url\r\n Chocolatey Package Source: n/a\r\n Tags: installpackage admin\r\n Software Site: n/a\r\n Software License: n/a\r\n Summary: __REPLACE__\r\n Description: __REPLACE__\r\n".format_with(lastWriteDate));
+            }
+
+            [Fact]
+            public void should_log_package_count_as_warning()
+            {
+                MockLogger.Messages.Keys.ShouldContain(LogLevel.Warn.to_string());
+                MockLogger.Messages[LogLevel.Warn.to_string()].ShouldContain("1 packages found.");
+            }
+        }
+
+        public class when_searching_for_exact_package_with_dot_relative_path_source : when_searching_for_exact_package_through_command
+        {
+            public override void Context()
+            {
+                base.Context();
+                Configuration.Sources = ".";
+            }
+
+            public override void Because()
+            {
+                var currentDirectory = Environment.CurrentDirectory;
+                Environment.CurrentDirectory = Path.Combine(Environment.CurrentDirectory, "PackageOutput");
+
+                try
+                {
+                    base.Because();
+                }
+                finally
+                {
+                    Environment.CurrentDirectory = currentDirectory;
+                }
+            }
+
+            [Fact]
+            public new void should_log_standalone_header_with_package_name_and_version()
+            {
+                MockLogger.Messages.Keys.ShouldContain(LogLevel.Info.to_string());
+                MockLogger.Messages[LogLevel.Info.to_string()].ShouldContain("installpackage 1.0.0");
+            }
+
+            [Fact]
+            public new void should_log_package_information()
+            {
+                var lastWriteDate = File.GetLastWriteTimeUtc(Path.Combine("PackageOutput", "installpackage.1.0.0" + Constants.PackageExtension))
+                    .ToShortDateString();
+
+                MockLogger.Messages.Keys.ShouldContain(LogLevel.Info.to_string());
+                MockLogger.Messages[LogLevel.Info.to_string()].ShouldContain(" Title: installpackage | Published: 14.12.2022\r\n Number of Downloads: n/a | Downloads for this version: n/a\r\n Package url\r\n Chocolatey Package Source: n/a\r\n Tags: installpackage admin\r\n Software Site: n/a\r\n Software License: n/a\r\n Summary: __REPLACE__\r\n Description: __REPLACE__\r\n".format_with(lastWriteDate));
+            }
+
+            [Fact]
+            public new void should_log_package_count_as_warning()
+            {
+                MockLogger.Messages.Keys.ShouldContain(LogLevel.Warn.to_string());
+                MockLogger.Messages[LogLevel.Warn.to_string()].ShouldContain("1 packages found.");
+            }
+        }
+
+        public class when_searching_for_exact_package_with_verbose_output : ScenariosBase
+        {
+            public override void Context()
+            {
+                base.Context();
+
+                Configuration.PackageNames = Configuration.Input = "installpackage";
+                Configuration.Sources = "PackageOutput";
+                Scenario.add_packages_to_source_location(Configuration, "installpackage.*" + Constants.PackageExtension);
+            }
+
+            [Fact]
+            public void should_show_only_one_result()
+            {
+                Results.Count.ShouldEqual(1, "Expected 1 package to be returned!");
+            }
+
+            [Fact]
+            public void should_set_exit_code_to_zero()
+            {
+                Results[0].ExitCode.ShouldEqual(0);
+            }
+
+            [Fact]
+            public void should_not_be_reported_as_inconclusive()
+            {
+                Results[0].Inconclusive.ShouldBeFalse();
+            }
+
+            [Fact]
+            public void should_report_expected_name()
+            {
+                Results[0].Name.ShouldEqual("installpackage");
+            }
+
+            [Fact]
+            public void should_set_source_to_expected_value()
+            {
+                Results[0].Source.ShouldEqual("PackageOutput");
+            }
+
+            [Fact]
+            public void should_set_expected_version()
+            {
+                Results[0].Version.ShouldEqual("1.0.0");
+            }
+        }
+
+        [Categories.SourcePriority]
+        public class when_searching_for_a_package_in_a_priority_source : ScenariosBase
+        {
+            public override void Context()
+            {
+                base.Context();
+
+                Configuration.PackageNames = Configuration.Input = "test-package";
+                Configuration.Sources = Scenario.add_packages_to_priority_source_location(Configuration, "test-package.*" + Constants.PackageExtension, priority: 1);
+            }
+
+            [Fact]
+            public void should_show_only_one_result()
+            {
+                Results.Count.ShouldEqual(1, "Expected 1 package to be returned!");
+            }
+
+            [Fact]
+            public void should_set_exit_code_to_zero()
+            {
+                Results[0].ExitCode.ShouldEqual(0);
+            }
+
+            [Fact]
+            public void should_not_be_reported_as_inconclusive()
+            {
+                Results[0].Inconclusive.ShouldBeFalse();
+            }
+
+            [Fact]
+            public void should_report_expected_name()
+            {
+                Results[0].Name.ShouldEqual("test-package");
+            }
+
+            [Fact]
+            public void should_set_source_to_expected_value()
+            {
+                var expectedSource = "file:///" + Path.Combine(
+                    Scenario.get_top_level(),
+                    "PrioritySources",
+                    "Priority1").Replace('\\', '/');
+
+                Results[0].Source.ShouldEqual(expectedSource);
+            }
+
+            [Fact]
+            public void should_set_expected_version()
+            {
+                Results[0].Version.ShouldEqual("0.1.0");
+            }
+        }
+
+        [Categories.SourcePriority]
+        public class when_searching_for_a_package_in_and_prioritised_source_has_lower_version : ScenariosBase
+        {
+            public override void Context()
+            {
+                base.Context();
+
+                Configuration.PackageNames = Configuration.Input = "upgradepackage";
+                Configuration.Sources = string.Join(",",
+                    Scenario.add_packages_to_priority_source_location(Configuration, "upgradepackage.1.0.0" + Constants.PackageExtension, priority: 1),
+                    Scenario.add_packages_to_priority_source_location(Configuration,
+                      "upgradepackage.1.1.0" + Constants.PackageExtension, priority: 0));
+            }
+
+            [Fact]
+            public void should_show_only_one_result()
+            {
+                Results.Count.ShouldEqual(1, "Expected 1 package to be returned!");
+            }
+
+            [Fact]
+            public void should_set_exit_code_to_zero()
+            {
+                Results[0].ExitCode.ShouldEqual(0);
+            }
+
+            [Fact]
+            public void should_not_be_reported_as_inconclusive()
+            {
+                Results[0].Inconclusive.ShouldBeFalse();
+            }
+
+            [Fact]
+            public void should_report_expected_name()
+            {
+                Results[0].Name.ShouldEqual("upgradepackage");
+            }
+
+            [Fact]
+            public void should_set_source_to_expected_value()
+            {
+                var expectedSource = "file:///" + Path.Combine(
+                    Scenario.get_top_level(),
+                    "PrioritySources",
+                    "Priority1").Replace('\\', '/');
+
+                Results[0].Source.ShouldEqual(expectedSource);
+            }
+
+            [Fact]
+            public void should_set_expected_version()
+            {
+                Results[0].Version.ShouldEqual("1.0.0");
+            }
+        }
+    }
+}

--- a/src/chocolatey.tests.integration/scenarios/InfoScenarios.cs
+++ b/src/chocolatey.tests.integration/scenarios/InfoScenarios.cs
@@ -1,4 +1,4 @@
-﻿namespace chocolatey.tests.integration.scenarios
+namespace chocolatey.tests.integration.scenarios
 {
     using System;
     using System.Collections.Generic;
@@ -13,6 +13,7 @@
     using chocolatey.infrastructure.results;
 
     using NuGet;
+    using NuGet.Configuration;
 
     using NUnit.Framework;
 
@@ -66,6 +67,7 @@
             }
         }
 
+        [Broken, Pending("Need to be fixed in either NuGet.Client or before calling code in NuGet.Client")]
         public class when_searching_for_exact_package_through_command : CommandScenariosBase
         {
             public override void Context()
@@ -75,7 +77,7 @@
                 Configuration.PackageNames = Configuration.Input = "installpackage";
 
                 Configuration.Sources = "PackageOutput";
-                Scenario.add_packages_to_source_location(Configuration, "installpackage.*" + Constants.PackageExtension);
+                Scenario.add_packages_to_source_location(Configuration, "installpackage.*" + NuGetConstants.PackageExtension);
             }
 
             [Fact]
@@ -88,7 +90,7 @@
             [Fact]
             public void should_log_package_information()
             {
-                var lastWriteDate = File.GetLastWriteTimeUtc(Path.Combine("PackageOutput", "installpackage.1.0.0" + Constants.PackageExtension))
+                var lastWriteDate = File.GetLastWriteTimeUtc(Path.Combine("PackageOutput", "installpackage.1.0.0" + NuGetConstants.PackageExtension))
                     .ToShortDateString();
 
                 MockLogger.Messages.Keys.ShouldContain(LogLevel.Info.to_string());
@@ -103,6 +105,7 @@
             }
         }
 
+        [Broken, Pending("Need to be fixed in either NuGet.Client or before calling code in NuGet.Client")]
         public class when_searching_for_exact_package_with_dot_relative_path_source : when_searching_for_exact_package_through_command
         {
             public override void Context()
@@ -136,7 +139,7 @@
             [Fact]
             public new void should_log_package_information()
             {
-                var lastWriteDate = File.GetLastWriteTimeUtc(Path.Combine("PackageOutput", "installpackage.1.0.0" + Constants.PackageExtension))
+                var lastWriteDate = File.GetLastWriteTimeUtc(Path.Combine("PackageOutput", "installpackage.1.0.0" + NuGetConstants.PackageExtension))
                     .ToShortDateString();
 
                 MockLogger.Messages.Keys.ShouldContain(LogLevel.Info.to_string());
@@ -151,6 +154,7 @@
             }
         }
 
+        [Broken, Pending("Need to be fixed in either NuGet.Client or before calling code in NuGet.Client")]
         public class when_searching_for_exact_package_with_verbose_output : ScenariosBase
         {
             public override void Context()
@@ -159,7 +163,7 @@
 
                 Configuration.PackageNames = Configuration.Input = "installpackage";
                 Configuration.Sources = "PackageOutput";
-                Scenario.add_packages_to_source_location(Configuration, "installpackage.*" + Constants.PackageExtension);
+                Scenario.add_packages_to_source_location(Configuration, "installpackage.*" + NuGetConstants.PackageExtension);
             }
 
             [Fact]
@@ -207,7 +211,7 @@
                 base.Context();
 
                 Configuration.PackageNames = Configuration.Input = "test-package";
-                Configuration.Sources = Scenario.add_packages_to_priority_source_location(Configuration, "test-package.*" + Constants.PackageExtension, priority: 1);
+                Configuration.Sources = Scenario.add_packages_to_priority_source_location(Configuration, "test-package.*" + NuGetConstants.PackageExtension, priority: 1);
             }
 
             [Fact]
@@ -261,9 +265,9 @@
 
                 Configuration.PackageNames = Configuration.Input = "upgradepackage";
                 Configuration.Sources = string.Join(",",
-                    Scenario.add_packages_to_priority_source_location(Configuration, "upgradepackage.1.0.0" + Constants.PackageExtension, priority: 1),
+                    Scenario.add_packages_to_priority_source_location(Configuration, "upgradepackage.1.0.0" + NuGetConstants.PackageExtension, priority: 1),
                     Scenario.add_packages_to_priority_source_location(Configuration,
-                      "upgradepackage.1.1.0" + Constants.PackageExtension, priority: 0));
+                      "upgradepackage.1.1.0" + NuGetConstants.PackageExtension, priority: 0));
             }
 
             [Fact]

--- a/src/chocolatey.tests.integration/scenarios/InstallScenarios.cs
+++ b/src/chocolatey.tests.integration/scenarios/InstallScenarios.cs
@@ -16,6 +16,7 @@
 
 namespace chocolatey.tests.integration.scenarios
 {
+    using System.Collections;
     using System.Collections.Concurrent;
     using System.Collections.Generic;
     using System.IO;
@@ -4358,6 +4359,452 @@ namespace chocolatey.tests.integration.scenarios
             public void should_not_have_executed_beforemodify_hook_script()
             {
                 MockLogger.contains_message("pre-beforemodify-all.ps1 hook ran for portablepackage 1.0.0", LogLevel.Info).ShouldBeFalse();
+            }
+        }
+
+        [Categories.SourcePriority]
+        public class when_installing_package_from_lower_priority_source_with_version_specified : ScenariosBase
+        {
+            private PackageResult packageResult;
+            public override void Context()
+            {
+                base.Context();
+                Configuration.PackageNames = Configuration.Input = "isdependency";
+                Configuration.Version = "2.0.0";
+                Configuration.Sources = string.Join(",",
+                    Scenario.add_packages_to_priority_source_location(Configuration, "isdependency.1.1.0" + Constants.PackageExtension, priority: 1),
+                    Scenario.add_packages_to_priority_source_location(Configuration, "isdependency.2.0.0" + Constants.PackageExtension, name: "No-Priority"));
+            }
+
+            public override void Because()
+            {
+                MockLogger.reset();
+                Results = Service.install_run(Configuration);
+                packageResult = Results.Select(r => r.Value).FirstOrDefault();
+            }
+
+            [Fact]
+            public void should_install_where_install_location_reports()
+            {
+                Directory.Exists(packageResult.InstallLocation).ShouldBeTrue();
+            }
+
+            [Fact]
+            public void should_install_the_package_in_the_lib_directory()
+            {
+                var packageDir = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames);
+
+                Directory.Exists(packageDir).ShouldBeTrue();
+            }
+
+            [Fact]
+            public void should_install_the_expected_version_of_the_package()
+            {
+                var packageFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, Configuration.PackageNames + Constants.PackageExtension);
+                var package = new OptimizedZipPackage(packageFile);
+                package.Version.ToNormalizedString().ShouldEqual("2.0.0");
+            }
+
+            [Fact]
+            public void should_not_create_an_extensions_folder_for_the_package()
+            {
+                var extensionsDirectory = Path.Combine(Scenario.get_top_level(), "extensions", Configuration.PackageNames);
+
+                Directory.Exists(extensionsDirectory).ShouldBeFalse();
+            }
+
+            [Fact]
+            public void should_not_create_an_hooks_folder_for_the_package()
+            {
+                var hooksDirectory = Path.Combine(Scenario.get_top_level(), "hooks", Configuration.PackageNames);
+
+                Directory.Exists(hooksDirectory).ShouldBeFalse();
+            }
+
+            [Fact]
+            public void should_contain_a_warning_message_that_it_installed_successfully()
+            {
+                bool installedSuccessfully = false;
+                foreach (var message in MockLogger.MessagesFor(LogLevel.Warn).or_empty_list_if_null())
+                {
+                    if (message.Contains("1/1")) installedSuccessfully = true;
+                }
+
+                installedSuccessfully.ShouldBeTrue();
+            }
+
+            [Fact]
+            public void should_have_a_successful_package_result()
+            {
+                packageResult.Success.ShouldBeTrue();
+            }
+
+            [Fact]
+            public void should_not_have_inconclusive_package_result()
+            {
+                packageResult.Inconclusive.ShouldBeFalse();
+            }
+
+            [Fact]
+            public void should_not_have_warning_package_result()
+            {
+                packageResult.Warning.ShouldBeFalse();
+            }
+
+            [Fact]
+            public void config_should_match_package_result_name()
+            {
+                packageResult.Name.ShouldEqual(Configuration.PackageNames);
+            }
+
+            [Fact]
+            public void should_have_a_version_of_two_dot_zero_dot_zero()
+            {
+                packageResult.Version.ShouldEqual("2.0.0");
+            }
+
+            [Fact]
+            [WindowsOnly]
+            [Platform(Exclude = "Mono")]
+            public void should_have_reported_package_installed()
+            {
+                MockLogger.contains_message("isdependency 2.0.0 Installed", LogLevel.Info).ShouldBeTrue();
+            }
+        }
+
+        [Categories.SourcePriority]
+        public class when_installing_non_existing_package_from_priority_source : ScenariosBase
+        {
+            public override void Context()
+            {
+                base.Context();
+                Configuration.PackageNames = Configuration.Input = "non-existing";
+                Scenario.add_machine_source(Configuration, "Priority-Source", priority: 1);
+                Configuration.Sources = "Priority-Source";
+            }
+
+            public override void Because()
+            {
+                MockLogger.reset();
+                Results = Service.install_run(Configuration);
+            }
+
+            [Fact]
+            public void should_not_report_success()
+            {
+                foreach (var packageResult in Results)
+                {
+                    packageResult.Value.Success.ShouldBeFalse();
+                }
+            }
+
+            [Fact]
+            public void should_not_install_a_pakcage_in_the_lib_directory()
+            {
+                var packageDir = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames);
+
+                Directory.Exists(packageDir).ShouldBeFalse();
+            }
+
+            [Fact]
+            public void should_not_have_inconclusive_package_result()
+            {
+                foreach (var packageResult in Results)
+                {
+                    packageResult.Value.Inconclusive.ShouldBeFalse();
+                }
+            }
+
+            [Fact]
+            public void should_not_have_warning_package_results()
+            {
+                foreach (var packageResult in Results)
+                {
+                    packageResult.Value.Warning.ShouldBeFalse();
+                }
+            }
+
+            [Fact]
+            public void should_report_package_not_found()
+            {
+                foreach (var packageResult in Results)
+                {
+                    var message = packageResult.Value.Messages.First();
+                    message.MessageType.ShouldEqual(ResultType.Error);
+                    message.Message.ShouldStartWith("non-existing not installed. The package was not found with the source(s) listed.");
+                }
+            }
+        }
+
+        [Categories.SourcePriority]
+        public class when_installing_new_package_from_priority_source_with_repository_optimization : ScenariosBase
+        {
+            public override void Context()
+            {
+                base.Context();
+                Configuration.PackageNames = Configuration.Input = "upgradepackage";
+                Configuration.Features.UsePackageRepositoryOptimizations = true;
+                Scenario.add_machine_source(Configuration, "chocolatey", path: "https://community.chocolatey.org/api/v2/", createDirectory: false);
+
+                Configuration.Sources = string.Join(";", new[]
+                {
+                    Scenario.add_packages_to_priority_source_location(Configuration, "upgradepackage.1.1.0" + Constants.PackageExtension),
+                    Scenario.add_packages_to_priority_source_location(Configuration, "upgradepackage.1.0.0" + Constants.PackageExtension, priority: 1)
+                });
+            }
+
+            public override void Because()
+            {
+                MockLogger.reset();
+                Results = Service.install_run(Configuration);
+            }
+
+            [Fact]
+            public void should_install_where_install_location_reports()
+            {
+                foreach (var packageResult in Results)
+                {
+                    Directory.Exists(packageResult.Value.InstallLocation).ShouldBeTrue();
+                }
+            }
+
+            [Fact]
+            public void should_install_a_package_in_the_lib_directory()
+            {
+                var packageDir = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames);
+
+                Directory.Exists(packageDir).ShouldBeTrue();
+            }
+
+            [Fact]
+            public void should_install_lower_version_of_package()
+            {
+                foreach (var packageResult in Results)
+                {
+                    packageResult.Value.Version.ShouldEqual("1.0.0");
+                }
+            }
+
+            [Fact]
+            public void should_have_installed_expected_version_in_lib_directory()
+            {
+                var installedPath = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames);
+
+                var packageFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, Configuration.PackageNames + Constants.PackageExtension);
+                var package = new OptimizedZipPackage(packageFile);
+
+                package.Version.ToNormalizedString().ShouldEqual("1.0.0");
+            }
+
+            [Fact]
+            public void should_not_have_inconclusive_package_results()
+            {
+                foreach (var packageResult in Results)
+                {
+                    packageResult.Value.Inconclusive.ShouldBeFalse();
+                }
+            }
+
+            [Fact]
+            public void should_not_have_warning_package_results()
+            {
+                foreach (var packageResult in Results)
+                {
+                    packageResult.Value.Warning.ShouldBeFalse();
+                }
+            }
+
+            [Fact]
+            public void should_have_success_package_results()
+            {
+                foreach (var packageResult in Results)
+                {
+                    packageResult.Value.Success.ShouldBeTrue();
+                }
+            }
+        }
+
+        [Categories.SourcePriority]
+        public class when_installing_new_package_from_priority_source : ScenariosBase
+        {
+            public override void Context()
+            {
+                base.Context();
+                Configuration.PackageNames = Configuration.Input = "upgradepackage";
+
+                Configuration.Sources = string.Join(";", new[]
+                {
+                    Scenario.add_packages_to_priority_source_location(Configuration, "upgradepackage.1.1.0" + Constants.PackageExtension),
+                    Scenario.add_packages_to_priority_source_location(Configuration, "upgradepackage.1.0.0" + Constants.PackageExtension, priority: 1)
+                });
+            }
+
+            public override void Because()
+            {
+                MockLogger.reset();
+                Results = Service.install_run(Configuration);
+            }
+
+            [Fact]
+            public void should_install_where_install_location_reports()
+            {
+                foreach (var packageResult in Results)
+                {
+                    Directory.Exists(packageResult.Value.InstallLocation).ShouldBeTrue();
+                }
+            }
+
+            [Fact]
+            public void should_install_a_package_in_the_lib_directory()
+            {
+                var packageDir = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames);
+                Directory.Exists(packageDir).ShouldBeTrue();
+            }
+
+            [Fact]
+            public void should_have_installed_expected_version_in_lib_directory()
+            {
+                var packageFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, Configuration.PackageNames + Constants.PackageExtension);
+                var package = new OptimizedZipPackage(packageFile);
+                package.Version.ToNormalizedString().ShouldEqual("1.0.0");
+            }
+
+            [Fact]
+            public void should_install_lower_version_of_package()
+            {
+                foreach (var packageResult in Results)
+                {
+                    packageResult.Value.Version.ShouldEqual("1.0.0");
+                }
+            }
+
+            [Fact]
+            public void should_not_have_inconclusive_package_results()
+            {
+                foreach (var packageResult in Results)
+                {
+                    packageResult.Value.Inconclusive.ShouldBeFalse();
+                }
+            }
+
+            [Fact]
+            public void should_not_have_warning_package_results()
+            {
+                foreach (var packageResult in Results)
+                {
+                    packageResult.Value.Warning.ShouldBeFalse();
+                }
+            }
+
+            [Fact]
+            public void should_have_success_package_results()
+            {
+                foreach (var packageResult in Results)
+                {
+                    packageResult.Value.Success.ShouldBeTrue();
+                }
+            }
+        }
+
+        [Categories.SourcePriority]
+        public class when_installing_package_with_dependencies_on_different_priority_sources : ScenariosBase
+        {
+            public static IEnumerable ExpectedInstallations
+            {
+                get
+                {
+                    yield return "hasdependency";
+                    yield return "isdependency";
+                    yield return "isexactversiondependency";
+                }
+            }
+
+            public static IEnumerable ExpectedPackageVersions
+            {
+                get
+                {
+                    yield return new object[] { "hasdependency", "1.6.0" };
+                    yield return new object[] { "isdependency", "2.1.0" };
+                    yield return new object[] { "isexactversiondependency", "1.1.0" };
+                }
+            }
+
+            public override void Context()
+            {
+                base.Context();
+                Configuration.PackageNames = Configuration.Input = "hasdependency";
+
+                Configuration.Sources = string.Join(";", new[]
+                {
+                    Scenario.add_packages_to_priority_source_location(Configuration, "hasdependency.1.6.0" + Constants.PackageExtension, priority: 1),
+                    Scenario.add_packages_to_priority_source_location(Configuration, "isdependency.*" + Constants.PackageExtension, priority: 2),
+                    Scenario.add_packages_to_priority_source_location(Configuration, "isexactversiondependency.1.1.0" + Constants.PackageExtension)
+                });
+                Scenario.add_packages_to_priority_source_location(Configuration, "isexactversiondependency.2.0.0" + Constants.PackageExtension, priority: 1);
+            }
+
+            public override void Because()
+            {
+                MockLogger.reset();
+                Results = Service.install_run(Configuration);
+            }
+
+            [Fact]
+            public void should_install_where_install_location_reports()
+            {
+                foreach (var packageResult in Results)
+                {
+                    Directory.Exists(packageResult.Value.InstallLocation).ShouldBeTrue();
+                }
+            }
+
+            [TestCaseSource(nameof(ExpectedInstallations))]
+            public void should_install_hasdependency_package_to_lib_directory(string name)
+            {
+                var expectedPath = Path.Combine(Scenario.get_top_level(), "lib", name);
+                Directory.Exists(expectedPath).ShouldBeTrue();
+            }
+
+            [TestCaseSource(nameof(ExpectedPackageVersions))]
+            public void should_instal_expected_package_version(string name, string version)
+            {
+                var path = Path.Combine(Scenario.get_top_level(), "lib", name, name + Constants.PackageExtension);
+                var package = new OptimizedZipPackage(path);
+                package.Version.ToNormalizedString().ShouldEqual(version);
+            }
+
+            [TestCaseSource(nameof(ExpectedPackageVersions))]
+            public void should_report_installed_version_of_package(string name, string version)
+            {
+                var package = Results.First(r => r.Key == name);
+                package.Value.Version.ShouldEqual(version);
+            }
+
+            [Fact]
+            public void should_not_have_inconclusive_package_results()
+            {
+                foreach (var packageResult in Results)
+                {
+                    packageResult.Value.Inconclusive.ShouldBeFalse();
+                }
+            }
+
+            [Fact]
+            public void should_not_have_warning_package_results()
+            {
+                foreach (var packageResult in Results)
+                {
+                    packageResult.Value.Warning.ShouldBeFalse();
+                }
+            }
+
+            [Fact]
+            public void should_have_success_package_results()
+            {
+                foreach (var packageResult in Results)
+                {
+                    packageResult.Value.Success.ShouldBeTrue();
+                }
             }
         }
     }

--- a/src/chocolatey.tests.integration/scenarios/InstallScenarios.cs
+++ b/src/chocolatey.tests.integration/scenarios/InstallScenarios.cs
@@ -4372,8 +4372,8 @@ namespace chocolatey.tests.integration.scenarios
                 Configuration.PackageNames = Configuration.Input = "isdependency";
                 Configuration.Version = "2.0.0";
                 Configuration.Sources = string.Join(",",
-                    Scenario.add_packages_to_priority_source_location(Configuration, "isdependency.1.1.0" + Constants.PackageExtension, priority: 1),
-                    Scenario.add_packages_to_priority_source_location(Configuration, "isdependency.2.0.0" + Constants.PackageExtension, name: "No-Priority"));
+                    Scenario.add_packages_to_priority_source_location(Configuration, "isdependency.1.1.0" + NuGetConstants.PackageExtension, priority: 1),
+                    Scenario.add_packages_to_priority_source_location(Configuration, "isdependency.2.0.0" + NuGetConstants.PackageExtension, name: "No-Priority"));
             }
 
             public override void Because()
@@ -4386,7 +4386,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void should_install_where_install_location_reports()
             {
-                Directory.Exists(packageResult.InstallLocation).ShouldBeTrue();
+                DirectoryAssert.Exists(packageResult.InstallLocation);
             }
 
             [Fact]
@@ -4394,15 +4394,18 @@ namespace chocolatey.tests.integration.scenarios
             {
                 var packageDir = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames);
 
-                Directory.Exists(packageDir).ShouldBeTrue();
+                DirectoryAssert.Exists(packageDir);
             }
 
             [Fact]
             public void should_install_the_expected_version_of_the_package()
             {
-                var packageFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, Configuration.PackageNames + Constants.PackageExtension);
-                var package = new OptimizedZipPackage(packageFile);
-                package.Version.ToNormalizedString().ShouldEqual("2.0.0");
+                var packageDirectory = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames);
+
+                using (var reader = new PackageFolderReader(packageDirectory))
+                {
+                    reader.NuspecReader.GetVersion().ToNormalizedString().ShouldEqual("2.0.0");
+                }
             }
 
             [Fact]
@@ -4410,7 +4413,7 @@ namespace chocolatey.tests.integration.scenarios
             {
                 var extensionsDirectory = Path.Combine(Scenario.get_top_level(), "extensions", Configuration.PackageNames);
 
-                Directory.Exists(extensionsDirectory).ShouldBeFalse();
+                DirectoryAssert.DoesNotExist(extensionsDirectory);
             }
 
             [Fact]
@@ -4418,7 +4421,7 @@ namespace chocolatey.tests.integration.scenarios
             {
                 var hooksDirectory = Path.Combine(Scenario.get_top_level(), "hooks", Configuration.PackageNames);
 
-                Directory.Exists(hooksDirectory).ShouldBeFalse();
+                DirectoryAssert.DoesNotExist(hooksDirectory);
             }
 
             [Fact]
@@ -4503,7 +4506,7 @@ namespace chocolatey.tests.integration.scenarios
             {
                 var packageDir = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames);
 
-                Directory.Exists(packageDir).ShouldBeFalse();
+                DirectoryAssert.DoesNotExist(packageDir);
             }
 
             [Fact]
@@ -4548,8 +4551,8 @@ namespace chocolatey.tests.integration.scenarios
 
                 Configuration.Sources = string.Join(";", new[]
                 {
-                    Scenario.add_packages_to_priority_source_location(Configuration, "upgradepackage.1.1.0" + Constants.PackageExtension),
-                    Scenario.add_packages_to_priority_source_location(Configuration, "upgradepackage.1.0.0" + Constants.PackageExtension, priority: 1)
+                    Scenario.add_packages_to_priority_source_location(Configuration, "upgradepackage.1.1.0" + NuGetConstants.PackageExtension),
+                    Scenario.add_packages_to_priority_source_location(Configuration, "upgradepackage.1.0.0" + NuGetConstants.PackageExtension, priority: 1)
                 });
             }
 
@@ -4564,7 +4567,7 @@ namespace chocolatey.tests.integration.scenarios
             {
                 foreach (var packageResult in Results)
                 {
-                    Directory.Exists(packageResult.Value.InstallLocation).ShouldBeTrue();
+                    DirectoryAssert.Exists(packageResult.Value.InstallLocation);
                 }
             }
 
@@ -4573,7 +4576,7 @@ namespace chocolatey.tests.integration.scenarios
             {
                 var packageDir = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames);
 
-                Directory.Exists(packageDir).ShouldBeTrue();
+                DirectoryAssert.Exists(packageDir);
             }
 
             [Fact]
@@ -4590,10 +4593,12 @@ namespace chocolatey.tests.integration.scenarios
             {
                 var installedPath = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames);
 
-                var packageFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, Configuration.PackageNames + Constants.PackageExtension);
-                var package = new OptimizedZipPackage(packageFile);
+                var packageFolder = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames);
 
-                package.Version.ToNormalizedString().ShouldEqual("1.0.0");
+                using (var reader = new PackageFolderReader(packageFolder))
+                {
+                    reader.NuspecReader.GetVersion().ToNormalizedString().ShouldEqual("1.0.0");
+                }
             }
 
             [Fact]
@@ -4634,8 +4639,8 @@ namespace chocolatey.tests.integration.scenarios
 
                 Configuration.Sources = string.Join(";", new[]
                 {
-                    Scenario.add_packages_to_priority_source_location(Configuration, "upgradepackage.1.1.0" + Constants.PackageExtension),
-                    Scenario.add_packages_to_priority_source_location(Configuration, "upgradepackage.1.0.0" + Constants.PackageExtension, priority: 1)
+                    Scenario.add_packages_to_priority_source_location(Configuration, "upgradepackage.1.1.0" + NuGetConstants.PackageExtension),
+                    Scenario.add_packages_to_priority_source_location(Configuration, "upgradepackage.1.0.0" + NuGetConstants.PackageExtension, priority: 1)
                 });
             }
 
@@ -4650,7 +4655,7 @@ namespace chocolatey.tests.integration.scenarios
             {
                 foreach (var packageResult in Results)
                 {
-                    Directory.Exists(packageResult.Value.InstallLocation).ShouldBeTrue();
+                    DirectoryAssert.Exists(packageResult.Value.InstallLocation);
                 }
             }
 
@@ -4658,15 +4663,18 @@ namespace chocolatey.tests.integration.scenarios
             public void should_install_a_package_in_the_lib_directory()
             {
                 var packageDir = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames);
-                Directory.Exists(packageDir).ShouldBeTrue();
+                DirectoryAssert.Exists(packageDir);
             }
 
             [Fact]
             public void should_have_installed_expected_version_in_lib_directory()
             {
-                var packageFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, Configuration.PackageNames + Constants.PackageExtension);
-                var package = new OptimizedZipPackage(packageFile);
-                package.Version.ToNormalizedString().ShouldEqual("1.0.0");
+                var packageFolder = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, Configuration.PackageNames + NuGetConstants.PackageExtension);
+
+                using (var reader = new PackageFolderReader(packageFolder))
+                {
+                    reader.NuspecReader.GetVersion().ToNormalizedString().ShouldEqual("1.0.0");
+                }
             }
 
             [Fact]
@@ -4736,11 +4744,11 @@ namespace chocolatey.tests.integration.scenarios
 
                 Configuration.Sources = string.Join(";", new[]
                 {
-                    Scenario.add_packages_to_priority_source_location(Configuration, "hasdependency.1.6.0" + Constants.PackageExtension, priority: 1),
-                    Scenario.add_packages_to_priority_source_location(Configuration, "isdependency.*" + Constants.PackageExtension, priority: 2),
-                    Scenario.add_packages_to_priority_source_location(Configuration, "isexactversiondependency.1.1.0" + Constants.PackageExtension)
+                    Scenario.add_packages_to_priority_source_location(Configuration, "hasdependency.1.6.0" + NuGetConstants.PackageExtension, priority: 1),
+                    Scenario.add_packages_to_priority_source_location(Configuration, "isdependency.*" + NuGetConstants.PackageExtension, priority: 2),
+                    Scenario.add_packages_to_priority_source_location(Configuration, "isexactversiondependency.1.1.0" + NuGetConstants.PackageExtension)
                 });
-                Scenario.add_packages_to_priority_source_location(Configuration, "isexactversiondependency.2.0.0" + Constants.PackageExtension, priority: 1);
+                Scenario.add_packages_to_priority_source_location(Configuration, "isexactversiondependency.2.0.0" + NuGetConstants.PackageExtension, priority: 1);
             }
 
             public override void Because()
@@ -4754,7 +4762,7 @@ namespace chocolatey.tests.integration.scenarios
             {
                 foreach (var packageResult in Results)
                 {
-                    Directory.Exists(packageResult.Value.InstallLocation).ShouldBeTrue();
+                    DirectoryAssert.Exists(packageResult.Value.InstallLocation);
                 }
             }
 
@@ -4762,15 +4770,18 @@ namespace chocolatey.tests.integration.scenarios
             public void should_install_hasdependency_package_to_lib_directory(string name)
             {
                 var expectedPath = Path.Combine(Scenario.get_top_level(), "lib", name);
-                Directory.Exists(expectedPath).ShouldBeTrue();
+                DirectoryAssert.Exists(expectedPath);
             }
 
             [TestCaseSource(nameof(ExpectedPackageVersions))]
             public void should_instal_expected_package_version(string name, string version)
             {
-                var path = Path.Combine(Scenario.get_top_level(), "lib", name, name + Constants.PackageExtension);
-                var package = new OptimizedZipPackage(path);
-                package.Version.ToNormalizedString().ShouldEqual(version);
+                var path = Path.Combine(Scenario.get_top_level(), "lib", name);
+
+                using (var reader = new PackageFolderReader(path))
+                {
+                    reader.NuspecReader.GetVersion().ToNormalizedString().ShouldEqual(version);
+                }
             }
 
             [TestCaseSource(nameof(ExpectedPackageVersions))]

--- a/src/chocolatey.tests.integration/scenarios/InstallScenarios.cs
+++ b/src/chocolatey.tests.integration/scenarios/InstallScenarios.cs
@@ -733,7 +733,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, Configuration.PackageNames + NuGetConstants.PackageExtension);
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().to_string().ShouldEqual("1.0.0");
+                    packageReader.NuspecReader.GetVersion().ToNormalizedString().ShouldEqual("1.0.0");
                 }
             }
 
@@ -1285,7 +1285,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.Input, Configuration.Input + NuGetConstants.PackageExtension);
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().to_string().ShouldEqual("1.0.0");
+                    packageReader.NuspecReader.GetVersion().ToNormalizedString().ShouldEqual("1.0.0");
                 }
             }
 

--- a/src/chocolatey.tests.integration/scenarios/ListScenarios.cs
+++ b/src/chocolatey.tests.integration/scenarios/ListScenarios.cs
@@ -61,8 +61,8 @@ namespace chocolatey.tests.integration.scenarios
 
                 Configuration.Sources = string.Join(";", new[]
                 {
-                    Scenario.add_packages_to_priority_source_location(Configuration, "upgradepackage.1.1.0" + Constants.PackageExtension, name: "NormalPriority"),
-                    Scenario.add_packages_to_priority_source_location(Configuration, "upgradepackage.1.0.0" + Constants.PackageExtension, priority: 1)
+                    Scenario.add_packages_to_priority_source_location(Configuration, "upgradepackage.1.1.0" + NuGetConstants.PackageExtension, name: "NormalPriority"),
+                    Scenario.add_packages_to_priority_source_location(Configuration, "upgradepackage.1.0.0" + NuGetConstants.PackageExtension, priority: 1)
                 });
 
                 Service = NUnitSetup.Container.GetInstance<IChocolateyPackageService>();
@@ -95,12 +95,12 @@ namespace chocolatey.tests.integration.scenarios
 
                 Configuration.Sources = string.Join(";", new[]
                 {
-                    Scenario.add_packages_to_priority_source_location(Configuration, "upgradepackage.1.1.0" + Constants.PackageExtension, name: "NormalPriority"),
-                    Scenario.add_packages_to_priority_source_location(Configuration, "upgradepackage.1.0.0" + Constants.PackageExtension, priority: 1)
+                    Scenario.add_packages_to_priority_source_location(Configuration, "upgradepackage.1.1.0" + NuGetConstants.PackageExtension, name: "NormalPriority"),
+                    Scenario.add_packages_to_priority_source_location(Configuration, "upgradepackage.1.0.0" + NuGetConstants.PackageExtension, priority: 1)
                 });
 
-                Scenario.add_packages_to_priority_source_location(Configuration, "upgradepackage.1.1.1-beta2" + Constants.PackageExtension, name: "NormalPriority");
-                Scenario.add_packages_to_priority_source_location(Configuration, "upgradepackage.1.1.1-beta" + Constants.PackageExtension, priority: 1);
+                Scenario.add_packages_to_priority_source_location(Configuration, "upgradepackage.1.1.1-beta2" + NuGetConstants.PackageExtension, name: "NormalPriority");
+                Scenario.add_packages_to_priority_source_location(Configuration, "upgradepackage.1.1.1-beta" + NuGetConstants.PackageExtension, priority: 1);
 
                 Service = NUnitSetup.Container.GetInstance<IChocolateyPackageService>();
             }
@@ -133,13 +133,13 @@ namespace chocolatey.tests.integration.scenarios
 
                 Configuration.Sources = string.Join(";", new[]
                 {
-                    Scenario.add_packages_to_priority_source_location(Configuration, "hasdependency.*" + Constants.PackageExtension, name: "NormalPriority"),
-                    Scenario.add_packages_to_priority_source_location(Configuration, "isdependency.*" + Constants.PackageExtension, priority: 1)
+                    Scenario.add_packages_to_priority_source_location(Configuration, "hasdependency.*" + NuGetConstants.PackageExtension, name: "NormalPriority"),
+                    Scenario.add_packages_to_priority_source_location(Configuration, "isdependency.*" + NuGetConstants.PackageExtension, priority: 1)
                 });
 
-                Scenario.add_packages_to_priority_source_location(Configuration, "isexactdependency.1.1.0" + Constants.PackageExtension, name: "NormalPriority");
-                Scenario.add_packages_to_priority_source_location(Configuration, "isexactdependency.2.0.0" + Constants.PackageExtension, priority: 1);
-                Scenario.add_packages_to_priority_source_location(Configuration, "conflictingdependency.2.0.0" + Constants.PackageExtension, priority: 1);
+                Scenario.add_packages_to_priority_source_location(Configuration, "isexactdependency.1.1.0" + NuGetConstants.PackageExtension, name: "NormalPriority");
+                Scenario.add_packages_to_priority_source_location(Configuration, "isexactdependency.2.0.0" + NuGetConstants.PackageExtension, priority: 1);
+                Scenario.add_packages_to_priority_source_location(Configuration, "conflictingdependency.2.0.0" + NuGetConstants.PackageExtension, priority: 1);
 
 
                 Service = NUnitSetup.Container.GetInstance<IChocolateyPackageService>();

--- a/src/chocolatey.tests.integration/scenarios/UpgradeScenarios.cs
+++ b/src/chocolatey.tests.integration/scenarios/UpgradeScenarios.cs
@@ -353,8 +353,8 @@ namespace chocolatey.tests.integration.scenarios
             {
                 base.Context();
                 Configuration.Sources = string.Join(",",
-                    Scenario.add_packages_to_priority_source_location(Configuration, "upgradepackage.1.0.0" + Constants.PackageExtension, priority: 1),
-                    Scenario.add_packages_to_priority_source_location(Configuration, "upgradepackage.1.1.0" + Constants.PackageExtension, priority: 0));
+                    Scenario.add_packages_to_priority_source_location(Configuration, "upgradepackage.1.0.0" + NuGetConstants.PackageExtension, priority: 1),
+                    Scenario.add_packages_to_priority_source_location(Configuration, "upgradepackage.1.1.0" + NuGetConstants.PackageExtension, priority: 0));
                 Scenario.install_package(Configuration, "upgradepackage", "1.0.0");
             }
 
@@ -393,7 +393,7 @@ namespace chocolatey.tests.integration.scenarios
             {
                 var packageDir = Path.Combine(Scenario.get_top_level(), "lib-bkp", Configuration.PackageNames);
 
-                Directory.Exists(packageDir).ShouldBeFalse();
+                DirectoryAssert.DoesNotExist(packageDir);
             }
 
             [Fact]
@@ -401,15 +401,18 @@ namespace chocolatey.tests.integration.scenarios
             {
                 var packageDir = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames);
 
-                Directory.Exists(packageDir).ShouldBeTrue();
+                DirectoryAssert.Exists(packageDir);
             }
 
             [Fact]
             public void should_be_the_same_version_of_the_package()
             {
-                var packageFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, Configuration.PackageNames + Constants.PackageExtension);
-                var package = new OptimizedZipPackage(packageFile);
-                package.Version.ToNormalizedString().ShouldEqual("1.0.0");
+                var packageFolder = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, Configuration.PackageNames + NuGetConstants.PackageExtension);
+
+                using (var reader = new PackageFolderReader(packageFolder))
+                {
+                    reader.NuspecReader.GetVersion().ToNormalizedString().ShouldEqual("1.0.0");
+                }
             }
 
             [Fact]

--- a/src/chocolatey.tests.integration/scenarios/UpgradeScenarios.cs
+++ b/src/chocolatey.tests.integration/scenarios/UpgradeScenarios.cs
@@ -344,6 +344,99 @@ namespace chocolatey.tests.integration.scenarios
             }
         }
 
+        [Categories.SourcePriority]
+        public class when_upgrading_an_existing_package_with_higher_version_in_non_prioritised_source : ScenariosBase
+        {
+            private PackageResult _packageResult;
+
+            public override void Context()
+            {
+                base.Context();
+                Configuration.Sources = string.Join(",",
+                    Scenario.add_packages_to_priority_source_location(Configuration, "upgradepackage.1.0.0" + Constants.PackageExtension, priority: 1),
+                    Scenario.add_packages_to_priority_source_location(Configuration, "upgradepackage.1.1.0" + Constants.PackageExtension, priority: 0));
+                Scenario.install_package(Configuration, "upgradepackage", "1.0.0");
+            }
+
+            public override void Because()
+            {
+                Results = Service.upgrade_run(Configuration);
+                _packageResult = Results.Select(r => r.Value).FirstOrDefault();
+            }
+
+            [Fact]
+            public void should_contain_a_message_that_you_have_the_latest_version_available()
+            {
+                bool expectedMessage = false;
+                foreach (var message in MockLogger.MessagesFor(LogLevel.Info).or_empty_list_if_null())
+                {
+                    if (message.Contains("upgradepackage v1.0.0 is the latest version available based on your source(s)")) expectedMessage = true;
+                }
+
+                expectedMessage.ShouldBeTrue();
+            }
+
+            [Fact]
+            public void should_contain_a_message_that_no_packages_were_upgraded()
+            {
+                bool expectedMessage = false;
+                foreach (var message in MockLogger.MessagesFor(LogLevel.Warn).or_empty_list_if_null())
+                {
+                    if (message.Contains("upgraded 0/1 ")) expectedMessage = true;
+                }
+
+                expectedMessage.ShouldBeTrue();
+            }
+
+            [Fact]
+            public void should_not_create_a_rollback()
+            {
+                var packageDir = Path.Combine(Scenario.get_top_level(), "lib-bkp", Configuration.PackageNames);
+
+                Directory.Exists(packageDir).ShouldBeFalse();
+            }
+
+            [Fact]
+            public void should_not_remove_the_package_from_the_lib_directory()
+            {
+                var packageDir = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames);
+
+                Directory.Exists(packageDir).ShouldBeTrue();
+            }
+
+            [Fact]
+            public void should_be_the_same_version_of_the_package()
+            {
+                var packageFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, Configuration.PackageNames + Constants.PackageExtension);
+                var package = new OptimizedZipPackage(packageFile);
+                package.Version.ToNormalizedString().ShouldEqual("1.0.0");
+            }
+
+            [Fact]
+            public void should_have_a_successful_package_result()
+            {
+                _packageResult.Success.ShouldBeTrue();
+            }
+
+            [Fact]
+            public void should_have_inconclusive_package_result()
+            {
+                _packageResult.Inconclusive.ShouldBeTrue();
+            }
+
+            [Fact]
+            public void should_not_have_warning_package_result()
+            {
+                _packageResult.Warning.ShouldBeFalse();
+            }
+
+            [Fact]
+            public void should_match_the_original_package_version()
+            {
+                _packageResult.Version.ShouldEqual("1.0.0");
+            }
+        }
+
         public class when_upgrading_an_existing_package_with_prerelease_available_without_prerelease_specified : ScenariosBase
         {
             private PackageResult _packageResult;

--- a/src/chocolatey.tests/TinySpec.cs
+++ b/src/chocolatey.tests/TinySpec.cs
@@ -214,6 +214,19 @@ namespace chocolatey.tests
             {
             }
         }
+
+        /// <summary>
+        /// Attribute used to define a test class or method as belonging to source priorities.
+        /// </summary>
+        /// <remarks>This need to be changed to inherit from <see cref="CategoryAttribute"/> once we have a working implementation of source priorities.</remarks>
+        [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = false)]
+        public sealed class SourcePriorityAttribute : IgnoreAttribute
+        {
+            public SourcePriorityAttribute()
+                : base("Source priority is not implemented")
+            {
+            }
+        }
     }
 
     // ReSharper restore InconsistentNaming


### PR DESCRIPTION
## Description Of Changes

This pull request intends to add future tests that can be used when we have a chance to look at reimplementing/implementing support for source priority support.
It includes a couple of tests that are related to sources, but are currently broken in vNext of Chocolatey CLI.
THe first commit in this PR is intended to be cherry-picked into our support/1.x branch.

## Motivation and Context

To have future covering tests.

## Testing

1. Ran the unit tests.
2. As the feature is not working, it can not be tested completely.

### Operating Systems Testing

- Windows 11
- Windows 10

## Change Types Made
<!-- Tick the boxes for the type of changes that have been made -->

* [ ] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.
* [x] Tests

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [x] Tests to cover my changes, have been added.
* [x] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue

#1541  
https://app.clickup.com/t/20540031/PROJ-313  
https://app.clickup.com/t/20540031/PROJ-407
