### PR TITLE
(#2887) Tab completion: only complete license-appropriate things

### DIFF
--- a/src/chocolatey.resources/helpers/ChocolateyTabExpansion.ps1
+++ b/src/chocolatey.resources/helpers/ChocolateyTabExpansion.ps1
@@ -26,7 +26,7 @@ $script:choco = "$env:ChocolateyInstall\choco.exe"
 
 function script:chocoCmdOperations($commands, $command, $filter, $currentArguments) {
     $currentOptions = @('zzzz')
-    if ($currentArguments -ne $null -and $currentArguments.Trim() -ne '') {
+    if (-not [string]::IsNullOrWhiteSpace($currentArguments)) {
         $currentOptions = $currentArguments.Trim() -split ' '
     }
 
@@ -35,56 +35,94 @@ function script:chocoCmdOperations($commands, $command, $filter, $currentArgumen
         Where-Object { $_ -like "$filter*" }
 }
 
-$script:someCommands = @('-?', 'search', 'list', 'info', 'install', 'outdated', 'upgrade', 'uninstall', 'new', 'download', 'optimize', 'pack', 'push', 'sync', '-h', '--help', 'pin', 'source', 'config', 'feature', 'apikey', 'export', 'help', 'template', '--version')
+$script:chocoCommands = @('-?','search','list','info','install','outdated','upgrade','uninstall','new','pack','push','-h','--help','pin','source','config','feature','apikey','export','help','template','--version')
 
 # ensure these all have a space to start, or they will cause issues
-$allcommands = " --debug --verbose --trace --noop --help --accept-license --confirm --limit-output --no-progress --log-file='' --execution-timeout='' --cache-location='' --proxy='' --proxy-user='' --proxy-password='' --proxy-bypass-list='' --proxy-bypass-on-local --force --no-color --skip-compatibility-checks"
-$proListOptions = " --audit --use-self-service"
-$proSearchOptions = " --use-self-service"
-$proInfoOptions = " --use-self-service"
-$proInstallUpgradeOptions = " --install-directory='' --package-parameters-sensitive='' --max-download-rate='' --install-arguments-sensitive='' --skip-download-cache --use-download-cache --skip-virus-check --virus-check --virus-positives-minimum='' --deflate-package-size --no-deflate-package-size --deflate-nupkg-only --use-self-service"
-$proUpgradeOptions = " --exclude-chocolatey-packages-during-upgrade-all --include-chocolatey-packages-during-upgrade-all --use-self-service"
-$proNewOptions = " --file='' --build-package --file64='' --from-programs-and-features --use-original-location --keep-remote --url='' --url64='' --checksum='' --checksum64='' --checksumtype='' --pause-on-error --remove-architecture-from-name --include-architecture-in-name"
-$proUninstallOptions = " --from-programs-and-features --use-self-service"
-$proPinOptions = " --note='' --use-self-service"
-$proOutdatedOptions = " --use-self-service"
-$proPushOptions = " --use-self-service"
+$allcommands = " --debug --verbose --trace --noop --help -? --accept-license --confirm --limit-output --no-progress --log-file='' --execution-timeout='' --cache-location='' --proxy='' --proxy-user='' --proxy-password='' --proxy-bypass-list='' --proxy-bypass-on-local --force --no-color --skip-compatibility-checks"
 
 $commandOptions = @{
-    list      = "--id-only --pre --exact --by-id-only --id-starts-with --detailed --prerelease --include-programs --page='' --page-size=''" + $proListOptions + $allcommands
-    search    = "--pre --exact --by-id-only --id-starts-with --detailed --approved-only --not-broken --source='' --user='' --password='' --prerelease --page='' --page-size='' --order-by-popularity --download-cache-only --disable-package-repository-optimizations" + $proSearchOptions + $allcommands
-    info      = "--pre --lo --source='' --user='' --password='' --local-only --prerelease --disable-package-repository-optimizations" + $proInfoOptions + $allcommands
-    install   = "-y -whatif -? --pre --version= --params='' --install-arguments='' --override-arguments --ignore-dependencies --source='' --source='windowsfeatures' --user='' --password='' --prerelease --forcex86 --not-silent --package-parameters='' --exit-when-reboot-detected --ignore-detected-reboot --allow-downgrade --force-dependencies --require-checksums --use-package-exit-codes --ignore-package-exit-codes --skip-automation-scripts --ignore-checksums --allow-empty-checksums --allow-empty-checksums-secure --download-checksum='' --download-checksum-type='' --download-checksum-x64='' --download-checksum-type-x64='' --stop-on-first-package-failure --disable-package-repository-optimizations --pin" + $proInstallUpgradeOptions + $allcommands
-    pin       = "--name='' --version='' -?" + $proPinOptions + $allcommands
-    outdated  = "-? --source='' --user='' --password='' --ignore-pinned --ignore-unfound --pre --prerelease --disable-package-repository-optimizations" + $proOutdatedOptions + $allcommands
-    upgrade   = "-y -whatif -? --pre --version='' --except='' --params='' --install-arguments='' --override-arguments --ignore-dependencies --source='' --source='windowsfeatures' --user='' --password='' --prerelease --forcex86 --not-silent --package-parameters='' --exit-when-reboot-detected --ignore-detected-reboot --allow-downgrade --require-checksums --use-package-exit-codes --ignore-package-exit-codes --skip-automation-scripts --fail-on-unfound --fail-on-not-installed --ignore-checksums --allow-empty-checksums --allow-empty-checksums-secure --download-checksum='' --download-checksum-type='' --download-checksum-x64='' --download-checksum-type-x64='' --exclude-prerelease --stop-on-first-package-failure --use-remembered-options --ignore-remembered-options --skip-when-not-installed --install-if-not-installed --disable-package-repository-optimizations --pin" + $proInstallUpgradeOptions + $proUpgradeOptions + $allcommands
-    uninstall = "-y -whatif -? --force-dependencies --remove-dependencies --all-versions --source='windowsfeatures' --version= --uninstall-arguments='' --override-arguments --not-silent --params='' --package-parameters='' --exit-when-reboot-detected --ignore-detected-reboot --use-package-exit-codes --ignore-package-exit-codes --skip-automation-scripts --use-autouninstaller --skip-autouninstaller --fail-on-autouninstaller --ignore-autouninstaller-failure --stop-on-first-package-failure" + $proUninstallOptions + $allcommands
-    new       = "--template-name='' --output-directory='' --automaticpackage --version='' --maintainer='' packageversion='' maintainername='' maintainerrepo='' installertype='' url='' url64='' silentargs='' --use-built-in-template -?" + $proNewOptions + $allcommands
-    pack      = "--version='' --output-directory='' -?" + $allcommands
-    push      = "--source='' --api-key='' --timeout='' -?" + $proPushOptions + $allcommands
-    source    = "--name='' --source='' --user='' --password='' --priority= --bypass-proxy --allow-self-service -?" + $allcommands
-    config    = "--name='' --value='' -?" + $allcommands
-    feature   = "--name='' -?" + $allcommands
-    apikey    = "--source='' --api-key='' --remove -?" + $allcommands
-    download  = "--internalize --internalize-all-urls --ignore-dependencies --installed-packages --ignore-unfound-packages --resources-location='' --download-location='' --outputdirectory='' --source='' --version='' --prerelease --user='' --password='' --cert='' --certpassword='' --append-use-original-location --recompile --disable-package-repository-optimizations -? --use-self-service" + $allcommands
-    sync      = "--output-directory='' --id='' --package-id='' -? --use-self-service" + $allcommands
-    optimize  = "--deflate-nupkg-only --id='' -? --use-self-service" + $allcommands
-    export    = "--include-version-numbers --output-file-path='' -?" + $allcommands
-    template  = "--name=''" + $allcommands
+    list      = "--id-only --pre --exact --by-id-only --id-starts-with --detailed --prerelease --include-programs --page='' --page-size=''"
+    search    = "--lo --id-only --pre --exact --by-id-only --id-starts-with --detailed --approved-only --not-broken --source='' --user='' --password='' --local-only --prerelease --include-programs --page='' --page-size='' --order-by-popularity --download-cache-only --disable-package-repository-optimizations"
+    info      = "--pre --lo --source='' --user='' --password='' --local-only --prerelease --disable-package-repository-optimizations"
+    install   = "-y -whatif --pre --version= --params='' --install-arguments='' --override-arguments --ignore-dependencies --source='' --source='windowsfeatures' --user='' --password='' --prerelease --forcex86 --not-silent --package-parameters='' --exit-when-reboot-detected --ignore-detected-reboot --allow-downgrade --force-dependencies --require-checksums --use-package-exit-codes --ignore-package-exit-codes --skip-automation-scripts --ignore-checksums --allow-empty-checksums --allow-empty-checksums-secure --download-checksum='' --download-checksum-type='' --download-checksum-x64='' --download-checksum-type-x64='' --stop-on-first-package-failure --disable-package-repository-optimizations --pin"
+    pin       = "--name='' --version=''"
+    outdated  = "--source='' --user='' --password='' --ignore-pinned --ignore-unfound --pre --prerelease --disable-package-repository-optimizations"
+    upgrade   = "-y -whatif --pre --version='' --except='' --params='' --install-arguments='' --override-arguments --ignore-dependencies --source='' --source='windowsfeatures' --user='' --password='' --prerelease --forcex86 --not-silent --package-parameters='' --exit-when-reboot-detected --ignore-detected-reboot --allow-downgrade --require-checksums --use-package-exit-codes --ignore-package-exit-codes --skip-automation-scripts --fail-on-unfound --fail-on-not-installed --ignore-checksums --allow-empty-checksums --allow-empty-checksums-secure --download-checksum='' --download-checksum-type='' --download-checksum-x64='' --download-checksum-type-x64='' --exclude-prerelease --stop-on-first-package-failure --use-remembered-options --ignore-remembered-options --skip-when-not-installed --install-if-not-installed --disable-package-repository-optimizations --pin"
+    uninstall = "-y -whatif --force-dependencies --remove-dependencies --all-versions --source='windowsfeatures' --version= --uninstall-arguments='' --override-arguments --not-silent --params='' --package-parameters='' --exit-when-reboot-detected --ignore-detected-reboot --use-package-exit-codes --ignore-package-exit-codes --skip-automation-scripts --use-autouninstaller --skip-autouninstaller --fail-on-autouninstaller --ignore-autouninstaller-failure --stop-on-first-package-failure"
+    new       = "--template-name='' --output-directory='' --automaticpackage --version='' --maintainer='' packageversion='' maintainername='' maintainerrepo='' installertype='' url='' url64='' silentargs='' --use-built-in-template"
+    pack      = "--version='' --output-directory=''"
+    push      = "--source='' --api-key='' --timeout=''"
+    source    = "--name='' --source='' --user='' --password='' --priority= --bypass-proxy --allow-self-service"
+    config    = "--name='' --value=''"
+    feature   = "--name=''"
+    apikey    = "--source='' --api-key='' --remove"
+    export    = "--include-version-numbers --output-file-path=''"
+    template  = "--name=''"
 }
+
 $commandOptions['find'] = $commandOptions['search']
 
 try {
-    # if license exists
-    # add in pro/biz switches
+    $licenseFile = Get-Item -Path "$env:ChocolateyInstall\license\chocolatey.license.xml" -ErrorAction Ignore
+
+    if ($licenseFile) {
+        # Add pro-only commands
+        $script:chocoCommands = @(
+            $script:chocoCommands
+            'download'
+            'optimize'
+        )
+
+        $commandOptions.download = "--internalize --internalize-all-urls --ignore-dependencies --installed-packages --ignore-unfound-packages --resources-location='' --download-location='' --outputdirectory='' --source='' --version='' --prerelease --user='' --password='' --cert='' --certpassword='' --append-use-original-location --recompile --disable-package-repository-optimizations"
+        $commandOptions.sync = "--output-directory='' --id='' --package-id=''"
+        $commandOptions.optimize = "--deflate-nupkg-only --id=''"
+
+        # Add pro switches to commands that have additional switches on Pro
+        $proInstallUpgradeOptions = " --install-directory='' --package-parameters-sensitive='' --max-download-rate='' --install-arguments-sensitive='' --skip-download-cache --use-download-cache --skip-virus-check --virus-check --virus-positives-minimum='' --deflate-package-size --no-deflate-package-size --deflate-nupkg-only"
+
+        $commandOptions.install += $proInstallUpgradeOptions
+        $commandOptions.upgrade += $proInstallUpgradeOptions + " --exclude-chocolatey-packages-during-upgrade-all --include-chocolatey-packages-during-upgrade-all"
+        $commandOptions.new += " --build-package --use-original-location --keep-remote --url='' --url64='' --checksum='' --checksum64='' --checksumtype='' --pause-on-error"
+        $commandOptions.pin += " --note=''"
+
+        # Add Business-only commands and options if the license is a Business or Trial license
+        [xml]$xml = Get-Content -Path $licenseFile.FullName
+        $licenseType = $xml.license.type
+
+        if ('Business', 'BusinessTrial' -contains $licenseType) {
+
+            # Add business-only commands
+            $script:chocoCommands = @(
+                $script:chocoCommands
+                'sync'
+            )
+
+            $commandOptions.list += " --audit"
+            $commandOptions.uninstall += " --from-programs-and-features"
+            $commandOptions.new += " --file='' --file64='' --from-programs-and-features --remove-architecture-from-name --include-architecture-in-name"
+
+            # Add --use-self-service to commands that support it
+            $selfServiceCommands = 'list', 'find', 'search', 'info', 'install', 'upgrade', 'uninstall', 'pin', 'outdated', 'push', 'download', 'sync', 'optimize'
+            foreach ($command in $selfServiceCommands) {
+                $commandOptions.$command += ' --use-self-service'
+            }
+        }
+    }
 }
 catch {
 }
 
+foreach ($key in @($commandOptions.Keys)) {
+    $commandOptions.$key += $allcommands
+}
+
+# Consistent ordering for commands so the added pro commands aren't weirdly out of order
+$script:chocoCommands = $script:chocoCommands | Sort-Object -Property { $_ -replace '[^a-z]' }
+
 function script:chocoCommands($filter) {
     $cmdList = @()
     if (-not $global:ChocolateyTabSettings.AllCommands) {
-        $cmdList += $someCommands -like "$filter*"
+        $cmdList += $script:chocoCommands -like "$filter*"
     }
     else {
         $cmdList += (& $script:choco -h) |
@@ -97,14 +135,14 @@ function script:chocoCommands($filter) {
 }
 
 function script:chocoLocalPackages($filter) {
-    if ($filter -ne $null -and $filter.StartsWith(".")) {
+    if ($filter -and $filter.StartsWith(".")) {
         return;
     } #file search
     @(& $script:choco list $filter -r --id-starts-with) | ForEach-Object { $_.Split('|')[0] }
 }
 
 function script:chocoLocalPackagesUpgrade($filter) {
-    if ($filter -ne $null -and $filter.StartsWith(".")) {
+    if ($filter -and $filter.StartsWith(".")) {
         return;
     } #file search
     @('all|') + @(& $script:choco list $filter -r --id-starts-with) |
@@ -113,7 +151,7 @@ function script:chocoLocalPackagesUpgrade($filter) {
 }
 
 function script:chocoRemotePackages($filter) {
-    if ($filter -ne $null -and $filter.StartsWith(".")) {
+    if ($filter -and $filter.StartsWith(".")) {
         return;
     } #file search
     @('packages.config|') + @(& $script:choco search $filter --page='0' --page-size='30' -r --id-starts-with --order-by-popularity) |


### PR DESCRIPTION
## Description Of Changes

- Only add licensed / Business-only commands and options to tab completion if the user has the appropriate Chocolatey license.

Note that this check is deliberately naive; we don't look at the license too hard, just try to determine if there _is_ one and if it is a Business/Trial license. Since this only affects tab completion and Choco does its own license checks separately, we don't need to be too stringent about exactly what is needed for the licensed options to be returned.

In future, we should simply query available commands and options from choco directly, but this is a "good enough" patch in the meantime until that day comes.

## Motivation and Context

Previously all commands and options would be returned from tab completion regardless of whether they could actually be used.

With this change, tab completion (superficially) checks the user's Chocolatey license without checking too hard and populates the available commands and options appropriately.

## Testing

1. Ensure you have a Business license installed for Chocolatey (at `$env:ChocolateyInstall\license\chocolatey.license.xml`).
1. Import the `chocolateyProfile.psm1` module in a PowerShell session
1. Type `choco[SPACE]` and tab through the options.
1. You should have the usual FOSS commands, as well as `sync`, `optimize`, and `download`.
1. Add the `new` command to the current input and tab-complete through the options from there.
1. You should have the usual FOSS options, plus licensed options like `--build-package`, and also the business-only options like `--file`.
1. Try a few other commands and ensure that all expected options are available.

- Repeat the above with a `Professional` license installed instead, and you should have similar results to the above, though the specific business-only command `sync` should be missing, and `--file` and other Business-only options should be missing.
- Repeat once more with no license installed at all, and you should see all the licensed commands and options are no longer present.

### Operating Systems Testing

I tested on Windows 11, we should test on a few more platforms before merging.

## Change Types Made
<!-- Tick the boxes for the type of changes that have been made -->

* [ ] Bug fix (non-breaking change).
* [x] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [ ] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked? (TBD)

## Related Issue

Fixes #2887
