### PR TITLE
(#508) Attempt to resolve relative paths for sources

### DIFF
--- a/src/chocolatey.tests.integration/scenarios/InfoScenarios.cs
+++ b/src/chocolatey.tests.integration/scenarios/InfoScenarios.cs
@@ -10,6 +10,7 @@ namespace chocolatey.tests.integration.scenarios
     using chocolatey.infrastructure.app.configuration;
     using chocolatey.infrastructure.app.services;
     using chocolatey.infrastructure.commands;
+    using chocolatey.infrastructure.platforms;
     using chocolatey.infrastructure.results;
 
     using NuGet;
@@ -67,7 +68,6 @@ namespace chocolatey.tests.integration.scenarios
             }
         }
 
-        [Broken, Pending("Need to be fixed in either NuGet.Client or before calling code in NuGet.Client")]
         public class when_searching_for_exact_package_through_command : CommandScenariosBase
         {
             public override void Context()
@@ -94,7 +94,7 @@ namespace chocolatey.tests.integration.scenarios
                     .ToShortDateString();
 
                 MockLogger.Messages.Keys.ShouldContain(LogLevel.Info.to_string());
-                MockLogger.Messages[LogLevel.Info.to_string()].ShouldContain(" Title: installpackage | Published: 14.12.2022\r\n Number of Downloads: n/a | Downloads for this version: n/a\r\n Package url\r\n Chocolatey Package Source: n/a\r\n Tags: installpackage admin\r\n Software Site: n/a\r\n Software License: n/a\r\n Summary: __REPLACE__\r\n Description: __REPLACE__\r\n".format_with(lastWriteDate));
+                MockLogger.Messages[LogLevel.Info.to_string()].ShouldContain(" Title: installpackage | Published: {0}\r\n Number of Downloads: n/a | Downloads for this version: n/a\r\n Package url\r\n Chocolatey Package Source: n/a\r\n Tags: installpackage admin\r\n Software Site: n/a\r\n Software License: n/a\r\n Summary: __REPLACE__\r\n Description: __REPLACE__\r\n".format_with(lastWriteDate));
             }
 
             [Fact]
@@ -105,7 +105,6 @@ namespace chocolatey.tests.integration.scenarios
             }
         }
 
-        [Broken, Pending("Need to be fixed in either NuGet.Client or before calling code in NuGet.Client")]
         public class when_searching_for_exact_package_with_dot_relative_path_source : when_searching_for_exact_package_through_command
         {
             public override void Context()
@@ -143,7 +142,7 @@ namespace chocolatey.tests.integration.scenarios
                     .ToShortDateString();
 
                 MockLogger.Messages.Keys.ShouldContain(LogLevel.Info.to_string());
-                MockLogger.Messages[LogLevel.Info.to_string()].ShouldContain(" Title: installpackage | Published: 14.12.2022\r\n Number of Downloads: n/a | Downloads for this version: n/a\r\n Package url\r\n Chocolatey Package Source: n/a\r\n Tags: installpackage admin\r\n Software Site: n/a\r\n Software License: n/a\r\n Summary: __REPLACE__\r\n Description: __REPLACE__\r\n".format_with(lastWriteDate));
+                MockLogger.Messages[LogLevel.Info.to_string()].ShouldContain(" Title: installpackage | Published: {0}\r\n Number of Downloads: n/a | Downloads for this version: n/a\r\n Package url\r\n Chocolatey Package Source: n/a\r\n Tags: installpackage admin\r\n Software Site: n/a\r\n Software License: n/a\r\n Summary: __REPLACE__\r\n Description: __REPLACE__\r\n".format_with(lastWriteDate));
             }
 
             [Fact]
@@ -154,7 +153,6 @@ namespace chocolatey.tests.integration.scenarios
             }
         }
 
-        [Broken, Pending("Need to be fixed in either NuGet.Client or before calling code in NuGet.Client")]
         public class when_searching_for_exact_package_with_verbose_output : ScenariosBase
         {
             public override void Context()
@@ -193,7 +191,9 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void should_set_source_to_expected_value()
             {
-                Results[0].Source.ShouldEqual("PackageOutput");
+                Results[0].Source.ShouldEqual(
+                    ((Platform.get_platform() == PlatformType.Windows ? "file:///" : "file://") + Path.Combine(Environment.CurrentDirectory, "PackageOutput"))
+                    .Replace("\\","/"));
             }
 
             [Fact]

--- a/src/chocolatey.tests/infrastructure.app/nuget/NugetCommonSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/nuget/NugetCommonSpecs.cs
@@ -21,6 +21,7 @@ namespace chocolatey.tests.infrastructure.app.nuget
     using System.Linq;
     using chocolatey.infrastructure.app.configuration;
     using chocolatey.infrastructure.app.nuget;
+    using chocolatey.infrastructure.filesystem;
     using Moq;
     using NuGet.Common;
     using NuGet.Packaging;
@@ -35,6 +36,7 @@ namespace chocolatey.tests.infrastructure.app.nuget
             private Action because;
             private readonly Mock<ILogger> nugetLogger = new Mock<ILogger>();
             private readonly Mock<IPackageDownloader> packageDownloader = new Mock<IPackageDownloader>();
+            private readonly Mock<IFileSystem> filesystem = new Mock<IFileSystem>();
             private ChocolateyConfiguration configuration;
             private IEnumerable<SourceRepository> packageRepositories;
 
@@ -47,7 +49,7 @@ namespace chocolatey.tests.infrastructure.app.nuget
 
             public override void Because()
             {
-                because = () => packageRepositories = NugetCommon.GetRemoteRepositories(configuration, nugetLogger.Object);
+                because = () => packageRepositories = NugetCommon.GetRemoteRepositories(configuration, nugetLogger.Object, filesystem.Object);
             }
 
             [Fact]

--- a/src/chocolatey.tests/infrastructure.app/nuget/NugetCommonSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/nuget/NugetCommonSpecs.cs
@@ -45,6 +45,12 @@ namespace chocolatey.tests.infrastructure.app.nuget
                 configuration = new ChocolateyConfiguration();
                 nugetLogger.ResetCalls();
                 packageDownloader.ResetCalls();
+                filesystem.ResetCalls();
+
+                filesystem.Setup(f => f.get_full_path(It.IsAny<string>())).Returns((string a) =>
+                {
+                    return "C:\\packages\\" + a;
+                });
             }
 
             public override void Because()
@@ -61,6 +67,99 @@ namespace chocolatey.tests.infrastructure.app.nuget
                 because();
 
                 packageRepositories.Count().ShouldEqual(0);
+            }
+
+            [Fact]
+            public void should_parse_http_source()
+            {
+                Context();
+                var source = "http://nexus.example.com:8081/repository/choco";
+                configuration.Sources = source;
+                configuration.CacheLocation = "C:\\temp";
+
+                because();
+
+                packageRepositories.First().PackageSource.TrySourceAsUri.ShouldNotBeNull();
+                packageRepositories.First().PackageSource.SourceUri.to_string().ShouldEqual(source);
+                packageRepositories.First().PackageSource.IsHttp.ShouldBeTrue();
+            }
+
+            [Fact]
+            public void should_parse_https_source()
+            {
+                Context();
+                var source = "https://nexus.example.com/repository/choco";
+                configuration.Sources = source;
+                configuration.CacheLocation = "C:\\temp";
+
+                because();
+
+                packageRepositories.First().PackageSource.TrySourceAsUri.ShouldNotBeNull();
+                packageRepositories.First().PackageSource.SourceUri.to_string().ShouldEqual(source);
+                packageRepositories.First().PackageSource.IsHttps.ShouldBeTrue();
+            }
+
+            [Fact]
+            public void should_parse_absolute_path_source()
+            {
+                Context();
+                var source = "C:\\packages";
+                configuration.Sources = source;
+
+                because();
+
+                packageRepositories.First().PackageSource.TrySourceAsUri.ShouldNotBeNull();
+                packageRepositories.First().PackageSource.SourceUri.to_string()
+                    .ShouldEqual(("file:///" + source).Replace("\\","/"));
+                packageRepositories.First().PackageSource.IsLocal.ShouldBeTrue();
+            }
+
+            [Fact]
+            public void should_parse_relative_path_source()
+            {
+                Context();
+                var source = "choco";
+                var fullsource = "C:\\packages\\choco";
+                configuration.Sources = source;
+
+                because();
+
+                packageRepositories.First().PackageSource.TrySourceAsUri.ShouldNotBeNull();
+                packageRepositories.First().PackageSource.SourceUri.to_string()
+                    .ShouldEqual(("file:///" + fullsource).Replace("\\", "/"));
+                packageRepositories.First().PackageSource.IsLocal.ShouldBeTrue();
+            }
+
+            [Fact]
+            public void should_parse_dot_relative_path_source()
+            {
+                Context();
+                var source = ".";
+                var fullsource = "C:\\packages";
+                configuration.Sources = source;
+
+                because();
+
+                packageRepositories.First().PackageSource.TrySourceAsUri.ShouldNotBeNull();
+                packageRepositories.First().PackageSource.SourceUri.to_string()
+                    .ShouldEqual(("file:///" + fullsource + "/").Replace("\\", "/"));
+                packageRepositories.First().PackageSource.IsLocal.ShouldBeTrue();
+            }
+
+            [Fact]
+            public void should_parse_unc_source()
+            {
+                Context();
+                var source = "\\\\samba-server\\choco-share";
+                configuration.Sources = source;
+
+                because();
+
+                packageRepositories.First().PackageSource.TrySourceAsUri.ShouldNotBeNull();
+                packageRepositories.First().PackageSource.SourceUri.to_string()
+                    .ShouldEqual(("file:" + source).Replace("\\", "/"));
+                packageRepositories.First().PackageSource.IsLocal.ShouldBeTrue();
+                packageRepositories.First().PackageSource.SourceUri.IsUnc.ShouldBeTrue();
             }
         }
     }

--- a/src/chocolatey/infrastructure.app/nuget/NugetList.cs
+++ b/src/chocolatey/infrastructure.app/nuget/NugetList.cs
@@ -26,6 +26,7 @@ namespace chocolatey.infrastructure.app.nuget
     using System.Threading;
     using System.Threading.Tasks;
     using configuration;
+    using filesystem;
     using NuGet.Common;
     using NuGet.Configuration;
     using NuGet.PackageManagement;
@@ -39,19 +40,19 @@ namespace chocolatey.infrastructure.app.nuget
 
     public static class NugetList
     {
-        public static IEnumerable<IPackageSearchMetadata> GetPackages(ChocolateyConfiguration configuration, ILogger nugetLogger)
+        public static IEnumerable<IPackageSearchMetadata> GetPackages(ChocolateyConfiguration configuration, ILogger nugetLogger, IFileSystem filesystem)
         {
-            return execute_package_search(configuration, nugetLogger).GetAwaiter().GetResult();
+            return execute_package_search(configuration, nugetLogger, filesystem).GetAwaiter().GetResult();
         }
 
-        public static int GetCount(ChocolateyConfiguration configuration, ILogger nugetLogger)
+        public static int GetCount(ChocolateyConfiguration configuration, ILogger nugetLogger, IFileSystem filesystem)
         {
-            return execute_package_search(configuration, nugetLogger).GetAwaiter().GetResult().Count();
+            return execute_package_search(configuration, nugetLogger, filesystem).GetAwaiter().GetResult().Count();
         }
 
-        private async static Task<IQueryable<IPackageSearchMetadata>> execute_package_search(ChocolateyConfiguration configuration, ILogger nugetLogger)
+        private async static Task<IQueryable<IPackageSearchMetadata>> execute_package_search(ChocolateyConfiguration configuration, ILogger nugetLogger, IFileSystem filesystem)
         {
-            var packageRepositories = NugetCommon.GetRemoteRepositories(configuration, nugetLogger);
+            var packageRepositories = NugetCommon.GetRemoteRepositories(configuration, nugetLogger, filesystem);
             var packageRepositoriesResources = NugetCommon.GetRepositoryResources(packageRepositories);
             string searchTermLower = configuration.Input.to_lower();
             SearchFilter searchFilter = new SearchFilter(configuration.Prerelease);

--- a/src/chocolatey/infrastructure.app/nuget/NugetPush.cs
+++ b/src/chocolatey/infrastructure.app/nuget/NugetPush.cs
@@ -22,6 +22,7 @@ namespace chocolatey.infrastructure.app.nuget
     using System.Collections.Generic;
     using System.Linq;
     using System.Threading.Tasks;
+    using filesystem;
     using NuGet.Common;
     using NuGet.Configuration;
     using NuGet.Protocol;
@@ -29,7 +30,7 @@ namespace chocolatey.infrastructure.app.nuget
 
     public class NugetPush
     {
-        public static void push_package(ChocolateyConfiguration config, string nupkgFilePath, ILogger nugetLogger, string nupkgFileName)
+        public static void push_package(ChocolateyConfiguration config, string nupkgFilePath, ILogger nugetLogger, string nupkgFileName, IFileSystem filesystem)
         {
             var timeout = TimeSpan.FromSeconds(Math.Abs(config.CommandExecutionTimeoutSeconds));
             if (timeout.Seconds <= 0)
@@ -42,7 +43,7 @@ namespace chocolatey.infrastructure.app.nuget
             const bool noServiceEndpoint = true;
 
             //OK to use FirstOrDefault in this case as the command validates that there is only one source
-            SourceRepository sourceRepository = NugetCommon.GetRemoteRepositories(config, nugetLogger).FirstOrDefault();
+            SourceRepository sourceRepository = NugetCommon.GetRemoteRepositories(config, nugetLogger, filesystem).FirstOrDefault();
             PackageUpdateResource packageUpdateResource = sourceRepository.GetResource<PackageUpdateResource>();
             var nupkgFilePaths = new List<string>() { nupkgFilePath };
             UserAgent.SetUserAgentString(new UserAgentStringBuilder("{0}/{1} via NuGet Client".format_with(ApplicationParameters.UserAgent, config.Information.ChocolateyProductVersion)));

--- a/src/chocolatey/infrastructure.app/services/NugetService.cs
+++ b/src/chocolatey/infrastructure.app/services/NugetService.cs
@@ -198,7 +198,7 @@ namespace chocolatey.infrastructure.app.services
                         if (config.Verbose && !config.ListCommand.IdOnly) this.Log().Info(() =>
                             @" Title: {0} | Published: {1}{2}{3}
  Number of Downloads: {4} | Downloads for this version: {5}
- Package url: {6}
+ Package url{6}
  Chocolatey Package Source: {7}{8}
  Tags: {9}
  Software Site: {10}
@@ -217,12 +217,12 @@ namespace chocolatey.infrastructure.app.services
                                         package.PackageTestResultStatus,
                                         package.PackageValidationResultDate.GetValueOrDefault().ToString("MMM dd yyyy HH:mm:ss")
                                     ),
-                                package.DownloadCount <= 0 ? "n/a" : package.DownloadCount.to_string(),
-                                package.VersionDownloadCount <= 0 ? "n/a" : package.VersionDownloadCount.to_string(),
-                                package.PackageDetailsUrl == null || string.IsNullOrWhiteSpace(package.PackageDetailsUrl.AbsoluteUri) ? "N/A" : package.PackageDetailsUrl.AbsoluteUri,
+                                (package.DownloadCount == null || package.DownloadCount <= 0)  ? "n/a" : package.DownloadCount.to_string(),
+                                (package.VersionDownloadCount == null || package.VersionDownloadCount <= 0) ? "n/a" : package.VersionDownloadCount.to_string(),
+                                package.PackageDetailsUrl == null || string.IsNullOrWhiteSpace(package.PackageDetailsUrl.AbsoluteUri) ? string.Empty : " " + package.PackageDetailsUrl.AbsoluteUri,
                                 packageLocalMetadata != null && packageLocalMetadata.PackageSourceUrl != null && !string.IsNullOrWhiteSpace(packageLocalMetadata.PackageSourceUrl.to_string())
                                     ? packageLocalMetadata.PackageSourceUrl.to_string()
-                                    : "N/A",
+                                    : "n/a",
                                 string.IsNullOrWhiteSpace(package.PackageHash) ? string.Empty : "{0} Package Checksum: '{1}' ({2})".format_with(
                                         Environment.NewLine,
                                         package.PackageHash,
@@ -235,7 +235,7 @@ namespace chocolatey.infrastructure.app.services
                                 packageLocalMetadata != null && packageLocalMetadata.DocsUrl != null && !string.IsNullOrWhiteSpace(packageLocalMetadata.DocsUrl.to_string()) ? "{0} Documentation: {1}".format_with(Environment.NewLine, packageLocalMetadata.DocsUrl.to_string()) : string.Empty,
                                 packageLocalMetadata != null && packageLocalMetadata.MailingListUrl != null && !string.IsNullOrWhiteSpace(packageLocalMetadata.MailingListUrl.to_string()) ? "{0} Mailing List: {1}".format_with(Environment.NewLine, packageLocalMetadata.MailingListUrl.to_string()) : string.Empty,
                                 packageLocalMetadata != null && packageLocalMetadata.BugTrackerUrl != null && !string.IsNullOrWhiteSpace(packageLocalMetadata.BugTrackerUrl.to_string()) ? "{0} Issues: {1}".format_with(Environment.NewLine, packageLocalMetadata.BugTrackerUrl.to_string()) : string.Empty,
-                                package.Summary != null && !string.IsNullOrWhiteSpace(package.Summary.to_string()) ? "{0} Summary: {1}".format_with(Environment.NewLine, package.Summary.escape_curly_braces().to_string()) : string.Empty,
+                                package.Summary != null && !string.IsNullOrWhiteSpace(package.Summary.to_string()) ? "\r\n Summary: {0}".format_with(package.Summary.escape_curly_braces().to_string()) : string.Empty,
                                 package.Description.escape_curly_braces().Replace("\n    ", "\n").Replace("\n", "\n  "),
                                 packageLocalMetadata != null && packageLocalMetadata.ReleaseNotes != null && !string.IsNullOrWhiteSpace(packageLocalMetadata.ReleaseNotes.to_string()) ? "{0} Release Notes: {1}".format_with(Environment.NewLine, packageLocalMetadata.ReleaseNotes.escape_curly_braces().Replace("\n    ", "\n").Replace("\n", "\n  ")) : string.Empty
                             ));

--- a/src/chocolatey/infrastructure.app/services/NugetService.cs
+++ b/src/chocolatey/infrastructure.app/services/NugetService.cs
@@ -108,7 +108,7 @@ namespace chocolatey.infrastructure.app.services
             int? pageValue = config.ListCommand.Page;
             try
             {
-                return NugetList.GetCount(config, _nugetLogger);
+                return NugetList.GetCount(config, _nugetLogger, _fileSystem);
             }
             finally
             {
@@ -147,7 +147,7 @@ namespace chocolatey.infrastructure.app.services
 
             if (config.RegularOutput) this.Log().Debug(() => "Running list with the following filter = '{0}'".format_with(config.Input));
             if (config.RegularOutput) this.Log().Debug(ChocolateyLoggers.Verbose, () => "--- Start of List ---");
-            foreach (var pkg in NugetList.GetPackages(config, _nugetLogger))
+            foreach (var pkg in NugetList.GetPackages(config, _nugetLogger, _fileSystem))
             {
                 var package = pkg; // for lamda access
 
@@ -378,7 +378,7 @@ namespace chocolatey.infrastructure.app.services
             string nupkgFileName = _fileSystem.get_file_name(nupkgFilePath);
             if (config.RegularOutput) this.Log().Info(() => "Attempting to push {0} to {1}".format_with(nupkgFileName, config.Sources));
 
-            NugetPush.push_package(config, _fileSystem.get_full_path(nupkgFilePath), _nugetLogger, nupkgFileName);
+            NugetPush.push_package(config, _fileSystem.get_full_path(nupkgFilePath), _nugetLogger, nupkgFileName, _fileSystem);
 
             if (config.RegularOutput && (config.Sources.is_equal_to(ApplicationParameters.ChocolateyCommunityFeedPushSource) || config.Sources.is_equal_to(ApplicationParameters.ChocolateyCommunityFeedPushSourceOld)))
             {
@@ -438,7 +438,7 @@ folder.");
             if (config.Force) config.AllowDowngrade = true;
 
             var sourceCacheContext = new ChocolateySourceCacheContext(config);
-            var remoteRepositories = NugetCommon.GetRemoteRepositories(config, _nugetLogger);
+            var remoteRepositories = NugetCommon.GetRemoteRepositories(config, _nugetLogger, _fileSystem);
             var localRepositorySource = NugetCommon.GetLocalRepository();
             var pathResolver = NugetCommon.GetPathResolver(config, _fileSystem);
             var nugetProject = new FolderNuGetProject(ApplicationParameters.PackagesLocation, pathResolver, NuGetFramework.AnyFramework);
@@ -868,7 +868,7 @@ Please see https://docs.chocolatey.org/en-us/troubleshooting for more
             if (config.Force) config.AllowDowngrade = true;
 
             var sourceCacheContext = new ChocolateySourceCacheContext(config);
-            var remoteRepositories = NugetCommon.GetRemoteRepositories(config, _nugetLogger);
+            var remoteRepositories = NugetCommon.GetRemoteRepositories(config, _nugetLogger, _fileSystem);
             var localRepositorySource = NugetCommon.GetLocalRepository();
             var projectContext = new ChocolateyNuGetProjectContext(config, _nugetLogger);
 
@@ -1365,7 +1365,7 @@ Please see https://docs.chocolatey.org/en-us/troubleshooting for more
         public virtual ConcurrentDictionary<string, PackageResult> get_outdated(ChocolateyConfiguration config)
         {
 
-            var remoteRepositories = NugetCommon.GetRemoteRepositories(config, _nugetLogger);
+            var remoteRepositories = NugetCommon.GetRemoteRepositories(config, _nugetLogger, _fileSystem);
             var pathResolver = NugetCommon.GetPathResolver(config, _fileSystem);
 
             var outdatedPackages = new ConcurrentDictionary<string, PackageResult>();

--- a/src/chocolatey/infrastructure.app/services/TemplateService.cs
+++ b/src/chocolatey/infrastructure.app/services/TemplateService.cs
@@ -274,7 +274,7 @@ namespace chocolatey.infrastructure.app.services
 
         protected void list_custom_template_info(ChocolateyConfiguration configuration)
         {
-            var packageRepositories = NugetCommon.GetRemoteRepositories(configuration, _nugetLogger);
+            var packageRepositories = NugetCommon.GetRemoteRepositories(configuration, _nugetLogger, _fileSystem);
             var sourceCacheContext = new ChocolateySourceCacheContext(configuration);
             var pkg = NugetList.find_package(
                     "{0}.template".format_with(configuration.TemplateCommand.Name),


### PR DESCRIPTION
## Description Of Changes

When setting up NuGet sources, if NuGet is unable to parse the path, this tries to resolve relative paths to absolute, and then retries setting up the NuGet source. If the path is unable to be resolved, then this ignores the error and lets NuGet handle the resulting invalid source.

This path resolution requires the filesystem to be passed in. This means that various method signatures change to allow access to the filesystem.

## Motivation and Context

When using NuGet.Core, then relative paths were able to be resolved. But now with NuGet.Client, relative paths are resolved by clients, not by libraries, which is why this change has to be made. https://github.com/NuGet/NuGet.Client/pull/3783

## Testing

- Add wget `.nupkg` to `C:\packages`
- Open PowerShell at `C:\`
- Run `choco.exe` from this PR with `.\choco.exe info wget --source="C:\packages"`
- Run `choco.exe` from this PR with `.\choco.exe info wget --source="packages"`
- Change directory to `C:\packages`
- Run `choco.exe` from this PR with `.\choco.exe info wget --source="."`
- Validate that all of these output the wget info
- Rerun these commands, but with `install` (with `-n -f`) instead of `info`, and validate that the package installs each time.

### Operating Systems Testing
- Windows 10 22H2

## Change Types Made

* [x] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [x] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [x] Tests to cover my changes, have been added.
* [ ] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue

Part of #508