### PR TITLE
(#508) Change NuGet normal logging to be verbose logging

### DIFF
--- a/src/chocolatey.tests/MockLogger.cs
+++ b/src/chocolatey.tests/MockLogger.cs
@@ -35,6 +35,7 @@ namespace chocolatey.tests
     {
         public MockLogger()
         {
+            LoggerNames = new HashSet<string>();
         }
 
         public void reset()
@@ -42,6 +43,7 @@ namespace chocolatey.tests
             Messages.Clear();
             this.ResetCalls();
             LogMessagesToConsole = false;
+            LoggerNames.Clear();
         }
 
         public bool contains_message(string expectedMessage)
@@ -91,6 +93,8 @@ namespace chocolatey.tests
 
         private readonly Lazy<ConcurrentDictionary<string, IList<string>>> _messages = new Lazy<ConcurrentDictionary<string, IList<string>>>();
 
+        public HashSet<string> LoggerNames { get; private set; }
+
         public ConcurrentDictionary<string, IList<string>> Messages
         {
             get { return _messages.Value; }
@@ -103,6 +107,7 @@ namespace chocolatey.tests
 
         public void InitializeFor(string loggerName)
         {
+            LoggerNames.Add(loggerName);
         }
 
         public void LogMessage(LogLevel logLevel, string message)

--- a/src/chocolatey.tests/TinySpec.cs
+++ b/src/chocolatey.tests/TinySpec.cs
@@ -227,6 +227,15 @@ namespace chocolatey.tests
             {
             }
         }
+
+        [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = false)]
+        public sealed class LoggingAttribute : CategoryAttribute
+        {
+            public LoggingAttribute()
+                : base("Logging")
+            {
+            }
+        }
     }
 
     // ReSharper restore InconsistentNaming

--- a/src/chocolatey.tests/chocolatey.tests.csproj
+++ b/src/chocolatey.tests/chocolatey.tests.csproj
@@ -77,20 +77,41 @@
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Chocolatey.NuGet.Commands, Version=3.0.0.80, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
+      <HintPath>..\packages\Chocolatey.NuGet.Commands.3.0.0-alpha-20221213-80\lib\net472\Chocolatey.NuGet.Commands.dll</HintPath>
+    </Reference>
     <Reference Include="Chocolatey.NuGet.Common, Version=3.0.0.80, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
       <HintPath>..\packages\Chocolatey.NuGet.Common.3.0.0-alpha-20221213-80\lib\net472\Chocolatey.NuGet.Common.dll</HintPath>
     </Reference>
     <Reference Include="Chocolatey.NuGet.Configuration, Version=3.0.0.80, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
       <HintPath>..\packages\Chocolatey.NuGet.Configuration.3.0.0-alpha-20221213-80\lib\net472\Chocolatey.NuGet.Configuration.dll</HintPath>
     </Reference>
+    <Reference Include="Chocolatey.NuGet.Credentials, Version=3.0.0.80, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
+      <HintPath>..\packages\Chocolatey.NuGet.Credentials.3.0.0-alpha-20221213-80\lib\net472\Chocolatey.NuGet.Credentials.dll</HintPath>
+    </Reference>
+    <Reference Include="Chocolatey.NuGet.DependencyResolver.Core, Version=3.0.0.80, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
+      <HintPath>..\packages\Chocolatey.NuGet.DependencyResolver.Core.3.0.0-alpha-20221213-80\lib\net472\Chocolatey.NuGet.DependencyResolver.Core.dll</HintPath>
+    </Reference>
     <Reference Include="Chocolatey.NuGet.Frameworks, Version=3.0.0.80, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
       <HintPath>..\packages\Chocolatey.NuGet.Frameworks.3.0.0-alpha-20221213-80\lib\net472\Chocolatey.NuGet.Frameworks.dll</HintPath>
+    </Reference>
+    <Reference Include="Chocolatey.NuGet.LibraryModel, Version=3.0.0.80, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
+      <HintPath>..\packages\Chocolatey.NuGet.LibraryModel.3.0.0-alpha-20221213-80\lib\net472\Chocolatey.NuGet.LibraryModel.dll</HintPath>
+    </Reference>
+    <Reference Include="Chocolatey.NuGet.PackageManagement, Version=3.0.0.80, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
+      <HintPath>..\packages\Chocolatey.NuGet.PackageManagement.3.0.0-alpha-20221213-80\lib\net472\Chocolatey.NuGet.PackageManagement.dll</HintPath>
     </Reference>
     <Reference Include="Chocolatey.NuGet.Packaging, Version=3.0.0.80, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
       <HintPath>..\packages\Chocolatey.NuGet.Packaging.3.0.0-alpha-20221213-80\lib\net472\Chocolatey.NuGet.Packaging.dll</HintPath>
     </Reference>
+    <Reference Include="Chocolatey.NuGet.ProjectModel, Version=3.0.0.80, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
+      <HintPath>..\packages\Chocolatey.NuGet.ProjectModel.3.0.0-alpha-20221213-80\lib\net472\Chocolatey.NuGet.ProjectModel.dll</HintPath>
+    </Reference>
     <Reference Include="Chocolatey.NuGet.Protocol, Version=3.0.0.80, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
       <HintPath>..\packages\Chocolatey.NuGet.Protocol.3.0.0-alpha-20221213-80\lib\net472\Chocolatey.NuGet.Protocol.dll</HintPath>
+    </Reference>
+    <Reference Include="Chocolatey.NuGet.Resolver, Version=3.0.0.80, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
+      <HintPath>..\packages\Chocolatey.NuGet.Resolver.3.0.0-alpha-20221213-80\lib\net472\Chocolatey.NuGet.Resolver.dll</HintPath>
     </Reference>
     <Reference Include="Chocolatey.NuGet.Versioning, Version=3.0.0.80, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
       <HintPath>..\packages\Chocolatey.NuGet.Versioning.3.0.0-alpha-20221213-80\lib\net472\Chocolatey.NuGet.Versioning.dll</HintPath>
@@ -98,6 +119,7 @@
     <Reference Include="log4net, Version=2.0.12.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
       <HintPath>..\packages\log4net.2.0.12\lib\net45\log4net.dll</HintPath>
     </Reference>
+    <Reference Include="Microsoft.Build" />
     <Reference Include="Microsoft.Web.XmlTransform, Version=3.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Web.Xdt.3.1.0\lib\net40\Microsoft.Web.XmlTransform.dll</HintPath>
     </Reference>
@@ -117,6 +139,7 @@
       <HintPath>..\packages\SimpleInjector.2.8.3\lib\net45\SimpleInjector.dll</HintPath>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
     <Reference Include="System.IdentityModel" />
@@ -154,6 +177,7 @@
     <Compile Include="infrastructure.app\commands\ChocolateyUpgradeCommandSpecs.cs" />
     <Compile Include="infrastructure.app\configuration\ConfigurationOptionsSpec.cs" />
     <Compile Include="infrastructure.app\nuget\ChocolateyNugetLoggerSpecs.cs" />
+    <Compile Include="infrastructure.app\nuget\ChocolateyNuGetProjectContextSpecs.cs" />
     <Compile Include="infrastructure.app\nuget\NugetCommonSpecs.cs" />
     <Compile Include="infrastructure.app\services\AutomaticUninstallerServiceSpecs.cs" />
     <Compile Include="infrastructure.app\services\ChocolateyConfigSettingsServiceSpecs.cs" />

--- a/src/chocolatey.tests/chocolatey.tests.csproj
+++ b/src/chocolatey.tests/chocolatey.tests.csproj
@@ -153,6 +153,7 @@
     <Compile Include="infrastructure.app\commands\ChocolateyUnpackSelfCommandSpecs.cs" />
     <Compile Include="infrastructure.app\commands\ChocolateyUpgradeCommandSpecs.cs" />
     <Compile Include="infrastructure.app\configuration\ConfigurationOptionsSpec.cs" />
+    <Compile Include="infrastructure.app\nuget\ChocolateyNugetLoggerSpecs.cs" />
     <Compile Include="infrastructure.app\nuget\NugetCommonSpecs.cs" />
     <Compile Include="infrastructure.app\services\AutomaticUninstallerServiceSpecs.cs" />
     <Compile Include="infrastructure.app\services\ChocolateyConfigSettingsServiceSpecs.cs" />

--- a/src/chocolatey.tests/infrastructure.app/nuget/ChocolateyNuGetProjectContextSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/nuget/ChocolateyNuGetProjectContextSpecs.cs
@@ -1,0 +1,151 @@
+﻿// Copyright © 2022-Present Chocolatey Software, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace chocolatey.tests.infrastructure.app.nuget
+{
+    using chocolatey.infrastructure.app.configuration;
+    using chocolatey.infrastructure.app.nuget;
+    using Moq;
+    using NuGet.Common;
+    using NuGet.ProjectManagement;
+    using NUnit.Framework;
+    using Should;
+
+    public class ChocolateyNuGetProjectContextSpecs
+    {
+        public abstract class ChocolateyNuGetProjectContextSpecsBase : TinySpec
+        {
+            protected ChocolateyConfiguration Configuration;
+            protected Mock<ILogger> Logger = new Mock<ILogger>();
+            protected ChocolateyNuGetProjectContext Service;
+
+            public override void Context()
+            {
+                Configuration = new ChocolateyConfiguration();
+                Service = new ChocolateyNuGetProjectContext(Configuration, Logger.Object);
+            }
+        }
+
+        [Categories.Logging, Parallelizable(ParallelScope.Self)]
+        public class when_calling_logging_methods_the_passed_in_logger_is_used : ChocolateyNuGetProjectContextSpecsBase
+        {
+            public override void Because()
+            { }
+
+            public override void BeforeEachSpec()
+            {
+                base.BeforeEachSpec();
+
+                Logger.ResetCalls();
+            }
+
+            [Fact]
+            public void should_log_debug_information_in_child_logger()
+            {
+                Service.Log(MessageLevel.Debug, "Some {0} message", "DEBUG");
+
+                Logger.Verify(l => l.LogDebug("Some DEBUG message"), Times.Once);
+
+                // TODO: Uncomment once Moq is upgrade to v4.8 or later.
+                //Logger.VerifyNoOtherCalls();
+            }
+
+            [Fact]
+            public void should_log_error_information_in_child_logger()
+            {
+                Service.Log(MessageLevel.Error, "Some {0} message", "ERROR");
+
+                Logger.Verify(l => l.LogError("Some ERROR message"), Times.Once);
+
+                // TODO: Uncomment once Moq is upgrade to v4.8 or later.
+                //Logger.VerifyNoOtherCalls();
+            }
+
+            [Fact]
+            public void should_log_info_information_in_child_logger()
+            {
+                Service.Log(MessageLevel.Info, "Some {0} message", "INFO");
+
+                Logger.Verify(l => l.LogInformation("Some INFO message"), Times.Once);
+
+                // TODO: Uncomment once Moq is upgrade to v4.8 or later.
+                //Logger.VerifyNoOtherCalls();
+            }
+
+            [TestCase(LogLevel.Debug)]
+            public void should_log_to_child_logger_and_pass_along_original_message(LogLevel logLevel)
+            {
+                var logMessage = new LogMessage(logLevel, "My awesome message");
+
+                Service.Log(logMessage);
+
+                Logger.Verify(l => l.Log(logMessage), Times.Once);
+
+                // TODO: Uncomment once Moq is upgrade to v4.8 or later.
+                //Logger.VerifyNoOtherCalls();
+            }
+
+            [Fact]
+            public void should_log_warning_information_in_child_logger()
+            {
+                Service.Log(MessageLevel.Warning, "Some {0} message", "WARNING");
+
+                Logger.Verify(l => l.LogWarning("Some WARNING message"), Times.Once);
+
+                // TODO: Uncomment once Moq is upgrade to v4.8 or later.
+                //Logger.VerifyNoOtherCalls();
+            }
+
+            [Fact]
+            public void should_report_errors_to_child_logger()
+            {
+                Service.ReportError("Some kind of error!");
+
+                Logger.Verify(l => l.LogError("Some kind of error!"), Times.Once);
+
+                // TODO: Uncomment once Moq is upgrade to v4.8 or later.
+                //Logger.VerifyNoOtherCalls();
+            }
+
+            [Fact]
+            public void should_report_errors_with_message_to_child_logger()
+            {
+                var logMessage = new LogMessage(LogLevel.Debug, "Some message");
+
+                Service.ReportError(logMessage);
+
+                Logger.Verify(l => l.Log(logMessage), Times.Once);
+
+                // TODO: Uncomment once Moq is upgrade to v4.8 or later.
+                //Logger.VerifyNoOtherCalls();
+            }
+
+            [Fact]
+            public void should_report_warning_when_resolving_file_conflicts()
+            {
+                var message = "Some kind of message";
+
+                var result = Service.ResolveFileConflict(message);
+
+                result.ShouldEqual(FileConflictAction.OverwriteAll);
+
+                Logger.Verify(l => l.LogWarning("File conflict, overwriting all: Some kind of message"), Times.Once);
+
+                // TODO: Uncomment once Moq is upgrade to v4.8 or later.
+                //Logger.VerifyNoOtherCalls();
+            }
+        }
+    }
+}

--- a/src/chocolatey.tests/infrastructure.app/nuget/ChocolateyNugetLoggerSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/nuget/ChocolateyNugetLoggerSpecs.cs
@@ -48,6 +48,21 @@ namespace chocolatey.tests.infrastructure.app.nuget
             }
 
             [Fact]
+            public void should_log_debug_level_with_nuget_prefix_on_all_lines_when_calling_LogDebug()
+            {
+                const string testMessage = "This should be a debug message.\r\nThis is the second line after CRLF line ending.\nThis is the third line after LF line ending.";
+                var expectedMessage = "[NuGet] This should be a debug message.{0}[NuGet] This is the second line after CRLF line ending.{0}[NuGet] This is the third line after LF line ending.".format_with(Environment.NewLine);
+
+                _logger.LogDebug(testMessage);
+
+                var loggerName = LogLevel.Debug.to_string();
+                MockLogger.LoggerNames.Count.ShouldEqual(1);
+                MockLogger.LoggerNames.ShouldContain(typeof(ChocolateyNugetLogger).FullName);
+                MockLogger.Messages.Keys.ShouldContain(loggerName);
+                MockLogger.Messages[loggerName].ShouldContain(expectedMessage);
+            }
+
+            [Fact]
             public void should_log_debug_level_with_nuget_prefix_when_calling_LogDebug()
             {
                 const string testMessage = "This should be a debug message";
@@ -56,6 +71,21 @@ namespace chocolatey.tests.infrastructure.app.nuget
                 _logger.LogDebug(testMessage);
 
                 var loggerName = LogLevel.Debug.to_string();
+                MockLogger.LoggerNames.Count.ShouldEqual(1);
+                MockLogger.LoggerNames.ShouldContain(typeof(ChocolateyNugetLogger).FullName);
+                MockLogger.Messages.Keys.ShouldContain(loggerName);
+                MockLogger.Messages[loggerName].ShouldContain(expectedMessage);
+            }
+
+            [Fact]
+            public void should_log_error_level_with_nuget_prefix_on_all_lines_when_calling_LogError()
+            {
+                const string testMessage = "This should be a error message.\r\nThis is the second line after CRLF line ending.\nThis is the third line after LF line ending.";
+                var expectedMessage = "[NuGet] This should be a error message.{0}[NuGet] This is the second line after CRLF line ending.{0}[NuGet] This is the third line after LF line ending.".format_with(Environment.NewLine);
+
+                _logger.LogError(testMessage);
+
+                var loggerName = LogLevel.Error.to_string();
                 MockLogger.LoggerNames.Count.ShouldEqual(1);
                 MockLogger.LoggerNames.ShouldContain(typeof(ChocolateyNugetLogger).FullName);
                 MockLogger.Messages.Keys.ShouldContain(loggerName);
@@ -130,6 +160,21 @@ namespace chocolatey.tests.infrastructure.app.nuget
             }
 
             [Fact]
+            public void should_log_info_level_with_nuget_prefix_on_all_lines_when_calling_LogInformationSummary()
+            {
+                const string testMessage = "This should be a error message.\r\nThis is the second line after CRLF line ending.\nThis is the third line after LF line ending.";
+                var expectedMessage = "[NuGet] This should be a error message.{0}[NuGet] This is the second line after CRLF line ending.{0}[NuGet] This is the third line after LF line ending.".format_with(Environment.NewLine);
+
+                _logger.LogInformationSummary(testMessage);
+
+                var loggerName = LogLevel.Info.to_string();
+                MockLogger.LoggerNames.Count.ShouldEqual(1);
+                MockLogger.LoggerNames.ShouldContain(typeof(ChocolateyNugetLogger).FullName);
+                MockLogger.Messages.Keys.ShouldContain(loggerName);
+                MockLogger.Messages[loggerName].ShouldContain(expectedMessage);
+            }
+
+            [Fact]
             public void should_log_info_level_with_nuget_prefix_when_calling_LogInformationSummary()
             {
                 const string testMessage = "This should be a informational message";
@@ -189,6 +234,51 @@ namespace chocolatey.tests.infrastructure.app.nuget
             }
 
             [Fact]
+            public void should_log_verbose_level_with_nuget_prefix_on_all_lines_when_calling_LogInformation()
+            {
+                const string testMessage = "This should be a informational verbose message.\r\nThis is the second line after CRLF line ending.\nThis is the third line after LF line ending.";
+                var expectedMessage = "[NuGet] This should be a informational verbose message.{0}[NuGet] This is the second line after CRLF line ending.{0}[NuGet] This is the third line after LF line ending.".format_with(Environment.NewLine);
+
+                _logger.LogInformation(testMessage);
+
+                var loggerName = LogLevel.Info.to_string();
+                MockLogger.LoggerNames.Count.ShouldEqual(2);
+                MockLogger.LoggerNames.ShouldContain("Verbose");
+                MockLogger.Messages.Keys.ShouldContain(loggerName);
+                MockLogger.Messages[loggerName].ShouldContain(expectedMessage);
+            }
+
+            [Fact]
+            public void should_log_verbose_level_with_nuget_prefix_on_all_lines_when_calling_LogMinimal()
+            {
+                const string testMessage = "This should be a error message.\r\nThis is the second line after CRLF line ending.\nThis is the third line after LF line ending.";
+                var expectedMessage = "[NuGet] This should be a error message.{0}[NuGet] This is the second line after CRLF line ending.{0}[NuGet] This is the third line after LF line ending.".format_with(Environment.NewLine);
+
+                _logger.LogMinimal(testMessage);
+
+                var loggerName = LogLevel.Info.to_string();
+                MockLogger.LoggerNames.Count.ShouldEqual(2);
+                MockLogger.LoggerNames.ShouldContain("Verbose");
+                MockLogger.Messages.Keys.ShouldContain(loggerName);
+                MockLogger.Messages[loggerName].ShouldContain(expectedMessage);
+            }
+
+            [Fact]
+            public void should_log_verbose_level_with_nuget_prefix_on_all_lines_when_calling_LogVerbose()
+            {
+                const string testMessage = "This should be a verbose message.\r\nThis is the second line after CRLF line ending.\nThis is the third line after LF line ending.";
+                var expectedMessage = "[NuGet] This should be a verbose message.{0}[NuGet] This is the second line after CRLF line ending.{0}[NuGet] This is the third line after LF line ending.".format_with(Environment.NewLine);
+
+                _logger.LogVerbose(testMessage);
+
+                var loggerName = LogLevel.Info.to_string();
+                MockLogger.LoggerNames.Count.ShouldEqual(2);
+                MockLogger.LoggerNames.ShouldContain("Verbose");
+                MockLogger.Messages.Keys.ShouldContain(loggerName);
+                MockLogger.Messages[loggerName].ShouldContain(expectedMessage);
+            }
+
+            [Fact]
             public void should_log_verbose_level_with_nuget_prefix_when_calling_LogInformation()
             {
                 const string testMessage = "This should be a informational verbose message";
@@ -234,6 +324,21 @@ namespace chocolatey.tests.infrastructure.app.nuget
             }
 
             [Fact]
+            public void should_log_warn_level_with_nuget_prefix_on_all_lines_when_calling_LogWarning()
+            {
+                const string testMessage = "This should be a warning message.\r\nThis is the second line after CRLF line ending.\nThis is the third line after LF line ending.";
+                var expectedMessage = "[NuGet] This should be a warning message.{0}[NuGet] This is the second line after CRLF line ending.{0}[NuGet] This is the third line after LF line ending.".format_with(Environment.NewLine);
+
+                _logger.LogWarning(testMessage);
+
+                var loggerName = LogLevel.Warn.to_string();
+                MockLogger.LoggerNames.Count.ShouldEqual(1);
+                MockLogger.LoggerNames.ShouldContain(typeof(ChocolateyNugetLogger).FullName);
+                MockLogger.Messages.Keys.ShouldContain(loggerName);
+                MockLogger.Messages[loggerName].ShouldContain(expectedMessage);
+            }
+
+            [Fact]
             public void should_log_warn_level_with_nuget_prefix_when_calling_LogWarning()
             {
                 const string testMessage = "This should be a warning message";
@@ -246,6 +351,40 @@ namespace chocolatey.tests.infrastructure.app.nuget
                 MockLogger.LoggerNames.ShouldContain(typeof(ChocolateyNugetLogger).FullName);
                 MockLogger.Messages.Keys.ShouldContain(loggerName);
                 MockLogger.Messages[loggerName].ShouldContain(expectedMessage);
+            }
+
+            [TestCase("")]
+            [TestCase("       ")]
+            public void should_not_output_whitespace_only_line_in_multiline_logging(string testType)
+            {
+                var testValue = "I will be containing\n{0}\nsome whitespace".format_with(testType);
+                var expectedValue = "[NuGet] I will be containing{0}[NuGet]{0}[NuGet] some whitespace".format_with(Environment.NewLine);
+
+                _logger.Log(NuGetLogLevel.Minimal, testValue);
+                MockLogger.Messages.Keys.ShouldContain("Info");
+                MockLogger.Messages["Info"].ShouldContain(expectedValue);
+            }
+
+            [TestCase(null)]
+            [TestCase("")]
+            [TestCase("    ")]
+            public void should_only_output_prefix_for_null_or_empty_values(string testValue)
+            {
+                _logger.Log(NuGetLogLevel.Minimal, testValue);
+
+                MockLogger.Messages.Keys.ShouldContain("Info");
+                MockLogger.Messages["Info"].ShouldContain("[NuGet]");
+            }
+
+            [TestCase("\n\n\n\n\n")]
+            [TestCase("\r\n\r\n\r\n\r\n\r\n")]
+            public void should_only_output_prefixes_on_every_line(string testValue)
+            {
+                var expectedValue = "[NuGet]{0}[NuGet]{0}[NuGet]{0}[NuGet]{0}[NuGet]".format_with(Environment.NewLine);
+
+                _logger.Log(NuGetLogLevel.Information, testValue);
+                MockLogger.Messages.Keys.ShouldContain("Info");
+                MockLogger.Messages["Info"].ShouldContain(expectedValue);
             }
         }
     }

--- a/src/chocolatey.tests/infrastructure.app/nuget/ChocolateyNugetLoggerSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/nuget/ChocolateyNugetLoggerSpecs.cs
@@ -1,0 +1,252 @@
+﻿// Copyright © 2022-Present Chocolatey Software, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace chocolatey.tests.infrastructure.app.nuget
+{
+    using System;
+    using System.Threading.Tasks;
+    using chocolatey.infrastructure.app.nuget;
+    using NuGet.Common;
+    using NUnit.Framework;
+    using Should;
+
+    using LogLevel = chocolatey.tests.LogLevel;
+    using NuGetLogLevel = NuGet.Common.LogLevel;
+
+    public class ChocolateyNugetLoggerSpecs
+    {
+        [Categories.Logging]
+        public class when_calling_log_level_methods_should_log_with_appropriate_log_type : TinySpec
+        {
+            private ILogger _logger;
+
+            public override void Because()
+            {
+            }
+
+            public override void BeforeEachSpec()
+            {
+                base.BeforeEachSpec();
+                MockLogger.reset();
+            }
+
+            public override void Context()
+            {
+                _logger = new ChocolateyNugetLogger();
+            }
+
+            [Fact]
+            public void should_log_debug_level_with_nuget_prefix_when_calling_LogDebug()
+            {
+                const string testMessage = "This should be a debug message";
+                const string expectedMessage = "[NuGet] " + testMessage;
+
+                _logger.LogDebug(testMessage);
+
+                var loggerName = LogLevel.Debug.to_string();
+                MockLogger.LoggerNames.Count.ShouldEqual(1);
+                MockLogger.LoggerNames.ShouldContain(typeof(ChocolateyNugetLogger).FullName);
+                MockLogger.Messages.Keys.ShouldContain(loggerName);
+                MockLogger.Messages[loggerName].ShouldContain(expectedMessage);
+            }
+
+            [Fact]
+            public void should_log_error_level_with_nuget_prefix_when_calling_LogError()
+            {
+                const string testMessage = "This should be a error message";
+                const string expectedMessage = "[NuGet] " + testMessage;
+
+                _logger.LogError(testMessage);
+
+                var loggerName = LogLevel.Error.to_string();
+                MockLogger.LoggerNames.Count.ShouldEqual(1);
+                MockLogger.LoggerNames.ShouldContain(typeof(ChocolateyNugetLogger).FullName);
+                MockLogger.Messages.Keys.ShouldContain(loggerName);
+                MockLogger.Messages[loggerName].ShouldContain(expectedMessage);
+            }
+
+            [TestCase(NuGetLogLevel.Debug, LogLevel.Debug, "Test debug message", "[NuGet] Test debug message")]
+            [TestCase(NuGetLogLevel.Error, LogLevel.Error, "Test error message", "[NuGet] Test error message")]
+            [TestCase(NuGetLogLevel.Minimal, LogLevel.Info, "Test informational message", "[NuGet] Test informational message")]
+            [TestCase(NuGetLogLevel.Warning, LogLevel.Warn, "Test warning message", "[NuGet] Test warning message")]
+            public void should_log_expected_log_level_when_calling_Log_with_log_message(NuGetLogLevel nugetLogLevel, LogLevel logLevel, string testMessage, string expectedMessage)
+            {
+                _logger.Log(new LogMessage(nugetLogLevel, testMessage));
+                MockLogger.LoggerNames.Count.ShouldEqual(1);
+                MockLogger.LoggerNames.ShouldContain(typeof(ChocolateyNugetLogger).FullName);
+                MockLogger.Messages.Keys.ShouldContain(logLevel.to_string());
+                MockLogger.Messages[logLevel.to_string()].ShouldContain(expectedMessage);
+            }
+
+            [TestCase(NuGetLogLevel.Debug, LogLevel.Debug, "Test debug message", "[NuGet] Test debug message")]
+            [TestCase(NuGetLogLevel.Error, LogLevel.Error, "Test error message", "[NuGet] Test error message")]
+            [TestCase(NuGetLogLevel.Minimal, LogLevel.Info, "Test informational message", "[NuGet] Test informational message")]
+            [TestCase(NuGetLogLevel.Warning, LogLevel.Warn, "Test warning message", "[NuGet] Test warning message")]
+            public void should_log_expected_log_level_when_calling_Log_with_nuget_log_level(NuGetLogLevel nugetLogLevel, LogLevel logLevel, string testMessage, string expectedMessage)
+            {
+                _logger.Log(nugetLogLevel, testMessage);
+                MockLogger.LoggerNames.Count.ShouldEqual(1);
+                MockLogger.LoggerNames.ShouldContain(typeof(ChocolateyNugetLogger).FullName);
+                MockLogger.Messages.Keys.ShouldContain(logLevel.to_string());
+                MockLogger.Messages[logLevel.to_string()].ShouldContain(expectedMessage);
+            }
+
+            [TestCase(NuGetLogLevel.Debug, LogLevel.Debug, "Test debug message", "[NuGet] Test debug message")]
+            [TestCase(NuGetLogLevel.Error, LogLevel.Error, "Test error message", "[NuGet] Test error message")]
+            [TestCase(NuGetLogLevel.Minimal, LogLevel.Info, "Test informational message", "[NuGet] Test informational message")]
+            [TestCase(NuGetLogLevel.Warning, LogLevel.Warn, "Test warning message", "[NuGet] Test warning message")]
+            public async Task should_log_expected_log_level_when_calling_LogAsync_with_nuget_log_level(NuGetLogLevel nugetLogLevel, LogLevel logLevel, string testMessage, string expectedMessage)
+            {
+                await _logger.LogAsync(nugetLogLevel, testMessage);
+                MockLogger.LoggerNames.Count.ShouldEqual(1);
+                MockLogger.LoggerNames.ShouldContain(typeof(ChocolateyNugetLogger).FullName);
+                MockLogger.Messages.Keys.ShouldContain(logLevel.to_string());
+                MockLogger.Messages[logLevel.to_string()].ShouldContain(expectedMessage);
+            }
+
+            [TestCase(NuGetLogLevel.Debug, LogLevel.Debug, "Test debug message", "[NuGet] Test debug message")]
+            [TestCase(NuGetLogLevel.Error, LogLevel.Error, "Test error message", "[NuGet] Test error message")]
+            [TestCase(NuGetLogLevel.Minimal, LogLevel.Info, "Test informational message", "[NuGet] Test informational message")]
+            [TestCase(NuGetLogLevel.Warning, LogLevel.Warn, "Test warning message", "[NuGet] Test warning message")]
+            public async Task should_log_expected_log_level_when_calling_LogAsync_with_nuget_log_message(NuGetLogLevel nugetLogLevel, LogLevel logLevel, string testMessage, string expectedMessage)
+            {
+                await _logger.LogAsync(new LogMessage(nugetLogLevel, testMessage));
+                MockLogger.LoggerNames.Count.ShouldEqual(1);
+                MockLogger.LoggerNames.ShouldContain(typeof(ChocolateyNugetLogger).FullName);
+                MockLogger.Messages.Keys.ShouldContain(logLevel.to_string());
+                MockLogger.Messages[logLevel.to_string()].ShouldContain(expectedMessage);
+            }
+
+            [Fact]
+            public void should_log_info_level_with_nuget_prefix_when_calling_LogInformationSummary()
+            {
+                const string testMessage = "This should be a informational message";
+                const string expectedMessage = "[NuGet] " + testMessage;
+
+                _logger.LogInformationSummary(testMessage);
+
+                var loggerName = LogLevel.Info.to_string();
+                MockLogger.LoggerNames.Count.ShouldEqual(1);
+                MockLogger.LoggerNames.ShouldContain(typeof(ChocolateyNugetLogger).FullName);
+                MockLogger.Messages.Keys.ShouldContain(loggerName);
+                MockLogger.Messages[loggerName].ShouldContain(expectedMessage);
+            }
+
+            [TestCase(NuGetLogLevel.Verbose, "Test verbose message", "[NuGet] Test verbose message")]
+            [TestCase(NuGetLogLevel.Information, "Test informational verbose message", "[NuGet] Test informational verbose message")]
+            public void should_log_verbose_level_when_calling_Log_with_nuget_log_level(NuGetLogLevel nuGetLogLevel, string testMessage, string expectedMessage)
+            {
+                _logger.Log(nuGetLogLevel, testMessage);
+                MockLogger.LoggerNames.Count.ShouldEqual(2);
+                MockLogger.LoggerNames.ShouldContain("Verbose");
+                MockLogger.Messages.Keys.ShouldContain("Info");
+                MockLogger.Messages["Info"].ShouldContain(expectedMessage);
+            }
+
+            [TestCase(NuGetLogLevel.Verbose, "Test verbose message", "[NuGet] Test verbose message")]
+            [TestCase(NuGetLogLevel.Information, "Test informational verbose message", "[NuGet] Test informational verbose message")]
+            public void should_log_verbose_level_when_calling_Log_with_nuget_log_message(NuGetLogLevel nuGetLogLevel, string testMessage, string expectedMessage)
+            {
+                _logger.Log(new LogMessage(nuGetLogLevel, testMessage));
+                MockLogger.LoggerNames.Count.ShouldEqual(2);
+                MockLogger.LoggerNames.ShouldContain("Verbose");
+                MockLogger.Messages.Keys.ShouldContain("Info");
+                MockLogger.Messages["Info"].ShouldContain(expectedMessage);
+            }
+
+            [TestCase(NuGetLogLevel.Verbose, "Test verbose message", "[NuGet] Test verbose message")]
+            [TestCase(NuGetLogLevel.Information, "Test informational verbose message", "[NuGet] Test informational verbose message")]
+            public async Task should_log_verbose_level_when_calling_LogAsync_with_nuget_log_level(NuGetLogLevel nuGetLogLevel, string testMessage, string expectedMessage)
+            {
+                await _logger.LogAsync(nuGetLogLevel, testMessage);
+                MockLogger.LoggerNames.Count.ShouldEqual(2);
+                MockLogger.LoggerNames.ShouldContain("Verbose");
+                MockLogger.Messages.Keys.ShouldContain("Info");
+                MockLogger.Messages["Info"].ShouldContain(expectedMessage);
+            }
+
+            [TestCase(NuGetLogLevel.Verbose, "Test verbose message", "[NuGet] Test verbose message")]
+            [TestCase(NuGetLogLevel.Information, "Test informational verbose message", "[NuGet] Test informational verbose message")]
+            public async Task should_log_verbose_level_when_calling_LogAsync_with_nuget_log_message(NuGetLogLevel nuGetLogLevel, string testMessage, string expectedMessage)
+            {
+                await _logger.LogAsync(new LogMessage(nuGetLogLevel, testMessage));
+                MockLogger.LoggerNames.Count.ShouldEqual(2);
+                MockLogger.LoggerNames.ShouldContain("Verbose");
+                MockLogger.Messages.Keys.ShouldContain("Info");
+                MockLogger.Messages["Info"].ShouldContain(expectedMessage);
+            }
+
+            [Fact]
+            public void should_log_verbose_level_with_nuget_prefix_when_calling_LogInformation()
+            {
+                const string testMessage = "This should be a informational verbose message";
+                const string expectedMessage = "[NuGet] " + testMessage;
+
+                _logger.LogInformation(testMessage);
+
+                var loggerName = LogLevel.Info.to_string();
+                MockLogger.LoggerNames.Count.ShouldEqual(2);
+                MockLogger.LoggerNames.ShouldContain("Verbose");
+                MockLogger.Messages.Keys.ShouldContain(loggerName);
+                MockLogger.Messages[loggerName].ShouldContain(expectedMessage);
+            }
+
+            [Fact]
+            public void should_log_verbose_level_with_nuget_prefix_when_calling_LogMinimal()
+            {
+                const string testMessage = "This should be a informational message";
+                const string expectedMessage = "[NuGet] " + testMessage;
+
+                _logger.LogMinimal(testMessage);
+
+                var loggerName = LogLevel.Info.to_string();
+                MockLogger.LoggerNames.Count.ShouldEqual(2);
+                MockLogger.LoggerNames.ShouldContain("Verbose");
+                MockLogger.Messages.Keys.ShouldContain(loggerName);
+                MockLogger.Messages[loggerName].ShouldContain(expectedMessage);
+            }
+
+            [Fact]
+            public void should_log_verbose_level_with_nuget_prefix_when_calling_LogVerbose()
+            {
+                const string testMessage = "This should be a verbose message";
+                const string expectedMessage = "[NuGet] " + testMessage;
+
+                _logger.LogVerbose(testMessage);
+
+                var loggerName = LogLevel.Info.to_string();
+                MockLogger.LoggerNames.Count.ShouldEqual(2);
+                MockLogger.LoggerNames.ShouldContain("Verbose");
+                MockLogger.Messages.Keys.ShouldContain(loggerName);
+                MockLogger.Messages[loggerName].ShouldContain(expectedMessage);
+            }
+
+            [Fact]
+            public void should_log_warn_level_with_nuget_prefix_when_calling_LogWarning()
+            {
+                const string testMessage = "This should be a warning message";
+                const string expectedMessage = "[NuGet] " + testMessage;
+
+                _logger.LogWarning(testMessage);
+
+                var loggerName = LogLevel.Warn.to_string();
+                MockLogger.LoggerNames.Count.ShouldEqual(1);
+                MockLogger.LoggerNames.ShouldContain(typeof(ChocolateyNugetLogger).FullName);
+                MockLogger.Messages.Keys.ShouldContain(loggerName);
+                MockLogger.Messages[loggerName].ShouldContain(expectedMessage);
+            }
+        }
+    }
+}

--- a/src/chocolatey.tests/packages.config
+++ b/src/chocolatey.tests/packages.config
@@ -1,12 +1,20 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Chocolatey.NuGet.Commands" version="3.0.0-alpha-20221213-80" targetFramework="net48" />
   <package id="Chocolatey.NuGet.Common" version="3.0.0-alpha-20221213-80" targetFramework="net48" />
   <package id="Chocolatey.NuGet.Configuration" version="3.0.0-alpha-20221213-80" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.Credentials" version="3.0.0-alpha-20221213-80" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.DependencyResolver.Core" version="3.0.0-alpha-20221213-80" targetFramework="net48" />
   <package id="Chocolatey.NuGet.Frameworks" version="3.0.0-alpha-20221213-80" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.LibraryModel" version="3.0.0-alpha-20221213-80" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.PackageManagement" version="3.0.0-alpha-20221213-80" targetFramework="net48" />
   <package id="Chocolatey.NuGet.Packaging" version="3.0.0-alpha-20221213-80" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.ProjectModel" version="3.0.0-alpha-20221213-80" targetFramework="net48" />
   <package id="Chocolatey.NuGet.Protocol" version="3.0.0-alpha-20221213-80" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.Resolver" version="3.0.0-alpha-20221213-80" targetFramework="net48" />
   <package id="Chocolatey.NuGet.Versioning" version="3.0.0-alpha-20221213-80" targetFramework="net48" />
   <package id="log4net" version="2.0.12" targetFramework="net48" />
+  <package id="Microsoft.CSharp" version="4.3.0" targetFramework="net48" />
   <package id="Microsoft.Web.Xdt" version="3.1.0" targetFramework="net48" />
   <package id="Moq" version="4.2.1402.2112" targetFramework="net40" />
   <package id="Newtonsoft.Json" version="13.0.1" targetFramework="net48" />

--- a/src/chocolatey/infrastructure.app/nuget/ChocolateyNuGetProjectContext.cs
+++ b/src/chocolatey/infrastructure.app/nuget/ChocolateyNuGetProjectContext.cs
@@ -17,6 +17,8 @@ namespace chocolatey.infrastructure.app.nuget
 
     public class ChocolateyNuGetProjectContext : INuGetProjectContext
     {
+        private readonly ILogger _logger;
+
         public ChocolateyNuGetProjectContext(ChocolateyConfiguration config, ILogger logger)
         {
             //TODO, set client policy correctly here with settings, fix in chocolatey implementation of ISettings for this purpose
@@ -28,6 +30,7 @@ namespace chocolatey.infrastructure.app.nuget
                 clientPolicyContext,
                 logger
                 );
+            _logger = logger;
         }
 
         private PackageExtractionContext _extractionContext;
@@ -37,78 +40,38 @@ namespace chocolatey.infrastructure.app.nuget
             switch (level)
             {
                 case MessageLevel.Debug:
-                    this.Log().Debug("[NuGet] " + message, args);
+                    _logger.LogDebug(message.format_with(args));
                     break;
                 case MessageLevel.Info:
-                    this.Log().Info("[NuGet] " + message, args);
+                    _logger.LogInformation(message.format_with(args));
                     break;
                 case MessageLevel.Warning:
-                    this.Log().Warn("[NuGet] " + message, args);
+                    _logger.LogWarning(message.format_with(args));
                     break;
                 case MessageLevel.Error:
-                    this.Log().Error("[NuGet] " + message, args);
+                    _logger.LogError(message.format_with(args));
                     break;
             }
         }
 
         public void Log(ILogMessage message)
         {
-            switch (message.Level)
-            {
-                case LogLevel.Debug:
-                    this.Log().Debug("[NuGet] " + message.Message);
-                    break;
-                case LogLevel.Warning:
-                    this.Log().Warn("[NuGet] " + message.Message);
-                    break;
-                case LogLevel.Error:
-                    this.Log().Error("[NuGet] " + message.Message);
-                    break;
-                case LogLevel.Verbose:
-                    this.Log().Info(ChocolateyLoggers.Verbose, "[NuGet] " + message.Message);
-                    break;
-                case LogLevel.Information:
-                    this.Log().Info(ChocolateyLoggers.Verbose, "[NuGet] " + message.Message);
-                    break;
-                case LogLevel.Minimal:
-                    this.Log().Info("[NuGet] " + message.Message);
-                    break;
-            }
+            _logger.Log(message);
         }
 
         public void ReportError(string message)
         {
-            this.Log().Error("[NuGet] " + message);
+            _logger.LogError(message);
         }
 
         public void ReportError(ILogMessage message)
         {
-            switch (message.Level)
-            {
-                case LogLevel.Debug:
-                    this.Log().Debug("[NuGet] " + message.Message);
-                    break;
-                case LogLevel.Warning:
-                    this.Log().Warn("[NuGet] " + message.Message);
-                    break;
-                case LogLevel.Error:
-                    this.Log().Error("[NuGet] " + message.Message);
-                    break;
-                case LogLevel.Verbose:
-                    this.Log().Info(ChocolateyLoggers.Verbose, "[NuGet] " + message.Message);
-                    break;
-                case LogLevel.Information:
-                    this.Log().Info(ChocolateyLoggers.Verbose, "[NuGet] " + message.Message);
-                    break;
-                case LogLevel.Minimal:
-                    this.Log().Info("[NuGet] " + message.Message);
-                    break;
-            }
+            _logger.Log(message);
         }
 
         public FileConflictAction ResolveFileConflict(string message)
         {
-            this.Log().Warn("[NuGet] File conflict, overwriting all: " + message);
+            _logger.LogWarning("File conflict, overwriting all: {0}".format_with(message));
             return FileConflictAction.OverwriteAll;
         }
 

--- a/src/chocolatey/infrastructure.app/nuget/ChocolateyNugetLogger.cs
+++ b/src/chocolatey/infrastructure.app/nuget/ChocolateyNugetLogger.cs
@@ -46,12 +46,22 @@ namespace chocolatey.infrastructure.app.nuget
 
         public void LogMinimal(string message)
         {
-            this.Log().Info( "[NuGet] " + message);
+            // We log this as informational as we do not want
+            // the output being shown to the user by default.
+            // This includes information such as the time taken
+            // to resolve dependencies, where the package was added
+            // and so on.
+            Log(LogLevel.Information, message);
         }
 
         public void LogInformation(string message)
         {
-            this.Log().Info("[NuGet] " + message);
+            // We log this as informational as we do not want
+            // the output being shown to the user by default.
+            // This includes information such as the time taken
+            // to resolve dependencies, where the package was added
+            // and so on.
+            Log(LogLevel.Information, message);
         }
 
         public void LogInformationSummary(string message)

--- a/src/chocolatey/infrastructure.app/nuget/ChocolateyNugetLogger.cs
+++ b/src/chocolatey/infrastructure.app/nuget/ChocolateyNugetLogger.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2022 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,6 +16,7 @@
 
 namespace chocolatey.infrastructure.app.nuget
 {
+    using System;
     using System.Threading.Tasks;
     using logging;
     using NuGet.Common;
@@ -26,22 +27,22 @@ namespace chocolatey.infrastructure.app.nuget
     {
         public void LogDebug(string message)
         {
-            this.Log().Debug("[NuGet] " + message);
+            Log(LogLevel.Debug, message);
         }
 
         public void LogVerbose(string message)
         {
-            this.Log().Info(ChocolateyLoggers.Verbose, "[NuGet] " + message);
+            Log(LogLevel.Verbose, message);
         }
 
         public void LogWarning(string message)
         {
-            this.Log().Warn("[NuGet] " + message);
+            Log(LogLevel.Warning, message);
         }
 
         public void LogError(string message)
         {
-            this.Log().Error("[NuGet] " + message);
+            Log(LogLevel.Error, message);
         }
 
         public void LogMinimal(string message)
@@ -66,7 +67,9 @@ namespace chocolatey.infrastructure.app.nuget
 
         public void LogInformationSummary(string message)
         {
-            this.Log().Info("[NuGet] " + message);
+            // We log it as minimal as we want the output to
+            // be shown as an informational message in this case.
+            Log(LogLevel.Minimal, message);
         }
 
         public void Log(LogLevel level, string message)
@@ -91,85 +94,27 @@ namespace chocolatey.infrastructure.app.nuget
                 case LogLevel.Minimal:
                     this.Log().Info("[NuGet] " + message);
                     break;
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(level));
             }
         }
 
         public Task LogAsync(LogLevel level, string message)
         {
-            switch (level)
-            {
-                case LogLevel.Debug:
-                    this.Log().Debug("[NuGet] " + message);
-                    break;
-                case LogLevel.Warning:
-                    this.Log().Warn("[NuGet] " + message);
-                    break;
-                case LogLevel.Error:
-                    this.Log().Error("[NuGet] " + message);
-                    break;
-                case LogLevel.Verbose:
-                    this.Log().Info(ChocolateyLoggers.Verbose, "[NuGet] " + message);
-                    break;
-                case LogLevel.Information:
-                    this.Log().Info(ChocolateyLoggers.Verbose, "[NuGet] " + message);
-                    break;
-                case LogLevel.Minimal:
-                    this.Log().Info("[NuGet] " + message);
-                    break;
-            }
+            Log(level, message);
 
             return Task.CompletedTask;
         }
 
         public void Log(ILogMessage log)
         {
-            switch (log.Level)
-            {
-                case LogLevel.Debug:
-                    this.Log().Debug("[NuGet] " + log.Message);
-                    break;
-                case LogLevel.Warning:
-                    this.Log().Warn("[NuGet] " + log.Message);
-                    break;
-                case LogLevel.Error:
-                    this.Log().Error("[NuGet] " + log.Message);
-                    break;
-                case LogLevel.Verbose:
-                    this.Log().Info(ChocolateyLoggers.Verbose, "[NuGet] " + log.Message);
-                    break;
-                case LogLevel.Information:
-                    this.Log().Info(ChocolateyLoggers.Verbose, "[NuGet] " + log.Message);
-                    break;
-                case LogLevel.Minimal:
-                    this.Log().Info("[NuGet] " + log.Message);
-                    break;
-            }
+            Log(log.Level, log.Message);
         }
 
         public Task LogAsync(ILogMessage log)
         {
-            switch (log.Level)
-            {
-                case LogLevel.Debug:
-                    this.Log().Debug("[NuGet] " + log.Message);
-                    break;
-                case LogLevel.Warning:
-                    this.Log().Warn("[NuGet] " + log.Message);
-                    break;
-                case LogLevel.Error:
-                    this.Log().Error("[NuGet] " + log.Message);
-                    break;
-                case LogLevel.Verbose:
-                    this.Log().Info(ChocolateyLoggers.Verbose, "[NuGet] " + log.Message);
-                    break;
-                case LogLevel.Information:
-                    this.Log().Info(ChocolateyLoggers.Verbose, "[NuGet] " + log.Message);
-                    break;
-                case LogLevel.Minimal:
-                    this.Log().Info("[NuGet] " + log.Message);
-                    break;
-            }
-            return Task.CompletedTask;
+            return LogAsync(log.Level, log.Message);
         }
     }
 


### PR DESCRIPTION
## Description Of Changes

This pull request updates the custom nuget logger we are using to not log normal informational output to the console unless `--verbose` is being used.
Additionally, this pull request updates the nuget logger, and the custom project context logging functionality to get rid of duplicated code.

## Motivation and Context

We do not want to obscure normal output for the user by including the information from NuGet.
While these can be helpful in some cases, hiding it behind a verbose flag by default make sense.

## Testing

1. Run `choco search 7zip.install`
2. Verify no output from NuGet is being shown
3. Run `choco search 7zip.install --verbose` (verbose in this case is synanymous with `--detailed`).
4. Verify the output from NuGet is shown with green text.
5. Run `choco info firefox`
6. Verify no output from NuGet is being shown
7. Run `choco info firefox --verbose`
8. Verify the output from NuGet is shown with green text.
9. Run `choco install trid --version 2.24.20221127`
10. Verify no output from NuGet is shown
11. Run `choco outdated`
12. Verify no output from NuGet is shown
13. Run `choco upgrade all`
14. Verify no output from NuGet is shown
14. Run `choco install 7zip.portable --version 19.0 --verbose`
15. Verify the output from NuGet is shown with green text.
16. Run `choco outdated --verbose`
17. Verify the output from NuGet is shown with green text.
18. Run `choco upgrade all --verbose`


### Operating Systems Testing

- Windows 11/10

## Change Types Made
<!-- Tick the boxes for the type of changes that have been made -->

* [x] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [x] Tests to cover my changes, have been added.
* [x] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue

#508  
https://app.clickup.com/t/20540031/PROJ-395