### PR TITLE
(#508) Add check for unsupported metadata elements.

### DIFF
--- a/src/chocolatey.tests.integration/NUnitSetup.cs
+++ b/src/chocolatey.tests.integration/NUnitSetup.cs
@@ -141,6 +141,7 @@ namespace chocolatey.tests.integration
 
             var files = fileSystem.get_files(contextDir, "*.nuspec", SearchOption.AllDirectories);
 
+            config.PackCommand.PackThrowOnUnsupportedElements = false;
             var command = container.GetInstance<ChocolateyPackCommand>();
             foreach (var file in files.or_empty_list_if_null())
             {
@@ -148,6 +149,7 @@ namespace chocolatey.tests.integration
                 Console.WriteLine("Building {0}".format_with(file));
                 command.run(config);
             }
+            config.PackCommand.PackThrowOnUnsupportedElements = true;
 
             Console.WriteLine("Moving all nupkgs in {0} to context directory.".format_with(fileSystem.get_current_directory()));
             var nupkgs = fileSystem.get_files(fileSystem.get_current_directory(), "*.nupkg");

--- a/src/chocolatey.tests.integration/chocolatey.tests.integration.csproj
+++ b/src/chocolatey.tests.integration/chocolatey.tests.integration.csproj
@@ -141,6 +141,7 @@
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
+    <Reference Include="WindowsBase" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="infrastructure.app\services\FilesServiceSpecs.cs" />

--- a/src/chocolatey.tests.integration/context/unsupportedelements/1.0.0/icon.png
+++ b/src/chocolatey.tests.integration/context/unsupportedelements/1.0.0/icon.png
@@ -1,0 +1,1 @@
+Text here

--- a/src/chocolatey.tests.integration/context/unsupportedelements/1.0.0/readme.md
+++ b/src/chocolatey.tests.integration/context/unsupportedelements/1.0.0/readme.md
@@ -1,0 +1,1 @@
+Text here

--- a/src/chocolatey.tests.integration/context/unsupportedelements/1.0.0/tools/chocolateyBeforeModify.ps1
+++ b/src/chocolatey.tests.integration/context/unsupportedelements/1.0.0/tools/chocolateyBeforeModify.ps1
@@ -1,0 +1,3 @@
+﻿Write-Output "$env:PackageName $env:PackageVersion Before Modification"
+
+throw "This should not break the upgrade/uninstall"

--- a/src/chocolatey.tests.integration/context/unsupportedelements/1.0.0/tools/chocolateyinstall.ps1
+++ b/src/chocolatey.tests.integration/context/unsupportedelements/1.0.0/tools/chocolateyinstall.ps1
@@ -1,0 +1,1 @@
+﻿Write-Output "$env:PackageName $env:PackageVersion Installed"

--- a/src/chocolatey.tests.integration/context/unsupportedelements/1.0.0/tools/chocolateyuninstall.ps1
+++ b/src/chocolatey.tests.integration/context/unsupportedelements/1.0.0/tools/chocolateyuninstall.ps1
@@ -1,0 +1,1 @@
+﻿Write-Output "$env:PackageName $env:PackageVersion Uninstalled"

--- a/src/chocolatey.tests.integration/context/unsupportedelements/1.0.0/unsupportedelements.nuspec
+++ b/src/chocolatey.tests.integration/context/unsupportedelements/1.0.0/unsupportedelements.nuspec
@@ -1,0 +1,33 @@
+<?xml version="1.0"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+  <metadata>
+    <id>unsupportedelements</id>
+    <version>1.0.0</version>
+    <title>unsupportedelements</title>
+    <authors>__REPLACE_AUTHORS_OF_SOFTWARE__</authors>
+    <owners>__REPLACE_YOUR_NAME__</owners>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <description>__REPLACE__</description>
+    <summary>__REPLACE__</summary>
+    <releaseNotes />
+    <tags>unsupportedelements admin</tags>
+    <serviceable>true</serviceable>
+    <license type="expression">MIT</license>
+    <repository type="git" url="https://github.com/NuGet/NuGet.Client.git" branch="dev" commit="e1c65e4524cd70ee6e22abe33e6cb6ec73938cb3" />
+    <packageTypes>
+        <packageType name="ContosoExtension" />
+    </packageTypes>
+    <frameworkReferences>
+      <group targetFramework=".NETCoreApp3.1">
+        <frameworkReference name="Chocolatey.Cake.Recipe" />
+      </group>
+    </frameworkReferences>
+    <readme>readme.md</readme>
+    <icon>icon.png</icon>
+  </metadata>
+  <files>
+    <file src="tools\**" target="tools" />
+    <file src="icon.png" target="icon.png" />
+    <file src="readme.md" target="readme.md" />
+  </files>
+</package>

--- a/src/chocolatey.tests.integration/context/unsupportedelements/1.1.0/icon.png
+++ b/src/chocolatey.tests.integration/context/unsupportedelements/1.1.0/icon.png
@@ -1,0 +1,1 @@
+Text here

--- a/src/chocolatey.tests.integration/context/unsupportedelements/1.1.0/readme.md
+++ b/src/chocolatey.tests.integration/context/unsupportedelements/1.1.0/readme.md
@@ -1,0 +1,1 @@
+Text here

--- a/src/chocolatey.tests.integration/context/unsupportedelements/1.1.0/tools/chocolateyBeforeModify.ps1
+++ b/src/chocolatey.tests.integration/context/unsupportedelements/1.1.0/tools/chocolateyBeforeModify.ps1
@@ -1,0 +1,1 @@
+﻿Write-Output "$env:PackageName $env:PackageVersion Before Modification"

--- a/src/chocolatey.tests.integration/context/unsupportedelements/1.1.0/tools/chocolateyinstall.ps1
+++ b/src/chocolatey.tests.integration/context/unsupportedelements/1.1.0/tools/chocolateyinstall.ps1
@@ -1,0 +1,1 @@
+﻿Write-Output "$env:PackageName $env:PackageVersion Installed"

--- a/src/chocolatey.tests.integration/context/unsupportedelements/1.1.0/tools/chocolateyuninstall.ps1
+++ b/src/chocolatey.tests.integration/context/unsupportedelements/1.1.0/tools/chocolateyuninstall.ps1
@@ -1,0 +1,1 @@
+﻿Write-Output "$env:PackageName $env:PackageVersion Uninstalled"

--- a/src/chocolatey.tests.integration/context/unsupportedelements/1.1.0/unsupportedelements.nuspec
+++ b/src/chocolatey.tests.integration/context/unsupportedelements/1.1.0/unsupportedelements.nuspec
@@ -1,0 +1,33 @@
+<?xml version="1.0"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+  <metadata>
+    <id>unsupportedelements</id>
+    <version>1.1.0</version>
+    <title>unsupportedelements</title>
+    <authors>__REPLACE_AUTHORS_OF_SOFTWARE__</authors>
+    <owners>__REPLACE_YOUR_NAME__</owners>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <description>__REPLACE__</description>
+    <summary>__REPLACE__</summary>
+    <releaseNotes />
+    <tags>unsupportedelements admin</tags>
+    <serviceable>true</serviceable>
+    <license type="expression">MIT</license>
+    <repository type="git" url="https://github.com/NuGet/NuGet.Client.git" branch="dev" commit="e1c65e4524cd70ee6e22abe33e6cb6ec73938cb3" />
+    <packageTypes>
+        <packageType name="ContosoExtension" />
+    </packageTypes>
+    <frameworkReferences>
+      <group targetFramework=".NETCoreApp3.1">
+        <frameworkReference name="Chocolatey.Cake.Recipe" />
+      </group>
+    </frameworkReferences>
+    <readme>readme.md</readme>
+    <icon>icon.png</icon>
+  </metadata>
+  <files>
+    <file src="tools\**" target="tools" />
+    <file src="icon.png" target="icon.png" />
+    <file src="readme.md" target="readme.md" />
+  </files>
+</package>

--- a/src/chocolatey.tests.integration/scenarios/InstallScenarios.cs
+++ b/src/chocolatey.tests.integration/scenarios/InstallScenarios.cs
@@ -4933,5 +4933,124 @@ namespace chocolatey.tests.integration.scenarios
                 MockLogger.contains_message("UpperCase 1.0.0 Installed", LogLevel.Info).ShouldBeTrue();
             }
         }
+
+        public class when_installing_a_package_with_unsupported_metadata_elements : ScenariosBase
+        {
+            private PackageResult _packageResult;
+
+            public override void Context()
+            {
+                base.Context();
+                Scenario.add_packages_to_source_location(Configuration, "unsupportedelements" + ".1.0.0" + NuGetConstants.PackageExtension);
+                Configuration.PackageNames = Configuration.Input = "unsupportedelements";
+            }
+
+            public override void Because()
+            {
+                Results = Service.install_run(Configuration);
+                _packageResult = Results.FirstOrDefault().Value;
+            }
+
+            [Fact]
+            public void should_install_where_install_location_reports()
+            {
+                DirectoryAssert.Exists(_packageResult.InstallLocation);
+            }
+
+            [Fact]
+            public void should_install_the_package_in_the_lib_directory()
+            {
+                var packageDir = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames);
+
+                DirectoryAssert.Exists(packageDir);
+            }
+
+            [Fact]
+            public void should_install_the_expected_version_of_the_package()
+            {
+                var packageFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, Configuration.PackageNames + NuGetConstants.PackageExtension);
+                using (var packageReader = new PackageArchiveReader(packageFile))
+                {
+                    packageReader.NuspecReader.GetVersion().to_string().ShouldEqual("1.0.0");
+                }
+            }
+
+            [Fact]
+            public void should_not_create_an_extensions_folder_for_the_package()
+            {
+                var extensionsDirectory = Path.Combine(Scenario.get_top_level(), "extensions", Configuration.PackageNames);
+
+                DirectoryAssert.DoesNotExist(extensionsDirectory);
+            }
+
+            [Fact]
+            public void should_not_create_an_hooks_folder_for_the_package()
+            {
+                var hooksDirectory = Path.Combine(Scenario.get_top_level(), "hooks", Configuration.PackageNames);
+
+                DirectoryAssert.DoesNotExist(hooksDirectory);
+            }
+
+            [Fact]
+            public void should_contain_a_warning_message_that_it_installed_successfully()
+            {
+                bool installedSuccessfully = false;
+                foreach (var message in MockLogger.MessagesFor(LogLevel.Warn).or_empty_list_if_null())
+                {
+                    if (message.Contains("1/1")) installedSuccessfully = true;
+                }
+
+                installedSuccessfully.ShouldBeTrue();
+            }
+
+            [Fact]
+            public void should_contain_a_warning_message_about_unsupported_elements()
+            {
+                bool upgradeMessage = false;
+                foreach (var message in MockLogger.MessagesFor(LogLevel.Warn).or_empty_list_if_null())
+                {
+                    if (message.Contains("Issues found with nuspec elements")) upgradeMessage = true;
+                }
+                upgradeMessage.ShouldBeTrue();
+            }
+
+            [Fact]
+            public void should_have_a_successful_package_result()
+            {
+                _packageResult.Success.ShouldBeTrue();
+            }
+
+            [Fact]
+            public void should_not_have_inconclusive_package_result()
+            {
+                _packageResult.Inconclusive.ShouldBeFalse();
+            }
+
+            [Fact]
+            public void should_have_warning_package_result()
+            {
+                _packageResult.Warning.ShouldBeTrue();
+            }
+
+            [Fact]
+            public void config_should_match_package_result_name()
+            {
+                _packageResult.Name.ShouldEqual(Configuration.PackageNames);
+            }
+
+            [Fact]
+            public void should_have_a_version_of_one_dot_zero_dot_zero()
+            {
+                _packageResult.Version.ShouldEqual("1.0.0");
+            }
+
+            [Fact]
+            [WindowsOnly]
+            [Platform(Exclude = "Mono")]
+            public void should_have_executed_chocolateyInstall_script()
+            {
+                MockLogger.contains_message("unsupportedelements 1.0.0 Installed", LogLevel.Info).ShouldBeTrue();
+            }
+        }
     }
 }

--- a/src/chocolatey.tests.integration/scenarios/PackScenarios.cs
+++ b/src/chocolatey.tests.integration/scenarios/PackScenarios.cs
@@ -337,6 +337,73 @@ namespace chocolatey.tests.integration.scenarios
             }
         }
 
+        public class when_packing_with_unsupported_elements : ScenariosInvalidBase
+        {
+            [Fact]
+            public void should_throw_exception_on_all_unsupported_elements()
+            {
+                AddFile("myPackage.nuspec", NuspecContentWithAllUnsupportedElements);
+
+                ServiceAct.ShouldThrow<System.IO.FileFormatException>();
+            }
+
+            [Fact]
+            public void should_throw_exception_on_serviceable_element()
+            {
+                AddFile("myPackage.nuspec", NuspecContentWithServiceableElement);
+
+                ServiceAct.ShouldThrow<System.IO.FileFormatException>();
+            }
+
+            [Fact]
+            public void should_throw_exception_on_license_element()
+            {
+                AddFile("myPackage.nuspec", NuspecContentWithLicenseElement);
+
+                ServiceAct.ShouldThrow<System.IO.FileFormatException>();
+            }
+
+            [Fact]
+            public void should_throw_exception_on_repository_element()
+            {
+                AddFile("myPackage.nuspec", NuspecContentWithRepositoryElement);
+
+                ServiceAct.ShouldThrow<System.IO.FileFormatException>();
+            }
+
+            [Fact]
+            public void should_throw_exception_on_package_types_element()
+            {
+                AddFile("myPackage.nuspec", NuspecContentWithPackageTypesElement);
+
+                ServiceAct.ShouldThrow<System.IO.FileFormatException>();
+            }
+
+            [Fact]
+            public void should_throw_exception_on_framework_references_element()
+            {
+                AddFile("myPackage.nuspec", NuspecContentWithFrameWorkReferencesElement);
+
+                ServiceAct.ShouldThrow<System.IO.FileFormatException>();
+            }
+
+            [Fact]
+            public void should_throw_exception_on_readme_element()
+            {
+                AddFile("myPackage.nuspec", NuspecContentWithReadmeElement);
+
+                ServiceAct.ShouldThrow<System.IO.FileFormatException>();
+            }
+
+            [Fact]
+            public void should_throw_exception_on_icon_element()
+            {
+                AddFile("myPackage.nuspec", NuspecContentWithIconElement);
+
+                ServiceAct.ShouldThrow<System.IO.FileFormatException>();
+            }
+        }
+
         private const string NuspecContent = @"<?xml version=""1.0"" encoding=""utf-8""?>
 <package xmlns=""http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd"">
   <metadata>
@@ -479,6 +546,217 @@ namespace chocolatey.tests.integration.scenarios
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <releaseNotes></releaseNotes>
   </metadata>
+</package>";
+
+        private const string NuspecContentWithAllUnsupportedElements = @"<?xml version=""1.0"" encoding=""utf-8""?>
+<package xmlns=""http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd"">
+  <metadata>
+    <id>test-package</id>
+    <title>Test Package</title>
+    <version>1.0.0</version>
+    <authors>package author</authors>
+    <owners>package owner</owners>
+    <summary>A brief summary</summary>
+    <description>A big description</description>
+    <tags>test admin</tags>
+    <copyright></copyright>
+    <licenseUrl>http://apache.org/2</licenseUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <releaseNotes></releaseNotes>
+    <serviceable>true</serviceable>
+    <license type=""expression"">MIT</license>
+    <repository type=""git"" url=""https://github.com/NuGet/NuGet.Client.git"" branch=""dev"" commit=""e1c65e4524cd70ee6e22abe33e6cb6ec73938cb3"" />
+    <packageTypes>
+        <packageType name=""ContosoExtension"" />
+    </packageTypes>
+    <frameworkReferences>
+      <group targetFramework="".NETCoreApp3.1"">
+        <frameworkReference name=""Chocolatey.Cake.Recipe"" />
+      </group>
+    </frameworkReferences>
+    <readme>readme.md</readme>
+    <icon>icon.png</icon>
+    <dependencies>
+      <dependency id=""chocolatey-core.extension"" />
+    </dependencies>
+  </metadata>
+  <files>
+  </files>
+</package>";
+
+        private const string NuspecContentWithServiceableElement = @"<?xml version=""1.0"" encoding=""utf-8""?>
+<package xmlns=""http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd"">
+  <metadata>
+    <id>test-package</id>
+    <title>Test Package</title>
+    <version>1.0.0</version>
+    <authors>package author</authors>
+    <owners>package owner</owners>
+    <summary>A brief summary</summary>
+    <description>A big description</description>
+    <tags>test admin</tags>
+    <copyright></copyright>
+    <licenseUrl>http://apache.org/2</licenseUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <releaseNotes></releaseNotes>
+    <serviceable>true</serviceable>
+    <dependencies>
+      <dependency id=""chocolatey-core.extension"" />
+    </dependencies>
+  </metadata>
+  <files>
+  </files>
+</package>";
+
+
+        private const string NuspecContentWithLicenseElement = @"<?xml version=""1.0"" encoding=""utf-8""?>
+<package xmlns=""http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd"">
+  <metadata>
+    <id>test-package</id>
+    <title>Test Package</title>
+    <version>1.0.0</version>
+    <authors>package author</authors>
+    <owners>package owner</owners>
+    <summary>A brief summary</summary>
+    <description>A big description</description>
+    <tags>test admin</tags>
+    <copyright></copyright>
+    <licenseUrl>http://apache.org/2</licenseUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <releaseNotes></releaseNotes>
+    <license type=""expression"">MIT</license>
+    <dependencies>
+      <dependency id=""chocolatey-core.extension"" />
+    </dependencies>
+  </metadata>
+  <files>
+  </files>
+</package>";
+
+        private const string NuspecContentWithRepositoryElement = @"<?xml version=""1.0"" encoding=""utf-8""?>
+<package xmlns=""http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd"">
+  <metadata>
+    <id>test-package</id>
+    <title>Test Package</title>
+    <version>1.0.0</version>
+    <authors>package author</authors>
+    <owners>package owner</owners>
+    <summary>A brief summary</summary>
+    <description>A big description</description>
+    <tags>test admin</tags>
+    <copyright></copyright>
+    <licenseUrl>http://apache.org/2</licenseUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <releaseNotes></releaseNotes>
+    <repository type=""git"" url=""https://github.com/NuGet/NuGet.Client.git"" branch=""dev"" commit=""e1c65e4524cd70ee6e22abe33e6cb6ec73938cb3"" />
+    <dependencies>
+      <dependency id=""chocolatey-core.extension"" />
+    </dependencies>
+  </metadata>
+  <files>
+  </files>
+</package>";
+
+        private const string NuspecContentWithPackageTypesElement = @"<?xml version=""1.0"" encoding=""utf-8""?>
+<package xmlns=""http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd"">
+  <metadata>
+    <id>test-package</id>
+    <title>Test Package</title>
+    <version>1.0.0</version>
+    <authors>package author</authors>
+    <owners>package owner</owners>
+    <summary>A brief summary</summary>
+    <description>A big description</description>
+    <tags>test admin</tags>
+    <copyright></copyright>
+    <licenseUrl>http://apache.org/2</licenseUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <releaseNotes></releaseNotes>
+    <packageTypes>
+        <packageType name=""ContosoExtension"" />
+    </packageTypes>
+    <dependencies>
+      <dependency id=""chocolatey-core.extension"" />
+    </dependencies>
+  </metadata>
+  <files>
+  </files>
+</package>";
+
+        private const string NuspecContentWithFrameWorkReferencesElement = @"<?xml version=""1.0"" encoding=""utf-8""?>
+<package xmlns=""http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd"">
+  <metadata>
+    <id>test-package</id>
+    <title>Test Package</title>
+    <version>1.0.0</version>
+    <authors>package author</authors>
+    <owners>package owner</owners>
+    <summary>A brief summary</summary>
+    <description>A big description</description>
+    <tags>test admin</tags>
+    <copyright></copyright>
+    <licenseUrl>http://apache.org/2</licenseUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <releaseNotes></releaseNotes>
+    <frameworkReferences>
+      <group targetFramework="".NETCoreApp3.1"">
+        <frameworkReference name=""Chocolatey.Cake.Recipe"" />
+      </group>
+    </frameworkReferences>
+    <dependencies>
+      <dependency id=""chocolatey-core.extension"" />
+    </dependencies>
+  </metadata>
+  <files>
+  </files>
+</package>";
+
+        private const string NuspecContentWithReadmeElement = @"<?xml version=""1.0"" encoding=""utf-8""?>
+<package xmlns=""http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd"">
+  <metadata>
+    <id>test-package</id>
+    <title>Test Package</title>
+    <version>1.0.0</version>
+    <authors>package author</authors>
+    <owners>package owner</owners>
+    <summary>A brief summary</summary>
+    <description>A big description</description>
+    <tags>test admin</tags>
+    <copyright></copyright>
+    <licenseUrl>http://apache.org/2</licenseUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <releaseNotes></releaseNotes>
+    <readme>readme.md</readme>
+    <dependencies>
+      <dependency id=""chocolatey-core.extension"" />
+    </dependencies>
+  </metadata>
+  <files>
+  </files>
+</package>";
+
+        private const string NuspecContentWithIconElement = @"<?xml version=""1.0"" encoding=""utf-8""?>
+<package xmlns=""http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd"">
+  <metadata>
+    <id>test-package</id>
+    <title>Test Package</title>
+    <version>1.0.0</version>
+    <authors>package author</authors>
+    <owners>package owner</owners>
+    <summary>A brief summary</summary>
+    <description>A big description</description>
+    <tags>test admin</tags>
+    <copyright></copyright>
+    <licenseUrl>http://apache.org/2</licenseUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <releaseNotes></releaseNotes>
+    <icon>icon.png</icon>
+    <dependencies>
+      <dependency id=""chocolatey-core.extension"" />
+    </dependencies>
+  </metadata>
+  <files>
+  </files>
 </package>";
     }
 }

--- a/src/chocolatey/infrastructure.app/configuration/ChocolateyConfiguration.cs
+++ b/src/chocolatey/infrastructure.app/configuration/ChocolateyConfiguration.cs
@@ -657,6 +657,7 @@ NOTE: Hiding sensitive configuration data! Please double and triple
         }
 
         public IDictionary<string, string> Properties { get; private set; }
+        public bool PackThrowOnUnsupportedElements = true;
     }
 
     [Serializable]


### PR DESCRIPTION
## Description Of Changes

This adds a check for the new metadata elements added in NuGet.Client, which throws pack if any are found, and warns during install and upgrade.

Specifically, this checks for the `serviceable`, `frameworkReferences`, `readme`, `icon`, `repository`, `license`, and `packageTypes` nuspec elements. These elements were found by comparing `nuspec.xsd` files in the nuget-chocolatey and NuGet.Client repository.

https://github.com/chocolatey/nuget-chocolatey/blob/1162255ce5e02fc6a5ca486639e088f2cff909ee/src/Core/Authoring/nuspec.xsd
https://github.com/chocolatey/NuGet.Client/blob/6ab0442268394c0f12c4f0b42688ac55dec42337/src/NuGet.Core/NuGet.Packaging/compiler/resources/nuspec.xsd

Also, an additional config value is added to disable the check during pack so the
setup for tests packages with unsupported elements can be packed.

## Motivation and Context

The metadata elements added in newer versions of NuGet are not supported on CCR, and they do not have explicit handling in Chocolatey GUI/CLI (for example, `icon` support in Chocolatey GUI).

Therefore, to prevent usage of these elements, a check is required. This check throws on pack, if any of the elements are detected. Therefore, anyone creating Chocolatey packages will not be able to use these elements. There is not a check added for push, as that would be a breaking change, and validation is expected to be completed server side. 

This check is also added to install/upgrade, but only warns on unsupported metadata elements. If any of these metadata elements become supported in the future, this allows packages created with that newer version of Chocolatey to still be installed, and it also allows NuGet packages to be installed. The added metadata elements do not break things in Chocolatey CLI, they merely are ignored. 

## Testing

To ensure that the new metadata elements do not affect list/search/info, run 
`.\choco info Chocolatey.NuGet.Frameworks --pre --source=https://api.nuget.org/v3/index.json`
This demonstrates that the unsupported nuspec elements do not affect searches. This is expected, because searches in NuGet.Client return `IPackageSearchMetadata`, and any extra potential members of that would simply be unused, and should not break anything in Chocolatey CLI.

To test the throw on pack if there are unsupported elements:
- Save this text as `test-package.nuspec`:
```
<?xml version="1.0" encoding="utf-8"?>
<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
  <metadata>
    <id>test-package</id>
    <title>Test Package</title>
    <version>1.0.0</version>
    <authors>package author</authors>
    <owners>package owner</owners>
    <summary>A brief summary</summary>
    <description>A big description</description>
    <tags>test admin</tags>
    <copyright></copyright>
    <licenseUrl>http://apache.org/2</licenseUrl>
    <requireLicenseAcceptance>false</requireLicenseAcceptance>
    <releaseNotes></releaseNotes>
    <serviceable>true</serviceable>
    <license type="expression">MIT</license>
    <repository type="git" url="https://github.com/NuGet/NuGet.Client.git" branch="dev" commit="e1c65e4524cd70ee6e22abe33e6cb6ec73938cb3" />
    <packageTypes>
        <packageType name="ContosoExtension" />
    </packageTypes>
    <frameworkReferences>
      <group targetFramework=".NETCoreApp3.1">
        <frameworkReference name="Chocolatey.Cake.Recipe" />
      </group>
    </frameworkReferences>
    <readme>readme.md</readme>
    <icon>icon.png</icon>
  </metadata>
</package>
```
- Then run `.\choco.exe pack .\test-package.nuspec`
- Validate that it throws an error, which contains all of the unsupported elements.




### Operating Systems Testing
- Windows 10 22H2

## Change Types Made

* [ ] Bug fix (non-breaking change).
* [x] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [x] Tests to cover my changes, have been added.
* [x] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue
Part of #508
https://app.clickup.com/t/20540031/PROJ-401