### PR TITLE
(#508) Fix --page and --page-size arguments

### DIFF
--- a/src/chocolatey/infrastructure.app/services/NugetService.cs
+++ b/src/chocolatey/infrastructure.app/services/NugetService.cs
@@ -100,6 +100,11 @@ namespace chocolatey.infrastructure.app.services
             {
                 config.Sources = ApplicationParameters.PackagesLocation;
                 config.Prerelease = true;
+
+                if (!_fileSystem.directory_exists(ApplicationParameters.PackagesLocation))
+                {
+                    return 0;
+                }
             }
 
             int? pageValue = config.ListCommand.Page;
@@ -135,6 +140,11 @@ namespace chocolatey.infrastructure.app.services
                 config.Sources = ApplicationParameters.PackagesLocation;
                 config.Prerelease = true;
                 config.ListCommand.IncludeVersionOverrides = true;
+
+                if (!_fileSystem.directory_exists(ApplicationParameters.PackagesLocation))
+                {
+                    yield break;
+                }
             }
 
             if (config.RegularOutput) this.Log().Debug(() => "Running list with the following filter = '{0}'".format_with(config.Input));


### PR DESCRIPTION
## Description Of Changes

This fixes `--page` and `--page-size`. These arguments are inefficient because they require querying for all packages, and throw away everything but the page requested.


## Motivation and Context

When the list command was switched to use NuGet.Client libraries, support for `--page` and `--page-size` was removed 

## Testing

- Run `.\choco.exe search google --source=https://community.chocolatey.org/api/v2`, validate that about 248 packages are returned
- Run `.\choco.exe search google --source=https://community.chocolatey.org/api/v2 --page=0`, validate that 25 packages are returned
- Run `.\choco.exe search google --source=https://community.chocolatey.org/api/v2 --page=2`, validate that 25 packages are returned and that they are the different from `--page=0`
- Run  `.\choco.exe search google --source=https://community.chocolatey.org/api/v2 --page=0 --page-size=100`, validate that 100 packages are returned.


### Operating Systems Testing
- Windows 10 22H2

## Change Types Made

* [x] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [x] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue

Part of #508
https://app.clickup.com/t/20540031/PROJ-449