### PR TITLE
(#508) Set NuGet http cache directory

### DIFF
--- a/src/chocolatey/infrastructure.app/nuget/NugetCommon.cs
+++ b/src/chocolatey/infrastructure.app/nuget/NugetCommon.cs
@@ -190,6 +190,16 @@ namespace chocolatey.infrastructure.app.nuget
                 var nugetSource = new PackageSource(source);
                 nugetSource.ClientCertificates = sourceClientCertificates;
                 var repo = Repository.Factory.GetCoreV3(nugetSource);
+
+                if (nugetSource.IsHttp || nugetSource.IsHttps)
+                {
+                    var httpSourceResource = repo.GetResource<HttpSourceResource>();
+                    if (httpSourceResource != null)
+                    {
+                        httpSourceResource.HttpSource.HttpCacheDirectory = System.IO.Path.Combine(configuration.CacheLocation, "NuGetHttpCache");
+                    }
+                }
+
                 repositories.Add(repo);
             }
 


### PR DESCRIPTION
## Description Of Changes

If a source is a http/https source, this sets nuget http cache directory to a folder inside the Chocolatey cache location. 

## Motivation and Context

This prevents conflicts with the NuGet http cache. If this is not set, then cached http results will be located alongside results from NuGet.

## Testing

- Open `%temp%\Chocolatey` (aka Chocolatey cache location) and remove `NuGetHttpCache` if it exists
- Run `.\choco search chocolatey --source=https://api.nuget.org/v3/index.json`
- Validate that the `NuGetHttpCache` folder appears and that it contains a subfolder with cached results from the search.
- Run `.\choco install curl` 
- Validate that the `NuGetHttpCache` folder has a subfolder with cached results for `curl`
- Open `%localappdata%\NuGet\v3-cache` and remove contents
- Rerun above `choco` commands and validate that cached results do not appear.

### Operating Systems Testing
- Windows 10 22H2

## Change Types Made

* [x] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [x] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue

Part of #508
https://app.clickup.com/t/20540031/PROJ-450