### PR TITLE
(#508) Fix nuspec casing on non-Windows

### DIFF
--- a/src/chocolatey.tests.integration/context/uppercase/1.0.0/UpperCase.nuspec
+++ b/src/chocolatey.tests.integration/context/uppercase/1.0.0/UpperCase.nuspec
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+  <metadata>
+    <id>UpperCase</id>
+    <version>1.0.0</version>
+    <title>UpperCase</title>
+    <authors>__REPLACE_AUTHORS_OF_SOFTWARE__</authors>
+    <owners>__REPLACE_YOUR_NAME__</owners>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <description>__REPLACE__</description>
+    <summary>__REPLACE__</summary>
+    <releaseNotes />
+    <tags>UpperCase admin</tags>
+  </metadata>
+  <files>
+    <file src="tools\**" target="tools" />
+  </files>
+</package>

--- a/src/chocolatey.tests.integration/context/uppercase/1.0.0/tools/chocolateyBeforeModify.ps1
+++ b/src/chocolatey.tests.integration/context/uppercase/1.0.0/tools/chocolateyBeforeModify.ps1
@@ -1,0 +1,1 @@
+﻿Write-Output "$env:PackageName $env:PackageVersion Before Modification"

--- a/src/chocolatey.tests.integration/context/uppercase/1.0.0/tools/chocolateyinstall.ps1
+++ b/src/chocolatey.tests.integration/context/uppercase/1.0.0/tools/chocolateyinstall.ps1
@@ -1,0 +1,1 @@
+﻿Write-Output "$env:PackageName $env:PackageVersion Installed"

--- a/src/chocolatey.tests.integration/context/uppercase/1.0.0/tools/chocolateyuninstall.ps1
+++ b/src/chocolatey.tests.integration/context/uppercase/1.0.0/tools/chocolateyuninstall.ps1
@@ -1,0 +1,1 @@
+﻿Write-Output "$env:PackageName $env:PackageVersion Uninstalled"

--- a/src/chocolatey.tests.integration/context/uppercase/1.1.0/UpperCase.nuspec
+++ b/src/chocolatey.tests.integration/context/uppercase/1.1.0/UpperCase.nuspec
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+  <metadata>
+    <id>UpperCase</id>
+    <version>1.1.0</version>
+    <title>UpperCase</title>
+    <authors>__REPLACE_AUTHORS_OF_SOFTWARE__</authors>
+    <owners>__REPLACE_YOUR_NAME__</owners>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <description>__REPLACE__</description>
+    <summary>__REPLACE__</summary>
+    <releaseNotes />
+    <tags>UpperCase admin</tags>
+  </metadata>
+  <files>
+    <file src="tools\**" target="tools" />
+  </files>
+</package>

--- a/src/chocolatey.tests.integration/context/uppercase/1.1.0/tools/chocolateyBeforeModify.ps1
+++ b/src/chocolatey.tests.integration/context/uppercase/1.1.0/tools/chocolateyBeforeModify.ps1
@@ -1,0 +1,1 @@
+﻿Write-Output "$env:PackageName $env:PackageVersion Before Modification"

--- a/src/chocolatey.tests.integration/context/uppercase/1.1.0/tools/chocolateyinstall.ps1
+++ b/src/chocolatey.tests.integration/context/uppercase/1.1.0/tools/chocolateyinstall.ps1
@@ -1,0 +1,1 @@
+﻿Write-Output "$env:PackageName $env:PackageVersion Installed"

--- a/src/chocolatey.tests.integration/context/uppercase/1.1.0/tools/chocolateyuninstall.ps1
+++ b/src/chocolatey.tests.integration/context/uppercase/1.1.0/tools/chocolateyuninstall.ps1
@@ -1,0 +1,1 @@
+﻿Write-Output "$env:PackageName $env:PackageVersion Uninstalled"

--- a/src/chocolatey.tests.integration/scenarios/ListScenarios.cs
+++ b/src/chocolatey.tests.integration/scenarios/ListScenarios.cs
@@ -759,5 +759,57 @@ namespace chocolatey.tests.integration.scenarios
                 Results[2].PackageMetadata.Version.ToNormalizedString().ShouldEqual("0.9.0");
             }
         }
+
+        public class when_listing_local_packages_with_uppercase_id_package_installed : ScenariosBase
+        {
+            public override void Context()
+            {
+                base.Context();
+                Scenario.add_packages_to_source_location(Configuration, "UpperCase" + "*" + NuGetConstants.PackageExtension);
+                Scenario.install_package(Configuration, "UpperCase", "1.1.0");
+
+                Configuration.ListCommand.LocalOnly = true;
+                Configuration.Sources = ApplicationParameters.PackagesLocation;
+            }
+
+            public override void Because()
+            {
+                MockLogger.reset();
+                Results = Service.list_run(Configuration).ToList();
+            }
+
+            [Fact]
+            public void should_contain_packages_and_versions_with_a_space_between_them()
+            {
+                MockLogger.contains_message("upgradepackage 1.0.0").ShouldBeTrue();
+            }
+
+            [Fact]
+            public void should_contain_uppercase_id_package()
+            {
+                MockLogger.contains_message("UpperCase 1.1.0").ShouldBeTrue();
+            }
+
+            [Fact]
+            public void should_not_contain_packages_and_versions_with_a_pipe_between_them()
+            {
+                MockLogger.contains_message("upgradepackage|1.0.0").ShouldBeFalse();
+            }
+
+            [Fact]
+            public void should_contain_a_summary()
+            {
+                MockLogger.contains_message("packages installed").ShouldBeTrue();
+            }
+
+            [Fact]
+            public void should_contain_debugging_messages()
+            {
+                MockLogger.contains_message("Searching for package information", LogLevel.Debug).ShouldBeTrue();
+                MockLogger.contains_message("Running list with the following filter", LogLevel.Debug).ShouldBeTrue();
+                MockLogger.contains_message("Start of List", LogLevel.Debug).ShouldBeTrue();
+                MockLogger.contains_message("End of List", LogLevel.Debug).ShouldBeTrue();
+            }
+        }
     }
 }

--- a/src/chocolatey.tests.integration/scenarios/UpgradeScenarios.cs
+++ b/src/chocolatey.tests.integration/scenarios/UpgradeScenarios.cs
@@ -4364,5 +4364,148 @@ namespace chocolatey.tests.integration.scenarios
                 MockLogger.contains_message("pre-beforemodify-all.ps1 hook ran for upgradepackage 1.1.0", LogLevel.Info).ShouldBeFalse();
             }
         }
+        public class when_upgrading_an_existing_package_with_uppercase_id : ScenariosBase
+        {
+            private PackageResult _packageResult;
+
+            public override void Context()
+            {
+                base.Context();
+                Scenario.add_packages_to_source_location(Configuration, "UpperCase" + "*" + NuGetConstants.PackageExtension);
+                Scenario.install_package(Configuration, "UpperCase", "1.0.0");
+
+                Configuration.PackageNames = Configuration.Input = "UpperCase";
+            }
+
+            public override void Because()
+            {
+                Results = Service.upgrade_run(Configuration);
+                _packageResult = Results.FirstOrDefault().Value;
+            }
+
+            [Fact]
+            public void should_have_the_correct_casing_for_the_nuspec()
+            {
+                var nuspecFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, Configuration.PackageNames + NuGetConstants.ManifestExtension);
+                FileAssert.Exists(nuspecFile);
+            }
+
+            [Fact]
+            public void should_upgrade_where_install_location_reports()
+            {
+                DirectoryAssert.Exists(_packageResult.InstallLocation);
+            }
+
+            [Fact]
+            public void should_upgrade_a_package_in_the_lib_directory()
+            {
+                var packageDir = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames);
+
+                DirectoryAssert.Exists(packageDir);
+            }
+
+            [Fact]
+            public void should_upgrade_the_package()
+            {
+                var packageFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, Configuration.PackageNames + NuGetConstants.PackageExtension);
+                using (var packageReader = new PackageArchiveReader(packageFile))
+                {
+                    packageReader.NuspecReader.GetVersion().to_string().ShouldEqual("1.1.0");
+                }
+            }
+
+            [Fact]
+            public void should_contain_a_warning_message_that_it_upgraded_successfully()
+            {
+                bool upgradedSuccessMessage = false;
+                foreach (var message in MockLogger.MessagesFor(LogLevel.Warn).or_empty_list_if_null())
+                {
+                    if (message.Contains("upgraded 1/1")) upgradedSuccessMessage = true;
+                }
+
+                upgradedSuccessMessage.ShouldBeTrue();
+            }
+
+            [Fact]
+            public void should_contain_a_warning_message_with_old_and_new_versions()
+            {
+                bool upgradeMessage = false;
+                foreach (var message in MockLogger.MessagesFor(LogLevel.Warn).or_empty_list_if_null())
+                {
+                    if (message.Contains("You have UpperCase v1.0.0 installed. Version 1.1.0 is available based on your source")) upgradeMessage = true;
+                }
+
+                upgradeMessage.ShouldBeTrue();
+            }
+
+            [Fact]
+            public void should_have_a_successful_package_result()
+            {
+                _packageResult.Success.ShouldBeTrue();
+            }
+
+            [Fact]
+            public void should_not_have_inconclusive_package_result()
+            {
+                _packageResult.Inconclusive.ShouldBeFalse();
+            }
+
+            [Fact]
+            public void should_not_have_warning_package_result()
+            {
+                _packageResult.Warning.ShouldBeFalse();
+            }
+
+            [Fact]
+            public void config_should_match_package_result_name()
+            {
+                _packageResult.Name.ShouldEqual(Configuration.PackageNames);
+            }
+
+            [Fact]
+            public void should_match_the_upgrade_version_of_one_dot_one_dot_zero()
+            {
+                _packageResult.Version.ShouldEqual("1.1.0");
+            }
+
+            [Fact]
+            [WindowsOnly]
+            [Platform(Exclude = "Mono")]
+            public void should_have_executed_chocolateyBeforeModify_script_for_original_package()
+            {
+                MockLogger.contains_message("UpperCase 1.0.0 Before Modification", LogLevel.Info).ShouldBeTrue();
+            }
+
+            [Fact]
+            [WindowsOnly]
+            [Platform(Exclude = "Mono")]
+            public void should_have_executed_chocolateyBeforeModify_before_chocolateyInstall()
+            {
+                MockLogger.MessagesFor(LogLevel.Info).or_empty_list_if_null()
+                    .SkipWhile(p => !p.Contains("UpperCase 1.0.0 Before Modification"))
+                    .Any(p => p.EndsWith("UpperCase 1.1.0 Installed"))
+                    .ShouldBeTrue();
+            }
+
+            [Fact]
+            public void should_not_have_executed_chocolateyUninstall_script_for_original_package()
+            {
+                MockLogger.contains_message("UpperCase 1.0.0 Uninstalled", LogLevel.Info).ShouldBeFalse();
+            }
+
+            [Fact]
+            public void should_not_have_executed_chocolateyBeforeModify_script_for_new_package()
+            {
+                MockLogger.contains_message("UpperCase 1.1.0 Before Modification", LogLevel.Info).ShouldBeFalse();
+            }
+
+            [Fact]
+            [WindowsOnly]
+            [Platform(Exclude = "Mono")]
+            public void should_have_executed_chocolateyInstall_script_for_new_package()
+            {
+                MockLogger.contains_message("UpperCase 1.1.0 Installed", LogLevel.Info).ShouldBeTrue();
+            }
+        }
     }
 }

--- a/src/chocolatey/infrastructure.app/services/NugetService.cs
+++ b/src/chocolatey/infrastructure.app/services/NugetService.cs
@@ -1943,7 +1943,7 @@ Side by side installations are deprecated and is pending removal in v2.0.0".form
                                 remove_rollback_directory_if_exists(packageName);
                                 backup_existing_version(config, packageToUninstall.PackageMetadata, uninstallPkgInfo);
 
-                                var packageResult = packageResultsToReturn.GetOrAdd(packageToUninstall.Name.to_lower() + "." + packageToUninstall.Version.to_string(), packageToUninstall);
+                                var packageResult = packageResultsToReturn.GetOrAdd(packageToUninstall.Name + "." + packageToUninstall.Version.to_string(), packageToUninstall);
                                 packageResult.InstallLocation = packageToUninstall.InstallLocation;
                                 string logMessage = "{0}{1} v{2}{3}".format_with(Environment.NewLine, packageToUninstall.Name, packageToUninstall.Version.to_string(), config.Force ? " (forced)" : string.Empty);
                                 packageResult.Messages.Add(new ResultMessage(ResultType.Debug, ApplicationParameters.Messages.ContinueChocolateyAction));
@@ -1978,12 +1978,12 @@ Side by side installations are deprecated and is pending removal in v2.0.0".form
                             {
                                 var logMessage = "{0} not uninstalled. An error occurred during uninstall:{1} {2}".format_with(packageName, Environment.NewLine, ex.Message);
                                 this.Log().Error(ChocolateyLoggers.Important, logMessage);
-                                var result = packageResultsToReturn.GetOrAdd(packageToUninstall.Name.to_lower() + "." + packageToUninstall.Version.to_string(), new PackageResult(packageToUninstall.PackageMetadata, pathResolver.GetInstallPath(packageToUninstall.PackageMetadata.Id, packageToUninstall.PackageMetadata.Version)));
+                                var result = packageResultsToReturn.GetOrAdd(packageToUninstall.Name + "." + packageToUninstall.Version.to_string(), new PackageResult(packageToUninstall.PackageMetadata, pathResolver.GetInstallPath(packageToUninstall.PackageMetadata.Id, packageToUninstall.PackageMetadata.Version)));
                                 result.Messages.Add(new ResultMessage(ResultType.Error, logMessage));
                                 if (result.ExitCode == 0) result.ExitCode = 1;
                                 if (config.Features.StopOnFirstPackageFailure)
                                 {
-                                    throw new ApplicationException("Stopping further execution as {0} has failed uninstallation".format_with(packageToUninstall.Name.to_lower()));
+                                    throw new ApplicationException("Stopping further execution as {0} has failed uninstallation".format_with(packageToUninstall.Name));
                                 }
                                 // do not call continueAction - will result in multiple passes
                             }
@@ -1992,7 +1992,7 @@ Side by side installations are deprecated and is pending removal in v2.0.0".form
                     else
                     {
                         // continue action won't be found b/c we are not actually uninstalling (this is noop)
-                        var result = packageResultsToReturn.GetOrAdd(installedPackage.Name.to_lower() + "." + installedPackage.Version.to_string(), new PackageResult(installedPackage.PackageMetadata, pathResolver.GetInstallPath(installedPackage.PackageMetadata.Id, installedPackage.PackageMetadata.Version)));
+                        var result = packageResultsToReturn.GetOrAdd(installedPackage.Name + "." + installedPackage.Version.to_string(), new PackageResult(installedPackage.PackageMetadata, pathResolver.GetInstallPath(installedPackage.PackageMetadata.Id, installedPackage.PackageMetadata.Version)));
                         if (continueAction != null) continueAction.Invoke(result, config);
                     }
                 }

--- a/src/chocolatey/infrastructure/results/PackageResult.cs
+++ b/src/chocolatey/infrastructure/results/PackageResult.cs
@@ -54,17 +54,17 @@ namespace chocolatey.infrastructure.results
         {
             PackageMetadata = metadata;
             SearchMetadata = search;
-            Name = metadata.Id.to_lower();
+            Name = metadata.Id;
             Version = metadata.Version.to_string();
         }
 
-        public PackageResult(IPackageMetadata packageMetadata, string installLocation, string source = null) : this(packageMetadata.Id.to_lower(), packageMetadata.Version.to_string(), installLocation)
+        public PackageResult(IPackageMetadata packageMetadata, string installLocation, string source = null) : this(packageMetadata.Id, packageMetadata.Version.to_string(), installLocation)
         {
             PackageMetadata = packageMetadata;
             Source = source;
         }
 
-        public PackageResult(IPackageSearchMetadata packageSearch, string installLocation, string source = null) : this(packageSearch.Identity.Id.to_lower(), packageSearch.Identity.Version.to_string(), installLocation)
+        public PackageResult(IPackageSearchMetadata packageSearch, string installLocation, string source = null) : this(packageSearch.Identity.Id, packageSearch.Identity.Version.to_string(), installLocation)
         {
             SearchMetadata = packageSearch;
             Source = source;
@@ -103,7 +103,7 @@ namespace chocolatey.infrastructure.results
             */
         }
 
-        public PackageResult(IPackageMetadata packageMetadata, IPackageSearchMetadata packageSearch, string installLocation, string source = null) : this(packageMetadata.Id.to_lower(), packageMetadata.Version.to_string(), installLocation)
+        public PackageResult(IPackageMetadata packageMetadata, IPackageSearchMetadata packageSearch, string installLocation, string source = null) : this(packageMetadata.Id, packageMetadata.Version.to_string(), installLocation)
         {
             SearchMetadata = packageSearch;
             PackageMetadata = packageMetadata;


### PR DESCRIPTION
## Description Of Changes

The NuGet.Client libraries will install nuspec files with a lowercase filename, even if the package ID contains uppercase character(s) and the nuspec in the nupkg is also uppercase. This behavior means that on non-Windows platforms, the nuspec is not able to be found, because it has incorrect casing in the filename.

This corrects that behavior on non-Windows platforms by renaming the nuspec to the correct cased filename. On Windows, there is no need to adjust the casing, because the filesystem is case-insensitive.

The `to_lower()` calls when setting the PackageResult.Name are removed, so the output of the name of the package will match the actual casing of the name.

Also, integration tests are added to ensure that packages that have IDs
with uppercase character(s) can be installed, upgraded, listed,
and uninstalled.

## Motivation and Context

Not being able to install/upgrade packages with uppercase IDs would be a breaking change.
This also adds tests to ensure that #2409 is fixed.

## Testing

On a Linux system run:
```
mono ./choco.exe install wget
mono ./choco.exe list --local-only
mono ./choco.exe uninstall wget
mono ./choco.exe install wget --version=1.21.2
mono ./choco.exe upgrade wget
```
And ensure all operations succeed 

### Operating Systems Testing
- Windows 10 22H2

## Change Types Made

* [x] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [x] Tests to cover my changes, have been added.
* [x] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue

Fixes #2409 
Part of #508 
https://app.clickup.com/t/20540031/PROJ-451