### PR TITLE
(#508) Always override proxy

### DIFF
--- a/src/chocolatey/infrastructure.app/nuget/NugetCommon.cs
+++ b/src/chocolatey/infrastructure.app/nuget/NugetCommon.cs
@@ -137,6 +137,10 @@ namespace chocolatey.infrastructure.app.nuget
 
                 ProxyCache.Instance.Override(proxy);
             }
+            else
+            {
+                ProxyCache.Instance.Override(new System.Net.WebProxy());
+            }
 
             IEnumerable<string> sources = configuration.Sources.to_string().Split(new[] { ";", "," }, StringSplitOptions.RemoveEmptyEntries);
 


### PR DESCRIPTION
## Description Of Changes

This ensures that it always the Chocolatey specified proxy used, and it does not attempt to get a proxy from the NuGet settings file.

## Motivation and Context

See description.

See https://github.com/chocolatey/NuGet.Client/pull/18

## Testing

- Replace `NuGet.Configuration.Settings.GetSection()` with a `throw new NotImplementedException();` 
- Build NuGet and Chocolatey (with the NuGet build)
- Run `choco search wget`
- Run `choco install wget`
- Run `choco uninstall wget`
- Validate that choco does not trigger that exception for any of these.

### Operating Systems Testing
- Windows 

## Change Types Made

* [x] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [x] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue

Part of #508 
https://app.clickup.com/t/20540031/PROJ-444