### PR TITLE
(#2738) Temporarily prevent loading chocolatey.licensed.dll

### DIFF
--- a/src/chocolatey.resources/helpers/chocolateyInstaller.psm1
+++ b/src/chocolatey.resources/helpers/chocolateyInstaller.psm1
@@ -57,6 +57,7 @@ $currentAssemblies = [System.AppDomain]::CurrentDomain.GetAssemblies()
 # Load community extensions if they exist
 $extensionsPath = Join-Path $helpersPath -ChildPath '..\extensions'
 if (Test-Path $extensionsPath) {
+    <# RESTORE THIS BEFORE CHOCOLATEY CLI V2.0
     $licensedExtensionPath = Join-Path $extensionsPath -ChildPath 'chocolatey\chocolatey.licensed.dll'
     if (Test-Path $licensedExtensionPath) {
         Write-Debug "Importing '$licensedExtensionPath'"
@@ -82,9 +83,11 @@ if (Test-Path $extensionsPath) {
             Write-Warning "Import failed for Chocolatey Licensed Extension. Error: '$_'"
         }
     }
+    #>
 
     Write-Debug 'Loading community extensions'
     Get-ChildItem -Path $extensionsPath -Recurse -Filter '*.psm1' |
+        Where-Object { $_.Name -ne 'chocolatey.extensions.psm1' } # REMOVE THIS LINE BEFORE CHOCOLATEY CLI V2.0
         Select-Object -ExpandProperty FullName |
         ForEach-Object {
             Write-Debug "Importing '$_'"

--- a/src/chocolatey/FileSystemExtensions.cs
+++ b/src/chocolatey/FileSystemExtensions.cs
@@ -43,6 +43,15 @@ namespace chocolatey
             {
                 var name = fileSystem.get_file_name_without_extension(extensionFile);
 
+                ////////////////////////////////////////////
+                // REMOVE THIS BEFORE CHOCOLATEY CLI V2.0 //
+                ////////////////////////////////////////////
+                if (name == ApplicationParameters.LicensedChocolateyAssemblySimpleName)
+                {
+                    "chocolatey".Log().Warn("Loading the Chocolatey Licensed Extension is disabled in this pre-release version of Chocolatey.");
+                    continue;
+                }
+
                 try
                 {
                     var assembly = AssemblyResolution.load_extension(name);

--- a/src/chocolatey/infrastructure/licensing/License.cs
+++ b/src/chocolatey/infrastructure/licensing/License.cs
@@ -27,6 +27,12 @@ namespace chocolatey.infrastructure.licensing
         public static ChocolateyLicense validate_license()
         {
             var license = LicenseValidation.validate();
+
+            ////////////////////////////////////////////
+            // REMOVE THIS BEFORE CHOCOLATEY CLI V2.0 //
+            ////////////////////////////////////////////
+            return license;
+
             if (license.is_licensed_version())
             {
                 try


### PR DESCRIPTION
## Description Of Changes

- Prevent loading the chocolatey.licensed.dll for the present, and emit a warning when it is found to alert users that licensed functionality is currently not available.

## Motivation and Context

Since we have a known incompatibility with the existing licensed extension dll that makes it completely unusable, we should prevent loading it for the present.

This commit should be removed once we have updated the licensed extension, prior to stable release.

## Testing

1. Build and run choco with the licensed extension in play
2. A single warning should be emitted, indicating that the licensed extension will currently not work
3. Licensed functionality (e.g. the `download` command) should not be available

### Operating Systems Testing

N/A

## Change Types Made
<!-- Tick the boxes for the type of changes that have been made -->

* [x] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [x] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue

#2738
