### PR TITLE
(#508) Enable download progress in NuGet

### DIFF
--- a/src/chocolatey/infrastructure.app/services/NugetService.cs
+++ b/src/chocolatey/infrastructure.app/services/NugetService.cs
@@ -809,6 +809,8 @@ Please see https://docs.chocolatey.org/en-us/troubleshooting for more
 
                         _fileSystem.delete_file(pathResolver.GetInstalledPackageFilePath(packageDependencyInfo));
 
+                        ChocolateyProgressInfo.ShouldDisplayDownloadProgress = config.Features.ShowDownloadProgress;
+
                         using (var downloadResult = downloadResource.GetDownloadResourceResultAsync(
                                    packageDependencyInfo,
                                    new PackageDownloadContext(sourceCacheContext),
@@ -1353,6 +1355,8 @@ Please see https://docs.chocolatey.org/en-us/troubleshooting for more
                                 var downloadResource = packageDependencyInfo.Source.GetResource<DownloadResource>();
 
                                 _fileSystem.delete_file(pathResolver.GetInstalledPackageFilePath(packageDependencyInfo));
+
+                                ChocolateyProgressInfo.ShouldDisplayDownloadProgress = config.Features.ShowDownloadProgress;
 
                                 using (var downloadResult = downloadResource.GetDownloadResourceResultAsync(
                                            packageDependencyInfo,


### PR DESCRIPTION
## Description Of Changes

This enables the download progress message output from NuGet. 

## Motivation and Context

See chocolatey/NuGet.Client#12

If any other downloads of `.nupkg` files are added, then a similar line should be added before the download to enable the download progress

## Testing

- Build nuget libraries
- Set Chocolatey to use them
- Run `.\choco install wget --force`
- Run `.\choco install wget --force --no-progress`
- Run `.\choco install WGETWindows --force --source=https://api.nuget.org/v3/index.json`
- Run  `.\choco install WGETWindows --force --source=https://api.nuget.org/v3/index.json --no-progress`
- Validate that download is progress is shown or not shown as appropriate.

### Operating Systems Testing
- Windows 10 22H2

## Change Types Made

* [x] Bug fix (non-breaking change).
* [x] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [x] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue

Part of #508 
Enablement of chocolatey/NuGet.Client#12
https://app.clickup.com/t/20540031/PROJ-430