### PR TITLE
(#508) Only set package install location when local only list

### DIFF
--- a/src/chocolatey/infrastructure.app/services/NugetService.cs
+++ b/src/chocolatey/infrastructure.app/services/NugetService.cs
@@ -261,7 +261,7 @@ namespace chocolatey.infrastructure.app.services
                 }
                 else
                 {
-                    yield return new PackageResult(packageLocalMetadata, package, packageInstallLocation, config.Sources);
+                    yield return new PackageResult(packageLocalMetadata, package, config.ListCommand.LocalOnly ? packageInstallLocation : null, config.Sources);
                 }
             }
 


### PR DESCRIPTION
## Description Of Changes

The PackageResult install location should only be set by the list method if searching/listing the installed packages.

## Motivation and Context

This fixes an issue where all packages on local/folder feeds show as installed when using ChocolateyGUI

## Testing

- Build chocolatey.lib package from PR
- Bring into ChocolateyGUI
- Add a local folder source (e.g. `C:\packages`) that has some `.nupkg`s
- Open ChocolateyGUI and install a package that exists in that local source.
- Validate that only package(s) which are installed show up as installed when viewing the local source in ChocolateyGUI

### Operating Systems Testing
- Windows 10 22H2

## Change Types Made

* [x] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [x] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue

Part of #508