### PR TITLE
(#508) Fix spelling/grammar in nuspec errors/warnings for unsupported elements

### DIFF
--- a/src/chocolatey/infrastructure.app/services/NugetService.cs
+++ b/src/chocolatey/infrastructure.app/services/NugetService.cs
@@ -323,12 +323,12 @@ namespace chocolatey.infrastructure.app.services
 
             if (!(metadataNode.Elements(XName.Get("repository", metadataNamespace)).FirstOrDefault() is null))
             {
-                issuesList.Add("<repository> elements are not supported in Chocolatey CLI, used <packageSourceUrl> instead");
+                issuesList.Add("<repository> elements are not supported in Chocolatey CLI, use <packageSourceUrl> instead");
             }
 
             if (!(nuspecReader.GetLicenseMetadata() is null))
             {
-                issuesList.Add("<license> elements are not supported in Chocolatey CLI, used <licenseUrl> instead");
+                issuesList.Add("<license> elements are not supported in Chocolatey CLI, use <licenseUrl> instead");
             }
 
             if (!(metadataNode.Elements(XName.Get("packageTypes", metadataNamespace)).FirstOrDefault() is null))


### PR DESCRIPTION
## Description Of Changes

- Small grammar fix for wording of the nuspec errors/warnings for elements that are not currently supported.

## Motivation and Context

The wording/grammar was inconsistent.

## Testing

1. Attempt to `choco pack` or `choco install` a package containing some of the nuspec elements we check for as unsupported.
2. Verify the wording is given as expected, and recommendations for alternatives state `use X instead` and not `used X instead`.

### Operating Systems Testing

Win11

## Change Types Made
<!-- Tick the boxes for the type of changes that have been made -->

* [x] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [x] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue
<!-- Make sure you have raised an issue for this pull request before
continuing. -->

#508
