### PR TITLE
(#2738) Add tests for .Net registry checks

### DIFF
--- a/tests/helpers/common/Set-RegistryKeyOwner.ps1
+++ b/tests/helpers/common/Set-RegistryKeyOwner.ps1
@@ -1,0 +1,103 @@
+function Set-RegistryKeyOwner {
+    param(
+        $Key,
+        $Username = "$env:USERDOMAIN\$env:USERNAME"
+    )
+    # Purposely keeping enable-privilege private to this function. It is absolutely a janky way to do it, and don't want to encourage it outside of this very specific use case.
+    # This code taken from: https://social.technet.microsoft.com/Forums/en-US/e718a560-2908-4b91-ad42-d392e7f8f1ad/take-ownership-of-a-registry-key-and-change-permissions?forum=winserverpowershell
+    # which appears to derive the bulk of the actual work from: https://www.leeholmes.com/adjusting-token-privileges-in-powershell/
+    function enable-privilege {
+        param(
+            ## The privilege to adjust. This set is taken from
+            ## http://msdn.microsoft.com/en-us/library/bb530716(VS.85).aspx
+            [ValidateSet(
+                "SeAssignPrimaryTokenPrivilege", "SeAuditPrivilege", "SeBackupPrivilege",
+                "SeChangeNotifyPrivilege", "SeCreateGlobalPrivilege", "SeCreatePagefilePrivilege",
+                "SeCreatePermanentPrivilege", "SeCreateSymbolicLinkPrivilege", "SeCreateTokenPrivilege",
+                "SeDebugPrivilege", "SeEnableDelegationPrivilege", "SeImpersonatePrivilege", "SeIncreaseBasePriorityPrivilege",
+                "SeIncreaseQuotaPrivilege", "SeIncreaseWorkingSetPrivilege", "SeLoadDriverPrivilege",
+                "SeLockMemoryPrivilege", "SeMachineAccountPrivilege", "SeManageVolumePrivilege",
+                "SeProfileSingleProcessPrivilege", "SeRelabelPrivilege", "SeRemoteShutdownPrivilege",
+                "SeRestorePrivilege", "SeSecurityPrivilege", "SeShutdownPrivilege", "SeSyncAgentPrivilege",
+                "SeSystemEnvironmentPrivilege", "SeSystemProfilePrivilege", "SeSystemtimePrivilege",
+                "SeTakeOwnershipPrivilege", "SeTcbPrivilege", "SeTimeZonePrivilege", "SeTrustedCredManAccessPrivilege",
+                "SeUndockPrivilege", "SeUnsolicitedInputPrivilege")]
+            $Privilege,
+            ## The process on which to adjust the privilege. Defaults to the current process.
+            $ProcessId = $pid,
+            ## Switch to disable the privilege, rather than enable it.
+            [Switch] $Disable
+        )
+
+        ## Taken from P/Invoke.NET with minor adjustments.
+        $definition = @'
+ using System;
+ using System.Runtime.InteropServices;
+
+ public class AdjPriv
+ {
+  [DllImport("advapi32.dll", ExactSpelling = true, SetLastError = true)]
+  internal static extern bool AdjustTokenPrivileges(IntPtr htok, bool disall,
+   ref TokPriv1Luid newst, int len, IntPtr prev, IntPtr relen);
+
+  [DllImport("advapi32.dll", ExactSpelling = true, SetLastError = true)]
+  internal static extern bool OpenProcessToken(IntPtr h, int acc, ref IntPtr phtok);
+  [DllImport("advapi32.dll", SetLastError = true)]
+  internal static extern bool LookupPrivilegeValue(string host, string name, ref long pluid);
+  [StructLayout(LayoutKind.Sequential, Pack = 1)]
+  internal struct TokPriv1Luid
+  {
+   public int Count;
+   public long Luid;
+   public int Attr;
+  }
+
+  internal const int SE_PRIVILEGE_ENABLED = 0x00000002;
+  internal const int SE_PRIVILEGE_DISABLED = 0x00000000;
+  internal const int TOKEN_QUERY = 0x00000008;
+  internal const int TOKEN_ADJUST_PRIVILEGES = 0x00000020;
+  public static bool EnablePrivilege(long processHandle, string privilege, bool disable)
+  {
+   bool retVal;
+   TokPriv1Luid tp;
+   IntPtr hproc = new IntPtr(processHandle);
+   IntPtr htok = IntPtr.Zero;
+   retVal = OpenProcessToken(hproc, TOKEN_ADJUST_PRIVILEGES | TOKEN_QUERY, ref htok);
+   tp.Count = 1;
+   tp.Luid = 0;
+   if(disable)
+   {
+    tp.Attr = SE_PRIVILEGE_DISABLED;
+   }
+   else
+   {
+    tp.Attr = SE_PRIVILEGE_ENABLED;
+   }
+   retVal = LookupPrivilegeValue(null, privilege, ref tp.Luid);
+   retVal = AdjustTokenPrivileges(htok, false, ref tp, 0, IntPtr.Zero, IntPtr.Zero);
+   return retVal;
+  }
+ }
+'@
+
+        $processHandle = (Get-Process -Id $ProcessId).Handle
+        $type = Add-Type $definition -PassThru
+        $type[0]::EnablePrivilege($processHandle, $Privilege, $Disable)
+    }
+
+    enable-privilege SeTakeOwnershipPrivilege
+    $key = [Microsoft.Win32.Registry]::LocalMachine.OpenSubKey($Key, [Microsoft.Win32.RegistryKeyPermissionCheck]::ReadWriteSubTree, [System.Security.AccessControl.RegistryRights]::takeownership)
+    # You must get a blank acl for the key b/c you do not currently have access
+    $acl = $key.GetAccessControl([System.Security.AccessControl.AccessControlSections]::None)
+    $me = [System.Security.Principal.NTAccount]$Username
+    $acl.SetOwner($me)
+    $key.SetAccessControl($acl)
+
+    # After you have set owner you need to get the acl with the perms so you can modify it.
+    $acl = $key.GetAccessControl()
+    $rule = New-Object System.Security.AccessControl.RegistryAccessRule ($Username, "FullControl", "Allow")
+    $acl.SetAccessRule($rule)
+    $key.SetAccessControl($acl)
+
+    $key.Close()
+}


### PR DESCRIPTION
## Description Of Changes

Chocolatey CLI should not execute when the .Net version is below 4.8 as set in the Registry. This adds an end to end pester test that takes ownership of the key and removes the value to verify that Chocolatey behaves as expected.

## Motivation and Context

We need to ensure that Chocolatey doesn't run when .Net 4.8 isn't detected as being installed.

## Testing

* Used the updated vagrant file from my `test-with-net-48` branch (this updates the tests Vagrantfile to include .net 4.8), ran tests through there.
* Ran tests through Test Kitchen against latest develop build and targeting this branch. 

### Operating Systems Testing

Test Kitchen or Vagrant: Windows Server 2016, 2019, 2022

## Change Types Made

* [ ] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.
* [x] End to end tests.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [x] Tests to cover my changes, have been added.
* [x] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue

* Related to #2738 
* CU-PROJ-442
