### PR TITLE
(#508) Add Pester tests for unsupported metadata

### DIFF
--- a/tests/chocolatey-tests/commands/choco-upgrade.Tests.ps1
+++ b/tests/chocolatey-tests/commands/choco-upgrade.Tests.ps1
@@ -258,7 +258,70 @@ Describe "choco upgrade" -Tag Chocolatey, UpgradeCommand {
         }
     }
 
+    Context 'Upgrading a package with unsupported nuspec elements shows a warning' {
 
+        BeforeDiscovery {
+            $testCases = @(
+                '<license>'
+                '<packageTypes>'
+                '<readme>'
+                '<repository>'
+                '<serviceable>'
+            )
+        }
+
+        BeforeAll {
+            Restore-ChocolateyInstallSnapshot
+            $nuspec = @'
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
+  <metadata>
+    <id>unsupportedmetadata</id>
+    <version>1.0.0</version>
+    <title>unsupportedmetadata (Install)</title>
+    <authors>Chocolatey Software</authors>
+    <tags>unsupportedmetadata</tags>
+
+    <license type="expression">MIT</license>
+    <packageTypes>
+        <packageType name="Unsupported" />
+    </packageTypes>
+    <readme>readme.md</readme>
+    <repository type="git" url="https://github.com/chocolatey/choco.git" />
+    <serviceable>true</serviceable>
+
+    <summary>Test of unsupported metadata</summary>
+    <description>Some metadata fields are not supported by chocolatey. `choco pack` should fail to pack them, while `choco install` or `upgrade` should allow them with a warning.</description>
+  </metadata>
+</package>
+'@
+            $tempPath = "$env:TEMP/$(New-Guid)"
+            $packageName = 'unsupportedmetadata'
+            $nuspecPath = "$tempPath/$packageName/$packageName.nuspec"
+
+            $null = New-Item -Path "$tempPath/$packageName" -ItemType Directory
+            $nuspec | Set-Content -Path $nuspecPath
+            "readme content" | Set-Content -Path "$tempPath/$packageName/readme.md"
+
+            $null = Invoke-Choco install nuget.commandline
+            $null = & "$env:ChocolateyInstall/bin/nuget.exe" pack $nuspecPath
+
+            $Output = Invoke-Choco upgrade $packageName --source $tempPath
+        }
+
+        AfterAll {
+            Remove-Item $tempPath -Recurse -Force
+        }
+
+        It 'Installs successfully and exits with success (0)' {
+            $Output.ExitCode | Should -Be 0
+        }
+
+        It 'Shows a warning about the unsupported nuspec metadata element "<_>"' -TestCases $testCases {
+            $Output.String | Should -Match "$_ elements are not supported in Chocolatey CLI"
+        }
+    }
+    
     # This needs to be the last test in this block, to ensure NuGet configurations aren't being created.
     Test-NuGetPaths
 }


### PR DESCRIPTION
## Description Of Changes

- Adds some end to end tests for how choco behaves when handling a package with unsupported metadata elements in the nuspec.

## Motivation and Context

We should have some tests confirming the end-user behaviour of package installs and packs when choco finds unsupported elements in the nuspec metadata.

## Testing

1. Locally tested with Invoke-Tests.ps1
2. Tests will be run in TeamCity

The added tests should pass with no issues.

### Operating Systems Testing

Win11

## Change Types Made
<!-- Tick the boxes for the type of changes that have been made -->

* [ ] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.
* [x] Tests added

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [x] Tests to cover my changes, have been added.
* [x] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue

#508

<!-- PLEASE REMOVE ALL COMMENTS BEFORE SUBMITTING -->
