### PR TITLE
(#1174)(#1610) Add tests for package versions with leading zeros

### DIFF
--- a/src/chocolatey.tests.integration/scenarios/InfoScenarios.cs
+++ b/src/chocolatey.tests.integration/scenarios/InfoScenarios.cs
@@ -105,6 +105,211 @@ namespace chocolatey.tests.integration.scenarios
             }
         }
 
+        public class when_searching_for_exact_package_with_version_specified : CommandScenariosBase
+        {
+            public override void Context()
+            {
+                base.Context();
+
+                Configuration.PackageNames = Configuration.Input = "installpackage";
+
+                Configuration.Sources = "PackageOutput";
+                Scenario.add_packages_to_source_location(Configuration, "installpackage.*" + NuGetConstants.PackageExtension);
+
+                Configuration.Version = "1.0.0";
+            }
+
+            [Fact]
+            public void should_log_standalone_header_with_package_name_and_version()
+            {
+                MockLogger.Messages.Keys.ShouldContain(LogLevel.Info.to_string());
+                MockLogger.Messages[LogLevel.Info.to_string()].ShouldContain("installpackage 1.0.0");
+            }
+
+            [Fact]
+            public void should_log_package_information()
+            {
+                var lastWriteDate = File.GetLastWriteTimeUtc(Path.Combine("PackageOutput", "installpackage.1.0.0" + NuGetConstants.PackageExtension))
+                    .ToShortDateString();
+
+                MockLogger.Messages.Keys.ShouldContain(LogLevel.Info.to_string());
+                MockLogger.Messages[LogLevel.Info.to_string()].ShouldContain(" Title: installpackage | Published: {0}\r\n Number of Downloads: n/a | Downloads for this version: n/a\r\n Package url\r\n Chocolatey Package Source: n/a\r\n Tags: installpackage admin\r\n Software Site: n/a\r\n Software License: n/a\r\n Summary: __REPLACE__\r\n Description: __REPLACE__\r\n".format_with(lastWriteDate));
+            }
+
+            [Fact]
+            public void should_log_package_count_as_warning()
+            {
+                MockLogger.Messages.Keys.ShouldContain(LogLevel.Warn.to_string());
+                MockLogger.Messages[LogLevel.Warn.to_string()].ShouldContain("1 packages found.");
+            }
+        }
+
+        public class when_searching_for_exact_package_with_non_normalized_version_specified : CommandScenariosBase
+        {
+            public override void Context()
+            {
+                base.Context();
+
+                Configuration.PackageNames = Configuration.Input = "installpackage";
+
+                Configuration.Sources = "PackageOutput";
+                Scenario.add_packages_to_source_location(Configuration, "installpackage.*" + NuGetConstants.PackageExtension);
+
+                Configuration.Version = "01.0.0.0";
+            }
+
+            [Fact]
+            public void should_log_standalone_header_with_package_name_and_version()
+            {
+                MockLogger.Messages.Keys.ShouldContain(LogLevel.Info.to_string());
+                MockLogger.Messages[LogLevel.Info.to_string()].ShouldContain("installpackage 1.0.0");
+            }
+
+            [Fact]
+            public void should_log_package_information()
+            {
+                var lastWriteDate = File.GetLastWriteTimeUtc(Path.Combine("PackageOutput", "installpackage.1.0.0" + NuGetConstants.PackageExtension))
+                    .ToShortDateString();
+
+                MockLogger.Messages.Keys.ShouldContain(LogLevel.Info.to_string());
+                MockLogger.Messages[LogLevel.Info.to_string()].ShouldContain(" Title: installpackage | Published: {0}\r\n Number of Downloads: n/a | Downloads for this version: n/a\r\n Package url\r\n Chocolatey Package Source: n/a\r\n Tags: installpackage admin\r\n Software Site: n/a\r\n Software License: n/a\r\n Summary: __REPLACE__\r\n Description: __REPLACE__\r\n".format_with(lastWriteDate));
+            }
+
+            [Fact]
+            public void should_log_package_count_as_warning()
+            {
+                MockLogger.Messages.Keys.ShouldContain(LogLevel.Warn.to_string());
+                MockLogger.Messages[LogLevel.Warn.to_string()].ShouldContain("1 packages found.");
+            }
+        }
+
+        public class when_searching_for_non_normalized_exact_package : CommandScenariosBase
+        {
+            private string NonNormalizedVersion = "004.0.01.0";
+            private string NormalizedVersion = "4.0.1";
+
+            public override void Context()
+            {
+                base.Context();
+
+                Configuration.PackageNames = Configuration.Input = "installpackage";
+
+                Configuration.Sources = "PackageOutput";
+
+                Scenario.add_changed_version_package_to_source_location(Configuration, "installpackage.1.0.0" + NuGetConstants.PackageExtension, NonNormalizedVersion);
+            }
+
+            [Fact]
+            public void should_log_standalone_header_with_package_name_and_version()
+            {
+                MockLogger.Messages.Keys.ShouldContain(LogLevel.Info.to_string());
+                MockLogger.Messages[LogLevel.Info.to_string()].ShouldContain("installpackage {0}".format_with(NormalizedVersion));
+            }
+
+            [Fact]
+            public void should_log_package_information()
+            {
+                var lastWriteDate = File.GetLastWriteTimeUtc(Path.Combine("PackageOutput", "installpackage.{0}".format_with(NonNormalizedVersion) + NuGetConstants.PackageExtension))
+                    .ToShortDateString();
+
+                MockLogger.Messages.Keys.ShouldContain(LogLevel.Info.to_string());
+                MockLogger.Messages[LogLevel.Info.to_string()].ShouldContain(" Title: installpackage | Published: {0}\r\n Number of Downloads: n/a | Downloads for this version: n/a\r\n Package url\r\n Chocolatey Package Source: n/a\r\n Tags: installpackage admin\r\n Software Site: n/a\r\n Software License: n/a\r\n Summary: __REPLACE__\r\n Description: __REPLACE__\r\n".format_with(lastWriteDate));
+            }
+
+            [Fact]
+            public void should_log_package_count_as_warning()
+            {
+                MockLogger.Messages.Keys.ShouldContain(LogLevel.Warn.to_string());
+                MockLogger.Messages[LogLevel.Warn.to_string()].ShouldContain("1 packages found.");
+            }
+        }
+
+        public class when_searching_for_non_normalized_exact_package_with_version_specified : CommandScenariosBase
+        {
+            private string NonNormalizedVersion = "004.0.01.0";
+            private string NormalizedVersion = "4.0.1";
+
+            public override void Context()
+            {
+                base.Context();
+
+                Configuration.PackageNames = Configuration.Input = "installpackage";
+
+                Configuration.Sources = "PackageOutput";
+
+                Scenario.add_changed_version_package_to_source_location(Configuration, "installpackage.1.0.0" + NuGetConstants.PackageExtension, NonNormalizedVersion);
+
+                Configuration.Version = "4.0.1";
+            }
+
+            [Fact]
+            public void should_log_standalone_header_with_package_name_and_version()
+            {
+                MockLogger.Messages.Keys.ShouldContain(LogLevel.Info.to_string());
+                MockLogger.Messages[LogLevel.Info.to_string()].ShouldContain("installpackage {0}".format_with(NormalizedVersion));
+            }
+
+            [Fact]
+            public void should_log_package_information()
+            {
+                var lastWriteDate = File.GetLastWriteTimeUtc(Path.Combine("PackageOutput", "installpackage.{0}".format_with(NonNormalizedVersion) + NuGetConstants.PackageExtension))
+                    .ToShortDateString();
+
+                MockLogger.Messages.Keys.ShouldContain(LogLevel.Info.to_string());
+                MockLogger.Messages[LogLevel.Info.to_string()].ShouldContain(" Title: installpackage | Published: {0}\r\n Number of Downloads: n/a | Downloads for this version: n/a\r\n Package url\r\n Chocolatey Package Source: n/a\r\n Tags: installpackage admin\r\n Software Site: n/a\r\n Software License: n/a\r\n Summary: __REPLACE__\r\n Description: __REPLACE__\r\n".format_with(lastWriteDate));
+            }
+
+            [Fact]
+            public void should_log_package_count_as_warning()
+            {
+                MockLogger.Messages.Keys.ShouldContain(LogLevel.Warn.to_string());
+                MockLogger.Messages[LogLevel.Warn.to_string()].ShouldContain("1 packages found.");
+            }
+        }
+
+        public class when_searching_for_non_normalized_exact_package_with_non_normalized_version_specified : CommandScenariosBase
+        {
+            private string NonNormalizedVersion = "004.0.01.0";
+            private string NormalizedVersion = "4.0.1";
+
+            public override void Context()
+            {
+                base.Context();
+
+                Configuration.PackageNames = Configuration.Input = "installpackage";
+
+                Configuration.Sources = "PackageOutput";
+
+                Scenario.add_changed_version_package_to_source_location(Configuration, "installpackage.1.0.0" + NuGetConstants.PackageExtension, NonNormalizedVersion);
+
+                Configuration.Version = NonNormalizedVersion;
+            }
+
+            [Fact]
+            public void should_log_standalone_header_with_package_name_and_version()
+            {
+                MockLogger.Messages.Keys.ShouldContain(LogLevel.Info.to_string());
+                MockLogger.Messages[LogLevel.Info.to_string()].ShouldContain("installpackage {0}".format_with(NormalizedVersion));
+            }
+
+            [Fact]
+            public void should_log_package_information()
+            {
+                var lastWriteDate = File.GetLastWriteTimeUtc(Path.Combine("PackageOutput", "installpackage.{0}".format_with(NonNormalizedVersion) + NuGetConstants.PackageExtension))
+                    .ToShortDateString();
+
+                MockLogger.Messages.Keys.ShouldContain(LogLevel.Info.to_string());
+                MockLogger.Messages[LogLevel.Info.to_string()].ShouldContain(" Title: installpackage | Published: {0}\r\n Number of Downloads: n/a | Downloads for this version: n/a\r\n Package url\r\n Chocolatey Package Source: n/a\r\n Tags: installpackage admin\r\n Software Site: n/a\r\n Software License: n/a\r\n Summary: __REPLACE__\r\n Description: __REPLACE__\r\n".format_with(lastWriteDate));
+            }
+
+            [Fact]
+            public void should_log_package_count_as_warning()
+            {
+                MockLogger.Messages.Keys.ShouldContain(LogLevel.Warn.to_string());
+                MockLogger.Messages[LogLevel.Warn.to_string()].ShouldContain("1 packages found.");
+            }
+        }
+
         public class when_searching_for_exact_package_with_dot_relative_path_source : when_searching_for_exact_package_through_command
         {
             public override void Context()

--- a/src/chocolatey.tests.integration/scenarios/PackScenarios.cs
+++ b/src/chocolatey.tests.integration/scenarios/PackScenarios.cs
@@ -514,7 +514,12 @@ namespace chocolatey.tests.integration.scenarios
     <licenseUrl>http://apache.org/2</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <releaseNotes></releaseNotes>
+    <dependencies>
+      <dependency id=""chocolatey-core.extension"" />
+    </dependencies>
   </metadata>
+  <files>
+  </files>
 </package>";
 
         private const string NuspecContentWithBuildMetadata = @"<?xml version=""1.0"" encoding=""utf-8""?>
@@ -532,7 +537,12 @@ namespace chocolatey.tests.integration.scenarios
     <licenseUrl>http://apache.org/2</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <releaseNotes></releaseNotes>
+    <dependencies>
+      <dependency id=""chocolatey-core.extension"" />
+    </dependencies>
   </metadata>
+  <files>
+  </files>
 </package>";
 
         private const string NuspecContentWithChocolateyData = @"<?xml version=""1.0"" encoding=""utf-8""?>
@@ -550,7 +560,12 @@ namespace chocolatey.tests.integration.scenarios
     <licenseUrl>http://apache.org/2</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <releaseNotes></releaseNotes>
+    <dependencies>
+      <dependency id=""chocolatey-core.extension"" />
+    </dependencies>
   </metadata>
+  <files>
+  </files>
 </package>";
 
         private const string NuspecContentWithVariables = @"<?xml version=""1.0"" encoding=""utf-8""?>
@@ -568,7 +583,12 @@ namespace chocolatey.tests.integration.scenarios
     <licenseUrl>https://github.com/chocolatey/choco/tree/$commitId$/LICENSE</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <releaseNotes></releaseNotes>
+    <dependencies>
+      <dependency id=""chocolatey-core.extension"" />
+    </dependencies>
   </metadata>
+  <files>
+  </files>
 </package>";
 
         private const string NuspecContentWithSemVer20PreReleaseVersioning = @"<?xml version=""1.0"" encoding=""utf-8""?>
@@ -586,7 +606,12 @@ namespace chocolatey.tests.integration.scenarios
     <licenseUrl>http://apache.org/2</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <releaseNotes></releaseNotes>
+    <dependencies>
+      <dependency id=""chocolatey-core.extension"" />
+    </dependencies>
   </metadata>
+  <files>
+  </files>
 </package>";
 
         private const string NuspecContentWithLegacySemVerPreReleaseVersioning = @"<?xml version=""1.0"" encoding=""utf-8""?>
@@ -604,7 +629,12 @@ namespace chocolatey.tests.integration.scenarios
     <licenseUrl>http://apache.org/2</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <releaseNotes></releaseNotes>
+    <dependencies>
+      <dependency id=""chocolatey-core.extension"" />
+    </dependencies>
   </metadata>
+  <files>
+  </files>
 </package>";
 
         private const string NuspecContentWithOnlyMajorMinorVersion = @"<?xml version=""1.0"" encoding=""utf-8""?>
@@ -622,7 +652,12 @@ namespace chocolatey.tests.integration.scenarios
     <licenseUrl>http://apache.org/2</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <releaseNotes></releaseNotes>
+    <dependencies>
+      <dependency id=""chocolatey-core.extension"" />
+    </dependencies>
   </metadata>
+  <files>
+  </files>
 </package>";
 
         private const string NuspecContentWithFull4PartVersioning = @"<?xml version=""1.0"" encoding=""utf-8""?>
@@ -640,7 +675,12 @@ namespace chocolatey.tests.integration.scenarios
     <licenseUrl>http://apache.org/2</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <releaseNotes></releaseNotes>
+    <dependencies>
+      <dependency id=""chocolatey-core.extension"" />
+    </dependencies>
   </metadata>
+  <files>
+  </files>
 </package>";
 
         private const string NuspecContentWithAllUnsupportedElements = @"<?xml version=""1.0"" encoding=""utf-8""?>

--- a/src/chocolatey.tests.integration/scenarios/PackScenarios.cs
+++ b/src/chocolatey.tests.integration/scenarios/PackScenarios.cs
@@ -307,6 +307,101 @@ namespace chocolatey.tests.integration.scenarios
             }
         }
 
+        [Categories.SemVer20]
+        public class when_packaging_with_four_part_version_with_trailing_zero : ScenariosBase
+        {
+            private string _originalVersion = "0.1.0.0";
+            protected override string ExpectedNuspecVersion => "0.1.0";
+            protected override string ExpectedSubDirectory => "PackageOutput";
+
+            public override void Because()
+            {
+                MockLogger.reset();
+                Service.pack_run(Configuration);
+            }
+
+            protected override string GetNuspecContent()
+            {
+                return NuspecContentWithFormatableVersion.format_with(_originalVersion);
+            }
+        }
+
+        [Categories.SemVer20]
+        public class when_packaging_with_leading_zeros_four_part : ScenariosBase
+        {
+            private string _originalVersion = "01.02.03.04";
+            protected override string ExpectedNuspecVersion => "1.2.3.4";
+            protected override string ExpectedSubDirectory => "PackageOutput";
+
+            public override void Because()
+            {
+                MockLogger.reset();
+                Service.pack_run(Configuration);
+            }
+
+            protected override string GetNuspecContent()
+            {
+                return NuspecContentWithFormatableVersion.format_with(_originalVersion);
+            }
+        }
+
+        [Categories.SemVer20]
+        public class when_packaging_with_leading_zeros_three_part : ScenariosBase
+        {
+            private string _originalVersion = "01.02.04";
+            protected override string ExpectedNuspecVersion => "1.2.4";
+            protected override string ExpectedSubDirectory => "PackageOutput";
+
+            public override void Because()
+            {
+                MockLogger.reset();
+                Service.pack_run(Configuration);
+            }
+
+            protected override string GetNuspecContent()
+            {
+                return NuspecContentWithFormatableVersion.format_with(_originalVersion);
+            }
+        }
+
+        [Categories.SemVer20]
+        public class when_packaging_with_leading_zeros_two_part : ScenariosBase
+        {
+            private string _originalVersion = "01.02";
+            protected override string ExpectedNuspecVersion => "1.2.0";
+            protected override string ExpectedSubDirectory => "PackageOutput";
+
+            public override void Because()
+            {
+                MockLogger.reset();
+                Service.pack_run(Configuration);
+            }
+
+            protected override string GetNuspecContent()
+            {
+                return NuspecContentWithFormatableVersion.format_with(_originalVersion);
+            }
+        }
+
+        [Categories.SemVer20]
+        public class when_packaging_with_multiple_leading_zeros : ScenariosBase
+        {
+            private string _originalVersion = "0001.0002.0003";
+            protected override string ExpectedNuspecVersion => "1.2.3";
+            protected override string ExpectedSubDirectory => "PackageOutput";
+
+            public override void Because()
+            {
+                MockLogger.reset();
+                Service.pack_run(Configuration);
+            }
+
+            protected override string GetNuspecContent()
+            {
+                return NuspecContentWithFormatableVersion.format_with(_originalVersion);
+            }
+        }
+
         public class when_packing_with_properties : ScenariosBase
         {
             protected override string ExpectedNuspecVersion => "0.1.0";
@@ -751,6 +846,29 @@ namespace chocolatey.tests.integration.scenarios
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <releaseNotes></releaseNotes>
     <icon>icon.png</icon>
+    <dependencies>
+      <dependency id=""chocolatey-core.extension"" />
+    </dependencies>
+  </metadata>
+  <files>
+  </files>
+</package>";
+
+        private const string NuspecContentWithFormatableVersion = @"<?xml version=""1.0"" encoding=""utf-8""?>
+<package xmlns=""http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd"">
+  <metadata>
+    <id>test-package</id>
+    <title>Test Package</title>
+    <version>{0}</version>
+    <authors>package author</authors>
+    <owners>package owner</owners>
+    <summary>A brief summary</summary>
+    <description>A big description</description>
+    <tags>test admin</tags>
+    <copyright></copyright>
+    <licenseUrl>http://apache.org/2</licenseUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <releaseNotes></releaseNotes>
     <dependencies>
       <dependency id=""chocolatey-core.extension"" />
     </dependencies>

--- a/src/chocolatey.tests.integration/scenarios/UninstallScenarios.cs
+++ b/src/chocolatey.tests.integration/scenarios/UninstallScenarios.cs
@@ -1409,5 +1409,123 @@ namespace chocolatey.tests.integration.scenarios
                 MockLogger.contains_message("UpperCase 1.1.0 Uninstalled", LogLevel.Info).ShouldBeTrue();
             }
         }
+
+        public class when_uninstalling_a_package_with_non_normalized_version : ScenariosBase
+        {
+            private PackageResult packageResult;
+
+            private string NonNormalizedVersion = "0004.0004.00005.00";
+
+            public override void Context()
+            {
+                base.Context();
+
+                Configuration.PackageNames = Configuration.Input = "upgradepackage";
+                Scenario.add_changed_version_package_to_source_location(Configuration, "upgradepackage.1.1.0" + NuGetConstants.PackageExtension, NonNormalizedVersion);
+                Scenario.install_package(Configuration, "upgradepackage", NonNormalizedVersion);
+            }
+
+            public override void Because()
+            {
+                Results = Service.uninstall_run(Configuration);
+                packageResult = Results.FirstOrDefault().Value;
+            }
+
+            [Fact]
+            public void should_remove_the_package_from_the_lib_directory()
+            {
+                var packageDir = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames);
+
+                DirectoryAssert.DoesNotExist(packageDir);
+            }
+
+            [Fact]
+            public void should_delete_the_rollback()
+            {
+                var packageDir = Path.Combine(Scenario.get_top_level(), "lib-bkp", Configuration.PackageNames);
+
+                DirectoryAssert.DoesNotExist(packageDir);
+            }
+
+            [Fact]
+            [WindowsOnly]
+            [Platform(Exclude = "Mono")]
+            public void should_delete_a_shim_for_console_in_the_bin_directory()
+            {
+                var shimfile = Path.Combine(Scenario.get_top_level(), "bin", "console.exe");
+
+                FileAssert.DoesNotExist(shimfile);
+            }
+
+            [Fact]
+            [WindowsOnly]
+            [Platform(Exclude = "Mono")]
+            public void should_delete_a_shim_for_graphical_in_the_bin_directory()
+            {
+                var shimfile = Path.Combine(Scenario.get_top_level(), "bin", "graphical.exe");
+
+                FileAssert.DoesNotExist(shimfile);
+            }
+
+            [Fact]
+            public void should_delete_any_files_created_during_the_install()
+            {
+                var generatedFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, "simplefile.txt");
+
+                FileAssert.DoesNotExist(generatedFile);
+            }
+
+            [Fact]
+            public void should_contain_a_warning_message_that_it_uninstalled_successfully()
+            {
+                bool installedSuccessfully = false;
+                foreach (var message in MockLogger.MessagesFor(LogLevel.Warn).or_empty_list_if_null())
+                {
+                    if (message.Contains("1/1")) installedSuccessfully = true;
+                }
+
+                installedSuccessfully.ShouldBeTrue();
+            }
+
+            [Fact]
+            public void should_have_a_successful_package_result()
+            {
+                packageResult.Success.ShouldBeTrue();
+            }
+
+            [Fact]
+            public void should_not_have_inconclusive_package_result()
+            {
+                packageResult.Inconclusive.ShouldBeFalse();
+            }
+
+            [Fact]
+            public void should_not_have_warning_package_result()
+            {
+                packageResult.Warning.ShouldBeFalse();
+            }
+
+            [Fact]
+            public void config_should_match_package_result_name()
+            {
+                packageResult.Name.ShouldEqual(Configuration.PackageNames);
+            }
+
+            [Fact]
+            [WindowsOnly]
+            [Platform(Exclude = "Mono")]
+            public void should_have_executed_chocolateyBeforeModify_script()
+            {
+                MockLogger.contains_message("upgradepackage {0} Before Modification".format_with(NonNormalizedVersion), LogLevel.Info).ShouldBeTrue();
+            }
+
+            [Fact]
+            [WindowsOnly]
+            [Platform(Exclude = "Mono")]
+            public void should_have_executed_chocolateyUninstall_script()
+            {
+                MockLogger.contains_message("upgradepackage {0} Uninstalled".format_with(NonNormalizedVersion), LogLevel.Info).ShouldBeTrue();
+            }
+        }
     }
 }

--- a/src/chocolatey/infrastructure.app/nuget/NugetList.cs
+++ b/src/chocolatey/infrastructure.app/nuget/NugetList.cs
@@ -163,6 +163,11 @@ namespace chocolatey.infrastructure.app.nuget
                 }
             }
 
+            if (version != null)
+            {
+                results = results.Where(p => p.Identity.Version.Equals(version)).ToHashSet();
+            }
+
             if (configuration.ListCommand.ByIdOnly)
             {
                 results = results.Where(p => p.Identity.Id.ToLower().Contains(searchTermLower)).ToHashSet();

--- a/src/chocolatey/infrastructure.app/services/NugetService.cs
+++ b/src/chocolatey/infrastructure.app/services/NugetService.cs
@@ -153,11 +153,6 @@ namespace chocolatey.infrastructure.app.services
             {
                 var package = pkg; // for lamda access
 
-                if (!string.IsNullOrWhiteSpace(config.Version))
-                {
-                    if (!pkg.Identity.Version.to_string().is_equal_to(config.Version)) continue;
-                }
-
                 ChocolateyPackageMetadata packageLocalMetadata;
                 string packageInstallLocation = null;
                 if (package.PackagePath != null && !string.IsNullOrWhiteSpace(package.PackagePath))


### PR DESCRIPTION
## Description Of Changes

This adds pack tests to ensure that leading zeros are removed, and that a zero in the fourth part of the version will be trimmed down to three parts. 

More scenarios are added to ensure that pre-existing packages with non-normalized versions can be installed/upgrade/uninstalled, and that they can be found when searching with a version.

## Motivation and Context

As a part of supporting SemVer v2, some version normalization was added.
https://learn.microsoft.com/en-us/nuget/concepts/package-versioning#normalized-version-numbers

The pack tests are to ensure that the version normalization on pack with the new NuGet assemblies is consistent into the future. There were already pack tests for removing semver v2 build metadata and that four part versions still work. 

The other tests make sure that pre-existing non-normalized versions of packages still install/upgrade/uninstall correctly, and that when specifying a version they can be found.

## Testing

- Ran added tests

### Operating Systems Testing
- Windows 10 22H2

## Change Types Made

* [ ] Bug fix (non-breaking change).
* [x] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [x] Tests to cover my changes, have been added.
* [x] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue

Tests for #1174 
Part of #1610
https://app.clickup.com/t/20540031/PROJ-381
