### PR TITLE
(#2738) Add tests to ensure NuGet configuration directories aren't created

### DIFF
--- a/tests/chocolatey-tests/commands/choco-apikey.Tests.ps1
+++ b/tests/chocolatey-tests/commands/choco-apikey.Tests.ps1
@@ -10,6 +10,7 @@ Import-Module helpers/common-helpers
 
 Describe "choco <_>" -ForEach $Command -Tag Chocolatey, ApiKeyCommand {
     BeforeAll {
+        Remove-NuGetPaths
         Initialize-ChocolateyTestInstall
         $CurrentCommand = $_
 
@@ -229,4 +230,7 @@ Describe "choco <_>" -ForEach $Command -Tag Chocolatey, ApiKeyCommand {
             $Output.Lines | Should -Contain "https://test.com/api - (Authenticated)"
         }
     }
+
+    # This needs to be the last test in this block, to ensure NuGet configurations aren't being created.
+    Test-NuGetPaths
 }

--- a/tests/chocolatey-tests/commands/choco-config.Tests.ps1
+++ b/tests/chocolatey-tests/commands/choco-config.Tests.ps1
@@ -2,6 +2,7 @@
 
 Describe "choco config" -Tag Chocolatey, ConfigCommand {
     BeforeAll {
+        Remove-NuGetPaths
         Initialize-ChocolateyTestInstall
         New-ChocolateyInstallSnapshot
 
@@ -348,4 +349,7 @@ Describe "choco config" -Tag Chocolatey, ConfigCommand {
             $value | Should -HaveCount 0
         }
     }
+
+    # This needs to be the last test in this block, to ensure NuGet configurations aren't being created.
+    Test-NuGetPaths
 }

--- a/tests/chocolatey-tests/commands/choco-export.Tests.ps1
+++ b/tests/chocolatey-tests/commands/choco-export.Tests.ps1
@@ -12,6 +12,7 @@ Describe "choco export" -Tag Chocolatey, ExportCommand {
     }
 
     BeforeAll {
+        Remove-NuGetPaths
         $expectedHeader = Get-ExpectedChocolateyHeader
         Initialize-ChocolateyTestInstall
 
@@ -466,4 +467,7 @@ Describe "choco export" -Tag Chocolatey, ExportCommand {
             $Output.Lines | Should -Contain "Export all currently installed packages to a file."
         }
     }
+
+    # This needs to be the last test in this block, to ensure NuGet configurations aren't being created.
+    Test-NuGetPaths
 }

--- a/tests/chocolatey-tests/commands/choco-feature.Tests.ps1
+++ b/tests/chocolatey-tests/commands/choco-feature.Tests.ps1
@@ -14,6 +14,7 @@ Describe "choco <_>" -ForEach $Command -Tag Chocolatey, FeatureCommand {
     }
 
     BeforeAll {
+        Remove-NuGetPaths
         $CommandUnderTest = $_
         Initialize-ChocolateyTestInstall
 
@@ -212,4 +213,7 @@ Describe "choco <_>" -ForEach $Command -Tag Chocolatey, FeatureCommand {
             $Output.String | Should -Match "Feature 'nonExistingFeature' not found"
         }
     }
+
+    # This needs to be the last test in this block, to ensure NuGet configurations aren't being created.
+    Test-NuGetPaths
 }

--- a/tests/chocolatey-tests/commands/choco-help.Tests.ps1
+++ b/tests/chocolatey-tests/commands/choco-help.Tests.ps1
@@ -27,6 +27,7 @@ Describe "choco help sections with command <_>" -ForEach $Command -Tag Chocolate
     }
 
     BeforeAll {
+        Remove-NuGetPaths
         $helpArgument = $_
         Initialize-ChocolateyTestInstall
         New-ChocolateyInstallSnapshot
@@ -90,4 +91,7 @@ Describe "choco help sections with command <_>" -ForEach $Command -Tag Chocolate
             $Output.Lines | Should -Contain "Options and Switches"
         }
     }
+
+    # This needs to be the last test in this block, to ensure NuGet configurations aren't being created.
+    Test-NuGetPaths
 }

--- a/tests/chocolatey-tests/commands/choco-info.Tests.ps1
+++ b/tests/chocolatey-tests/commands/choco-info.Tests.ps1
@@ -23,6 +23,7 @@ Describe "choco info" -Tag Chocolatey, InfoCommand {
         }
 
         BeforeAll {
+            Remove-NuGetPaths
             $Output = Invoke-Choco info mvcmusicstore-web
             $Output.Lines = $Output.Lines
         }
@@ -160,4 +161,7 @@ Describe "choco info" -Tag Chocolatey, InfoCommand {
             $Output.Lines | Should -Contain "Side by side installations are deprecated and is pending removal in v2.0.0." -Because $Output.String
         }
     }
+
+    # This needs to be the last test in this block, to ensure NuGet configurations aren't being created.
+    Test-NuGetPaths
 }

--- a/tests/chocolatey-tests/commands/choco-install.Tests.ps1
+++ b/tests/chocolatey-tests/commands/choco-install.Tests.ps1
@@ -14,6 +14,7 @@ Describe "choco install" -Tag Chocolatey, InstallCommand {
     }
 
     BeforeAll {
+        Remove-NuGetPaths
         Initialize-ChocolateyTestInstall
 
         New-ChocolateyInstallSnapshot
@@ -1624,4 +1625,7 @@ Describe "choco install" -Tag Chocolatey, InstallCommand {
             $prompts.Count | Should -Be 1
         }
     }
+
+    # This needs to be the last test in this block, to ensure NuGet configurations aren't being created.
+    Test-NuGetPaths
 }

--- a/tests/chocolatey-tests/commands/choco-list.Tests.ps1
+++ b/tests/chocolatey-tests/commands/choco-list.Tests.ps1
@@ -22,6 +22,7 @@ Describe "choco <_>" -ForEach $Command -Tag Chocolatey, ListCommand, SearchComma
     }
 
     BeforeAll {
+        Remove-NuGetPaths
         Initialize-ChocolateyTestInstall -Source $PSScriptRoot\testpackages
         Invoke-Choco install installpackage --version 1.0.0 --confirm
         Invoke-Choco install upgradepackage --version 1.0.0 --confirm
@@ -414,4 +415,8 @@ Describe "choco <_>" -ForEach $Command -Tag Chocolatey, ListCommand, SearchComma
             $Output.Lines | Should -Contain "isexactversiondependency $_"
         }
     }
+
+
+    # This needs to be the last test in this block, to ensure NuGet configurations aren't being created.
+    Test-NuGetPaths
 }

--- a/tests/chocolatey-tests/commands/choco-new.Tests.ps1
+++ b/tests/chocolatey-tests/commands/choco-new.Tests.ps1
@@ -17,6 +17,7 @@ $EmptyFolders = @(
 )
 Describe "choco new" -Tag Chocolatey, NewCommand {
     BeforeAll {
+        Remove-NuGetPaths
         Initialize-ChocolateyTestInstall
 
         $expectedHeader = Get-ExpectedChocolateyHeader
@@ -157,4 +158,7 @@ Describe "choco new" -Tag Chocolatey, NewCommand {
             "$PWD\emptyfolder\$_" | Should -Exist
         }
     }
+
+    # This needs to be the last test in this block, to ensure NuGet configurations aren't being created.
+    Test-NuGetPaths
 }

--- a/tests/chocolatey-tests/commands/choco-outdated.Tests.ps1
+++ b/tests/chocolatey-tests/commands/choco-outdated.Tests.ps1
@@ -2,6 +2,7 @@
 
 Describe "choco outdated" -Tag Chocolatey, OutdatedCommand {
     BeforeAll {
+        Remove-NuGetPaths
         Initialize-ChocolateyTestInstall
         # Pin all of the Chocolatey packages
         @(
@@ -41,4 +42,7 @@ Describe "choco outdated" -Tag Chocolatey, OutdatedCommand {
             $Output.Lines | Should -Not:($ExitCode -eq 0) -Contain 'upgradepackage|1.0.0|1.1.0|true'
         }
     }
+
+    # This needs to be the last test in this block, to ensure NuGet configurations aren't being created.
+    Test-NuGetPaths
 }

--- a/tests/chocolatey-tests/commands/choco-pack.Tests.ps1
+++ b/tests/chocolatey-tests/commands/choco-pack.Tests.ps1
@@ -26,6 +26,7 @@ $invalidFailures = @(
 
 Describe "choco pack" -Tag Chocolatey, PackCommand {
     BeforeAll {
+        Remove-NuGetPaths
         $testPackageLocation = "$(Get-TempDirectory)ChocolateyTests\packages"
         Initialize-ChocolateyTestInstall -Source $testPackageLocation
 
@@ -367,4 +368,7 @@ Describe "choco pack" -Tag Chocolatey, PackCommand {
             "$PWD\archiveContents\tools\purpose.txt" | Should -Exist
         }
     }
+
+    # This needs to be the last test in this block, to ensure NuGet configurations aren't being created.
+    Test-NuGetPaths
 }

--- a/tests/chocolatey-tests/commands/choco-pin.Tests.ps1
+++ b/tests/chocolatey-tests/commands/choco-pin.Tests.ps1
@@ -4,6 +4,7 @@
 
 Describe "choco pin" -Tag Chocolatey, PinCommand {
     BeforeAll {
+        Remove-NuGetPaths
         $testPackageLocation = "$(Get-TempDirectory)ChocolateyTests\packages"
         Initialize-ChocolateyTestInstall -Source $testPackageLocation
 
@@ -185,4 +186,7 @@ Describe "choco pin" -Tag Chocolatey, PinCommand {
             $Output.Lines | Should -Contain "Unable to find package named 'whatisthis' to pin. Please check to ensure it is installed."
         }
     }
+
+    # This needs to be the last test in this block, to ensure NuGet configurations aren't being created.
+    Test-NuGetPaths
 }

--- a/tests/chocolatey-tests/commands/choco-push.Tests.ps1
+++ b/tests/chocolatey-tests/commands/choco-push.Tests.ps1
@@ -12,6 +12,7 @@ Describe "choco push" -Tag Chocolatey, PushCommand -Skip:($null -eq $env:API_KEY
     }
 
     BeforeAll {
+        Remove-NuGetPaths
         # Ideally this comes from an environment variable, but that's proving harder to put into the tests than is desired.
         $ApiKey = $env:API_KEY
         # Using Chocolatey Community Repository for pushing as choco-test could be blown away at any time, and we'd have to reset up the user and packages.
@@ -122,4 +123,7 @@ Describe "choco push" -Tag Chocolatey, PushCommand -Skip:($null -eq $env:API_KEY
             $Output.Lines | Should -Contain "The remote server returned an error: (409) Conflict.."
         }
     }
+
+    # This needs to be the last test in this block, to ensure NuGet configurations aren't being created.
+    Test-NuGetPaths
 }

--- a/tests/chocolatey-tests/commands/choco-source.Tests.ps1
+++ b/tests/chocolatey-tests/commands/choco-source.Tests.ps1
@@ -10,6 +10,7 @@ Import-Module helpers/common-helpers
 
 Describe "choco <_>" -ForEach $Command -Tag Chocolatey, SourceCommand {
     BeforeAll {
+        Remove-NuGetPaths
         Initialize-ChocolateyTestInstall
         New-ChocolateyInstallSnapshot
 
@@ -425,4 +426,7 @@ Describe "choco <_>" -ForEach $Command -Tag Chocolatey, SourceCommand {
             $Output.Lines | Should -Contain "Nothing to change. Config already set."
         }
     }
+
+    # This needs to be the last test in this block, to ensure NuGet configurations aren't being created.
+    Test-NuGetPaths
 }

--- a/tests/chocolatey-tests/commands/choco-template.Tests.ps1
+++ b/tests/chocolatey-tests/commands/choco-template.Tests.ps1
@@ -8,6 +8,7 @@ Describe "choco <_>" -ForEach @(
     }
 
     BeforeAll {
+        Remove-NuGetPaths
         Initialize-ChocolateyTestInstall
 
         New-ChocolateyInstallSnapshot
@@ -295,4 +296,7 @@ Describe "choco <_>" -ForEach @(
             "$env:ChocolateyInstall\templates\$_\.parameters" | Should -Exist
         }
     }
+
+    # This needs to be the last test in this block, to ensure NuGet configurations aren't being created.
+    Test-NuGetPaths
 }

--- a/tests/chocolatey-tests/commands/choco-uninstall.Tests.ps1
+++ b/tests/chocolatey-tests/commands/choco-uninstall.Tests.ps1
@@ -1,7 +1,8 @@
-﻿Import-Module helpers/common-helpers
+Import-Module helpers/common-helpers
 
 Describe "choco uninstall" -Tag Chocolatey, UninstallCommand {
     BeforeAll {
+        Remove-NuGetPaths
         Initialize-ChocolateyTestInstall
 
         New-ChocolateyInstallSnapshot
@@ -65,4 +66,7 @@ Describe "choco uninstall" -Tag Chocolatey, UninstallCommand {
             $Output.Lines | Should -Contain ($_ -replace '<installPath>', $env:ChocolateyInstall) -Because $Output.String
         }
     }
+
+    # This needs to be the last test in this block, to ensure NuGet configurations aren't being created.
+    Test-NuGetPaths
 }

--- a/tests/chocolatey-tests/commands/choco-upgrade.Tests.ps1
+++ b/tests/chocolatey-tests/commands/choco-upgrade.Tests.ps1
@@ -2,6 +2,7 @@ Import-Module helpers/common-helpers
 
 Describe "choco upgrade" -Tag Chocolatey, UpgradeCommand {
     BeforeAll {
+        Remove-NuGetPaths
         Initialize-ChocolateyTestInstall
 
         New-ChocolateyInstallSnapshot
@@ -256,4 +257,8 @@ Describe "choco upgrade" -Tag Chocolatey, UpgradeCommand {
             }
         }
     }
+
+
+    # This needs to be the last test in this block, to ensure NuGet configurations aren't being created.
+    Test-NuGetPaths
 }

--- a/tests/chocolatey-tests/commands/choco-version.Tests.ps1
+++ b/tests/chocolatey-tests/commands/choco-version.Tests.ps1
@@ -2,6 +2,7 @@
 
 Describe "choco version" -Tag Chocolatey, VersionCommand -Skip:(Test-ChocolateyVersionEqualOrHigherThan "1.0.0") {
     BeforeAll {
+        Remove-NuGetPaths
         Initialize-ChocolateyTestInstall
         New-ChocolateyInstallSnapshot
     }
@@ -50,4 +51,7 @@ Describe "choco version" -Tag Chocolatey, VersionCommand -Skip:(Test-ChocolateyV
             $Output.String | Should -Match "has been deprecated"
         }
     }
+
+    # This needs to be the last test in this block, to ensure NuGet configurations aren't being created.
+    Test-NuGetPaths
 }

--- a/tests/helpers/common/NuGet/Get-NuGetPaths.ps1
+++ b/tests/helpers/common/NuGet/Get-NuGetPaths.ps1
@@ -1,0 +1,8 @@
+function Get-NuGetPaths {
+    @(
+        "$env:localappdata\NuGet"
+        "$(Get-TempDirectory)\NuGetScratch"
+        "$env:userprofile\.nuget"
+        "${env:programfiles(x86)}\NuGet"
+    )
+}

--- a/tests/helpers/common/NuGet/Remove-NuGetPaths.ps1
+++ b/tests/helpers/common/NuGet/Remove-NuGetPaths.ps1
@@ -1,0 +1,19 @@
+function Remove-NuGetPaths {
+    $NuGetPathsToRemove = Get-NuGetPaths
+    $ChocolateyNuGetPath = "$(Get-TempDirectory)\chocolatey-invalid"
+
+    if (Test-Path $ChocolateyNuGetPath) {
+        Remove-Item -Path $ChocolateyNuGetPath -Recurse -Force -ErrorAction Stop
+    }
+
+    $script:NuGetCleared = $true
+
+    # If we're in Test Kitchen, we're going to remove the NuGet config files because we don't need to worry about a user's config
+    if ($env:TEST_KITCHEN) {
+        foreach ($path in $NuGetPathsToRemove) {
+            if (Test-Path $path) {
+                Remove-Item -Path $path -Recurse -Force -ErrorAction Stop
+            }
+        }
+    }
+}

--- a/tests/helpers/common/NuGet/Test-NuGetPaths.ps1
+++ b/tests/helpers/common/NuGet/Test-NuGetPaths.ps1
@@ -1,0 +1,16 @@
+function Test-NuGetPaths {
+    $script:NuGetCleared = $false
+    $NuGetPathsToCheck = Get-NuGetPaths
+    $ChocolateyNuGetPath = "$(Get-TempDirectory)chocolatey-invalid"
+
+    It 'Did not create <_> directory' -ForEach $NuGetPathsToCheck -Skip:((-not $env:TEST_KITCHEN)) {
+        if (-not $script:NuGetCleared) {
+            Set-ItResult -Skipped -Because 'NuGet configurations were not removed before running tests'
+        }
+        $_ | Should -Not -Exist
+    }
+
+    It "Did not create <_>" -ForEach $ChocolateyNuGetPath {
+        $_ | Should -Not -Exist
+    }
+}


### PR DESCRIPTION
## Description Of Changes

Add end to end tests to ensure that NuGet directories aren't being created by Chocolatey CLI.

## Motivation and Context

Our code shouldn't touch anywhere that creates these directories. This ensures we don't accidentally introduce anything.

## Testing

1. Ran tests in the Vagrant environment
2. All added tests completed successfully.

### Operating Systems Testing

- Windows Server 2022 (Vagrant file from #2971)
- Windows Server 2019 (Test Kitchen)
- Windows Server 2016 (Test Kitchen)

## Change Types Made
<!-- Tick the boxes for the type of changes that have been made -->

* [ ] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.
* [x] End to end tests

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [x] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue

* Related to #2738 
* CU-PROJ-443
* https://github.com/chocolatey/NuGet.Client/pull/17
