### PR TITLE
(#508) Set NuGet user agent for all commands.

### DIFF
--- a/src/chocolatey/infrastructure.app/nuget/NugetCommon.cs
+++ b/src/chocolatey/infrastructure.app/nuget/NugetCommon.cs
@@ -113,6 +113,8 @@ namespace chocolatey.infrastructure.app.nuget
             }
             */
 
+            // Set user agent for all NuGet library calls. Should not affect any HTTP calls that Chocolatey itself would make.
+            UserAgent.SetUserAgentString(new UserAgentStringBuilder("{0}/{1} via NuGet Client".format_with(ApplicationParameters.UserAgent, configuration.Information.ChocolateyProductVersion)));
 
             // ensure credentials can be grabbed from configuration
             SetHttpHandlerCredentialService(configuration);

--- a/src/chocolatey/infrastructure.app/nuget/NugetPush.cs
+++ b/src/chocolatey/infrastructure.app/nuget/NugetPush.cs
@@ -46,7 +46,6 @@ namespace chocolatey.infrastructure.app.nuget
             SourceRepository sourceRepository = NugetCommon.GetRemoteRepositories(config, nugetLogger, filesystem).FirstOrDefault();
             PackageUpdateResource packageUpdateResource = sourceRepository.GetResource<PackageUpdateResource>();
             var nupkgFilePaths = new List<string>() { nupkgFilePath };
-            UserAgent.SetUserAgentString(new UserAgentStringBuilder("{0}/{1} via NuGet Client".format_with(ApplicationParameters.UserAgent, config.Information.ChocolateyProductVersion)));
 
             try
             {


### PR DESCRIPTION
## Description Of Changes

This moves the NuGet user agent setting from only the Push command to
`NugetCommon.GetRemoteRepositories` so it is set for all commands that use remote sources.

## Motivation and Context

User agent should be set to indicate that the client is Chocolatey for all commands.

## Testing

- Ran `choco install wget --trace` and ensured that the user agent was set for all calls (see line starting with `user-agent:` in trace output)
- Ran `choco push --trace` with a package to an internal repository and ensure that the user agent was set

### Operating Systems Testing
- Windows 10 22H2

## Change Types Made

* [x] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [x] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue

Part of #508

