### PR TITLE
(#508) Re-introduce license acceptance rule validation

### DIFF
--- a/src/chocolatey/infrastructure.app/services/NugetService.cs
+++ b/src/chocolatey/infrastructure.app/services/NugetService.cs
@@ -326,6 +326,11 @@ namespace chocolatey.infrastructure.app.services
                 issuesList.Add("<license> elements are not supported in Chocolatey CLI, use <licenseUrl> instead");
             }
 
+            if (string.IsNullOrWhiteSpace(nuspecReader.GetLicenseUrl()) && nuspecReader.GetRequireLicenseAcceptance())
+            {
+                issuesList.Add("Enabling license acceptance requires a license url.");
+            }
+
             if (!(metadataNode.Elements(XName.Get("packageTypes", metadataNamespace)).FirstOrDefault() is null))
             {
                 issuesList.Add("<packageTypes> elements are not supported in Chocolatey CLI");

--- a/tests/chocolatey-tests/commands/choco-pack.Tests.ps1
+++ b/tests/chocolatey-tests/commands/choco-pack.Tests.ps1
@@ -62,6 +62,14 @@ Describe "choco pack" -Tag Chocolatey, PackCommand {
         It "Outputs Error Message" {
             $Output.String | Should -Match "No \.nuspec files \(or more than 1\) were found to build in .*Please specify the \.nuspec file or try in a different directory\."
         }
+
+        It "Should not output message about license url being deprecated" {
+            $Output.String | Should -Not -Match "The 'licenseUrl' element will be deprecated"
+        }
+
+        It "Should not output message about iconUrl being deprecated" {
+            $Output.String | Should -Not -Match "The 'PackageIconUrl'/'iconUrl' element is deprecated"
+        }
     }
 
     Context "Package <_> metadata in current directory" -ForEach $successPack {
@@ -86,6 +94,14 @@ Describe "choco pack" -Tag Chocolatey, PackCommand {
         It "Creates nuget package" {
             "$_\$_.1.0.0.nupkg" | Should -Exist
         }
+
+        It "Should not output message about license url being deprecated" {
+            $Output.String | Should -Not -Match "The 'licenseUrl' element will be deprecated"
+        }
+
+        It "Should not output message about iconUrl being deprecated" {
+            $Output.String | Should -Not -Match "The 'PackageIconUrl'/'iconUrl' element is deprecated"
+        }
     }
 
     Context "Package <_> metadata with path" -ForEach $successPack {
@@ -107,6 +123,14 @@ Describe "choco pack" -Tag Chocolatey, PackCommand {
 
         It "Creates nuget package" {
             "$_.1.0.0.nupkg" | Should -Exist
+        }
+
+        It "Should not output message about license url being deprecated" {
+            $Output.String | Should -Not -Match "The 'licenseUrl' element will be deprecated"
+        }
+
+        It "Should not output message about iconUrl being deprecated" {
+            $Output.String | Should -Not -Match "The 'PackageIconUrl'/'iconUrl' element is deprecated"
         }
     }
 
@@ -131,6 +155,14 @@ Describe "choco pack" -Tag Chocolatey, PackCommand {
         It "Does not create the nuget package" {
             "required.1.0.0.nupkg" | Should -Not -Exist
         }
+
+        It "Should not output message about license url being deprecated" {
+            $Output.String | Should -Not -Match "The 'licenseUrl' element will be deprecated"
+        }
+
+        It "Should not output message about iconUrl being deprecated" {
+            $Output.String | Should -Not -Match "The 'PackageIconUrl'/'iconUrl' element is deprecated"
+        }
     }
 
     # TODO: Validation messages are incomplete and are missing some items
@@ -154,6 +186,14 @@ Describe "choco pack" -Tag Chocolatey, PackCommand {
         It "Does not create the nuget package" {
             "empty.1.0.0.nupkg" | Should -Not -Exist
         }
+
+        It "Should not output message about license url being deprecated" {
+            $Output.String | Should -Not -Match "The 'licenseUrl' element will be deprecated"
+        }
+
+        It "Should not output message about iconUrl being deprecated" {
+            $Output.String | Should -Not -Match "The 'PackageIconUrl'/'iconUrl' element is deprecated"
+        }
     }
 
     # This empty element must be in a seperate nuspec file as it will be a serializing error
@@ -172,6 +212,14 @@ Describe "choco pack" -Tag Chocolatey, PackCommand {
 
         It "Does not create the nuget package" {
             "requireLicenseAcceptance.1.0.0.nupkg" | Should -Not -Exist
+        }
+
+        It "Should not output message about license url being deprecated" {
+            $Output.String | Should -Not -Match "The 'licenseUrl' element will be deprecated"
+        }
+
+        It "Should not output message about iconUrl being deprecated" {
+            $Output.String | Should -Not -Match "The 'PackageIconUrl'/'iconUrl' element is deprecated"
         }
     }
 
@@ -194,6 +242,14 @@ Describe "choco pack" -Tag Chocolatey, PackCommand {
 
         It "Does not create the nuget package" {
             "missing.1.0.0.nupkg" | Should -Not -Exist
+        }
+
+        It "Should not output message about license url being deprecated" {
+            $Output.String | Should -Not -Match "The 'licenseUrl' element will be deprecated"
+        }
+
+        It "Should not output message about iconUrl being deprecated" {
+            $Output.String | Should -Not -Match "The 'PackageIconUrl'/'iconUrl' element is deprecated"
         }
     }
 
@@ -218,6 +274,14 @@ Describe "choco pack" -Tag Chocolatey, PackCommand {
         It "Does not create the nuget package" {
             "invalid-$($_.id).1.0.0.nupkg" | Should -Not -Exist
         }
+
+        It "Should not output message about license url being deprecated" {
+            $Output.String | Should -Not -Match "The 'licenseUrl' element will be deprecated"
+        }
+
+        It "Should not output message about iconUrl being deprecated" {
+            $Output.String | Should -Not -Match "The 'PackageIconUrl'/'iconUrl' element is deprecated"
+        }
     }
 
     Context "Package with invalid character '&'" {
@@ -239,6 +303,14 @@ Describe "choco pack" -Tag Chocolatey, PackCommand {
 
         It "Does not create the nuget package" {
             "invalid-character-and.1.0.0.nupkg" | Should -Not -Exist
+        }
+
+        It "Should not output message about license url being deprecated" {
+            $Output.String | Should -Not -Match "The 'licenseUrl' element will be deprecated"
+        }
+
+        It "Should not output message about iconUrl being deprecated" {
+            $Output.String | Should -Not -Match "The 'PackageIconUrl'/'iconUrl' element is deprecated"
         }
     }
 
@@ -262,6 +334,14 @@ Describe "choco pack" -Tag Chocolatey, PackCommand {
         It "Does not create the nuget package" {
             "invalid-character-lesser.1.0.0.nupkg" | Should -Not -Exist
         }
+
+        It "Should not output message about license url being deprecated" {
+            $Output.String | Should -Not -Match "The 'licenseUrl' element will be deprecated"
+        }
+
+        It "Should not output message about iconUrl being deprecated" {
+            $Output.String | Should -Not -Match "The 'PackageIconUrl'/'iconUrl' element is deprecated"
+        }
     }
 
     Context "Package with version override" {
@@ -283,6 +363,14 @@ Describe "choco pack" -Tag Chocolatey, PackCommand {
 
         It "Does create the nuget package" {
             "basic.3.0.4.nupkg" | Should -Exist
+        }
+
+        It "Should not output message about license url being deprecated" {
+            $Output.String | Should -Not -Match "The 'licenseUrl' element will be deprecated"
+        }
+
+        It "Should not output message about iconUrl being deprecated" {
+            $Output.String | Should -Not -Match "The 'PackageIconUrl'/'iconUrl' element is deprecated"
         }
     }
 
@@ -316,6 +404,14 @@ Describe "choco pack" -Tag Chocolatey, PackCommand {
         It "Does create the nuget package" {
             "$OutDirectory\basic.1.0.0.nupkg" | Should -Exist
         }
+
+        It "Should not output message about license url being deprecated" {
+            $Output.String | Should -Not -Match "The 'licenseUrl' element will be deprecated"
+        }
+
+        It "Should not output message about iconUrl being deprecated" {
+            $Output.String | Should -Not -Match "The 'PackageIconUrl'/'iconUrl' element is deprecated"
+        }
     }
 
     Context "Package with custom equals out directory" -ForEach @(
@@ -345,6 +441,14 @@ Describe "choco pack" -Tag Chocolatey, PackCommand {
         It "Does create the nuget package" {
             "$OutDirectory\basic.1.0.0.nupkg" | Should -Exist
         }
+
+        It "Should not output message about license url being deprecated" {
+            $Output.String | Should -Not -Match "The 'licenseUrl' element will be deprecated"
+        }
+
+        It "Should not output message about iconUrl being deprecated" {
+            $Output.String | Should -Not -Match "The 'PackageIconUrl'/'iconUrl' element is deprecated"
+        }
     }
 
     # Issue: https://github.com/chocolatey/choco/issues/2166
@@ -369,6 +473,14 @@ Describe "choco pack" -Tag Chocolatey, PackCommand {
             # otherwise if the extraction fails, so will the previous test
             Expand-ZipArchive "$PWD\forward-slash.1.0.0.nupkg" "archiveContents"
             "$PWD\archiveContents\tools\purpose.txt" | Should -Exist
+        }
+
+        It "Should not output message about license url being deprecated" {
+            $Output.String | Should -Not -Match "The 'licenseUrl' element will be deprecated"
+        }
+
+        It "Should not output message about iconUrl being deprecated" {
+            $Output.String | Should -Not -Match "The 'PackageIconUrl'/'iconUrl' element is deprecated"
         }
     }
 
@@ -425,6 +537,14 @@ Describe "choco pack" -Tag Chocolatey, PackCommand {
 
         It 'Shows an error about the unsupported nuspec metadata element "<_>"' -TestCases $testCases {
             $Output.String | Should -Match "$_ elements are not supported in Chocolatey CLI"
+        }
+
+        It "Should not output message about license url being deprecated" {
+            $Output.String | Should -Not -Match "The 'licenseUrl' element will be deprecated"
+        }
+
+        It "Should not output message about iconUrl being deprecated" {
+            $Output.String | Should -Not -Match "The 'PackageIconUrl'/'iconUrl' element is deprecated"
         }
     }
 

--- a/tests/chocolatey-tests/commands/choco-pack.Tests.ps1
+++ b/tests/chocolatey-tests/commands/choco-pack.Tests.ps1
@@ -134,7 +134,7 @@ Describe "choco pack" -Tag Chocolatey, PackCommand {
     }
 
     # TODO: Validation messages are incomplete and are missing some items
-    Context "Package with empty elements" -Tag Broken {
+    Context "Package with empty elements" -Tag PartiallyBroken {
         BeforeAll {
             $Output = Invoke-Choco pack "empty.nuspec"
         }
@@ -147,7 +147,7 @@ Describe "choco pack" -Tag Chocolatey, PackCommand {
             $Output.Lines | Should -Contain $expectedHeader
         }
 
-        It "Displays empty error message for <_>" -ForEach $emptyFailures {
+        It "Displays empty error message for <_>" -ForEach ($emptyFailures | ? { $_ -eq 'licenseUrl' }) {
             $Output.Lines | Should -Contain "$_ cannot be empty."
         }
 
@@ -198,7 +198,7 @@ Describe "choco pack" -Tag Chocolatey, PackCommand {
     }
 
     # TODO: Message about verifying version string has changed, and should be fixed
-    Context "Package with invalid <_.id>" -ForEach ($invalidFailures | ? id -NotIn 'version','requirelicenseacceptance') -Tag PartiallyBroken {
+    Context "Package with invalid <_.id>" -ForEach ($invalidFailures | ? id -NotIn 'version') -Tag PartiallyBroken {
         BeforeAll {
             $Output = Invoke-Choco pack "invalid-$($_.id).nuspec"
         }


### PR DESCRIPTION
## Description Of Changes

This pull request updates the validation that is done when
creating packages to fail the pack when the user has
specified that the package requires license acceptance,
but the license url has not been set.


## Motivation and Context

We want to keep the validation error message we had in v1.2.1 when the package requires license acceptance, but there is no license URL specified.

## Testing

1. Ran through test kitchen locally for the PackCommand
2. Packaged the nuspec file in the repository called `invalid-requirelicenseacceptance.nuspec` and checked the error message

### Operating Systems Testing

- Windows 11/10

## Change Types Made

* [x] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [x] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue

#508  
https://app.clickup.com/t/20540031/PROJ-462
