### PR TITLE
(#508) Use Chocolatey specific server metadata

### DIFF
--- a/src/chocolatey.tests.integration/chocolatey.tests.integration.csproj
+++ b/src/chocolatey.tests.integration/chocolatey.tests.integration.csproj
@@ -78,23 +78,23 @@
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Chocolatey.NuGet.Common, Version=3.0.0.108, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
-      <HintPath>..\packages\Chocolatey.NuGet.Common.3.0.0-alpha-20230112-108\lib\net472\Chocolatey.NuGet.Common.dll</HintPath>
+    <Reference Include="Chocolatey.NuGet.Common, Version=3.0.0.128, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
+      <HintPath>..\packages\Chocolatey.NuGet.Common.3.0.0-alpha-20230123-128\lib\net472\Chocolatey.NuGet.Common.dll</HintPath>
     </Reference>
-    <Reference Include="Chocolatey.NuGet.Configuration, Version=3.0.0.108, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
-      <HintPath>..\packages\Chocolatey.NuGet.Configuration.3.0.0-alpha-20230112-108\lib\net472\Chocolatey.NuGet.Configuration.dll</HintPath>
+    <Reference Include="Chocolatey.NuGet.Configuration, Version=3.0.0.128, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
+      <HintPath>..\packages\Chocolatey.NuGet.Configuration.3.0.0-alpha-20230123-128\lib\net472\Chocolatey.NuGet.Configuration.dll</HintPath>
     </Reference>
-    <Reference Include="Chocolatey.NuGet.Frameworks, Version=3.0.0.108, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
-      <HintPath>..\packages\Chocolatey.NuGet.Frameworks.3.0.0-alpha-20230112-108\lib\net472\Chocolatey.NuGet.Frameworks.dll</HintPath>
+    <Reference Include="Chocolatey.NuGet.Frameworks, Version=3.0.0.128, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
+      <HintPath>..\packages\Chocolatey.NuGet.Frameworks.3.0.0-alpha-20230123-128\lib\net472\Chocolatey.NuGet.Frameworks.dll</HintPath>
     </Reference>
-    <Reference Include="Chocolatey.NuGet.Packaging, Version=3.0.0.108, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
-      <HintPath>..\packages\Chocolatey.NuGet.Packaging.3.0.0-alpha-20230112-108\lib\net472\Chocolatey.NuGet.Packaging.dll</HintPath>
+    <Reference Include="Chocolatey.NuGet.Packaging, Version=3.0.0.128, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
+      <HintPath>..\packages\Chocolatey.NuGet.Packaging.3.0.0-alpha-20230123-128\lib\net472\Chocolatey.NuGet.Packaging.dll</HintPath>
     </Reference>
-    <Reference Include="Chocolatey.NuGet.Protocol, Version=3.0.0.108, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
-      <HintPath>..\packages\Chocolatey.NuGet.Protocol.3.0.0-alpha-20230112-108\lib\net472\Chocolatey.NuGet.Protocol.dll</HintPath>
+    <Reference Include="Chocolatey.NuGet.Protocol, Version=3.0.0.128, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
+      <HintPath>..\packages\Chocolatey.NuGet.Protocol.3.0.0-alpha-20230123-128\lib\net472\Chocolatey.NuGet.Protocol.dll</HintPath>
     </Reference>
-    <Reference Include="Chocolatey.NuGet.Versioning, Version=3.0.0.108, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
-      <HintPath>..\packages\Chocolatey.NuGet.Versioning.3.0.0-alpha-20230112-108\lib\net472\Chocolatey.NuGet.Versioning.dll</HintPath>
+    <Reference Include="Chocolatey.NuGet.Versioning, Version=3.0.0.128, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
+      <HintPath>..\packages\Chocolatey.NuGet.Versioning.3.0.0-alpha-20230123-128\lib\net472\Chocolatey.NuGet.Versioning.dll</HintPath>
     </Reference>
     <Reference Include="log4net, Version=2.0.12.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
       <HintPath>..\packages\log4net.2.0.12\lib\net45\log4net.dll</HintPath>

--- a/src/chocolatey.tests.integration/packages.config
+++ b/src/chocolatey.tests.integration/packages.config
@@ -1,11 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Chocolatey.NuGet.Common" version="3.0.0-alpha-20230112-108" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.Configuration" version="3.0.0-alpha-20230112-108" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.Frameworks" version="3.0.0-alpha-20230112-108" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.Packaging" version="3.0.0-alpha-20230112-108" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.Protocol" version="3.0.0-alpha-20230112-108" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.Versioning" version="3.0.0-alpha-20230112-108" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.Common" version="3.0.0-alpha-20230123-128" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.Configuration" version="3.0.0-alpha-20230123-128" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.Frameworks" version="3.0.0-alpha-20230123-128" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.Packaging" version="3.0.0-alpha-20230123-128" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.Protocol" version="3.0.0-alpha-20230123-128" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.Versioning" version="3.0.0-alpha-20230123-128" targetFramework="net48" />
   <package id="log4net" version="2.0.12" targetFramework="net48" />
   <package id="Microsoft.Web.Xdt" version="3.1.0" targetFramework="net48" />
   <package id="Moq" version="4.2.1402.2112" targetFramework="net40" />

--- a/src/chocolatey.tests/chocolatey.tests.csproj
+++ b/src/chocolatey.tests/chocolatey.tests.csproj
@@ -77,44 +77,44 @@
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Chocolatey.NuGet.Commands, Version=3.0.0.108, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
-      <HintPath>..\packages\Chocolatey.NuGet.Commands.3.0.0-alpha-20230112-108\lib\net472\Chocolatey.NuGet.Commands.dll</HintPath>
+    <Reference Include="Chocolatey.NuGet.Commands, Version=3.0.0.128, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
+      <HintPath>..\packages\Chocolatey.NuGet.Commands.3.0.0-alpha-20230123-128\lib\net472\Chocolatey.NuGet.Commands.dll</HintPath>
     </Reference>
-    <Reference Include="Chocolatey.NuGet.Common, Version=3.0.0.108, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
-      <HintPath>..\packages\Chocolatey.NuGet.Common.3.0.0-alpha-20230112-108\lib\net472\Chocolatey.NuGet.Common.dll</HintPath>
+    <Reference Include="Chocolatey.NuGet.Common, Version=3.0.0.128, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
+      <HintPath>..\packages\Chocolatey.NuGet.Common.3.0.0-alpha-20230123-128\lib\net472\Chocolatey.NuGet.Common.dll</HintPath>
     </Reference>
-    <Reference Include="Chocolatey.NuGet.Configuration, Version=3.0.0.108, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
-      <HintPath>..\packages\Chocolatey.NuGet.Configuration.3.0.0-alpha-20230112-108\lib\net472\Chocolatey.NuGet.Configuration.dll</HintPath>
+    <Reference Include="Chocolatey.NuGet.Configuration, Version=3.0.0.128, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
+      <HintPath>..\packages\Chocolatey.NuGet.Configuration.3.0.0-alpha-20230123-128\lib\net472\Chocolatey.NuGet.Configuration.dll</HintPath>
     </Reference>
-    <Reference Include="Chocolatey.NuGet.Credentials, Version=3.0.0.108, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
-      <HintPath>..\packages\Chocolatey.NuGet.Credentials.3.0.0-alpha-20230112-108\lib\net472\Chocolatey.NuGet.Credentials.dll</HintPath>
+    <Reference Include="Chocolatey.NuGet.Credentials, Version=3.0.0.128, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
+      <HintPath>..\packages\Chocolatey.NuGet.Credentials.3.0.0-alpha-20230123-128\lib\net472\Chocolatey.NuGet.Credentials.dll</HintPath>
     </Reference>
-    <Reference Include="Chocolatey.NuGet.DependencyResolver.Core, Version=3.0.0.108, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
-      <HintPath>..\packages\Chocolatey.NuGet.DependencyResolver.Core.3.0.0-alpha-20230112-108\lib\net472\Chocolatey.NuGet.DependencyResolver.Core.dll</HintPath>
+    <Reference Include="Chocolatey.NuGet.DependencyResolver.Core, Version=3.0.0.128, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
+      <HintPath>..\packages\Chocolatey.NuGet.DependencyResolver.Core.3.0.0-alpha-20230123-128\lib\net472\Chocolatey.NuGet.DependencyResolver.Core.dll</HintPath>
     </Reference>
-    <Reference Include="Chocolatey.NuGet.Frameworks, Version=3.0.0.108, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
-      <HintPath>..\packages\Chocolatey.NuGet.Frameworks.3.0.0-alpha-20230112-108\lib\net472\Chocolatey.NuGet.Frameworks.dll</HintPath>
+    <Reference Include="Chocolatey.NuGet.Frameworks, Version=3.0.0.128, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
+      <HintPath>..\packages\Chocolatey.NuGet.Frameworks.3.0.0-alpha-20230123-128\lib\net472\Chocolatey.NuGet.Frameworks.dll</HintPath>
     </Reference>
-    <Reference Include="Chocolatey.NuGet.LibraryModel, Version=3.0.0.108, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
-      <HintPath>..\packages\Chocolatey.NuGet.LibraryModel.3.0.0-alpha-20230112-108\lib\net472\Chocolatey.NuGet.LibraryModel.dll</HintPath>
+    <Reference Include="Chocolatey.NuGet.LibraryModel, Version=3.0.0.128, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
+      <HintPath>..\packages\Chocolatey.NuGet.LibraryModel.3.0.0-alpha-20230123-128\lib\net472\Chocolatey.NuGet.LibraryModel.dll</HintPath>
     </Reference>
-    <Reference Include="Chocolatey.NuGet.PackageManagement, Version=3.0.0.108, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
-      <HintPath>..\packages\Chocolatey.NuGet.PackageManagement.3.0.0-alpha-20230112-108\lib\net472\Chocolatey.NuGet.PackageManagement.dll</HintPath>
+    <Reference Include="Chocolatey.NuGet.PackageManagement, Version=3.0.0.128, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
+      <HintPath>..\packages\Chocolatey.NuGet.PackageManagement.3.0.0-alpha-20230123-128\lib\net472\Chocolatey.NuGet.PackageManagement.dll</HintPath>
     </Reference>
-    <Reference Include="Chocolatey.NuGet.Packaging, Version=3.0.0.108, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
-      <HintPath>..\packages\Chocolatey.NuGet.Packaging.3.0.0-alpha-20230112-108\lib\net472\Chocolatey.NuGet.Packaging.dll</HintPath>
+    <Reference Include="Chocolatey.NuGet.Packaging, Version=3.0.0.128, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
+      <HintPath>..\packages\Chocolatey.NuGet.Packaging.3.0.0-alpha-20230123-128\lib\net472\Chocolatey.NuGet.Packaging.dll</HintPath>
     </Reference>
-    <Reference Include="Chocolatey.NuGet.ProjectModel, Version=3.0.0.108, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
-      <HintPath>..\packages\Chocolatey.NuGet.ProjectModel.3.0.0-alpha-20230112-108\lib\net472\Chocolatey.NuGet.ProjectModel.dll</HintPath>
+    <Reference Include="Chocolatey.NuGet.ProjectModel, Version=3.0.0.128, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
+      <HintPath>..\packages\Chocolatey.NuGet.ProjectModel.3.0.0-alpha-20230123-128\lib\net472\Chocolatey.NuGet.ProjectModel.dll</HintPath>
     </Reference>
-    <Reference Include="Chocolatey.NuGet.Protocol, Version=3.0.0.108, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
-      <HintPath>..\packages\Chocolatey.NuGet.Protocol.3.0.0-alpha-20230112-108\lib\net472\Chocolatey.NuGet.Protocol.dll</HintPath>
+    <Reference Include="Chocolatey.NuGet.Protocol, Version=3.0.0.128, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
+      <HintPath>..\packages\Chocolatey.NuGet.Protocol.3.0.0-alpha-20230123-128\lib\net472\Chocolatey.NuGet.Protocol.dll</HintPath>
     </Reference>
-    <Reference Include="Chocolatey.NuGet.Resolver, Version=3.0.0.108, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
-      <HintPath>..\packages\Chocolatey.NuGet.Resolver.3.0.0-alpha-20230112-108\lib\net472\Chocolatey.NuGet.Resolver.dll</HintPath>
+    <Reference Include="Chocolatey.NuGet.Resolver, Version=3.0.0.128, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
+      <HintPath>..\packages\Chocolatey.NuGet.Resolver.3.0.0-alpha-20230123-128\lib\net472\Chocolatey.NuGet.Resolver.dll</HintPath>
     </Reference>
-    <Reference Include="Chocolatey.NuGet.Versioning, Version=3.0.0.108, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
-      <HintPath>..\packages\Chocolatey.NuGet.Versioning.3.0.0-alpha-20230112-108\lib\net472\Chocolatey.NuGet.Versioning.dll</HintPath>
+    <Reference Include="Chocolatey.NuGet.Versioning, Version=3.0.0.128, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
+      <HintPath>..\packages\Chocolatey.NuGet.Versioning.3.0.0-alpha-20230123-128\lib\net472\Chocolatey.NuGet.Versioning.dll</HintPath>
     </Reference>
     <Reference Include="log4net, Version=2.0.12.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
       <HintPath>..\packages\log4net.2.0.12\lib\net45\log4net.dll</HintPath>

--- a/src/chocolatey.tests/packages.config
+++ b/src/chocolatey.tests/packages.config
@@ -1,18 +1,18 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Chocolatey.NuGet.Commands" version="3.0.0-alpha-20230112-108" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.Common" version="3.0.0-alpha-20230112-108" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.Configuration" version="3.0.0-alpha-20230112-108" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.Credentials" version="3.0.0-alpha-20230112-108" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.DependencyResolver.Core" version="3.0.0-alpha-20230112-108" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.Frameworks" version="3.0.0-alpha-20230112-108" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.LibraryModel" version="3.0.0-alpha-20230112-108" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.PackageManagement" version="3.0.0-alpha-20230112-108" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.Packaging" version="3.0.0-alpha-20230112-108" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.ProjectModel" version="3.0.0-alpha-20230112-108" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.Protocol" version="3.0.0-alpha-20230112-108" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.Resolver" version="3.0.0-alpha-20230112-108" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.Versioning" version="3.0.0-alpha-20230112-108" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.Commands" version="3.0.0-alpha-20230123-128" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.Common" version="3.0.0-alpha-20230123-128" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.Configuration" version="3.0.0-alpha-20230123-128" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.Credentials" version="3.0.0-alpha-20230123-128" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.DependencyResolver.Core" version="3.0.0-alpha-20230123-128" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.Frameworks" version="3.0.0-alpha-20230123-128" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.LibraryModel" version="3.0.0-alpha-20230123-128" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.PackageManagement" version="3.0.0-alpha-20230123-128" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.Packaging" version="3.0.0-alpha-20230123-128" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.ProjectModel" version="3.0.0-alpha-20230123-128" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.Protocol" version="3.0.0-alpha-20230123-128" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.Resolver" version="3.0.0-alpha-20230123-128" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.Versioning" version="3.0.0-alpha-20230123-128" targetFramework="net48" />
   <package id="log4net" version="2.0.12" targetFramework="net48" />
   <package id="Microsoft.CSharp" version="4.3.0" targetFramework="net48" />
   <package id="Microsoft.Web.Xdt" version="3.1.0" targetFramework="net48" />

--- a/src/chocolatey/chocolatey.csproj
+++ b/src/chocolatey/chocolatey.csproj
@@ -101,44 +101,44 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\AlphaFS.2.1.3\lib\net40\AlphaFS.dll</HintPath>
     </Reference>
-    <Reference Include="Chocolatey.NuGet.Commands, Version=3.0.0.108, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
-      <HintPath>..\packages\Chocolatey.NuGet.Commands.3.0.0-alpha-20230112-108\lib\net472\Chocolatey.NuGet.Commands.dll</HintPath>
+    <Reference Include="Chocolatey.NuGet.Commands, Version=3.0.0.128, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
+      <HintPath>..\packages\Chocolatey.NuGet.Commands.3.0.0-alpha-20230123-128\lib\net472\Chocolatey.NuGet.Commands.dll</HintPath>
     </Reference>
-    <Reference Include="Chocolatey.NuGet.Common, Version=3.0.0.108, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
-      <HintPath>..\packages\Chocolatey.NuGet.Common.3.0.0-alpha-20230112-108\lib\net472\Chocolatey.NuGet.Common.dll</HintPath>
+    <Reference Include="Chocolatey.NuGet.Common, Version=3.0.0.128, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
+      <HintPath>..\packages\Chocolatey.NuGet.Common.3.0.0-alpha-20230123-128\lib\net472\Chocolatey.NuGet.Common.dll</HintPath>
     </Reference>
-    <Reference Include="Chocolatey.NuGet.Configuration, Version=3.0.0.108, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
-      <HintPath>..\packages\Chocolatey.NuGet.Configuration.3.0.0-alpha-20230112-108\lib\net472\Chocolatey.NuGet.Configuration.dll</HintPath>
+    <Reference Include="Chocolatey.NuGet.Configuration, Version=3.0.0.128, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
+      <HintPath>..\packages\Chocolatey.NuGet.Configuration.3.0.0-alpha-20230123-128\lib\net472\Chocolatey.NuGet.Configuration.dll</HintPath>
     </Reference>
-    <Reference Include="Chocolatey.NuGet.Credentials, Version=3.0.0.108, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
-      <HintPath>..\packages\Chocolatey.NuGet.Credentials.3.0.0-alpha-20230112-108\lib\net472\Chocolatey.NuGet.Credentials.dll</HintPath>
+    <Reference Include="Chocolatey.NuGet.Credentials, Version=3.0.0.128, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
+      <HintPath>..\packages\Chocolatey.NuGet.Credentials.3.0.0-alpha-20230123-128\lib\net472\Chocolatey.NuGet.Credentials.dll</HintPath>
     </Reference>
-    <Reference Include="Chocolatey.NuGet.DependencyResolver.Core, Version=3.0.0.108, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
-      <HintPath>..\packages\Chocolatey.NuGet.DependencyResolver.Core.3.0.0-alpha-20230112-108\lib\net472\Chocolatey.NuGet.DependencyResolver.Core.dll</HintPath>
+    <Reference Include="Chocolatey.NuGet.DependencyResolver.Core, Version=3.0.0.128, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
+      <HintPath>..\packages\Chocolatey.NuGet.DependencyResolver.Core.3.0.0-alpha-20230123-128\lib\net472\Chocolatey.NuGet.DependencyResolver.Core.dll</HintPath>
     </Reference>
-    <Reference Include="Chocolatey.NuGet.Frameworks, Version=3.0.0.108, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
-      <HintPath>..\packages\Chocolatey.NuGet.Frameworks.3.0.0-alpha-20230112-108\lib\net472\Chocolatey.NuGet.Frameworks.dll</HintPath>
+    <Reference Include="Chocolatey.NuGet.Frameworks, Version=3.0.0.128, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
+      <HintPath>..\packages\Chocolatey.NuGet.Frameworks.3.0.0-alpha-20230123-128\lib\net472\Chocolatey.NuGet.Frameworks.dll</HintPath>
     </Reference>
-    <Reference Include="Chocolatey.NuGet.LibraryModel, Version=3.0.0.108, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
-      <HintPath>..\packages\Chocolatey.NuGet.LibraryModel.3.0.0-alpha-20230112-108\lib\net472\Chocolatey.NuGet.LibraryModel.dll</HintPath>
+    <Reference Include="Chocolatey.NuGet.LibraryModel, Version=3.0.0.128, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
+      <HintPath>..\packages\Chocolatey.NuGet.LibraryModel.3.0.0-alpha-20230123-128\lib\net472\Chocolatey.NuGet.LibraryModel.dll</HintPath>
     </Reference>
-    <Reference Include="Chocolatey.NuGet.PackageManagement, Version=3.0.0.108, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
-      <HintPath>..\packages\Chocolatey.NuGet.PackageManagement.3.0.0-alpha-20230112-108\lib\net472\Chocolatey.NuGet.PackageManagement.dll</HintPath>
+    <Reference Include="Chocolatey.NuGet.PackageManagement, Version=3.0.0.128, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
+      <HintPath>..\packages\Chocolatey.NuGet.PackageManagement.3.0.0-alpha-20230123-128\lib\net472\Chocolatey.NuGet.PackageManagement.dll</HintPath>
     </Reference>
-    <Reference Include="Chocolatey.NuGet.Packaging, Version=3.0.0.108, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
-      <HintPath>..\packages\Chocolatey.NuGet.Packaging.3.0.0-alpha-20230112-108\lib\net472\Chocolatey.NuGet.Packaging.dll</HintPath>
+    <Reference Include="Chocolatey.NuGet.Packaging, Version=3.0.0.128, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
+      <HintPath>..\packages\Chocolatey.NuGet.Packaging.3.0.0-alpha-20230123-128\lib\net472\Chocolatey.NuGet.Packaging.dll</HintPath>
     </Reference>
-    <Reference Include="Chocolatey.NuGet.ProjectModel, Version=3.0.0.108, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
-      <HintPath>..\packages\Chocolatey.NuGet.ProjectModel.3.0.0-alpha-20230112-108\lib\net472\Chocolatey.NuGet.ProjectModel.dll</HintPath>
+    <Reference Include="Chocolatey.NuGet.ProjectModel, Version=3.0.0.128, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
+      <HintPath>..\packages\Chocolatey.NuGet.ProjectModel.3.0.0-alpha-20230123-128\lib\net472\Chocolatey.NuGet.ProjectModel.dll</HintPath>
     </Reference>
-    <Reference Include="Chocolatey.NuGet.Protocol, Version=3.0.0.108, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
-      <HintPath>..\packages\Chocolatey.NuGet.Protocol.3.0.0-alpha-20230112-108\lib\net472\Chocolatey.NuGet.Protocol.dll</HintPath>
+    <Reference Include="Chocolatey.NuGet.Protocol, Version=3.0.0.128, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
+      <HintPath>..\packages\Chocolatey.NuGet.Protocol.3.0.0-alpha-20230123-128\lib\net472\Chocolatey.NuGet.Protocol.dll</HintPath>
     </Reference>
-    <Reference Include="Chocolatey.NuGet.Resolver, Version=3.0.0.108, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
-      <HintPath>..\packages\Chocolatey.NuGet.Resolver.3.0.0-alpha-20230112-108\lib\net472\Chocolatey.NuGet.Resolver.dll</HintPath>
+    <Reference Include="Chocolatey.NuGet.Resolver, Version=3.0.0.128, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
+      <HintPath>..\packages\Chocolatey.NuGet.Resolver.3.0.0-alpha-20230123-128\lib\net472\Chocolatey.NuGet.Resolver.dll</HintPath>
     </Reference>
-    <Reference Include="Chocolatey.NuGet.Versioning, Version=3.0.0.108, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
-      <HintPath>..\packages\Chocolatey.NuGet.Versioning.3.0.0-alpha-20230112-108\lib\net472\Chocolatey.NuGet.Versioning.dll</HintPath>
+    <Reference Include="Chocolatey.NuGet.Versioning, Version=3.0.0.128, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
+      <HintPath>..\packages\Chocolatey.NuGet.Versioning.3.0.0-alpha-20230123-128\lib\net472\Chocolatey.NuGet.Versioning.dll</HintPath>
     </Reference>
     <Reference Include="log4net, Version=2.0.12.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
       <HintPath>..\packages\log4net.2.0.12\lib\net45\log4net.dll</HintPath>

--- a/src/chocolatey/infrastructure.app/services/NugetService.cs
+++ b/src/chocolatey/infrastructure.app/services/NugetService.cs
@@ -217,8 +217,8 @@ namespace chocolatey.infrastructure.app.services
                                 (package.DownloadCount == null || package.DownloadCount <= 0)  ? "n/a" : package.DownloadCount.to_string(),
                                 (package.VersionDownloadCount == null || package.VersionDownloadCount <= 0) ? "n/a" : package.VersionDownloadCount.to_string(),
                                 package.PackageDetailsUrl == null || string.IsNullOrWhiteSpace(package.PackageDetailsUrl.AbsoluteUri) ? string.Empty : " " + package.PackageDetailsUrl.AbsoluteUri,
-                                packageLocalMetadata != null && packageLocalMetadata.PackageSourceUrl != null && !string.IsNullOrWhiteSpace(packageLocalMetadata.PackageSourceUrl.to_string())
-                                    ? packageLocalMetadata.PackageSourceUrl.to_string()
+                                !string.IsNullOrWhiteSpace(package.PackageSourceUrl.to_string())
+                                    ? package.PackageSourceUrl.to_string()
                                     : "n/a",
                                 string.IsNullOrWhiteSpace(package.PackageHash) ? string.Empty : "{0} Package Checksum: '{1}' ({2})".format_with(
                                         Environment.NewLine,
@@ -228,13 +228,13 @@ namespace chocolatey.infrastructure.app.services
                                 package.Tags.trim_safe().escape_curly_braces(),
                                 package.ProjectUrl != null ? package.ProjectUrl.to_string() : "n/a",
                                 package.LicenseUrl != null && !string.IsNullOrWhiteSpace(package.LicenseUrl.to_string()) ? package.LicenseUrl.to_string() : "n/a",
-                                packageLocalMetadata != null && packageLocalMetadata.ProjectSourceUrl != null && !string.IsNullOrWhiteSpace(packageLocalMetadata.ProjectSourceUrl.to_string()) ? "{0} Software Source: {1}".format_with(Environment.NewLine, packageLocalMetadata.ProjectSourceUrl.to_string()) : string.Empty,
-                                packageLocalMetadata != null && packageLocalMetadata.DocsUrl != null && !string.IsNullOrWhiteSpace(packageLocalMetadata.DocsUrl.to_string()) ? "{0} Documentation: {1}".format_with(Environment.NewLine, packageLocalMetadata.DocsUrl.to_string()) : string.Empty,
-                                packageLocalMetadata != null && packageLocalMetadata.MailingListUrl != null && !string.IsNullOrWhiteSpace(packageLocalMetadata.MailingListUrl.to_string()) ? "{0} Mailing List: {1}".format_with(Environment.NewLine, packageLocalMetadata.MailingListUrl.to_string()) : string.Empty,
-                                packageLocalMetadata != null && packageLocalMetadata.BugTrackerUrl != null && !string.IsNullOrWhiteSpace(packageLocalMetadata.BugTrackerUrl.to_string()) ? "{0} Issues: {1}".format_with(Environment.NewLine, packageLocalMetadata.BugTrackerUrl.to_string()) : string.Empty,
+                                !string.IsNullOrWhiteSpace(package.ProjectSourceUrl.to_string()) ? "{0} Software Source: {1}".format_with(Environment.NewLine, package.ProjectSourceUrl.to_string()) : string.Empty,
+                                !string.IsNullOrWhiteSpace(package.DocsUrl.to_string()) ? "{0} Documentation: {1}".format_with(Environment.NewLine, package.DocsUrl.to_string()) : string.Empty,
+                                !string.IsNullOrWhiteSpace(package.MailingListUrl.to_string()) ? "{0} Mailing List: {1}".format_with(Environment.NewLine, package.MailingListUrl.to_string()) : string.Empty,
+                                !string.IsNullOrWhiteSpace(package.BugTrackerUrl.to_string()) ? "{0} Issues: {1}".format_with(Environment.NewLine, package.BugTrackerUrl.to_string()) : string.Empty,
                                 package.Summary != null && !string.IsNullOrWhiteSpace(package.Summary.to_string()) ? "\r\n Summary: {0}".format_with(package.Summary.escape_curly_braces().to_string()) : string.Empty,
                                 package.Description.escape_curly_braces().Replace("\n    ", "\n").Replace("\n", "\n  "),
-                                packageLocalMetadata != null && packageLocalMetadata.ReleaseNotes != null && !string.IsNullOrWhiteSpace(packageLocalMetadata.ReleaseNotes.to_string()) ? "{0} Release Notes: {1}".format_with(Environment.NewLine, packageLocalMetadata.ReleaseNotes.escape_curly_braces().Replace("\n    ", "\n").Replace("\n", "\n  ")) : string.Empty
+                                !string.IsNullOrWhiteSpace(package.ReleaseNotes.to_string()) ? "{0} Release Notes: {1}".format_with(Environment.NewLine, package.ReleaseNotes.escape_curly_braces().Replace("\n    ", "\n").Replace("\n", "\n  ")) : string.Empty
                             ));
 
 

--- a/src/chocolatey/packages.config
+++ b/src/chocolatey/packages.config
@@ -1,19 +1,19 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="AlphaFS" version="2.1.3" targetFramework="net40-Client" />
-  <package id="Chocolatey.NuGet.Commands" version="3.0.0-alpha-20230112-108" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.Common" version="3.0.0-alpha-20230112-108" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.Configuration" version="3.0.0-alpha-20230112-108" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.Credentials" version="3.0.0-alpha-20230112-108" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.DependencyResolver.Core" version="3.0.0-alpha-20230112-108" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.Frameworks" version="3.0.0-alpha-20230112-108" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.LibraryModel" version="3.0.0-alpha-20230112-108" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.PackageManagement" version="3.0.0-alpha-20230112-108" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.Packaging" version="3.0.0-alpha-20230112-108" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.ProjectModel" version="3.0.0-alpha-20230112-108" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.Protocol" version="3.0.0-alpha-20230112-108" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.Resolver" version="3.0.0-alpha-20230112-108" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.Versioning" version="3.0.0-alpha-20230112-108" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.Commands" version="3.0.0-alpha-20230123-128" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.Common" version="3.0.0-alpha-20230123-128" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.Configuration" version="3.0.0-alpha-20230123-128" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.Credentials" version="3.0.0-alpha-20230123-128" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.DependencyResolver.Core" version="3.0.0-alpha-20230123-128" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.Frameworks" version="3.0.0-alpha-20230123-128" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.LibraryModel" version="3.0.0-alpha-20230123-128" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.PackageManagement" version="3.0.0-alpha-20230123-128" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.Packaging" version="3.0.0-alpha-20230123-128" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.ProjectModel" version="3.0.0-alpha-20230123-128" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.Protocol" version="3.0.0-alpha-20230123-128" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.Resolver" version="3.0.0-alpha-20230123-128" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.Versioning" version="3.0.0-alpha-20230123-128" targetFramework="net48" />
   <package id="log4net" version="2.0.12" targetFramework="net48" />
   <package id="Microsoft.CodeAnalysis.BannedApiAnalyzers" version="3.3.3" targetFramework="net48" developmentDependency="true" />
   <package id="Microsoft.CSharp" version="4.3.0" targetFramework="net48" />


### PR DESCRIPTION
## Description Of Changes

Switch away from using local package metadata (which isn't always available, for example when running the choco info command).

## Motivation and Context

Rather than relying on the metadata retrieved from the local package on disk (which isn't always available), use the newly added server side metadata to display the required information. For example, release notes, package URL's, etc.

This additional information was added into the NuGet.Client assemblies here:

https://github.com/chocolatey/NuGet.Client/pull/22

## Testing

This needs to be tested in conjunction with the PR here: 

https://github.com/chocolatey/NuGet.Client/pull/22

And the steps in that test used to valid the changes here.

### Operating Systems Testing

Windows 10 22H2

## Change Types Made
<!-- Tick the boxes for the type of changes that have been made -->

* [ ] Bug fix (non-breaking change).
* [x] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [x] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue

- Relates to #508 
- https://app.clickup.com/t/20540031/PROJ-459