### PR TITLE
(#2738) Add tests for NuGet v2 and v3 feeds

### DIFF
--- a/tests/helpers/common/Chocolatey/New-ChocolateyTestPackage.ps1
+++ b/tests/helpers/common/Chocolatey/New-ChocolateyTestPackage.ps1
@@ -20,10 +20,17 @@
 
         # Location to store the built package(s)
         [ValidateNotNullOrEmpty()]
-        [string]$Destination = $env:CHOCOLATEY_TEST_PACKAGES_PATH
+        [string]$Destination = $env:CHOCOLATEY_TEST_PACKAGES_PATH,
+
+        [Parameter()]
+        [string]$AddedVersion
     )
     process {
         $NuspecFile = Get-Item "$TestPath\$Name\$Version\$Name.nuspec"
+
+        if ($AddedVersion) {
+            $Version = "$Version-$AddedVersion"
+        }
 
         Write-Verbose "Building '$($NuspecFile.Count)' packages"
 
@@ -32,12 +39,14 @@
             $ExpectedPackage = Join-Path $Destination "$Name.$Version.nupkg"
 
             if (-not (Test-Path $ExpectedPackage)) {
-                $BuildOutput = Invoke-Choco pack $Package.FullName --outputdirectory $Destination
+                $BuildOutput = Invoke-Choco pack $Package.FullName --outputdirectory $Destination --version $Version
 
                 if ($BuildOutput.ExitCode -ne 0) {
                     throw $BuildOutput.String
                 }
             }
+
+            $ExpectedPackage
         }
     }
 }

--- a/tests/helpers/common/NuGet/Test-NuGetPaths.ps1
+++ b/tests/helpers/common/NuGet/Test-NuGetPaths.ps1
@@ -1,16 +1,21 @@
 function Test-NuGetPaths {
-    $script:NuGetCleared = $false
-    $NuGetPathsToCheck = Get-NuGetPaths
-    $ChocolateyNuGetPath = "$(Get-TempDirectory)chocolatey-invalid"
-
-    It 'Did not create <_> directory' -ForEach $NuGetPathsToCheck -Skip:((-not $env:TEST_KITCHEN)) {
-        if (-not $script:NuGetCleared) {
-            Set-ItResult -Skipped -Because 'NuGet configurations were not removed before running tests'
+    Context 'NuGet directory tests' {
+        BeforeDiscovery {
+            $NuGetPathsToCheck = Get-NuGetPaths
+            $ChocolateyNuGetPath = "$(Get-TempDirectory)chocolatey-invalid"
         }
-        $_ | Should -Not -Exist
-    }
 
-    It "Did not create <_>" -ForEach $ChocolateyNuGetPath {
-        $_ | Should -Not -Exist
+        AfterAll {
+            $script:NuGetCleared = $null
+        }
+
+        It 'Did not create <_> directory' -ForEach $NuGetPathsToCheck -Skip:((-not $env:TEST_KITCHEN)) {
+            $script:NuGetCleared | Should -BeTrue -Because 'NuGet configurations were not removed before running tests'
+            $_ | Should -Not -Exist
+        }
+
+        It "Did not create <_>" -ForEach $ChocolateyNuGetPath {
+            $_ | Should -Not -Exist
+        }
     }
 }


### PR DESCRIPTION
## Description Of Changes

Add tests for pushing to NuGet v2/v3 feeds

## Motivation and Context

With the addition of v3 feed support, need to ensure we can push to them. This also adds tests  for v2 feeds.

## Testing

In order for these tests to work, you must (currently) specify environment variables `$env:NUGET_API_KEY` and `$env:NUGET_PUSH_REPO`

1. Ran locally against a Test Kitchen instance
2. Ran through Team City setting the aforementioned environment variables.

### Operating Systems Testing

Windows Server 2016, 2019

## Change Types Made

* [ ] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.
* [x] End to end Pester test additions

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [ ] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue

* #2738 
* PROJ-377
* https://gitlab.com/chocolatey/build-automation/chocolatey-test-kitchen/-/merge_requests/136