### PR TITLE
(#1935) Add tests to ensure upstream NuGet version is used.

### DIFF
--- a/src/chocolatey.tests.integration/context/unsupportedelements/1.0.0/unsupportedelements.nuspec
+++ b/src/chocolatey.tests.integration/context/unsupportedelements/1.0.0/unsupportedelements.nuspec
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
-  <metadata>
+  <metadata minClientVersion="100.0.0">
     <id>unsupportedelements</id>
     <version>1.0.0</version>
     <title>unsupportedelements</title>

--- a/src/chocolatey.tests.integration/context/unsupportedelements/1.1.0/unsupportedelements.nuspec
+++ b/src/chocolatey.tests.integration/context/unsupportedelements/1.1.0/unsupportedelements.nuspec
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
-  <metadata>
+  <metadata minClientVersion="100.0.0">
     <id>unsupportedelements</id>
     <version>1.1.0</version>
     <title>unsupportedelements</title>

--- a/src/chocolatey.tests.integration/scenarios/PackScenarios.cs
+++ b/src/chocolatey.tests.integration/scenarios/PackScenarios.cs
@@ -499,6 +499,27 @@ namespace chocolatey.tests.integration.scenarios
             }
         }
 
+        public class when_packing_with_min_client_version : ScenariosBase
+        {
+            protected override string ExpectedNuspecVersion => "0.1.0";
+            protected override string ExpectedSubDirectory => "PackageOutput";
+
+            // This high version is to ensure that pack does not throw, even if the min client version is well
+            // above both the Chocolatey and NuGet assembly versions.
+            private string MinClientVersion = "100.0.0";
+
+            public override void Because()
+            {
+                MockLogger.reset();
+                Service.pack_run(Configuration);
+            }
+
+            protected override string GetNuspecContent()
+            {
+                return NuspecContentWithFormatableMinClientVersion.format_with(MinClientVersion);
+            }
+        }
+
         private const string NuspecContent = @"<?xml version=""1.0"" encoding=""utf-8""?>
 <package xmlns=""http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd"">
   <metadata>
@@ -900,6 +921,29 @@ namespace chocolatey.tests.integration.scenarios
     <id>test-package</id>
     <title>Test Package</title>
     <version>{0}</version>
+    <authors>package author</authors>
+    <owners>package owner</owners>
+    <summary>A brief summary</summary>
+    <description>A big description</description>
+    <tags>test admin</tags>
+    <copyright></copyright>
+    <licenseUrl>http://apache.org/2</licenseUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <releaseNotes></releaseNotes>
+    <dependencies>
+      <dependency id=""chocolatey-core.extension"" />
+    </dependencies>
+  </metadata>
+  <files>
+  </files>
+</package>";
+
+    private const string NuspecContentWithFormatableMinClientVersion = @"<?xml version=""1.0"" encoding=""utf-8""?>
+<package xmlns=""http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd"">
+  <metadata minClientVersion=""{0}"">
+    <id>test-package</id>
+    <title>Test Package</title>
+    <version>0.1.0</version>
     <authors>package author</authors>
     <owners>package owner</owners>
     <summary>A brief summary</summary>

--- a/src/chocolatey.tests.integration/scenarios/PackScenarios.cs
+++ b/src/chocolatey.tests.integration/scenarios/PackScenarios.cs
@@ -499,24 +499,24 @@ namespace chocolatey.tests.integration.scenarios
             }
         }
 
-        public class when_packing_with_min_client_version : ScenariosBase
+        public class When_packing_with_min_client_version : ScenariosBase
         {
             protected override string ExpectedNuspecVersion => "0.1.0";
             protected override string ExpectedSubDirectory => "PackageOutput";
 
             // This high version is to ensure that pack does not throw, even if the min client version is well
             // above both the Chocolatey and NuGet assembly versions.
-            private string MinClientVersion = "100.0.0";
+            private string _minClientVersion = "100.0.0";
 
             public override void Because()
             {
-                MockLogger.reset();
-                Service.pack_run(Configuration);
+                MockLogger.Reset();
+                Service.Pack(Configuration);
             }
 
             protected override string GetNuspecContent()
             {
-                return NuspecContentWithFormatableMinClientVersion.format_with(MinClientVersion);
+                return NuspecContentWithFormatableMinClientVersion.FormatWith(_minClientVersion);
             }
         }
 

--- a/src/chocolatey.tests/infrastructure.app/nuget/NugetCommonSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/nuget/NugetCommonSpecs.cs
@@ -19,6 +19,7 @@ namespace chocolatey.tests.infrastructure.app.nuget
     using System;
     using System.Collections.Generic;
     using System.Linq;
+    using chocolatey.infrastructure.app;
     using chocolatey.infrastructure.app.configuration;
     using chocolatey.infrastructure.app.nuget;
     using chocolatey.infrastructure.filesystem;
@@ -160,6 +161,22 @@ namespace chocolatey.tests.infrastructure.app.nuget
                     .ShouldEqual(("file:" + source).Replace("\\", "/"));
                 packageRepositories.First().PackageSource.IsLocal.ShouldBeTrue();
                 packageRepositories.First().PackageSource.SourceUri.IsUnc.ShouldBeTrue();
+            }
+
+            [Fact]
+            public void Should_set_user_agent_string()
+            {
+                Context();
+                var source = "https://community.chocolatey.org/api/v2/";
+                configuration.Sources = source;
+                configuration.Information.ChocolateyProductVersion = "vNext";
+
+                because();
+
+                // Change this when the NuGet version is updated.
+                string nugetClientVersion = "6.4.1";
+                string expectedUserAgentString = "{0}/{1} via NuGet Client/{2}".FormatWith(ApplicationParameters.UserAgent, configuration.Information.ChocolateyProductVersion, nugetClientVersion);
+                UserAgent.UserAgentString.ShouldStartWith(expectedUserAgentString);
             }
         }
     }


### PR DESCRIPTION
## Description Of Changes

The added integration tests ensure that a minClientVersion attribute that is higher
then the Chocolatey and NuGet assembly versions does not prevent installation
or packing. 

And a unit test ensures that the user agent is set, when NuGet sources are configured
and that it uses the upstream version of NuGet that the NuGet assembles are
based on. This same version is used in other areas as well, like minClientVersion,
so it applies to multiple areas.

## Motivation and Context

See #1935 

With the uplifted NuGet assemblies, the `minClientVersion` is no longer checked at all, bypasses the fixes the issue of the Chocolatey assembly version being used instead of the NuGet assembly version being used.

## Testing

Ran tests in Visual Studio and with `build.ps1`
Built and installed package with `minClientVersion` set to `100.0.0` to manually to ensure that it packs and installs ok.

### Operating Systems Testing
- Windows 10 22H2

## Change Types Made
<!-- Tick the boxes for the type of changes that have been made -->

* [x] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [x] Tests to cover my changes, have been added.
* [x] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue

Fixes #1935