### PR TITLE
(#3000) Create new rule service and read old validation messages

### DIFF
--- a/src/chocolatey.tests.integration/scenarios/PackScenarios.cs
+++ b/src/chocolatey.tests.integration/scenarios/PackScenarios.cs
@@ -439,7 +439,7 @@ namespace chocolatey.tests.integration.scenarios
             {
                 AddFile("myPackage.nuspec", NuspecContentWithAllUnsupportedElements);
 
-                ServiceAct.ShouldThrow<System.IO.FileFormatException>();
+                ServiceAct.ShouldThrow<System.IO.InvalidDataException>();
             }
 
             [Fact]
@@ -447,7 +447,7 @@ namespace chocolatey.tests.integration.scenarios
             {
                 AddFile("myPackage.nuspec", NuspecContentWithServiceableElement);
 
-                ServiceAct.ShouldThrow<System.IO.FileFormatException>();
+                ServiceAct.ShouldThrow<System.IO.InvalidDataException>();
             }
 
             [Fact]
@@ -455,7 +455,7 @@ namespace chocolatey.tests.integration.scenarios
             {
                 AddFile("myPackage.nuspec", NuspecContentWithLicenseElement);
 
-                ServiceAct.ShouldThrow<System.IO.FileFormatException>();
+                ServiceAct.ShouldThrow<System.IO.InvalidDataException>();
             }
 
             [Fact]
@@ -463,7 +463,7 @@ namespace chocolatey.tests.integration.scenarios
             {
                 AddFile("myPackage.nuspec", NuspecContentWithRepositoryElement);
 
-                ServiceAct.ShouldThrow<System.IO.FileFormatException>();
+                ServiceAct.ShouldThrow<System.IO.InvalidDataException>();
             }
 
             [Fact]
@@ -471,7 +471,7 @@ namespace chocolatey.tests.integration.scenarios
             {
                 AddFile("myPackage.nuspec", NuspecContentWithPackageTypesElement);
 
-                ServiceAct.ShouldThrow<System.IO.FileFormatException>();
+                ServiceAct.ShouldThrow<System.IO.InvalidDataException>();
             }
 
             [Fact]
@@ -479,7 +479,7 @@ namespace chocolatey.tests.integration.scenarios
             {
                 AddFile("myPackage.nuspec", NuspecContentWithFrameWorkReferencesElement);
 
-                ServiceAct.ShouldThrow<System.IO.FileFormatException>();
+                ServiceAct.ShouldThrow<System.IO.InvalidDataException>();
             }
 
             [Fact]
@@ -487,7 +487,7 @@ namespace chocolatey.tests.integration.scenarios
             {
                 AddFile("myPackage.nuspec", NuspecContentWithReadmeElement);
 
-                ServiceAct.ShouldThrow<System.IO.FileFormatException>();
+                ServiceAct.ShouldThrow<System.IO.InvalidDataException>();
             }
 
             [Fact]
@@ -495,7 +495,7 @@ namespace chocolatey.tests.integration.scenarios
             {
                 AddFile("myPackage.nuspec", NuspecContentWithIconElement);
 
-                ServiceAct.ShouldThrow<System.IO.FileFormatException>();
+                ServiceAct.ShouldThrow<System.IO.InvalidDataException>();
             }
         }
 

--- a/src/chocolatey.tests/infrastructure.app/services/NugetServiceSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/services/NugetServiceSpecs.cs
@@ -23,6 +23,7 @@ namespace chocolatey.tests.infrastructure.app.services
     using chocolatey.infrastructure.app.configuration;
     using chocolatey.infrastructure.app.domain;
     using chocolatey.infrastructure.app.services;
+    using chocolatey.infrastructure.services;
     using Moq;
     using NuGet.Common;
     using NuGet.Packaging;
@@ -40,6 +41,7 @@ namespace chocolatey.tests.infrastructure.app.services
             protected Mock<IFilesService> filesService = new Mock<IFilesService>();
             protected Mock<IPackageMetadata> package = new Mock<IPackageMetadata>();
             protected Mock<IPackageDownloader> packageDownloader = new Mock<IPackageDownloader>();
+            protected Mock<IRuleService> ruleService = new Mock<IRuleService>();
 
             public override void Context()
             {
@@ -49,7 +51,7 @@ namespace chocolatey.tests.infrastructure.app.services
                 filesService.ResetCalls();
                 package.ResetCalls();
 
-                service = new NugetService(fileSystem.Object, nugetLogger.Object, packageInfoService.Object, filesService.Object);
+                service = new NugetService(fileSystem.Object, nugetLogger.Object, packageInfoService.Object, filesService.Object, ruleService.Object);
             }
         }
 

--- a/src/chocolatey.tests/infrastructure/guards/EnsureSpecs.cs
+++ b/src/chocolatey.tests/infrastructure/guards/EnsureSpecs.cs
@@ -34,6 +34,30 @@ namespace chocolatey.tests.infrastructure.guards
         public class when_Ensure_is_being_set_to_a_type : EnsureSpecsBase
         {
             private object result;
+            private readonly object bob = "something";
+
+            public override void Because()
+            {
+                result = Ensure.that(() => bob);
+            }
+
+            [Fact]
+            public void should_return_a_type_of_object_for_ensuring()
+            {
+                result.ShouldBeType<Ensure<object>>();
+            }
+
+            [Fact]
+            public void should_have_the_value_specified()
+            {
+                var bobEnsure = result as Ensure<object>;
+                bobEnsure.Value.ShouldEqual(bob);
+            }
+        }
+
+        public class when_Ensure_is_a_string_type : EnsureSpecsBase
+        {
+            private object result;
             private readonly string bob = "something";
 
             public override void Because()
@@ -42,16 +66,77 @@ namespace chocolatey.tests.infrastructure.guards
             }
 
             [Fact]
-            public void should_return_a_type_of_string_for_ensuring()
+            public void should_return_a_ensure_string_type()
             {
-                result.ShouldBeType<Ensure<string>>();
+                result.ShouldBeType<EnsureString>();
             }
 
             [Fact]
             public void should_have_the_value_specified()
             {
-                var bobEnsure = result as Ensure<string>;
+                var bobEnsure = result as EnsureString;
                 bobEnsure.Value.ShouldEqual(bob);
+            }
+        }
+
+        public class when_using_EnsureString : EnsureSpecsBase
+        {
+            public override void Because()
+            {
+            }
+
+            [Fact]
+            public void when_testing_a_string_against_null_value_should_fail()
+            {
+                string test = null;
+
+                Action a = () => Ensure.that(() => test).is_not_null_or_whitespace();
+
+                a.ShouldThrow<ArgumentNullException>();
+            }
+
+            [Fact]
+            public void when_testing_a_string_against_an_empty_value_should_fail()
+            {
+                Action a = () => Ensure.that(() => string.Empty).is_not_null_or_whitespace();
+
+                a.ShouldThrow<ArgumentException>();
+            }
+
+            [Fact]
+            public void when_testing_a_string_against_a_whitespace_value_should_fail()
+            {
+                var test = "      ";
+
+                Action a = () => Ensure.that(() => test).is_not_null_or_whitespace();
+
+                a.ShouldThrow<ArgumentException>();
+            }
+
+            [Fact]
+            public void when_testing_a_string_against_a_non_empty_value_should_pass()
+            {
+                var test = "some value";
+
+                Ensure.that(() => test).is_not_null_or_whitespace();
+            }
+
+            [Fact]
+            public void when_testing_a_string_without_expected_extension_should_fail()
+            {
+                var test = "some-file.png";
+
+                Action a = () => Ensure.that(() => test).has_any_extension(".jpg", ".bmp", ".gif");
+
+                a.ShouldThrow<ArgumentException>();
+            }
+
+            [Fact]
+            public void when_testing_a_string_with_expected_extension_should_pass()
+            {
+                var test = "some-file.png";
+
+                Ensure.that(() => test).has_any_extension(".jpg", ".bmp", ".gif", ".png");
             }
         }
 

--- a/src/chocolatey/chocolatey.csproj
+++ b/src/chocolatey/chocolatey.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\packages\Microsoft.CodeAnalysis.BannedApiAnalyzers.3.3.3\build\Microsoft.CodeAnalysis.BannedApiAnalyzers.props" Condition="Exists('..\packages\Microsoft.CodeAnalysis.BannedApiAnalyzers.3.3.3\build\Microsoft.CodeAnalysis.BannedApiAnalyzers.props')" />
   <PropertyGroup>
@@ -216,6 +216,13 @@
     <Compile Include="infrastructure.app\nuget\ChocolateyNuGetSettings.cs" />
     <Compile Include="infrastructure.app\nuget\ChocolateySourceCacheContext.cs" />
     <Compile Include="infrastructure.app\rules\MetadataRuleBase.cs" />
+    <Compile Include="infrastructure.app\rules\FrameWorkReferencesMetadataRule.cs" />
+    <Compile Include="infrastructure.app\rules\IconMetadataRule.cs" />
+    <Compile Include="infrastructure.app\rules\LicenseMetadataRule.cs" />
+    <Compile Include="infrastructure.app\rules\PackageTypesMetadataRule.cs" />
+    <Compile Include="infrastructure.app\rules\ReadmeMetadataRule.cs" />
+    <Compile Include="infrastructure.app\rules\RepositoryMetadataRule.cs" />
+    <Compile Include="infrastructure.app\rules\ServicableMetadataRule.cs" />
     <Compile Include="infrastructure.app\services\RuleService.cs" />
     <Compile Include="infrastructure\cryptography\DefaultEncryptionUtility.cs" />
     <Compile Include="infrastructure\adapters\IEncryptionUtility.cs" />

--- a/src/chocolatey/chocolatey.csproj
+++ b/src/chocolatey/chocolatey.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\packages\Microsoft.CodeAnalysis.BannedApiAnalyzers.3.3.3\build\Microsoft.CodeAnalysis.BannedApiAnalyzers.props" Condition="Exists('..\packages\Microsoft.CodeAnalysis.BannedApiAnalyzers.3.3.3\build\Microsoft.CodeAnalysis.BannedApiAnalyzers.props')" />
   <PropertyGroup>
@@ -215,6 +215,8 @@
     <Compile Include="infrastructure.app\nuget\ChocolateyNuGetProjectContext.cs" />
     <Compile Include="infrastructure.app\nuget\ChocolateyNuGetSettings.cs" />
     <Compile Include="infrastructure.app\nuget\ChocolateySourceCacheContext.cs" />
+    <Compile Include="infrastructure.app\rules\MetadataRuleBase.cs" />
+    <Compile Include="infrastructure.app\services\RuleService.cs" />
     <Compile Include="infrastructure\cryptography\DefaultEncryptionUtility.cs" />
     <Compile Include="infrastructure\adapters\IEncryptionUtility.cs" />
     <Compile Include="infrastructure.app\validations\GlobalConfigurationValidation.cs" />
@@ -251,6 +253,10 @@
     <Compile Include="infrastructure\logging\LogMessage.cs" />
     <Compile Include="infrastructure\logging\LogSinkLog.cs" />
     <Compile Include="infrastructure\registration\AssemblyResolution.cs" />
+    <Compile Include="infrastructure\rules\IMetadataRule.cs" />
+    <Compile Include="infrastructure\rules\RuleResult.cs" />
+    <Compile Include="infrastructure\rules\RuleType.cs" />
+    <Compile Include="infrastructure\services\IRuleService.cs" />
     <Compile Include="infrastructure\synchronization\GlobalMutex.cs" />
     <Compile Include="infrastructure\logging\TraceLog.cs" />
     <Compile Include="infrastructure\registration\SecurityProtocol.cs" />

--- a/src/chocolatey/chocolatey.csproj
+++ b/src/chocolatey/chocolatey.csproj
@@ -216,13 +216,17 @@
     <Compile Include="infrastructure.app\nuget\ChocolateyNuGetSettings.cs" />
     <Compile Include="infrastructure.app\nuget\ChocolateySourceCacheContext.cs" />
     <Compile Include="infrastructure.app\rules\MetadataRuleBase.cs" />
+    <Compile Include="infrastructure.app\rules\RequiredMetadataRule.cs" />
+    <Compile Include="infrastructure.app\rules\EmptyOrInvalidUrlMetadataRule.cs" />
     <Compile Include="infrastructure.app\rules\FrameWorkReferencesMetadataRule.cs" />
     <Compile Include="infrastructure.app\rules\IconMetadataRule.cs" />
     <Compile Include="infrastructure.app\rules\LicenseMetadataRule.cs" />
     <Compile Include="infrastructure.app\rules\PackageTypesMetadataRule.cs" />
     <Compile Include="infrastructure.app\rules\ReadmeMetadataRule.cs" />
     <Compile Include="infrastructure.app\rules\RepositoryMetadataRule.cs" />
+    <Compile Include="infrastructure.app\rules\RequireLicenseAcceptanceMetadataRule.cs" />
     <Compile Include="infrastructure.app\rules\ServicableMetadataRule.cs" />
+    <Compile Include="infrastructure.app\rules\VersionMetadataRule.cs" />
     <Compile Include="infrastructure.app\services\RuleService.cs" />
     <Compile Include="infrastructure\cryptography\DefaultEncryptionUtility.cs" />
     <Compile Include="infrastructure\adapters\IEncryptionUtility.cs" />

--- a/src/chocolatey/infrastructure.app/registration/ChocolateyRegistrationModule.cs
+++ b/src/chocolatey/infrastructure.app/registration/ChocolateyRegistrationModule.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2022 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2023 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/registration/ChocolateyRegistrationModule.cs
+++ b/src/chocolatey/infrastructure.app/registration/ChocolateyRegistrationModule.cs
@@ -32,6 +32,9 @@ namespace chocolatey.infrastructure.app.registration
     using NuGet.Common;
     using NuGet.PackageManagement;
     using NuGet.Packaging;
+    using chocolatey.infrastructure.rules;
+    using chocolatey.infrastructure.app.rules;
+    using System.Linq;
 
     internal class ChocolateyRegistrationModule : IExtensionModule
     {
@@ -78,6 +81,16 @@ namespace chocolatey.infrastructure.app.registration
             registrator.register_service<IValidation>(
                 typeof(GlobalConfigurationValidation),
                 typeof(SystemStateValidation));
+
+            // Rule registrations
+            registrator.register_service<IRuleService, RuleService>();
+
+            var availableRules = GetType().Assembly
+                .GetTypes()
+                .Where(t => !t.IsInterface && !t.IsAbstract && typeof(IMetadataRule).IsAssignableFrom(t))
+                .ToArray();
+
+            registrator.register_service<IMetadataRule>(availableRules);
         }
     }
 }

--- a/src/chocolatey/infrastructure.app/rules/EmptyOrInvalidUrlMetadataRule.cs
+++ b/src/chocolatey/infrastructure.app/rules/EmptyOrInvalidUrlMetadataRule.cs
@@ -1,0 +1,56 @@
+﻿// Copyright © 2023-Present Chocolatey Software, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace chocolatey.infrastructure.app.rules
+{
+    using System;
+    using System.Collections.Generic;
+    using chocolatey.infrastructure.rules;
+    using NuGet.Packaging;
+
+    internal sealed class EmptyOrInvalidUrlMetadataRule : MetadataRuleBase
+    {
+        public override IEnumerable<RuleResult> validate(NuspecReader reader)
+        {
+            var items = new[]
+            {
+                "projectUrl",
+                "projectSourceUrl",
+                "docsUrl",
+                "bugTrackerUrl",
+                "mailingListUrl",
+                "iconUrl",
+                "licenseUrl"
+            };
+
+            foreach (var item in items)
+            {
+                if (has_element(reader, item))
+                {
+                    var value = get_element_value(reader, item);
+
+                    if (string.IsNullOrWhiteSpace(value))
+                    {
+                        yield return new RuleResult(RuleType.Error, "The {0} element in the package nuspec file cannot be empty.".format_with(item));
+                    }
+                    else if (!Uri.TryCreate(value, UriKind.Absolute, out _))
+                    {
+                        yield return new RuleResult(RuleType.Error, "'{0}' is not a valid URL for the {1} element in the package nuspec file.".format_with(value, item));
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/chocolatey/infrastructure.app/rules/FrameWorkReferencesMetadataRule.cs
+++ b/src/chocolatey/infrastructure.app/rules/FrameWorkReferencesMetadataRule.cs
@@ -1,0 +1,32 @@
+﻿// Copyright © 2023-Present Chocolatey Software, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace chocolatey.infrastructure.app.rules
+{
+    using System.Collections.Generic;
+    using chocolatey.infrastructure.rules;
+    using NuGet.Packaging;
+
+    internal sealed class FrameWorkReferencesMetadataRule : MetadataRuleBase
+    {
+        public override IEnumerable<RuleResult> validate(NuspecReader reader)
+        {
+            if (has_element(reader, "frameworkReferences"))
+            {
+                yield return new RuleResult(RuleType.Error, "<frameworkReferences> elements are not supported in Chocolatey CLI.");
+            }
+        }
+    }
+}

--- a/src/chocolatey/infrastructure.app/rules/IconMetadataRule.cs
+++ b/src/chocolatey/infrastructure.app/rules/IconMetadataRule.cs
@@ -1,0 +1,32 @@
+﻿// Copyright © 2023-Present Chocolatey Software, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace chocolatey.infrastructure.app.rules
+{
+    using System.Collections.Generic;
+    using chocolatey.infrastructure.rules;
+    using NuGet.Packaging;
+
+    internal sealed class IconMetadataRule : IMetadataRule
+    {
+        public IEnumerable<RuleResult> validate(NuspecReader reader)
+        {
+            if (!(reader.GetIcon() is null))
+            {
+                yield return new RuleResult(RuleType.Error, "<icon> elements are not supported in Chocolatey CLI, use <iconUrl> instead.");
+            }
+        }
+    }
+}

--- a/src/chocolatey/infrastructure.app/rules/LicenseMetadataRule.cs
+++ b/src/chocolatey/infrastructure.app/rules/LicenseMetadataRule.cs
@@ -1,0 +1,33 @@
+﻿// Copyright © 2023-Present Chocolatey Software, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace chocolatey.infrastructure.app.rules
+{
+    using System.Collections.Generic;
+    using System.Runtime.CompilerServices;
+    using chocolatey.infrastructure.rules;
+    using NuGet.Packaging;
+
+    internal sealed class LicenseMetadataRule : IMetadataRule
+    {
+        public IEnumerable<RuleResult> validate(NuspecReader reader)
+        {
+            if (!(reader.GetLicenseMetadata() is null))
+            {
+                yield return new RuleResult(RuleType.Error, "<license> elements are not supported in Chocolatey CLI, use <licenseUrl> instead.");
+            }
+        }
+    }
+}

--- a/src/chocolatey/infrastructure.app/rules/MetadataRuleBase.cs
+++ b/src/chocolatey/infrastructure.app/rules/MetadataRuleBase.cs
@@ -1,0 +1,55 @@
+﻿// Copyright © 2023-Present Chocolatey Software, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace chocolatey.infrastructure.app.rules
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Xml.Linq;
+    using chocolatey.infrastructure.rules;
+    using NuGet.Packaging;
+
+    public abstract class MetadataRuleBase : IMetadataRule
+    {
+        public abstract IEnumerable<RuleResult> validate(NuspecReader reader);
+
+        protected static bool has_element(NuspecReader reader, string name)
+        {
+            var metadataNode = reader.Xml.Root.Elements().FirstOrDefault(e => StringComparer.Ordinal.Equals(e.Name.LocalName, "metadata"));
+
+            return !(metadataNode is null || metadataNode.Elements(XName.Get(name, metadataNode.GetDefaultNamespace().NamespaceName)).FirstOrDefault() is null);
+        }
+
+        protected static string get_element_value(NuspecReader reader, string name)
+        {
+            var metadataNode = reader.Xml.Root.Elements().FirstOrDefault(e => StringComparer.Ordinal.Equals(e.Name.LocalName, "metadata"));
+
+            if (metadataNode is null)
+            {
+                return null;
+            }
+
+            var element = metadataNode.Elements(XName.Get(name, metadataNode.GetDefaultNamespace().NamespaceName)).FirstOrDefault();
+
+            if (element is null)
+            {
+                return null;
+            }
+
+            return element.Value;
+        }
+    }
+}

--- a/src/chocolatey/infrastructure.app/rules/PackageTypesMetadataRule.cs
+++ b/src/chocolatey/infrastructure.app/rules/PackageTypesMetadataRule.cs
@@ -1,0 +1,32 @@
+﻿// Copyright © 2023-Present Chocolatey Software, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace chocolatey.infrastructure.app.rules
+{
+    using System.Collections.Generic;
+    using chocolatey.infrastructure.rules;
+    using NuGet.Packaging;
+
+    internal sealed class PackageTypesMetadataRule : MetadataRuleBase
+    {
+        public override IEnumerable<RuleResult> validate(NuspecReader reader)
+        {
+            if (has_element(reader, "packageTypes"))
+            {
+                yield return new RuleResult(RuleType.Error, "<packageTypes> elements are not supported in Chocolatey CLI.");
+            }
+        }
+    }
+}

--- a/src/chocolatey/infrastructure.app/rules/ReadmeMetadataRule.cs
+++ b/src/chocolatey/infrastructure.app/rules/ReadmeMetadataRule.cs
@@ -1,0 +1,32 @@
+﻿// Copyright © 2023-Present Chocolatey Software, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace chocolatey.infrastructure.app.rules
+{
+    using System.Collections.Generic;
+    using chocolatey.infrastructure.rules;
+    using NuGet.Packaging;
+
+    internal sealed class ReadmeMetadataRule : IMetadataRule
+    {
+        public IEnumerable<RuleResult> validate(NuspecReader reader)
+        {
+            if (!(reader.GetReadme() is null))
+            {
+                yield return new RuleResult(RuleType.Error, "<readme> elements are not supported in Chocolatey CLI.");
+            }
+        }
+    }
+}

--- a/src/chocolatey/infrastructure.app/rules/RepositoryMetadataRule.cs
+++ b/src/chocolatey/infrastructure.app/rules/RepositoryMetadataRule.cs
@@ -1,0 +1,36 @@
+﻿// Copyright © 2023-Present Chocolatey Software, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace chocolatey.infrastructure.app.rules
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using chocolatey.infrastructure.rules;
+    using NuGet.Packaging;
+
+    internal sealed class RepositoryMetadataRule : MetadataRuleBase
+    {
+        public override IEnumerable<RuleResult> validate(NuspecReader reader)
+        {
+            var metadataNode = reader.Xml.Root.Elements().FirstOrDefault(e => StringComparer.Ordinal.Equals(e.Name.LocalName, "metadata"));
+
+            if (has_element(reader, "repository"))
+            {
+                yield return new RuleResult(RuleType.Error, "<repository> elements are not supported in Chocolatey CLI, use <packageSourceUrl> instead.");
+            }
+        }
+    }
+}

--- a/src/chocolatey/infrastructure.app/rules/RequireLicenseAcceptanceMetadataRule.cs
+++ b/src/chocolatey/infrastructure.app/rules/RequireLicenseAcceptanceMetadataRule.cs
@@ -1,0 +1,32 @@
+﻿// Copyright © 2023-Present Chocolatey Software, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace chocolatey.infrastructure.app.rules
+{
+    using System.Collections.Generic;
+    using chocolatey.infrastructure.rules;
+    using NuGet.Packaging;
+
+    internal sealed class RequireLicenseAcceptanceMetadataRule : IMetadataRule
+    {
+        public IEnumerable<RuleResult> validate(NuspecReader reader)
+        {
+            if (string.IsNullOrWhiteSpace(reader.GetLicenseUrl()) && reader.GetRequireLicenseAcceptance())
+            {
+                yield return new RuleResult(RuleType.Error, "Enabling license acceptance requires a license url.");
+            }
+        }
+    }
+}

--- a/src/chocolatey/infrastructure.app/rules/RequiredMetadataRule.cs
+++ b/src/chocolatey/infrastructure.app/rules/RequiredMetadataRule.cs
@@ -1,0 +1,43 @@
+﻿// Copyright © 2023-Present Chocolatey Software, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace chocolatey.infrastructure.app.rules
+{
+    using System.Collections.Generic;
+    using chocolatey.infrastructure.rules;
+    using NuGet.Packaging;
+
+    internal sealed class RequiredMetadataRule : MetadataRuleBase
+    {
+        public override IEnumerable<RuleResult> validate(NuspecReader reader)
+        {
+            var requiredItems = new[]
+            {
+                "id",
+                "version",
+                "authors",
+                "description"
+            };
+
+            foreach (var item in requiredItems)
+            {
+                if (string.IsNullOrWhiteSpace(get_element_value(reader, item)))
+                {
+                    yield return new RuleResult(RuleType.Error, "{0} is a required element in the package nuspec file.".format_with(item));
+                }
+            }
+        }
+    }
+}

--- a/src/chocolatey/infrastructure.app/rules/ServicableMetadataRule.cs
+++ b/src/chocolatey/infrastructure.app/rules/ServicableMetadataRule.cs
@@ -1,0 +1,32 @@
+﻿// Copyright © 2023-Present Chocolatey Software, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace chocolatey.infrastructure.app.rules
+{
+    using System.Collections.Generic;
+    using chocolatey.infrastructure.rules;
+    using NuGet.Packaging;
+
+    internal sealed class ServicableMetadataRule : MetadataRuleBase
+    {
+        public override IEnumerable<RuleResult> validate(NuspecReader reader)
+        {
+            if (has_element(reader, "serviceable"))
+            {
+                yield return new RuleResult(RuleType.Error, "<serviceable> elements are not supported in Chocolatey CLI.");
+            }
+        }
+    }
+}

--- a/src/chocolatey/infrastructure.app/rules/VersionMetadataRule.cs
+++ b/src/chocolatey/infrastructure.app/rules/VersionMetadataRule.cs
@@ -1,0 +1,37 @@
+﻿// Copyright © 2023-Present Chocolatey Software, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace chocolatey.infrastructure.app.rules
+{
+    using System.Collections.Generic;
+    using chocolatey.infrastructure.rules;
+    using NuGet.Packaging;
+    using NuGet.Versioning;
+
+    internal sealed class VersionMetadataRule : MetadataRuleBase
+    {
+        public override IEnumerable<RuleResult> validate(NuspecReader reader)
+        {
+            var version = get_element_value(reader, "version");
+
+            // We need to check for the $version$ substitution value,
+            // as it will not be replaced before the package gets created
+            if (!string.IsNullOrEmpty(version) && !version.is_equal_to("$version$") && !NuGetVersion.TryParse(version, out _))
+            {
+                yield return new RuleResult(RuleType.Error, "'{0}' is not a valid version string in the package nuspec file.".format_with(version));
+            }
+        }
+    }
+}

--- a/src/chocolatey/infrastructure.app/services/RuleService.cs
+++ b/src/chocolatey/infrastructure.app/services/RuleService.cs
@@ -1,0 +1,85 @@
+﻿// Copyright © 2023-Present Chocolatey Software, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace chocolatey.infrastructure.app.services
+{
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using chocolatey.infrastructure.guards;
+    using chocolatey.infrastructure.rules;
+    using chocolatey.infrastructure.services;
+    using NuGet.Configuration;
+    using NuGet.Packaging;
+
+    public sealed class RuleService : IRuleService
+    {
+        private readonly IMetadataRule[] _rules;
+
+        public RuleService(IMetadataRule[] rules)
+        {
+            _rules = rules;
+        }
+
+        public IEnumerable<RuleResult> validate_rules(string filePath)
+        {
+            Ensure.that(() => filePath)
+                .is_not_null_or_whitespace()
+                .has_any_extension(NuGetConstants.PackageExtension, NuGetConstants.ManifestExtension);
+
+            var rules = filePath.EndsWith(NuGetConstants.PackageExtension)
+                ? get_rules_from_package_async(filePath).GetAwaiter().GetResult()
+                : get_rules_from_metadata(filePath);
+
+            return rules
+                .OrderBy(r => r.Severity)
+                .ThenBy(r => r.Message);
+        }
+
+        private async Task<IEnumerable<RuleResult>> get_rules_from_package_async(string filePath, CancellationToken token = default)
+        {
+            using (var packageReader = new PackageArchiveReader(filePath))
+            {
+                var nuspecReader = await packageReader.GetNuspecReaderAsync(token);
+
+                // We add ToList here to ensure that the package
+                // reader hasn't been disposed of before we return
+                // any results.
+                return validate_nuspec(nuspecReader, _rules).ToList();
+            }
+        }
+
+        private IEnumerable<RuleResult> get_rules_from_metadata(string filePath)
+        {
+            var nuspecReader = new NuspecReader(filePath);
+
+            return validate_nuspec(nuspecReader, _rules);
+        }
+
+        private static IEnumerable<RuleResult> validate_nuspec(NuspecReader reader, IMetadataRule[] rules)
+        {
+            foreach (var rule in rules)
+            {
+                var validationResults = rule.validate(reader);
+
+                foreach (var result in validationResults.Where(v => v.Severity != RuleType.None))
+                {
+                    yield return result;
+                }
+            }
+        }
+    }
+}

--- a/src/chocolatey/infrastructure/rules/IMetadataRule.cs
+++ b/src/chocolatey/infrastructure/rules/IMetadataRule.cs
@@ -1,0 +1,27 @@
+﻿// Copyright © 2023-Present Chocolatey Software, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace chocolatey.infrastructure.rules
+{
+    using System.Collections.Generic;
+    using chocolatey.infrastructure.app.attributes;
+    using NuGet.Packaging;
+
+    [MultiService]
+    public interface IMetadataRule
+    {
+        IEnumerable<RuleResult> validate(NuspecReader reader);
+    }
+}

--- a/src/chocolatey/infrastructure/rules/RuleResult.cs
+++ b/src/chocolatey/infrastructure/rules/RuleResult.cs
@@ -1,0 +1,32 @@
+﻿// Copyright © 2023-Present Chocolatey Software, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace chocolatey.infrastructure.rules
+{
+    public readonly struct RuleResult
+    {
+        public static readonly RuleResult Success = new RuleResult(RuleType.None, string.Empty);
+
+        public RuleResult(RuleType severity, string message)
+        {
+            Severity = severity;
+            Message = message;
+        }
+
+        public readonly RuleType Severity;
+
+        public readonly string Message;
+    }
+}

--- a/src/chocolatey/infrastructure/rules/RuleType.cs
+++ b/src/chocolatey/infrastructure/rules/RuleType.cs
@@ -1,0 +1,25 @@
+﻿// Copyright © 2023-Present Chocolatey Software, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace chocolatey.infrastructure.rules
+{
+    public enum RuleType
+    {
+        None = 0,
+        Error,
+        Warning,
+        Information
+    }
+}

--- a/src/chocolatey/infrastructure/services/IRuleService.cs
+++ b/src/chocolatey/infrastructure/services/IRuleService.cs
@@ -1,0 +1,25 @@
+﻿// Copyright © 2023-Present Chocolatey Software, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace chocolatey.infrastructure.services
+{
+    using System.Collections.Generic;
+    using chocolatey.infrastructure.rules;
+
+    public interface IRuleService
+    {
+        IEnumerable<RuleResult> validate_rules(string filePath);
+    }
+}


### PR DESCRIPTION
## Description Of Changes

This pull request extracts the existing validation messages we had into a new rule service to make it easier to add new rules or changing existing rules, as well as it re-adds back the validation rules that was present in v1 but had been removed by the NuGet Client Uplift.
The outputted validation messages has also been changed to make more sense to the user for the messages that we had readded.

## Motivation and Context

To keep the same or similar validations happen when a user creates a new package.

## Testing

1. This has been ran through test kitchen locally

### Operating Systems Testing

- Windows 10 / 11

## Change Types Made

* [x] Bug fix (non-breaking change).
* [x] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [x] Tests to cover my changes, have been added. (E2E tests has been re-enabled)
* [x] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue

Fixes #3000  
https://app.clickup.com/t/20540031/PROJ-461
