### PR TITLE
(tests) Enable local source for tests that need to install chocolatey

### DIFF
--- a/tests/chocolatey-tests/chocolatey.Tests.ps1
+++ b/tests/chocolatey-tests/chocolatey.Tests.ps1
@@ -213,6 +213,7 @@ Describe "Ensuring Chocolatey is correctly installed" -Tag Environment, Chocolat
             Remove-Item $Profile.CurrentUserCurrentHost -ErrorAction Ignore
             New-Item $Profile.CurrentUserCurrentHost -Force
             $chocolatey = (Invoke-Choco list chocolatey -lo -r --exact).Lines | ConvertFrom-ChocolateyOutput -Command List
+            Enable-ChocolateySource -Name local
             $null = Invoke-Choco install chocolatey -f --version $chocolatey.Version
         }
 
@@ -284,6 +285,7 @@ Describe "Ensuring Chocolatey is correctly installed" -Tag Environment, Chocolat
                 }
             }
 
+            Enable-ChocolateySource -Name local
             $Output = Invoke-Choco install chocolatey -f --version $chocolatey.Version --no-progress
         }
 


### PR DESCRIPTION
## Description Of Changes

Enable `local` source when running tests that install chocolatey.

## Motivation and Context

When Test Kitchen is run with a local build, or a PR build, it is installed from a local source, and not from a nuget repository. This ensures that we enable the source for tests that require it.

## Testing

Team City Test Kitchen Before

![image](https://user-images.githubusercontent.com/30301021/216130714-c136ee29-db20-4624-a70d-cdae8ca29e5f.png)

Team City Test Kitchen After

![image](https://user-images.githubusercontent.com/30301021/216130762-988d56fe-aa0f-4251-a06d-2f1c02a18980.png)


1. Build Chocolatey locally
2. Run Test Kitchen build with the locally built package
3. Build Chocolatey PR in Team City
4. Run Test Kitchen in Team City targeting the PR build

### Operating Systems Testing

* Windows 2016 (test kitchen tests)
* Windows 2019 (test kitchen tests)
* Windows 2022 (vagrant tests)

## Change Types Made

* [ ] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.
* [x] End to end Pester tests

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [x] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue

N/A: This was identified when running some test kitchen tests
