### PR TITLE
(#3008) Remove support for passing in nupkg file when installing or upgrading packages

### DIFF
--- a/src/chocolatey.console/Program.cs
+++ b/src/chocolatey.console/Program.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2022 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2023 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -111,8 +111,6 @@ namespace chocolatey.console
 
                 trap_exit_scenarios(config);
 
-                warn_on_nuspec_or_nupkg_usage(args, config);
-
                 if (config.RegularOutput)
                 {
 #if DEBUG
@@ -218,15 +216,6 @@ namespace chocolatey.console
             // if it has been loaded using old method.
 
             return true;
-        }
-
-        private static void warn_on_nuspec_or_nupkg_usage(string[] args, ChocolateyConfiguration config)
-        {
-            var commandLine = Environment.CommandLine;
-            if (!(commandLine.contains(" pack ") || commandLine.contains(" push ") || commandLine.contains("convert")) && (commandLine.contains(".nupkg") || commandLine.contains(".nuspec")))
-            {
-                if (config.RegularOutput) "chocolatey".Log().Warn("The use of .nupkg or .nuspec in for package name or source is known to cause issues. Please use the package id from the nuspec `<id />` with `-s .` (for local folder where nupkg is found).");
-            }
         }
 
         private static void add_assembly_resolver()

--- a/src/chocolatey.tests/TinySpec.cs
+++ b/src/chocolatey.tests/TinySpec.cs
@@ -236,6 +236,16 @@ namespace chocolatey.tests
             {
             }
         }
+
+        [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = false)]
+        public sealed class UncAttribute : PlatformAttribute
+        {
+            public UncAttribute()
+                : base("Win")
+            {
+                Reason = "UNC Test paths are only available when running on Windows";
+            }
+        }
     }
 
     // ReSharper restore InconsistentNaming

--- a/src/chocolatey.tests/UNCHelper.cs
+++ b/src/chocolatey.tests/UNCHelper.cs
@@ -1,0 +1,41 @@
+﻿namespace chocolatey.tests
+{
+    using System;
+    using System.IO;
+    using System.Net;
+
+    public static class UNCHelper
+    {
+        public static string convert_local_folder_path_to_ip_based_unc_path(string localFolderName)
+        {
+            var rootFolder = Path.GetPathRoot(localFolderName);
+            var ipAddress = return_machine_ip();
+
+            return string.Format("\\\\{0}\\\\{1}$\\{2}", ipAddress, rootFolder.TrimEnd('\\', ':'), localFolderName.Substring(rootFolder.Length));
+        }
+
+        private static IPAddress return_machine_ip()
+        {
+            var hostName = Dns.GetHostName();
+            var ipEntry = Dns.GetHostEntry(hostName);
+            var addr = ipEntry.AddressList;
+            IPAddress ipV4 = null;
+
+            foreach (var item in addr)
+            {
+                if (item.AddressFamily == System.Net.Sockets.AddressFamily.InterNetwork)
+                {
+                    ipV4 = item;
+                    break;
+                }
+            }
+
+            if (ipV4 == null)
+            {
+                throw new ApplicationException("You have no IP of Version 4.");
+            }
+
+            return ipV4;
+        }
+    }
+}

--- a/src/chocolatey.tests/chocolatey.tests.csproj
+++ b/src/chocolatey.tests/chocolatey.tests.csproj
@@ -206,6 +206,7 @@
     <Compile Include="MockLogger.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="TinySpec.cs" />
+    <Compile Include="UNCHelper.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="App.config" />


### PR DESCRIPTION
## Description Of Changes

This pull request removes the support that was previously available to install a package by passing in its nupkg or nuspec file directly on the Commandline when calling `choco install` or `choco upgrade`.
Instead it will now fail the installation before it even tries to read the file by throwing an exception about it not being supported, as well as giving an example to the user how the package can be installed.
This example is only available when we reliably can determine that it is a absolute local file path, a UNC path or a relative file path where the file exists.
Otherwise a generic error output about passing in a nupkg file is shown.
If a nuspec file is shown, a different error is displayed mentioning that the file need to be packaged before attempting the installation.

## Motivation and Context

There has always been problems when installing a package when a path to the nupkg or nuspec file has been passed in, and with the uplift even more problems was discovered and it was decided to not support this feature anymore.

## Testing

Most tests can be ran without the package being available.

1. Run `choco install c:\testing\package.nupkg` (use any package, but without a version)
2. Verify the installation exits with code 1 and reports passing in a nupkg is not supported.
3. Verify the example given is along the lines of `choco install package --source="C:\testing"`
4. Run `choco install c:\testing\package.5.0.0.nupkg`
5. Verify same as number 2 and the example given is along the lines of `choco install package --version="5.0.0" --source="c:\testing"`
6. Run `choco install \\localhost\\c$\testing\package.5.0.0.nupkg`
6. Verify same as number 2, that it mentions UNC path and the example given is along the lines of `choco install package --version="5.0.0" --source="\\localhost\\c$\testing"`
7. Run `choco install c:\testing\another-package.2.0.0-alpha.nupkg`
8. Verify same as number 2, and the example given is along the lines of `choco install another-package --version="2.0.0-alpha" --prerelease --source="c:\testing"
9. Navigate into `c:\testing` and run `choco install existing-package.nupkg` (make sure this package exists)
10. Verify same as number 2, and the example given is along the lines of `choco install existing-package --source="c:\testing"`
11. Navigate into `c:\testing` and run `cohco install not-existing.nupkg` (make sure this package **DOES NOT** exist)
12. Verify a generic message about `nupkg` files passed in is not supported, and no example is given
13. Run `choco install https://testing.com/repository/some-package.nupkg`
14. Verify the same as number 12
15. Run `choco install C:\testing\meta-package.nuspec`
16. Verify an error message about the need to run `choco pack` is needed before installing the package. (No example should be given)

### Operating Systems Testing

- Windows 10/11

## Change Types Made
<!-- Tick the boxes for the type of changes that have been made -->

* [ ] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [x] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation. (Have not checked if there is any documentation changes needed)
* [ ] Documentation has been updated.
* [x] Tests to cover my changes, have been added.
* [x] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue

- Fixes #3008
- https://app.clickup.com/t/20540031/PROJ-464
