### PR TITLE
(#508) Warn users when a threshold has been hit, or when the threshold is close

### DIFF
--- a/src/chocolatey/infrastructure.app/commands/ChocolateyListCommand.cs
+++ b/src/chocolatey/infrastructure.app/commands/ChocolateyListCommand.cs
@@ -156,6 +156,12 @@ namespace chocolatey.infrastructure.app.commands
                 System.Console.Write("User name '{0}' provided. Password: ".format_with(configuration.SourceCommand.Username));
                 configuration.SourceCommand.Password = InteractivePrompt.get_password(configuration.PromptForConfirmation);
             }
+
+            if (configuration.ListCommand.PageSize < 1 || configuration.ListCommand.PageSize > 100)
+            {
+                var message = "The page size has been specified to be {0:N0} packages. The page size cannot be lower than 1 package, and no larger than 100 packages.".format_with(configuration.ListCommand.PageSize);
+                throw new ApplicationException(message);
+            }
         }
 
         public virtual void help_message(ChocolateyConfiguration configuration)

--- a/src/chocolatey/infrastructure.app/commands/ChocolateyListCommand.cs
+++ b/src/chocolatey/infrastructure.app/commands/ChocolateyListCommand.cs
@@ -98,7 +98,11 @@ namespace chocolatey.infrastructure.app.commands
                          })
                 .Add("page-size=",
                      "Page Size - the amount of package results to return per page. Defaults to 25. Available in 0.9.10+.",
-                     option => configuration.ListCommand.PageSize = int.Parse(option))
+                     option =>
+                     {
+                         configuration.ListCommand.PageSize = int.Parse(option);
+                         configuration.ListCommand.ExplicitPageSize = true;
+                     })
                 .Add("e|exact",
                      "Exact - Only return packages with this exact name. Available in 0.9.10+.",
                      option => configuration.ListCommand.Exact = option != null)

--- a/src/chocolatey/infrastructure.app/configuration/ChocolateyConfiguration.cs
+++ b/src/chocolatey/infrastructure.app/configuration/ChocolateyConfiguration.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2022 Chocolatey Software, Inc
+// Copyright © 2017 - 2022 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -556,6 +556,7 @@ NOTE: Hiding sensitive configuration data! Please double and triple
         public bool DownloadCacheAvailable { get; set; }
         public bool NotBroken { get; set; }
         public bool IncludeVersionOverrides { get; set; }
+        public bool ExplicitPageSize { get; set; }
     }
 
     [Serializable]

--- a/src/chocolatey/infrastructure.app/services/NugetService.cs
+++ b/src/chocolatey/infrastructure.app/services/NugetService.cs
@@ -277,6 +277,20 @@ namespace chocolatey.infrastructure.app.services
             config.Sources = sources;
             config.Prerelease = prerelease;
             config.ListCommand.IncludeVersionOverrides = includeVersionOverrides;
+
+            if (!config.ListCommand.Page.HasValue && !config.ListCommand.LocalOnly)
+            {
+                var logType = config.RegularOutput ? ChocolateyLoggers.Important : ChocolateyLoggers.LogFileOnly;
+
+                if (NugetList.ThresholdHit)
+                {
+                    this.Log().Warn(logType, "The threshold of {0:N0} packages per source has been met. Please refine your search, or specify a page to find any more results.".format_with(NugetList.LastPackageLimitUsed));
+                }
+                else if (NugetList.LowerThresholdHit)
+                {
+                    this.Log().Warn(logType, "Over {0:N0} packages was found per source, there may be more packages available that was filtered out. Please refine your search, or specify a page to check for more packages.".format_with(NugetList.LastPackageLimitUsed * 0.9));
+                }
+            }
         }
 
         public void pack_noop(ChocolateyConfiguration config)


### PR DESCRIPTION
## Description Of Changes

The main purpose of this pull request is to output warnings when a threshold of the amount of packages from at least 1 source has been hit, or if the threshold is very close to be hit and no page has been specified.
This will allow the user to decide to either refine their search, or to make use of the paging mechanism already built into Chocolatey CLI.

Additionally, there was a need to update the logic we use when querying sources to have a maximum amount of packages that can be returned per query.
If this maximum amount was not introduced there are sources that will return the wrong amount of packages.

## Motivation and Context

To give more information to users on their next step, and to do what we can to minimize impact on different servers used as sources.

## Testing

1. Run `choco search --source chocolatey` (this may take a while)
2. Verify only ~1000 packages are returned, and a warning about the threshold is hit.
3. Run `choco search 7zip --source chocolatey --page-size 32`
4. Verify a message about more than 29 packages was found per source, and there may be more packages that had been filtered out.
5. Run `choco search chocolatey --page 1 --page-size 2 --source chocolatey`
6. Verify the two packages `choco-package-list-backup` and `choco-persistent-packages` is outputted (may be different depending on caching)
7. Verify no message about thresholds being hit (due to paging)
8. Run `choco search --page-size 0`
9. Verify an error message is shown about the count needing to be between 1 and 100 packages
10. Run `choco search --page-size 101` 
11. Verify the same as 9
12. Run `choco search reader --order-by-popularity --page-size 1 --source chocolatey`
13. Verify adobereader package is shown, is the only package and a warning about the threshold being met is shown
14. Run 1, 3 and 5 and with the `-r` argument and verify no threshold message is shown

### Operating Systems Testing

- Windows 10/11

## Change Types Made
<!-- Tick the boxes for the type of changes that have been made -->

* [ ] Bug fix (non-breaking change).
* [x] Feature / Enhancement (non-breaking change).
* [x] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added. (Due to time constraint it was not added now, will be added later)
* [x] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue

- #508
- https://app.clickup.com/t/20540031/PROJ-453
