### PR TITLE
(#508) Fix force dependencies to not remove existing non-dependency packages

### DIFF
--- a/src/chocolatey.tests.integration/Scenario.cs
+++ b/src/chocolatey.tests.integration/Scenario.cs
@@ -49,6 +49,11 @@ namespace chocolatey.tests.integration
             return _fileSystem.combine_paths(get_top_level(), "lib");
         }
 
+        public static IEnumerable<string> get_installed_package_paths()
+        {
+            return _fileSystem.get_files(get_package_install_path(), "*" + NuGetConstants.PackageExtension, SearchOption.AllDirectories);
+        }
+
         public static void reset(ChocolateyConfiguration config)
         {
             string packagesInstallPath = get_package_install_path();

--- a/src/chocolatey.tests.integration/scenarios/InstallScenarios.cs
+++ b/src/chocolatey.tests.integration/scenarios/InstallScenarios.cs
@@ -2153,9 +2153,13 @@ namespace chocolatey.tests.integration.scenarios
 
         public class when_force_installing_an_already_installed_package_forcing_dependencies : ScenariosBase
         {
+            private IEnumerable<string> _installedPackagePaths;
             public override void Context()
             {
                 base.Context();
+
+                Scenario.add_packages_to_source_location(Configuration, "installpackage*" + NuGetConstants.PackageExtension);
+                Scenario.install_package(Configuration, "installpackage", "1.0.0");
 
                 Configuration.PackageNames = Configuration.Input = "hasdependency";
                 Scenario.add_packages_to_source_location(Configuration, "hasdependency.1*" + NuGetConstants.PackageExtension);
@@ -2163,6 +2167,8 @@ namespace chocolatey.tests.integration.scenarios
                 Scenario.add_packages_to_source_location(Configuration, "isexactversiondependency*" + NuGetConstants.PackageExtension);
                 Scenario.install_package(Configuration, "hasdependency", "1.0.0");
                 Scenario.add_packages_to_source_location(Configuration, "isdependency*" + NuGetConstants.PackageExtension);
+                _installedPackagePaths = Scenario.get_installed_package_paths().ToList();
+
                 Configuration.Force = true;
                 Configuration.ForceDependencies = true;
             }
@@ -2196,6 +2202,15 @@ namespace chocolatey.tests.integration.scenarios
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
                     packageReader.NuspecReader.GetVersion().to_string().ShouldEqual("1.0.0");
+                }
+            }
+
+            [Fact]
+            public void should_not_remove_any_existing_packages_in_the_lib_directory()
+            {
+                foreach (var packagePath in _installedPackagePaths)
+                {
+                    FileAssert.Exists(packagePath);
                 }
             }
 

--- a/tests/chocolatey-tests/commands/choco-install.Tests.ps1
+++ b/tests/chocolatey-tests/commands/choco-install.Tests.ps1
@@ -1,4 +1,4 @@
-﻿Import-Module helpers/common-helpers
+Import-Module helpers/common-helpers
 
 # https://github.com/chocolatey/choco/blob/master/src/chocolatey.tests.integration/scenarios/InstallScenarios.cs
 
@@ -769,7 +769,7 @@ Describe "choco install" -Tag Chocolatey, InstallCommand {
             $Output = Invoke-Choco install $PackageUnderTest --force --forcedependencies --confirm
         }
 
-        It "Exits with Success (0)" -Tag Broken {
+        It "Exits with Success (0)" {
             $Output.ExitCode | Should -Be 0
         }
 
@@ -803,7 +803,7 @@ Describe "choco install" -Tag Chocolatey, InstallCommand {
             $XML.package.metadata.version | Should -Be "1.0.0"
         }
 
-        It "Outputs a message indicating that it installed the package(s) successfully" -Tag Broken {
+        It "Outputs a message indicating that it installed the package(s) successfully" {
             $Output.Lines | Should -Contain "Chocolatey installed 3/3 packages."
         }
     }


### PR DESCRIPTION
## Description Of Changes

When forcing dependency reinstallations, don't mark local non-dependency packages as requiring uninstall/reinstall.

## Motivation and Context

When doing `choco install hasdependencies --force --forcedependencies` Chocolatey would mark all local packages for uninstallation and reinstallation. It would then remove the local packages, but fail to reinstall any that weren't dependencies.

## Testing

1. Ran in test kitchen against current develop branch (only InstallCommand) - Confirmed failed the updated tests

![image](https://user-images.githubusercontent.com/30301021/216780974-0d10affc-a9a1-4d5a-9733-c9df4a2a5bb9.png)

2. Ran in test kitchen against changes (only InstallCommand) - Confirmed no longer failed the updated tests

![image](https://user-images.githubusercontent.com/30301021/216780983-d0557a61-42a3-4b1e-b58a-f8141c98459f.png)

3. Ran Integration Tests after the first commit  - Confirmed new tests failed
5. Ran Integration Tests after the second commit - Confirmed new tests no longer fail

### Operating Systems Testing

* Windows 10 (Manual testing with debug build/integration tests)
* Windows Server 2016 (Test Kitchen)
* Windows Server 2019 (Test Kitchen)

## Change Types Made

* [x] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [x] Tests to cover my changes, have been added.
* [x] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue

* Fixes #508 
* PROJ-474