### PR TITLE
(tests) Update some tests to be more consistent

### DIFF
--- a/tests/chocolatey-tests/commands/choco-install.Tests.ps1
+++ b/tests/chocolatey-tests/commands/choco-install.Tests.ps1
@@ -1149,9 +1149,9 @@ Describe "choco install" -Tag Chocolatey, InstallCommand {
 
         It "Outputs expected error message" {
             $Output.String | Should -Match @"
-Package name cannot be a path to a file on a remote or local file system.
+Package name cannot be a path to a file on a remote, or local file system.
 
-To install or upgrade a local or remote file, you may use:
+To install a local, or remote file, you may use:
   choco install $packageUnderTest --version="1.0.0" --source="$([regex]::Escape($snapshotPath.PackagesPath))
 "@
         }

--- a/tests/chocolatey-tests/commands/choco-push.Tests.ps1
+++ b/tests/chocolatey-tests/commands/choco-push.Tests.ps1
@@ -1,4 +1,4 @@
-Import-Module helpers/common-helpers
+﻿Import-Module helpers/common-helpers
 
 Describe "choco push" -Tag Chocolatey, PushCommand -Skip:($null -eq $env:API_KEY -or $null -eq $env:PUSH_REPO) {
     BeforeAll {
@@ -175,7 +175,7 @@ Describe 'choco push nuget <_> repository' -Tag Chocolatey, PushCommand -Skip:($
 
             # Nexus can take a moment to index the package, but we want to validate that it was successfully pushed
             $Timer =  [System.Diagnostics.Stopwatch]::StartNew()
-            while ($Timer.Elapsed.TotalSeconds -lt 60 -and -not (
+            while ($Timer.Elapsed.TotalSeconds -lt 300 -and -not (
                 $Packages = (Invoke-Choco find $PackageUnderTest @VerifyPackagesSplat --Limit-Output).Lines | ConvertFrom-ChocolateyOutput -Command List
             )) {
                 Write-Verbose "$($PackageUnderTest) was not found on $($RepositoryToUse)$($RepositoryEndpoint). Waiting for 5 seconds before trying again."

--- a/tests/chocolatey-tests/commands/choco-upgrade.Tests.ps1
+++ b/tests/chocolatey-tests/commands/choco-upgrade.Tests.ps1
@@ -183,9 +183,9 @@ Describe "choco upgrade" -Tag Chocolatey, UpgradeCommand {
 
         It "Outputs expected error message" {
             $Output.String | Should -Match @"
-Package name cannot be a path to a file on a remote or local file system.
+Package name cannot be a path to a file on a remote, or local file system.
 
-To install or upgrade a local or remote file, you may use:
+To upgrade a local, or remote file, you may use:
   choco upgrade $packageUnderTest --version="1.0.0" --source="$([regex]::Escape($snapshotPath.PackagesPath))
 "@
         }


### PR DESCRIPTION
## Description Of Changes

Update the end to end Pester tests:

* Update the upgrade and install test message when provided with a nupkg
* Update nuget v2/3 push tests to more consistently detect if the package pushed successfully

## Motivation and Context

* The error message when provided with a nupkg file is not consistent with the pester tests
* Sometimes the push tests are failing, but the push itself is not failing. This seems to be a timing issue with the feeds.

## Testing

1. Will run them in Team City when a team city agent is available

### Operating Systems Testing

Server 2016/2019 (Team City Test Kitchen environments)

## Change Types Made

* [ ] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.
* [x] End to end tests update

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [x] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue

No issue, this is related to tests we're seeing having issues while working on other things.
