### PR TITLE
(#508) Fix exception happening when http cache location is too long

### DIFF
--- a/src/chocolatey.console/choco.exe.manifest
+++ b/src/chocolatey.console/choco.exe.manifest
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<asmv1:assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1" xmlns:asmv1="urn:schemas-microsoft-com:asm.v1" xmlns:asmv2="urn:schemas-microsoft-com:asm.v2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<asmv1:assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1" xmlns:asmv1="urn:schemas-microsoft-com:asm.v1" xmlns:asmv2="urn:schemas-microsoft-com:asm.v2" xmlns:asmv3="urn:schemas-microsoft-com:asm.v3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <assemblyIdentity version="1.0.0.0" name="choco.app"/>
   <trustInfo xmlns="urn:schemas-microsoft-com:asm.v2">
     <security>
@@ -54,4 +54,10 @@
       <supportedOS Id="{e2011457-1546-43c5-a5fe-008deee3d3f0}"/>
     </application>
   </compatibility>
+
+  <asmv3:application>
+    <asmv3:windowsSettings xmlns:ws2="http://schemas.microsoft.com/SMI/2016/WindowsSettings">
+      <ws2:longPathAware>true</ws2:longPathAware>
+    </asmv3:windowsSettings>
+  </asmv3:application>
 </asmv1:assembly>

--- a/src/chocolatey/infrastructure.app/ApplicationParameters.cs
+++ b/src/chocolatey/infrastructure.app/ApplicationParameters.cs
@@ -22,6 +22,7 @@ namespace chocolatey.infrastructure.app
     using filesystem;
     using Environment = System.Environment;
     using chocolatey.infrastructure.platforms;
+    using chocolatey.infrastructure.information;
 
     /// <summary>
     ///   Application constants and settings for the application
@@ -72,6 +73,9 @@ namespace chocolatey.infrastructure.app
         public static readonly string UserProfilePath = !string.IsNullOrWhiteSpace(System.Environment.GetFolderPath(System.Environment.SpecialFolder.UserProfile, System.Environment.SpecialFolderOption.DoNotVerify)) ?
               System.Environment.GetFolderPath(System.Environment.SpecialFolder.UserProfile, System.Environment.SpecialFolderOption.DoNotVerify)
             : CommonAppDataChocolatey;
+        public static readonly string HttpCacheUserLocation = _fileSystem.combine_paths(UserProfilePath, ".chocolatey", "http-cache");
+        public static readonly string HttpCacheLocation = get_http_cache_location();
+
         public static readonly string UserLicenseFileLocation = _fileSystem.combine_paths(UserProfilePath, "chocolatey.license.xml");
         public static readonly string LicensedChocolateyAssemblySimpleName = "chocolatey.licensed";
         public static readonly string LicensedComponentRegistry = @"chocolatey.licensed.infrastructure.app.registration.ContainerBinding";
@@ -103,6 +107,20 @@ namespace chocolatey.infrastructure.app
         public static readonly string PowerShellModulePathProcessDocuments = _fileSystem.combine_paths(System.Environment.GetFolderPath(System.Environment.SpecialFolder.MyDocuments), "WindowsPowerShell\\Modules");
         public static readonly string LocalSystemSidString = "S-1-5-18";
         public static readonly SecurityIdentifier LocalSystemSid = new SecurityIdentifier(LocalSystemSidString);
+
+        private static string get_http_cache_location()
+        {
+            if (ProcessInformation.process_is_elevated() || string.IsNullOrEmpty(System.Environment.GetFolderPath(System.Environment.SpecialFolder.UserProfile, System.Environment.SpecialFolderOption.DoNotVerify)))
+            {
+                // CommonAppDataChocolatey is always set to ProgramData\Chocolatey.
+                // So we append HttpCache to that name if it is possible.
+                return CommonAppDataChocolatey + "HttpCache";
+            }
+            else
+            {
+                return HttpCacheUserLocation;
+            }
+        }
 
         public static class Environment
         {

--- a/src/chocolatey/infrastructure.app/nuget/NugetCommon.cs
+++ b/src/chocolatey/infrastructure.app/nuget/NugetCommon.cs
@@ -214,7 +214,7 @@ var source = sourceValue;
                         var httpSourceResource = repo.GetResource<HttpSourceResource>();
                         if (httpSourceResource != null)
                         {
-                            httpSourceResource.HttpSource.HttpCacheDirectory = System.IO.Path.Combine(configuration.CacheLocation, "NuGetHttpCache");
+                            httpSourceResource.HttpSource.HttpCacheDirectory = ApplicationParameters.HttpCacheLocation;
                         }
                     }
 

--- a/tests/helpers/common/Chocolatey/New-ChocolateyInstallSnapshot.ps1
+++ b/tests/helpers/common/Chocolatey/New-ChocolateyInstallSnapshot.ps1
@@ -62,5 +62,7 @@
     [PSCustomObject]@{
         InstallPath  = $env:ChocolateyInstall
         PackagesPath = $env:CHOCOLATEY_TEST_PACKAGES_PATH
+        CachePathLong= "$SnapshotPath\ChocolateyCache\This\Cache\Is\Intended\to\Be\Very\Long\On\Purpose" # This path will most likely not be removed due to long path errors
+        CachePath    = "$SnapshotPath\Cache"
     }
 }


### PR DESCRIPTION
## Description Of Changes

Update Chocolatey to handle long paths, add tests for http cache being long path.

## Motivation and Context

Should be able to operate with long paths since Windows has had the ability for some time.

## Testing

Manually verified that the long paths worked.

### Operating Systems Testing

- Windows 10/11
- Windows Server 2019

## Change Types Made
<!-- Tick the boxes for the type of changes that have been made -->

* [x] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [ ] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue

https://app.clickup.com/t/20540031/PROJ-496

<!-- PLEASE REMOVE ALL COMMENTS BEFORE SUBMITTING -->
