### PR TITLE
(#508) Correct installation E2E tests for long and cache paths

### DIFF
--- a/tests/chocolatey-tests/commands/choco-upgrade.Tests.ps1
+++ b/tests/chocolatey-tests/commands/choco-upgrade.Tests.ps1
@@ -150,7 +150,7 @@ Describe "choco upgrade" -Tag Chocolatey, UpgradeCommand {
         }
     }
 
-    Context "Upgrading a Package from a nupkg file" -Tag Testing {
+    Context "Upgrading a Package from a nupkg file" {
         BeforeAll {
             $snapshotPath = New-ChocolateyInstallSnapshot
 

--- a/tests/chocolatey-tests/commands/choco-upgrade.Tests.ps1
+++ b/tests/chocolatey-tests/commands/choco-upgrade.Tests.ps1
@@ -6,6 +6,7 @@ Describe "choco upgrade" -Tag Chocolatey, UpgradeCommand {
         Initialize-ChocolateyTestInstall
 
         New-ChocolateyInstallSnapshot
+        $features = Get-ChocolateyFeatures
     }
 
     AfterAll {
@@ -188,6 +189,73 @@ Package name cannot be a path to a file on a remote, or local file system.
 To upgrade a local, or remote file, you may use:
   choco upgrade $packageUnderTest --version="1.0.0" --source="$([regex]::Escape($snapshotPath.PackagesPath))
 "@
+        }
+    }
+
+    # We are marking this test as internal, as the package we need to make use
+    # of downloads a zip archive from a internal server, and the package is also
+    # only located on an internal feed.
+    Context "Upgrading non-existing package while specifying a cache location (Arg: <_>)" -ForEach '-c', '--cache', '--cachelocation', '--cache-location' -Tag Internal, LongPaths, CacheLocation {
+        BeforeAll {
+            $paths = Restore-ChocolateyInstallSnapshot
+
+            $Output = Invoke-Choco upgrade install-chocolateyzip --version 3.21.2 --confirm "$_" "$($paths.CachePathLong)" --no-progress
+        }
+
+        AfterAll {
+            $null = Invoke-Choco uninstall install-chocolateyzip --confirm
+        }
+
+        It 'Exits with Success (0)' {
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
+        }
+
+        It 'Runs under background Service' -Tag Background {
+            $Output.Lines | Should -Contain 'Running in background mode' -Because $Output.String
+        }
+
+        It 'Outputs downloading 64bit package' {
+            $Output.Lines | Should -Contain 'Downloading install-chocolateyzip 64 bit' -Because $Output.String
+        }
+
+        It 'Outputs download completed' {
+            $testMessage = if ($features.License) {
+                "Download of 'cmake-3.21.2-windows-x86_64.zip' (36.01 MB) completed."
+            } else {
+                "Download of cmake-3.21.2-windows-x86_64.zip (36.01 MB) completed."
+            }
+            $Output.Lines | Should -Contain $testMessage -Because $Output.String
+        }
+
+        It 'Outputs extracting correct archive' {
+            $testMessage = if ($features.License) {
+                "Extracting cmake-3.21.2-windows-x86_64.zip to $env:ChocolateyInstall\lib\install-chocolateyzip\tools..."
+            } else {
+                "Extracting $($paths.CachePathLong)\install-chocolateyzip\3.21.2\cmake-3.21.2-windows-x86_64.zip to $env:ChocolateyInstall\lib\install-chocolateyzip\tools..."
+            }
+            $Output.Lines | Should -Contain $testMessage -Because $Output.String
+        }
+
+        It 'Created shim for <_>' -ForEach 'cmake-gui.exe', 'cmake.exe', 'cmcldeps.exe', 'cpack.exe', 'ctest.exe' {
+            $Output.Lines | Should -Contain "ShimGen has successfully created a shim for $_"
+            "$env:ChocolateyInstall\bin\$_" | Should -Exist
+        }
+
+        It 'Outputs upgrading was successful' {
+            $Output.Lines | Should -Contain 'The upgrade of install-chocolateyzip was successful.' -Because $Output.String
+        }
+
+        It 'Outputs software installation directory' {
+            $Output.Lines | Should -Contain "Software installed to '$env:ChocolateyInstall\lib\install-chocolateyzip\tools'" -Because $Output.String
+        }
+
+        It 'Should have cached installed directory in custom cache' {
+            # Need to be verified, but the file may not exist on licensed edition
+            "$($paths.CachePathLong)\install-chocolateyzip\3.21.2\cmake-3.21.2-windows-x86_64.zip" | Should -Exist
+        }
+
+        It 'Installed software to expected directory' {
+            "$env:ChocolateyInstall\lib\install-chocolateyzip\tools\cmake-3.21.2-windows-x86_64\bin\cmake.exe" | Should -Exist
         }
     }
 


### PR DESCRIPTION
## Description Of Changes

This pull request fixes the tests that had been included in the PR #3017 with the correct paths and the correct output that is expected for both open source and licensed extension.

## Motivation and Context

To have working tests.

## Testing

1. Run through test kitchen using the Tag `LongPaths`

### Operating Systems Testing

- Windows Server 2019

## Change Types Made

* [ ] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.
* [x] E2E test fixes

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [ ] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue

- #508
- https://app.clickup.com/t/20540031/PROJ-496
