### PR TITLE
(#508) Ensure PackagesLocation exists.

### DIFF
--- a/src/chocolatey.console/Program.cs
+++ b/src/chocolatey.console/Program.cs
@@ -162,6 +162,7 @@ namespace chocolatey.console
 #if !NoResources
                 AssemblyFileExtractor.extract_all_resources_to_relative_directory(fileSystem, Assembly.GetAssembly(typeof(ChocolateyResourcesAssembly)), ApplicationParameters.InstallLocation, folders, ApplicationParameters.ChocolateyFileResources, throwError: false);
 #endif
+                ensure_lib_directory_exists(fileSystem);
                 var application = new ConsoleApplication();
                 application.run(args, config, container);
             }
@@ -311,6 +312,18 @@ Download at 'https://download.visualstudio.microsoft.com/download/pr/2d6bb6b2-22
                     }
                 }
             }
+        }
+
+        private static void ensure_lib_directory_exists(IFileSystem fileSystem)
+        {
+            FaultTolerance.try_catch_with_logging_exception(
+                () =>
+                {
+                    fileSystem.create_directory_if_not_exists(ApplicationParameters.PackagesLocation);
+                },
+                errorMessage: "Attempting to create lib directory ran into an issue",
+                throwError: true,
+                isSilent: true);
         }
     }
 }

--- a/tests/chocolatey-tests/chocolatey.Tests.ps1
+++ b/tests/chocolatey-tests/chocolatey.Tests.ps1
@@ -395,7 +395,7 @@ Describe "Ensuring Chocolatey is correctly installed" -Tag Environment, Chocolat
         BeforeAll {
             New-ChocolateyInstallSnapshot
             Remove-Item -Path $env:ChocolateyInstall/lib/ -Recurse -Force
-            $Output = Invoke-Choco
+            $Output = Invoke-Choco list --local-only
         }
 
         AfterAll {
@@ -404,6 +404,14 @@ Describe "Ensuring Chocolatey is correctly installed" -Tag Environment, Chocolat
 
         It 'Exits with success (0)' {
             $Output.ExitCode | Should -Be 0 -Because $Output.String
+        }
+
+        It 'Does not emit a warning about the missing directory' {
+            $Output.Lines | Should -Not -Contain "Directory '$($env:ChocolateyInstall)\lib' does not exist." -Because $Output.String
+        }
+
+        It 'Creates Chocolatey Lib directory' {
+            "$($env:ChocolateyInstall)/lib/" | Should -Exist -Because $Output.String
         }
     }
 }

--- a/tests/chocolatey-tests/chocolatey.Tests.ps1
+++ b/tests/chocolatey-tests/chocolatey.Tests.ps1
@@ -390,4 +390,20 @@ Describe "Ensuring Chocolatey is correctly installed" -Tag Environment, Chocolat
             $Output.Lines | Should -Contain '.NET 4.8 is not installed or may need a reboot to complete installation.'
         }
     }
+
+    Context 'Chocolatey lib directory missing' {
+        BeforeAll {
+            New-ChocolateyInstallSnapshot
+            Remove-Item -Path $env:ChocolateyInstall/lib/ -Recurse -Force
+            $Output = Invoke-Choco
+        }
+
+        AfterAll {
+            Remove-ChocolateyInstallSnapshot
+        }
+
+        It 'Exits with success (0)' {
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
+        }
+    }
 }


### PR DESCRIPTION
## Description Of Changes

Ensure the PackagesLocation exists as the new NuGet library doesn't handle it missing very well.

## Motivation and Context

If we get into a scenario where anything is done within NuGet.Client and the `lib` directory doesn't exist, then it will throw an exception instead of handling the missing directory. This ensures that we have a directory there.

## Testing

1. I have tested with previous develop build and deleting the `lib` directory. This encountered an error.
2. Tested with this build, and there is no error.
3. Running tests on Test Kitchen

### Operating Systems Testing

* Windows 10 22H2
* Windows Server 2016 (Test Kitchen)
* Windows Server 2019 (Test Kitchen)

## Change Types Made

* [x] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [ ] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue

Related to #508