### PR TITLE
(#508) Fix dependency resolution

### DIFF
--- a/src/chocolatey/infrastructure.app/services/NugetService.cs
+++ b/src/chocolatey/infrastructure.app/services/NugetService.cs
@@ -700,7 +700,7 @@ Please see https://docs.chocolatey.org/en-us/troubleshooting for more
 
                         if (!invalidDependencyMatch.Groups["packageId"].Success)
                         {
-                            string resolvePattern = @"Unable to resolve dependency \'(?<packageId>\w+)\'";
+                            string resolvePattern = @"Unable to resolve dependency \'(?<packageId>[\w\-\.]+)\'";
                             var resolveDependencyMatch = Regex.Match(ex.Message, resolvePattern, RegexOptions.IgnoreCase);
                             invalidDependencyName = resolveDependencyMatch.Groups["packageId"].Success ? resolveDependencyMatch.Groups["packageId"].Value : string.Empty;
 
@@ -1248,7 +1248,7 @@ Please see https://docs.chocolatey.org/en-us/troubleshooting for more
 
                                 if (!invalidDependencyMatch.Groups["packageId"].Success)
                                 {
-                                    string resolvePattern = @"Unable to resolve dependency \'(?<packageId>\w+)\'";
+                                    string resolvePattern = @"Unable to resolve dependency \'(?<packageId>[\w\-\.]+)\'";
                                     var resolveDependencyMatch = Regex.Match(ex.Message, resolvePattern, RegexOptions.IgnoreCase);
                                     invalidDependencyName = resolveDependencyMatch.Groups["packageId"].Success ? resolveDependencyMatch.Groups["packageId"].Value : string.Empty;
 

--- a/src/chocolatey/infrastructure.app/services/NugetService.cs
+++ b/src/chocolatey/infrastructure.app/services/NugetService.cs
@@ -622,12 +622,18 @@ Please see https://docs.chocolatey.org/en-us/troubleshooting for more
 
                 var dependencyResolver = new PackageResolver();
 
-                var allPackagesIdentities = allLocalPackages
-                    .Select(p => p.SearchMetadata.Identity)
-                    // If we're forcing dependencies, we only need to know which dependencies are installed locally, not the entire list of packages
-                    .Where(p => config.ForceDependencies
-                        ? sourcePackageDependencyInfos.Any(s => s.Id == p.Id) 
-                        : !targetIdsToInstall.Contains(p.Id, StringComparer.OrdinalIgnoreCase)).ToList();
+                var allPackagesIdentities = Enumerable.Empty<PackageIdentity>();
+
+                if (availablePackage.DependencySets.Any() || localPackagesDependencyInfos.Any(d => d.Dependencies.Any(dd => dd.Id == availablePackage.Identity.Id)))
+                {
+                    allPackagesIdentities = allLocalPackages
+                        .Select(p => p.SearchMetadata.Identity)
+                        // If we're forcing dependencies, we only need to know which dependencies are installed locally, not the entire list of packages
+                        .Where(p => config.ForceDependencies
+                            ? sourcePackageDependencyInfos.Any(s => s.Id == p.Id)
+                            : !targetIdsToInstall.Contains(p.Id, StringComparer.OrdinalIgnoreCase)).ToList();
+                }
+
                 var allPackagesReferences = allPackagesIdentities.Select(p => new PackageReference(p, NuGetFramework.AnyFramework));
 
                 var resolverContext = new PackageResolverContext(
@@ -1174,7 +1180,16 @@ Please see https://docs.chocolatey.org/en-us/troubleshooting for more
                         var dependencyResolver = new PackageResolver();
 
                         var targetIdsToInstall = packagesToInstall.Select(p => p.Identity.Id);
-                        var allPackagesIdentities = allLocalPackages.Where(x => !targetIdsToInstall.Contains(x.Identity.Id, StringComparer.OrdinalIgnoreCase)).Select(p => p.SearchMetadata.Identity).ToList();
+
+                        var allPackagesIdentities = Enumerable.Empty<PackageIdentity>();
+
+                        if (availablePackage.DependencySets.Any() || localPackagesDependencyInfos.Any(d => d.Dependencies.Any(dd => dd.Id == availablePackage.Identity.Id)))
+                        {
+                            allPackagesIdentities = allLocalPackages
+                                .Where(x => !targetIdsToInstall.Contains(x.Identity.Id, StringComparer.OrdinalIgnoreCase))
+                                .Select(p => p.SearchMetadata.Identity).ToList();
+                        }
+
                         //var allPackagesIdentities = allLocalPackages.Select(p => p.SearchMetadata.Identity).ToList();
                         var allPackagesReferences = allPackagesIdentities.Select(p => new PackageReference(p, NuGetFramework.AnyFramework));
 

--- a/src/chocolatey/infrastructure.app/services/NugetService.cs
+++ b/src/chocolatey/infrastructure.app/services/NugetService.cs
@@ -720,7 +720,7 @@ Please see https://docs.chocolatey.org/en-us/troubleshooting for more
                     }
                     catch (Exception ex)
                     {
-                        this.Log().Warn("Need to add specific handling for exception type {0}".format_with(nameof(ex)));
+                        this.Log().Warn("Need to add specific handling for exception type {0}".format_with(ex.GetType().Name));
                         this.Log().Warn(ex.Message);
                     }
                 }
@@ -1268,7 +1268,7 @@ Please see https://docs.chocolatey.org/en-us/troubleshooting for more
                             }
                             catch (Exception ex)
                             {
-                                this.Log().Warn("Need to add specific handling for exception type {0}".format_with(nameof(ex)));
+                                this.Log().Warn("Need to add specific handling for exception type {0}".format_with(ex.GetType().Name));
                                 this.Log().Warn(ex.Message);
                             }
                         }

--- a/src/chocolatey/infrastructure.app/services/NugetService.cs
+++ b/src/chocolatey/infrastructure.app/services/NugetService.cs
@@ -727,7 +727,6 @@ Please see https://docs.chocolatey.org/en-us/troubleshooting for more
 
                 foreach (SourcePackageDependencyInfo packageDependencyInfo in resolvedPackages)
                 {
-
                     var packageRemoteMetadata = packagesToInstall.FirstOrDefault(p => p.Identity.Equals(packageDependencyInfo));
 
                     if (packageRemoteMetadata is null)
@@ -1195,7 +1194,6 @@ Please see https://docs.chocolatey.org/en-us/troubleshooting for more
                         {
                             resolvedPackages = packagesToInstall.Select(p => sourcePackageDependencyInfos.Single(x => p.Identity.Equals(new PackageIdentity(x.Id, x.Version))));
 
-
                             if (config.ForceDependencies)
                             {
                                 //TODO Log warning here about dependencies being removed and not being reinstalled?
@@ -1224,7 +1222,6 @@ Please see https://docs.chocolatey.org/en-us/troubleshooting for more
                             {
                                 resolvedPackages = dependencyResolver.Resolve(resolverContext, CancellationToken.None)
                                     .Select(p => sourcePackageDependencyInfos.Single(x => PackageIdentityComparer.Default.Equals(x, p)));
-
 
                                 if (!config.ForceDependencies)
                                 {


### PR DESCRIPTION
## Description Of Changes

There are times when the dependency resolution, and the attempt to find
a valid solution for package installation is too aggressive.  For
example, if you install a package and omit the installation of the
dependencies, then any follow up attempt to install a package will
fail, since it is checking for all dependencies to be met for all
installed packages.  This is not always valid, since it should only
worry about the package that is being installed/upgraded.

This commit adds a check to see if the package being installed has any
dependencies, and if it doesn't, don't check for dependencies for the
locally installed packages.  On top of this, check to also see if the
package being installed is an existing dependency on an existing
installed package.  If this is the case, then go through normal
dependency resolution.

In addition, this PR improves the regex used to extract the dependency name, by
ensuring that `-` and `.` are allowed to be included in the dependency
name.  This fixes an issue where the error output includes something
like the following:

> Unable to resolve dependency ()

i.e. where the dependency name was not output.

## Motivation and Context

During testing of Chocolatey Licensed extension, an edge case was found where a package
fails to install due to a resolution dependency problem.  Investigation was performed, and
it was found that the error came back to Chocolatey OSS, after the uplift to NuGet.Client
assemblies.

## Testing

1. Tested locally out of Visual Studio as well as ran full suite of Unit/Integration Tests (there were some failing tests during the refactoring of this issue), and with these changes in place, all tests pass
1. Full Test-Kitchen pass has been performed on this PR, and all tests pass
1. The steps of a failing Pester test from Chocolatey Licensed code base has been performed and known to pass

### Operating Systems Testing

N/A

## Change Types Made

* [x] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [x] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue

Relates to #508