### PR TITLE
(#2953, #3026) Ensure CygwinService can find the correct RootDirectory

### DIFF
--- a/src/chocolatey/infrastructure.app/services/CygwinService.cs
+++ b/src/chocolatey/infrastructure.app/services/CygwinService.cs
@@ -45,7 +45,20 @@ namespace chocolatey.infrastructure.app.services
         private const string PACKAGE_NAME_TOKEN = "{{packagename}}";
         private const string INSTALL_ROOT_TOKEN = "{{installroot}}";
         public const string CYGWIN_PACKAGE = "cygwin";
-        private string _rootDirectory = string.Empty;
+
+        private string _rootDirectory;
+        private string RootDirectory
+        {
+            get
+            {
+                if (string.IsNullOrWhiteSpace(_rootDirectory))
+                {
+                    _rootDirectory = get_root_directory();
+                }
+
+                return _rootDirectory;
+            }
+        }
 
         private const string APP_NAME = "Cygwin";
         public const string PACKAGE_NAME_GROUP = "PkgName";
@@ -156,8 +169,6 @@ namespace chocolatey.infrastructure.app.services
                 _nugetService.install_run(runnerConfig, ensureAction.Invoke);
                 config.PromptForConfirmation = prompt;
             }
-
-            set_root_dir_if_not_set();
         }
 
         public int count_run(ChocolateyConfiguration config)
@@ -167,21 +178,26 @@ namespace chocolatey.infrastructure.app.services
 
         public void set_root_dir_if_not_set()
         {
-            if (!string.IsNullOrWhiteSpace(_rootDirectory)) return;
+            if (!string.IsNullOrWhiteSpace(_rootDirectory))
+            {
+                return;
+            }
 
+            _rootDirectory = get_root_directory();
+        }
+
+        private string get_root_directory()
+        {
             var setupKey = _registryService.get_key(RegistryHive.LocalMachine, "SOFTWARE\\Cygwin\\setup");
             if (setupKey != null)
             {
-                _rootDirectory = setupKey.GetValue("rootdir", string.Empty).to_string();
+                return setupKey.GetValue("rootdir", string.Empty).to_string();
             }
 
-            if (string.IsNullOrWhiteSpace(_rootDirectory))
-            {
-                var binRoot = Environment.GetEnvironmentVariable("ChocolateyBinRoot");
-                if (string.IsNullOrWhiteSpace(binRoot)) binRoot = "c:\\tools";
+            var binRoot = Environment.GetEnvironmentVariable("ChocolateyBinRoot");
+            if (string.IsNullOrWhiteSpace(binRoot)) binRoot = "c:\\tools";
 
-                _rootDirectory = _fileSystem.combine_paths(binRoot, "cygwin");
-            }
+            return _fileSystem.combine_paths(binRoot, "cygwin");
         }
 
         public string get_exe(string rootpath)
@@ -203,7 +219,7 @@ namespace chocolatey.infrastructure.app.services
         {
             var args = ExternalCommandArgsBuilder.build_arguments(config, argsDictionary);
 
-            args = args.Replace(INSTALL_ROOT_TOKEN, _rootDirectory);
+            args = args.Replace(INSTALL_ROOT_TOKEN, RootDirectory);
 
             return args;
         }
@@ -211,7 +227,7 @@ namespace chocolatey.infrastructure.app.services
         public void install_noop(ChocolateyConfiguration config, Action<PackageResult> continueAction)
         {
             var args = build_args(config, _installArguments);
-            this.Log().Info("Would have run '{0} {1}'".format_with(get_exe(_rootDirectory).escape_curly_braces(), args.escape_curly_braces()));
+            this.Log().Info("Would have run '{0} {1}'".format_with(get_exe(RootDirectory).escape_curly_braces(), args.escape_curly_braces()));
         }
 
         public ConcurrentDictionary<string, PackageResult> install_run(ChocolateyConfiguration config, Action<PackageResult> continueAction)
@@ -224,7 +240,7 @@ namespace chocolatey.infrastructure.app.services
                 var argsForPackage = args.Replace(PACKAGE_NAME_TOKEN, packageToInstall);
 
                 var exitCode = _commandExecutor.execute(
-                    get_exe(_rootDirectory),
+                    get_exe(RootDirectory),
                     argsForPackage,
                     config.CommandExecutionTimeoutSeconds,
                     _fileSystem.get_current_directory(),

--- a/src/chocolatey/infrastructure.app/services/CygwinService.cs
+++ b/src/chocolatey/infrastructure.app/services/CygwinService.cs
@@ -176,6 +176,7 @@ namespace chocolatey.infrastructure.app.services
             throw new NotImplementedException("Count is not supported for this source runner.");
         }
 
+        [Obsolete("This method does not need to be called publicly and may be made private or removed in a later version.")]
         public void set_root_dir_if_not_set()
         {
             if (!string.IsNullOrWhiteSpace(_rootDirectory))
@@ -200,6 +201,7 @@ namespace chocolatey.infrastructure.app.services
             return _fileSystem.combine_paths(binRoot, "cygwin");
         }
 
+        [Obsolete("This method does not need to be called publicly and may be made private or removed in a later version.")]
         public string get_exe(string rootpath)
         {
             return _fileSystem.combine_paths(rootpath, "cygwinsetup.exe");
@@ -215,6 +217,7 @@ namespace chocolatey.infrastructure.app.services
             throw new NotImplementedException("{0} does not implement list".format_with(APP_NAME));
         }
 
+        [Obsolete("This method does not need to be called publicly and may be made private or removed in a later version.")]
         public string build_args(ChocolateyConfiguration config, IDictionary<string, ExternalCommandArgument> argsDictionary)
         {
             var args = ExternalCommandArgsBuilder.build_arguments(config, argsDictionary);


### PR DESCRIPTION
## Description Of Changes

- Wrap _rootDirectory field in CygwinService in a property that null/empty-checks and sets the field if needed.
- Remove the manual call to update the root directory in the ensure_source_app_installed.
- Update references throughout CygwinService to use the property instead of accessing the field directly.
- Move most of the logic in `set_root_dir_if_not_set()` to a new `get_root_directory()` private method
- Flag extraneous / non-ISourceRunner interface methods as [Obsolete]

## Motivation and Context

Currently, `ISourceRunner` instances seem to be managed as transient. This is reasonable for many things, but it means we cannot rely on storing state in instance fields for `ISourceRunner` instances at the current time.

This change ensures that the state data created by `ensure_source_app_installed()` can be kept around for the followup call to `install_run()` by storing it in a static field that all instances can make use of.

We may want to discuss a design improvement/refactor to ensure that we aren't losing any other critical state data between these invocations for any other ISourceRunners. I have discussed this with @AdmiringWorm and will open a follow up issue for this shortly.

## Testing

Followed repro steps in #2953 and confirmed we do not get the "file not found" error, and Cygwin successfully runs.

NOTE: On my machine, the `cmake` package didn't install the first time, but Cygwin _does_ run correctly as it should, so whatever issue there is there seems to be between Cygwin and the package source it uses. On a rerun it seemed to work correctly, so maybe the servers were down for a short while or something, I'm not sure.

I will add a manual test step for this issue to avoid future regressions, it doesn't seem like a good fit for an automated test at this point given that interacting with the Cygwin source runner relies on the Cygwin source repository being available and has a couple of package dependencies as well.

### Operating Systems Testing

Tested locally on Windows 11

## Change Types Made

* [x] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [x] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue
<!-- Make sure you have raised an issue for this pull request before
continuing. -->

Fixes #2953

<!-- PLEASE REMOVE ALL COMMENTS BEFORE SUBMITTING -->
