### PR TITLE
(maint) Update Gitreleasemanager configuration

### DIFF
--- a/gitreleasemanager.yaml
+++ b/gitreleasemanager.yaml
@@ -1,5 +1,6 @@
 issue-labels-include:
 - Breaking Change
+- Deprecate
 - Feature
 - C4B Feature
 - Bug
@@ -13,6 +14,12 @@ issue-labels-alias:
     - name:    Documentation
       header:  Documentation
       plural:  Documentation
+    - name: Bug
+      header: Bug Fix
+      plural: Bug Fixes
+    - name: Deprecate
+      header: Deprecated Feature
+      plural: Deprecated Features
 create:
     include-sha-section: true
     sha-section-heading: "SHA256 Hashes of the release artifacts"


### PR DESCRIPTION
## Description Of Changes

- Added the Deprecate label to GRM configuration.
- Added config to set headers in the release notes specifically for Deprecate and Bug so that their headers match our release notes format.
**NOTE:** We should cherry-pick this commit into support/1.x branch after it's merged as well.

## Motivation and Context

We're deprecating quite a few things, we should probably use a proper label for it.

Also, the auto-gen'd release notes don't quite match our release notes format, so updated the config to make that work as expected.

## Testing

Ran `./build.ps1 -Target releasenotes` from the support/1.x branch with this configuration change and verified the generated release notes match up to what we want.

### Operating Systems Testing

N/A

## Change Types Made
<!-- Tick the boxes for the type of changes that have been made -->

* [ ] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.
* [x] Build enhancement

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [ ] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue

N/A, build adjustment only

<!-- PLEASE REMOVE ALL COMMENTS BEFORE SUBMITTING -->
