### PR TITLE
(tests) Enhance Invoke-Choco to force proxy use

### DIFF
--- a/tests/helpers/common/Chocolatey/Invoke-Choco.ps1
+++ b/tests/helpers/common/Chocolatey/Invoke-Choco.ps1
@@ -18,8 +18,22 @@
     )
     begin {
         $chocoPath = Get-ChocoPath
-    $firstArgument, [string[]]$remainingArguments = $Arguments
-        $arguments = @($firstArgument; '--allow-unofficial'; $remainingArguments)
+        $firstArgument, [string[]]$remainingArguments = $Arguments
+        $arguments = @(
+            $firstArgument
+            '--allow-unofficial'
+
+            if ($env:CHOCO_TEST_PROXY) {
+                "--proxy='$($env:CHOCO_TEST_PROXY)'"
+                if ($env:CHOCO_TEST_PROXY_USER) {
+                    "--proxy-user='$($env:CHOCO_TEST_PROXY_USER)'"
+                    "--proxy-password='$($env:CHOCO_TEST_PROXY_PASSWORD)'"
+                }
+            }
+
+            $remainingArguments
+        )
+
     }
     end {
         $output = if ($PipelineInput) {


### PR DESCRIPTION
## Description Of Changes

Enhance the `Invoke-Choco` function to look for custom environment variables and append the proxy parameters if they're found.

## Motivation and Context

We're adding some Test Kitchen instances that set custom environment variables so that we can test the proxy parameters.

## Testing

1. Ran Test Kitchen locally with configuration to set these environment variables.
2. Watched the proxy logs to see it was hitting the proxy as expected.

### Operating Systems Testing

* Windows Server 2019
* Windows Server 2016

## Change Types Made

* [ ] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.
* [x] End to end Pester test helper module changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [ ] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue

* PROJ-374
* PROJ-478
* PROJ-479
