### PR TITLE
(#3000) Add additional information in validation messages

### DIFF
--- a/src/chocolatey/RuleResultExtensions.cs
+++ b/src/chocolatey/RuleResultExtensions.cs
@@ -1,0 +1,43 @@
+﻿// Copyright © 2023-Present Chocolatey Software, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace chocolatey
+{
+    using System.Collections.Generic;
+    using System.Linq;
+    using chocolatey.infrastructure.rules;
+
+    public static class RuleResultExtensions
+    {
+        /// <summary>
+        /// Extension method used to filter out any rules that hasn't been marked as either unsupported or deprecated.
+        /// </summary>
+        /// <param name="ruleResults">The rule results to apply the filter to.</param>
+        /// <param name="inverse"><c>True</c> if the applied filters should exclude unsupported and deprecated rules; otherwise <c>False</c></param>
+        /// <returns>The passed in rule results with the applied filters.</returns>
+        public static IEnumerable<RuleResult> where_unsupported_or_deprecated(this IEnumerable<RuleResult> ruleResults, bool inverse = false)
+        {
+            if (!inverse)
+            {
+                return ruleResults
+                    .Where(r => r != null && !string.IsNullOrEmpty(r.Id))
+                    .Where(r => r.Id.StartsWith("CHCU") || r.Id.StartsWith("CHCD"));
+            }
+            return ruleResults
+                .Where(r => r != null)
+                .Where(r => string.IsNullOrEmpty(r.Id) || (!r.Id.StartsWith("CHCU") && !r.Id.StartsWith("CHCD")));
+        }
+    }
+}

--- a/src/chocolatey/chocolatey.csproj
+++ b/src/chocolatey/chocolatey.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\packages\Microsoft.CodeAnalysis.BannedApiAnalyzers.3.3.3\build\Microsoft.CodeAnalysis.BannedApiAnalyzers.props" Condition="Exists('..\packages\Microsoft.CodeAnalysis.BannedApiAnalyzers.3.3.3\build\Microsoft.CodeAnalysis.BannedApiAnalyzers.props')" />
   <PropertyGroup>
@@ -225,6 +225,7 @@
     <Compile Include="infrastructure.app\rules\ReadmeMetadataRule.cs" />
     <Compile Include="infrastructure.app\rules\RepositoryMetadataRule.cs" />
     <Compile Include="infrastructure.app\rules\RequireLicenseAcceptanceMetadataRule.cs" />
+    <Compile Include="infrastructure.app\rules\RuleIdentifiers.cs" />
     <Compile Include="infrastructure.app\rules\ServicableMetadataRule.cs" />
     <Compile Include="infrastructure.app\rules\VersionMetadataRule.cs" />
     <Compile Include="infrastructure.app\services\RuleService.cs" />
@@ -460,6 +461,7 @@
     <Compile Include="NuGetVersionExtensions.cs" />
     <Compile Include="ObjectExtensions.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="RuleResultExtensions.cs" />
     <Compile Include="StringExtensions.cs" />
     <Compile Include="TypeExtensions.cs" />
   </ItemGroup>

--- a/src/chocolatey/infrastructure.app/rules/EmptyOrInvalidUrlMetadataRule.cs
+++ b/src/chocolatey/infrastructure.app/rules/EmptyOrInvalidUrlMetadataRule.cs
@@ -43,11 +43,11 @@ namespace chocolatey.infrastructure.app.rules
 
                     if (string.IsNullOrWhiteSpace(value))
                     {
-                        yield return new RuleResult(RuleType.Error, "The {0} element in the package nuspec file cannot be empty.".format_with(item));
+                        yield return new RuleResult(RuleType.Error, RuleIdentifiers.EmptyRequiredElement, "The {0} element in the package nuspec file cannot be empty.".format_with(item));
                     }
                     else if (!Uri.TryCreate(value, UriKind.Absolute, out _))
                     {
-                        yield return new RuleResult(RuleType.Error, "'{0}' is not a valid URL for the {1} element in the package nuspec file.".format_with(value, item));
+                        yield return new RuleResult(RuleType.Error, RuleIdentifiers.InvalidTypeElement, "'{0}' is not a valid URL for the {1} element in the package nuspec file.".format_with(value, item));
                     }
                 }
             }

--- a/src/chocolatey/infrastructure.app/rules/FrameWorkReferencesMetadataRule.cs
+++ b/src/chocolatey/infrastructure.app/rules/FrameWorkReferencesMetadataRule.cs
@@ -25,7 +25,7 @@ namespace chocolatey.infrastructure.app.rules
         {
             if (has_element(reader, "frameworkReferences"))
             {
-                yield return new RuleResult(RuleType.Error, "<frameworkReferences> elements are not supported in Chocolatey CLI.");
+                yield return new RuleResult(RuleType.Error, RuleIdentifiers.UnsupportedElementUsed, "<frameworkReferences> elements are not supported in Chocolatey CLI.");
             }
         }
     }

--- a/src/chocolatey/infrastructure.app/rules/IconMetadataRule.cs
+++ b/src/chocolatey/infrastructure.app/rules/IconMetadataRule.cs
@@ -25,7 +25,7 @@ namespace chocolatey.infrastructure.app.rules
         {
             if (!(reader.GetIcon() is null))
             {
-                yield return new RuleResult(RuleType.Error, "<icon> elements are not supported in Chocolatey CLI, use <iconUrl> instead.");
+                yield return new RuleResult(RuleType.Error, RuleIdentifiers.UnsupportedElementUsed, "<icon> elements are not supported in Chocolatey CLI, use <iconUrl> instead.");
             }
         }
     }

--- a/src/chocolatey/infrastructure.app/rules/PackageTypesMetadataRule.cs
+++ b/src/chocolatey/infrastructure.app/rules/PackageTypesMetadataRule.cs
@@ -25,7 +25,7 @@ namespace chocolatey.infrastructure.app.rules
         {
             if (has_element(reader, "packageTypes"))
             {
-                yield return new RuleResult(RuleType.Error, "<packageTypes> elements are not supported in Chocolatey CLI.");
+                yield return new RuleResult(RuleType.Error, RuleIdentifiers.UnsupportedElementUsed, "<packageTypes> elements are not supported in Chocolatey CLI.");
             }
         }
     }

--- a/src/chocolatey/infrastructure.app/rules/ReadmeMetadataRule.cs
+++ b/src/chocolatey/infrastructure.app/rules/ReadmeMetadataRule.cs
@@ -25,7 +25,7 @@ namespace chocolatey.infrastructure.app.rules
         {
             if (!(reader.GetReadme() is null))
             {
-                yield return new RuleResult(RuleType.Error, "<readme> elements are not supported in Chocolatey CLI.");
+                yield return new RuleResult(RuleType.Error, RuleIdentifiers.UnsupportedElementUsed, "<readme> elements are not supported in Chocolatey CLI.");
             }
         }
     }

--- a/src/chocolatey/infrastructure.app/rules/RepositoryMetadataRule.cs
+++ b/src/chocolatey/infrastructure.app/rules/RepositoryMetadataRule.cs
@@ -29,7 +29,7 @@ namespace chocolatey.infrastructure.app.rules
 
             if (has_element(reader, "repository"))
             {
-                yield return new RuleResult(RuleType.Error, "<repository> elements are not supported in Chocolatey CLI, use <packageSourceUrl> instead.");
+                yield return new RuleResult(RuleType.Error, RuleIdentifiers.UnsupportedElementUsed, "<repository> elements are not supported in Chocolatey CLI, use <packageSourceUrl> instead.");
             }
         }
     }

--- a/src/chocolatey/infrastructure.app/rules/RequireLicenseAcceptanceMetadataRule.cs
+++ b/src/chocolatey/infrastructure.app/rules/RequireLicenseAcceptanceMetadataRule.cs
@@ -25,7 +25,7 @@ namespace chocolatey.infrastructure.app.rules
         {
             if (string.IsNullOrWhiteSpace(reader.GetLicenseUrl()) && reader.GetRequireLicenseAcceptance())
             {
-                yield return new RuleResult(RuleType.Error, "Enabling license acceptance requires a license url.");
+                yield return new RuleResult(RuleType.Error, RuleIdentifiers.MissingElementOnRequiringLicenseAcceptance, "Enabling license acceptance requires a license url.");
             }
         }
     }

--- a/src/chocolatey/infrastructure.app/rules/RequiredMetadataRule.cs
+++ b/src/chocolatey/infrastructure.app/rules/RequiredMetadataRule.cs
@@ -35,7 +35,7 @@ namespace chocolatey.infrastructure.app.rules
             {
                 if (string.IsNullOrWhiteSpace(get_element_value(reader, item)))
                 {
-                    yield return new RuleResult(RuleType.Error, "{0} is a required element in the package nuspec file.".format_with(item));
+                    yield return new RuleResult(RuleType.Error, RuleIdentifiers.EmptyRequiredElement, "{0} is a required element in the package nuspec file.".format_with(item));
                 }
             }
         }

--- a/src/chocolatey/infrastructure.app/rules/RuleIdentifiers.cs
+++ b/src/chocolatey/infrastructure.app/rules/RuleIdentifiers.cs
@@ -15,19 +15,11 @@
 
 namespace chocolatey.infrastructure.app.rules
 {
-    using System.Collections.Generic;
-    using System.Runtime.CompilerServices;
-    using chocolatey.infrastructure.rules;
-    using NuGet.Packaging;
-
-    internal sealed class LicenseMetadataRule : IMetadataRule
+    internal static class RuleIdentifiers
     {
-        public IEnumerable<RuleResult> validate(NuspecReader reader)
-        {
-            if (!(reader.GetLicenseMetadata() is null))
-            {
-                yield return new RuleResult(RuleType.Error, RuleIdentifiers.UnsupportedElementUsed, "<license> elements are not supported in Chocolatey CLI, use <licenseUrl> instead.");
-            }
-        }
+        public const string EmptyRequiredElement = "CHCR0001";
+        public const string InvalidTypeElement = "CHCU0001";
+        public const string MissingElementOnRequiringLicenseAcceptance = "CHCR0002";
+        public const string UnsupportedElementUsed = "CHCU0002";
     }
 }

--- a/src/chocolatey/infrastructure.app/rules/ServicableMetadataRule.cs
+++ b/src/chocolatey/infrastructure.app/rules/ServicableMetadataRule.cs
@@ -25,7 +25,7 @@ namespace chocolatey.infrastructure.app.rules
         {
             if (has_element(reader, "serviceable"))
             {
-                yield return new RuleResult(RuleType.Error, "<serviceable> elements are not supported in Chocolatey CLI.");
+                yield return new RuleResult(RuleType.Error, RuleIdentifiers.UnsupportedElementUsed, "<serviceable> elements are not supported in Chocolatey CLI.");
             }
         }
     }

--- a/src/chocolatey/infrastructure.app/rules/VersionMetadataRule.cs
+++ b/src/chocolatey/infrastructure.app/rules/VersionMetadataRule.cs
@@ -26,11 +26,11 @@ namespace chocolatey.infrastructure.app.rules
         {
             var version = get_element_value(reader, "version");
 
-            // We need to check for the $version$ substitution value,
-            // as it will not be replaced before the package gets created
+            // We need to check for the $version$ substitution value, as it will not be replaced
+            // before the package gets created
             if (!string.IsNullOrEmpty(version) && !version.is_equal_to("$version$") && !NuGetVersion.TryParse(version, out _))
             {
-                yield return new RuleResult(RuleType.Error, "'{0}' is not a valid version string in the package nuspec file.".format_with(version));
+                yield return new RuleResult(RuleType.Error, RuleIdentifiers.InvalidTypeElement, "'{0}' is not a valid version string in the package nuspec file.".format_with(version));
             }
         }
     }

--- a/src/chocolatey/infrastructure.app/services/RuleService.cs
+++ b/src/chocolatey/infrastructure.app/services/RuleService.cs
@@ -46,6 +46,7 @@ namespace chocolatey.infrastructure.app.services
 
             return rules
                 .OrderBy(r => r.Severity)
+                .ThenBy(r => r.Id)
                 .ThenBy(r => r.Message);
         }
 

--- a/src/chocolatey/infrastructure/rules/RuleResult.cs
+++ b/src/chocolatey/infrastructure/rules/RuleResult.cs
@@ -15,18 +15,18 @@
 
 namespace chocolatey.infrastructure.rules
 {
-    public readonly struct RuleResult
+    public sealed class RuleResult
     {
-        public static readonly RuleResult Success = new RuleResult(RuleType.None, string.Empty);
-
-        public RuleResult(RuleType severity, string message)
+        public RuleResult(RuleType severity, string id, string message)
         {
             Severity = severity;
+            Id = id;
             Message = message;
         }
 
-        public readonly RuleType Severity;
-
-        public readonly string Message;
+        public string HelpUrl { get; set; }
+        public string Id { get; private set; }
+        public string Message { get; private set; }
+        public RuleType Severity { get; set; }
     }
 }

--- a/src/chocolatey/infrastructure/rules/RuleType.cs
+++ b/src/chocolatey/infrastructure/rules/RuleType.cs
@@ -20,6 +20,7 @@ namespace chocolatey.infrastructure.rules
         None = 0,
         Error,
         Warning,
-        Information
+        Information,
+        Note
     }
 }

--- a/tests/chocolatey-tests/commands/choco-pack.Tests.ps1
+++ b/tests/chocolatey-tests/commands/choco-pack.Tests.ps1
@@ -15,17 +15,17 @@ $emptyFailures = @(
 )
 # Elements that will return an invalid failure (usually due to serialization)
 $invalidFailures = @(
-    @{id = 'projectUrl'; message = "ERROR: 'invalid project url' is not a valid URL for the projectUrl element in the package nuspec file." }
-    @{id = 'projectSourceUrl'; message = "ERROR: 'invalid project source url' is not a valid URL for the projectSourceUrl element in the package nuspec file." }
-    @{id = 'docsUrl'; message = "ERROR: 'invalid docs url' is not a valid URL for the docsUrl element in the package nuspec file." }
-    @{id = 'bugTrackerUrl'; message = "ERROR: 'invalid bug tracker url' is not a valid URL for the bugTrackerUrl element in the package nuspec file." }
-    @{id = 'mailingListUrl'; message = "ERROR: 'invalid mailing list url' is not a valid URL for the mailingListUrl element in the package nuspec file." }
-    @{id = 'iconUrl'; message = "ERROR: 'invalid icon url' is not a valid URL for the iconUrl element in the package nuspec file." }
-    @{id = 'licenseUrl'; message = "ERROR: 'invalid license url' is not a valid URL for the licenseUrl element in the package nuspec file." }
-    @{id = "version"; message = "ERROR: 'INVALID' is not a valid version string in the package nuspec file." }
+    @{id = 'projectUrl'; message = "ERROR: CHCU0001: 'invalid project url' is not a valid URL for the projectUrl element in the package nuspec file." }
+    @{id = 'projectSourceUrl'; message = "ERROR: CHCU0001: 'invalid project source url' is not a valid URL for the projectSourceUrl element in the package nuspec file." }
+    @{id = 'docsUrl'; message = "ERROR: CHCU0001: 'invalid docs url' is not a valid URL for the docsUrl element in the package nuspec file." }
+    @{id = 'bugTrackerUrl'; message = "ERROR: CHCU0001: 'invalid bug tracker url' is not a valid URL for the bugTrackerUrl element in the package nuspec file." }
+    @{id = 'mailingListUrl'; message = "ERROR: CHCU0001: 'invalid mailing list url' is not a valid URL for the mailingListUrl element in the package nuspec file." }
+    @{id = 'iconUrl'; message = "ERROR: CHCU0001: 'invalid icon url' is not a valid URL for the iconUrl element in the package nuspec file." }
+    @{id = 'licenseUrl'; message = "ERROR: CHCU0001: 'invalid license url' is not a valid URL for the licenseUrl element in the package nuspec file." }
+    @{id = "version"; message = "ERROR: CHCU0001: 'INVALID' is not a valid version string in the package nuspec file." }
     @{id = "no-content"; message = "Cannot create a package that has no dependencies nor content." } # This is a message from NuGet.Client, we may want to take ownership of it eventually.
     @{id = "id"; message = "The package ID 'invalid id' contains invalid characters. Examples of valid package IDs include 'MyPackage' and 'MyPackage.Sample'." } # This is a message from NuGet.Client, we may want to take ownership of it eventually.
-    @{id = "requirelicenseacceptance"; message = "ERROR: Enabling license acceptance requires a license url." }
+    @{id = "requirelicenseacceptance"; message = "ERROR: CHCR0002: Enabling license acceptance requires a license url." }
 )
 
 Describe "choco pack" -Tag Chocolatey, PackCommand {
@@ -153,7 +153,7 @@ Describe "choco pack" -Tag Chocolatey, PackCommand {
         }
 
         It "Displays required error message for <_>" -ForEach $missingFailures {
-            $Output.Lines | Should -Contain "ERROR: $_ is a required element in the package nuspec file."
+            $Output.Lines | Should -Contain "ERROR: CHCR0001: $_ is a required element in the package nuspec file."
         }
 
         It "Does not create the nuget package" {
@@ -188,7 +188,7 @@ Describe "choco pack" -Tag Chocolatey, PackCommand {
         }
 
         It "Displays empty error message for <_>" -ForEach $emptyFailures {
-            $Output.Lines | Should -Contain "ERROR: The $_ element in the package nuspec file cannot be empty."
+            $Output.Lines | Should -Contain "ERROR: CHCR0001: The $_ element in the package nuspec file cannot be empty."
         }
 
         It "Does not create the nuget package" {
@@ -255,7 +255,7 @@ Describe "choco pack" -Tag Chocolatey, PackCommand {
         }
 
         It "Displays empty error message for <_>" -ForEach $missingFailures {
-            $Output.Lines | Should -Contain "ERROR: $_ is a required element in the package nuspec file."
+            $Output.Lines | Should -Contain "ERROR: CHCR0001: $_ is a required element in the package nuspec file."
         }
 
         It "Does not create the nuget package" {
@@ -568,7 +568,7 @@ Describe "choco pack" -Tag Chocolatey, PackCommand {
         }
 
         It 'Shows an error about the unsupported nuspec metadata element "<_>"' -TestCases $testCases {
-            $Output.String | Should -Match "ERROR: $_ elements are not supported in Chocolatey CLI"
+            $Output.String | Should -Match "ERROR: CHCU0002: $_ elements are not supported in Chocolatey CLI"
         }
 
         It "Should not output message about license url being deprecated" {


### PR DESCRIPTION
## Description Of Changes

This pull request updates the new rule engine implemented in #3000 by additionally allowing an identifier and a help url being added to give more information about the rule that was triggered.

## Motivation and Context

To give more information to the user and to allow us to identify as soon as possible what caused a rule to be triggered.

## Testing

1. Run `choco pack` on the different nuspec files in the `tests/chocolatey-tests/commands/testnuspecs` that start with empty, invalid, missing or required.

### Operating Systems Testing

- Windows 11

## Change Types Made
<!-- Tick the boxes for the type of changes that have been made -->

* [ ] Bug fix (non-breaking change).
* [x] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [ ] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue

#3000
