### PR TITLE
(#508) Add version to search order by

### DIFF
--- a/src/chocolatey.tests.integration/chocolatey.tests.integration.csproj
+++ b/src/chocolatey.tests.integration/chocolatey.tests.integration.csproj
@@ -78,23 +78,23 @@
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Chocolatey.NuGet.Common, Version=3.0.0.156, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
-      <HintPath>..\packages\Chocolatey.NuGet.Common.3.0.0-alpha-20230219-156\lib\net472\Chocolatey.NuGet.Common.dll</HintPath>
+    <Reference Include="Chocolatey.NuGet.Common, Version=3.0.0.169, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
+      <HintPath>..\packages\Chocolatey.NuGet.Common.3.0.0-alpha-20230224-169\lib\net472\Chocolatey.NuGet.Common.dll</HintPath>
     </Reference>
-    <Reference Include="Chocolatey.NuGet.Configuration, Version=3.0.0.156, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
-      <HintPath>..\packages\Chocolatey.NuGet.Configuration.3.0.0-alpha-20230219-156\lib\net472\Chocolatey.NuGet.Configuration.dll</HintPath>
+    <Reference Include="Chocolatey.NuGet.Configuration, Version=3.0.0.169, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
+      <HintPath>..\packages\Chocolatey.NuGet.Configuration.3.0.0-alpha-20230224-169\lib\net472\Chocolatey.NuGet.Configuration.dll</HintPath>
     </Reference>
-    <Reference Include="Chocolatey.NuGet.Frameworks, Version=3.0.0.156, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
-      <HintPath>..\packages\Chocolatey.NuGet.Frameworks.3.0.0-alpha-20230219-156\lib\net472\Chocolatey.NuGet.Frameworks.dll</HintPath>
+    <Reference Include="Chocolatey.NuGet.Frameworks, Version=3.0.0.169, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
+      <HintPath>..\packages\Chocolatey.NuGet.Frameworks.3.0.0-alpha-20230224-169\lib\net472\Chocolatey.NuGet.Frameworks.dll</HintPath>
     </Reference>
-    <Reference Include="Chocolatey.NuGet.Packaging, Version=3.0.0.156, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
-      <HintPath>..\packages\Chocolatey.NuGet.Packaging.3.0.0-alpha-20230219-156\lib\net472\Chocolatey.NuGet.Packaging.dll</HintPath>
+    <Reference Include="Chocolatey.NuGet.Packaging, Version=3.0.0.169, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
+      <HintPath>..\packages\Chocolatey.NuGet.Packaging.3.0.0-alpha-20230224-169\lib\net472\Chocolatey.NuGet.Packaging.dll</HintPath>
     </Reference>
-    <Reference Include="Chocolatey.NuGet.Protocol, Version=3.0.0.156, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
-      <HintPath>..\packages\Chocolatey.NuGet.Protocol.3.0.0-alpha-20230219-156\lib\net472\Chocolatey.NuGet.Protocol.dll</HintPath>
+    <Reference Include="Chocolatey.NuGet.Protocol, Version=3.0.0.169, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
+      <HintPath>..\packages\Chocolatey.NuGet.Protocol.3.0.0-alpha-20230224-169\lib\net472\Chocolatey.NuGet.Protocol.dll</HintPath>
     </Reference>
-    <Reference Include="Chocolatey.NuGet.Versioning, Version=3.0.0.156, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
-      <HintPath>..\packages\Chocolatey.NuGet.Versioning.3.0.0-alpha-20230219-156\lib\net472\Chocolatey.NuGet.Versioning.dll</HintPath>
+    <Reference Include="Chocolatey.NuGet.Versioning, Version=3.0.0.169, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
+      <HintPath>..\packages\Chocolatey.NuGet.Versioning.3.0.0-alpha-20230224-169\lib\net472\Chocolatey.NuGet.Versioning.dll</HintPath>
     </Reference>
     <Reference Include="log4net, Version=2.0.12.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
       <HintPath>..\packages\log4net.2.0.12\lib\net45\log4net.dll</HintPath>

--- a/src/chocolatey.tests.integration/packages.config
+++ b/src/chocolatey.tests.integration/packages.config
@@ -1,11 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Chocolatey.NuGet.Common" version="3.0.0-alpha-20230219-156" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.Configuration" version="3.0.0-alpha-20230219-156" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.Frameworks" version="3.0.0-alpha-20230219-156" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.Packaging" version="3.0.0-alpha-20230219-156" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.Protocol" version="3.0.0-alpha-20230219-156" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.Versioning" version="3.0.0-alpha-20230219-156" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.Common" version="3.0.0-alpha-20230224-169" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.Configuration" version="3.0.0-alpha-20230224-169" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.Frameworks" version="3.0.0-alpha-20230224-169" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.Packaging" version="3.0.0-alpha-20230224-169" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.Protocol" version="3.0.0-alpha-20230224-169" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.Versioning" version="3.0.0-alpha-20230224-169" targetFramework="net48" />
   <package id="log4net" version="2.0.12" targetFramework="net48" />
   <package id="Microsoft.Web.Xdt" version="3.1.0" targetFramework="net48" />
   <package id="Moq" version="4.2.1402.2112" targetFramework="net40" />

--- a/src/chocolatey.tests/chocolatey.tests.csproj
+++ b/src/chocolatey.tests/chocolatey.tests.csproj
@@ -77,44 +77,44 @@
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Chocolatey.NuGet.Commands, Version=3.0.0.156, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
-      <HintPath>..\packages\Chocolatey.NuGet.Commands.3.0.0-alpha-20230219-156\lib\net472\Chocolatey.NuGet.Commands.dll</HintPath>
+    <Reference Include="Chocolatey.NuGet.Commands, Version=3.0.0.169, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
+      <HintPath>..\packages\Chocolatey.NuGet.Commands.3.0.0-alpha-20230224-169\lib\net472\Chocolatey.NuGet.Commands.dll</HintPath>
     </Reference>
-    <Reference Include="Chocolatey.NuGet.Common, Version=3.0.0.156, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
-      <HintPath>..\packages\Chocolatey.NuGet.Common.3.0.0-alpha-20230219-156\lib\net472\Chocolatey.NuGet.Common.dll</HintPath>
+    <Reference Include="Chocolatey.NuGet.Common, Version=3.0.0.169, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
+      <HintPath>..\packages\Chocolatey.NuGet.Common.3.0.0-alpha-20230224-169\lib\net472\Chocolatey.NuGet.Common.dll</HintPath>
     </Reference>
-    <Reference Include="Chocolatey.NuGet.Configuration, Version=3.0.0.156, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
-      <HintPath>..\packages\Chocolatey.NuGet.Configuration.3.0.0-alpha-20230219-156\lib\net472\Chocolatey.NuGet.Configuration.dll</HintPath>
+    <Reference Include="Chocolatey.NuGet.Configuration, Version=3.0.0.169, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
+      <HintPath>..\packages\Chocolatey.NuGet.Configuration.3.0.0-alpha-20230224-169\lib\net472\Chocolatey.NuGet.Configuration.dll</HintPath>
     </Reference>
-    <Reference Include="Chocolatey.NuGet.Credentials, Version=3.0.0.156, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
-      <HintPath>..\packages\Chocolatey.NuGet.Credentials.3.0.0-alpha-20230219-156\lib\net472\Chocolatey.NuGet.Credentials.dll</HintPath>
+    <Reference Include="Chocolatey.NuGet.Credentials, Version=3.0.0.169, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
+      <HintPath>..\packages\Chocolatey.NuGet.Credentials.3.0.0-alpha-20230224-169\lib\net472\Chocolatey.NuGet.Credentials.dll</HintPath>
     </Reference>
-    <Reference Include="Chocolatey.NuGet.DependencyResolver.Core, Version=3.0.0.156, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
-      <HintPath>..\packages\Chocolatey.NuGet.DependencyResolver.Core.3.0.0-alpha-20230219-156\lib\net472\Chocolatey.NuGet.DependencyResolver.Core.dll</HintPath>
+    <Reference Include="Chocolatey.NuGet.DependencyResolver.Core, Version=3.0.0.169, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
+      <HintPath>..\packages\Chocolatey.NuGet.DependencyResolver.Core.3.0.0-alpha-20230224-169\lib\net472\Chocolatey.NuGet.DependencyResolver.Core.dll</HintPath>
     </Reference>
-    <Reference Include="Chocolatey.NuGet.Frameworks, Version=3.0.0.156, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
-      <HintPath>..\packages\Chocolatey.NuGet.Frameworks.3.0.0-alpha-20230219-156\lib\net472\Chocolatey.NuGet.Frameworks.dll</HintPath>
+    <Reference Include="Chocolatey.NuGet.Frameworks, Version=3.0.0.169, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
+      <HintPath>..\packages\Chocolatey.NuGet.Frameworks.3.0.0-alpha-20230224-169\lib\net472\Chocolatey.NuGet.Frameworks.dll</HintPath>
     </Reference>
-    <Reference Include="Chocolatey.NuGet.LibraryModel, Version=3.0.0.156, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
-      <HintPath>..\packages\Chocolatey.NuGet.LibraryModel.3.0.0-alpha-20230219-156\lib\net472\Chocolatey.NuGet.LibraryModel.dll</HintPath>
+    <Reference Include="Chocolatey.NuGet.LibraryModel, Version=3.0.0.169, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
+      <HintPath>..\packages\Chocolatey.NuGet.LibraryModel.3.0.0-alpha-20230224-169\lib\net472\Chocolatey.NuGet.LibraryModel.dll</HintPath>
     </Reference>
-    <Reference Include="Chocolatey.NuGet.PackageManagement, Version=3.0.0.156, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
-      <HintPath>..\packages\Chocolatey.NuGet.PackageManagement.3.0.0-alpha-20230219-156\lib\net472\Chocolatey.NuGet.PackageManagement.dll</HintPath>
+    <Reference Include="Chocolatey.NuGet.PackageManagement, Version=3.0.0.169, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
+      <HintPath>..\packages\Chocolatey.NuGet.PackageManagement.3.0.0-alpha-20230224-169\lib\net472\Chocolatey.NuGet.PackageManagement.dll</HintPath>
     </Reference>
-    <Reference Include="Chocolatey.NuGet.Packaging, Version=3.0.0.156, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
-      <HintPath>..\packages\Chocolatey.NuGet.Packaging.3.0.0-alpha-20230219-156\lib\net472\Chocolatey.NuGet.Packaging.dll</HintPath>
+    <Reference Include="Chocolatey.NuGet.Packaging, Version=3.0.0.169, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
+      <HintPath>..\packages\Chocolatey.NuGet.Packaging.3.0.0-alpha-20230224-169\lib\net472\Chocolatey.NuGet.Packaging.dll</HintPath>
     </Reference>
-    <Reference Include="Chocolatey.NuGet.ProjectModel, Version=3.0.0.156, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
-      <HintPath>..\packages\Chocolatey.NuGet.ProjectModel.3.0.0-alpha-20230219-156\lib\net472\Chocolatey.NuGet.ProjectModel.dll</HintPath>
+    <Reference Include="Chocolatey.NuGet.ProjectModel, Version=3.0.0.169, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
+      <HintPath>..\packages\Chocolatey.NuGet.ProjectModel.3.0.0-alpha-20230224-169\lib\net472\Chocolatey.NuGet.ProjectModel.dll</HintPath>
     </Reference>
-    <Reference Include="Chocolatey.NuGet.Protocol, Version=3.0.0.156, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
-      <HintPath>..\packages\Chocolatey.NuGet.Protocol.3.0.0-alpha-20230219-156\lib\net472\Chocolatey.NuGet.Protocol.dll</HintPath>
+    <Reference Include="Chocolatey.NuGet.Protocol, Version=3.0.0.169, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
+      <HintPath>..\packages\Chocolatey.NuGet.Protocol.3.0.0-alpha-20230224-169\lib\net472\Chocolatey.NuGet.Protocol.dll</HintPath>
     </Reference>
-    <Reference Include="Chocolatey.NuGet.Resolver, Version=3.0.0.156, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
-      <HintPath>..\packages\Chocolatey.NuGet.Resolver.3.0.0-alpha-20230219-156\lib\net472\Chocolatey.NuGet.Resolver.dll</HintPath>
+    <Reference Include="Chocolatey.NuGet.Resolver, Version=3.0.0.169, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
+      <HintPath>..\packages\Chocolatey.NuGet.Resolver.3.0.0-alpha-20230224-169\lib\net472\Chocolatey.NuGet.Resolver.dll</HintPath>
     </Reference>
-    <Reference Include="Chocolatey.NuGet.Versioning, Version=3.0.0.156, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
-      <HintPath>..\packages\Chocolatey.NuGet.Versioning.3.0.0-alpha-20230219-156\lib\net472\Chocolatey.NuGet.Versioning.dll</HintPath>
+    <Reference Include="Chocolatey.NuGet.Versioning, Version=3.0.0.169, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
+      <HintPath>..\packages\Chocolatey.NuGet.Versioning.3.0.0-alpha-20230224-169\lib\net472\Chocolatey.NuGet.Versioning.dll</HintPath>
     </Reference>
     <Reference Include="log4net, Version=2.0.12.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
       <HintPath>..\packages\log4net.2.0.12\lib\net45\log4net.dll</HintPath>

--- a/src/chocolatey.tests/packages.config
+++ b/src/chocolatey.tests/packages.config
@@ -1,18 +1,18 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Chocolatey.NuGet.Commands" version="3.0.0-alpha-20230219-156" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.Common" version="3.0.0-alpha-20230219-156" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.Configuration" version="3.0.0-alpha-20230219-156" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.Credentials" version="3.0.0-alpha-20230219-156" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.DependencyResolver.Core" version="3.0.0-alpha-20230219-156" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.Frameworks" version="3.0.0-alpha-20230219-156" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.LibraryModel" version="3.0.0-alpha-20230219-156" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.PackageManagement" version="3.0.0-alpha-20230219-156" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.Packaging" version="3.0.0-alpha-20230219-156" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.ProjectModel" version="3.0.0-alpha-20230219-156" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.Protocol" version="3.0.0-alpha-20230219-156" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.Resolver" version="3.0.0-alpha-20230219-156" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.Versioning" version="3.0.0-alpha-20230219-156" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.Commands" version="3.0.0-alpha-20230224-169" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.Common" version="3.0.0-alpha-20230224-169" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.Configuration" version="3.0.0-alpha-20230224-169" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.Credentials" version="3.0.0-alpha-20230224-169" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.DependencyResolver.Core" version="3.0.0-alpha-20230224-169" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.Frameworks" version="3.0.0-alpha-20230224-169" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.LibraryModel" version="3.0.0-alpha-20230224-169" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.PackageManagement" version="3.0.0-alpha-20230224-169" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.Packaging" version="3.0.0-alpha-20230224-169" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.ProjectModel" version="3.0.0-alpha-20230224-169" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.Protocol" version="3.0.0-alpha-20230224-169" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.Resolver" version="3.0.0-alpha-20230224-169" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.Versioning" version="3.0.0-alpha-20230224-169" targetFramework="net48" />
   <package id="log4net" version="2.0.12" targetFramework="net48" />
   <package id="Microsoft.CSharp" version="4.3.0" targetFramework="net48" />
   <package id="Microsoft.Web.Xdt" version="3.1.0" targetFramework="net48" />

--- a/src/chocolatey/chocolatey.csproj
+++ b/src/chocolatey/chocolatey.csproj
@@ -101,44 +101,44 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\AlphaFS.2.1.3\lib\net40\AlphaFS.dll</HintPath>
     </Reference>
-    <Reference Include="Chocolatey.NuGet.Commands, Version=3.0.0.156, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
-      <HintPath>..\packages\Chocolatey.NuGet.Commands.3.0.0-alpha-20230219-156\lib\net472\Chocolatey.NuGet.Commands.dll</HintPath>
+    <Reference Include="Chocolatey.NuGet.Commands, Version=3.0.0.169, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
+      <HintPath>..\packages\Chocolatey.NuGet.Commands.3.0.0-alpha-20230224-169\lib\net472\Chocolatey.NuGet.Commands.dll</HintPath>
     </Reference>
-    <Reference Include="Chocolatey.NuGet.Common, Version=3.0.0.156, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
-      <HintPath>..\packages\Chocolatey.NuGet.Common.3.0.0-alpha-20230219-156\lib\net472\Chocolatey.NuGet.Common.dll</HintPath>
+    <Reference Include="Chocolatey.NuGet.Common, Version=3.0.0.169, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
+      <HintPath>..\packages\Chocolatey.NuGet.Common.3.0.0-alpha-20230224-169\lib\net472\Chocolatey.NuGet.Common.dll</HintPath>
     </Reference>
-    <Reference Include="Chocolatey.NuGet.Configuration, Version=3.0.0.156, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
-      <HintPath>..\packages\Chocolatey.NuGet.Configuration.3.0.0-alpha-20230219-156\lib\net472\Chocolatey.NuGet.Configuration.dll</HintPath>
+    <Reference Include="Chocolatey.NuGet.Configuration, Version=3.0.0.169, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
+      <HintPath>..\packages\Chocolatey.NuGet.Configuration.3.0.0-alpha-20230224-169\lib\net472\Chocolatey.NuGet.Configuration.dll</HintPath>
     </Reference>
-    <Reference Include="Chocolatey.NuGet.Credentials, Version=3.0.0.156, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
-      <HintPath>..\packages\Chocolatey.NuGet.Credentials.3.0.0-alpha-20230219-156\lib\net472\Chocolatey.NuGet.Credentials.dll</HintPath>
+    <Reference Include="Chocolatey.NuGet.Credentials, Version=3.0.0.169, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
+      <HintPath>..\packages\Chocolatey.NuGet.Credentials.3.0.0-alpha-20230224-169\lib\net472\Chocolatey.NuGet.Credentials.dll</HintPath>
     </Reference>
-    <Reference Include="Chocolatey.NuGet.DependencyResolver.Core, Version=3.0.0.156, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
-      <HintPath>..\packages\Chocolatey.NuGet.DependencyResolver.Core.3.0.0-alpha-20230219-156\lib\net472\Chocolatey.NuGet.DependencyResolver.Core.dll</HintPath>
+    <Reference Include="Chocolatey.NuGet.DependencyResolver.Core, Version=3.0.0.169, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
+      <HintPath>..\packages\Chocolatey.NuGet.DependencyResolver.Core.3.0.0-alpha-20230224-169\lib\net472\Chocolatey.NuGet.DependencyResolver.Core.dll</HintPath>
     </Reference>
-    <Reference Include="Chocolatey.NuGet.Frameworks, Version=3.0.0.156, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
-      <HintPath>..\packages\Chocolatey.NuGet.Frameworks.3.0.0-alpha-20230219-156\lib\net472\Chocolatey.NuGet.Frameworks.dll</HintPath>
+    <Reference Include="Chocolatey.NuGet.Frameworks, Version=3.0.0.169, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
+      <HintPath>..\packages\Chocolatey.NuGet.Frameworks.3.0.0-alpha-20230224-169\lib\net472\Chocolatey.NuGet.Frameworks.dll</HintPath>
     </Reference>
-    <Reference Include="Chocolatey.NuGet.LibraryModel, Version=3.0.0.156, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
-      <HintPath>..\packages\Chocolatey.NuGet.LibraryModel.3.0.0-alpha-20230219-156\lib\net472\Chocolatey.NuGet.LibraryModel.dll</HintPath>
+    <Reference Include="Chocolatey.NuGet.LibraryModel, Version=3.0.0.169, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
+      <HintPath>..\packages\Chocolatey.NuGet.LibraryModel.3.0.0-alpha-20230224-169\lib\net472\Chocolatey.NuGet.LibraryModel.dll</HintPath>
     </Reference>
-    <Reference Include="Chocolatey.NuGet.PackageManagement, Version=3.0.0.156, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
-      <HintPath>..\packages\Chocolatey.NuGet.PackageManagement.3.0.0-alpha-20230219-156\lib\net472\Chocolatey.NuGet.PackageManagement.dll</HintPath>
+    <Reference Include="Chocolatey.NuGet.PackageManagement, Version=3.0.0.169, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
+      <HintPath>..\packages\Chocolatey.NuGet.PackageManagement.3.0.0-alpha-20230224-169\lib\net472\Chocolatey.NuGet.PackageManagement.dll</HintPath>
     </Reference>
-    <Reference Include="Chocolatey.NuGet.Packaging, Version=3.0.0.156, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
-      <HintPath>..\packages\Chocolatey.NuGet.Packaging.3.0.0-alpha-20230219-156\lib\net472\Chocolatey.NuGet.Packaging.dll</HintPath>
+    <Reference Include="Chocolatey.NuGet.Packaging, Version=3.0.0.169, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
+      <HintPath>..\packages\Chocolatey.NuGet.Packaging.3.0.0-alpha-20230224-169\lib\net472\Chocolatey.NuGet.Packaging.dll</HintPath>
     </Reference>
-    <Reference Include="Chocolatey.NuGet.ProjectModel, Version=3.0.0.156, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
-      <HintPath>..\packages\Chocolatey.NuGet.ProjectModel.3.0.0-alpha-20230219-156\lib\net472\Chocolatey.NuGet.ProjectModel.dll</HintPath>
+    <Reference Include="Chocolatey.NuGet.ProjectModel, Version=3.0.0.169, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
+      <HintPath>..\packages\Chocolatey.NuGet.ProjectModel.3.0.0-alpha-20230224-169\lib\net472\Chocolatey.NuGet.ProjectModel.dll</HintPath>
     </Reference>
-    <Reference Include="Chocolatey.NuGet.Protocol, Version=3.0.0.156, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
-      <HintPath>..\packages\Chocolatey.NuGet.Protocol.3.0.0-alpha-20230219-156\lib\net472\Chocolatey.NuGet.Protocol.dll</HintPath>
+    <Reference Include="Chocolatey.NuGet.Protocol, Version=3.0.0.169, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
+      <HintPath>..\packages\Chocolatey.NuGet.Protocol.3.0.0-alpha-20230224-169\lib\net472\Chocolatey.NuGet.Protocol.dll</HintPath>
     </Reference>
-    <Reference Include="Chocolatey.NuGet.Resolver, Version=3.0.0.156, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
-      <HintPath>..\packages\Chocolatey.NuGet.Resolver.3.0.0-alpha-20230219-156\lib\net472\Chocolatey.NuGet.Resolver.dll</HintPath>
+    <Reference Include="Chocolatey.NuGet.Resolver, Version=3.0.0.169, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
+      <HintPath>..\packages\Chocolatey.NuGet.Resolver.3.0.0-alpha-20230224-169\lib\net472\Chocolatey.NuGet.Resolver.dll</HintPath>
     </Reference>
-    <Reference Include="Chocolatey.NuGet.Versioning, Version=3.0.0.156, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
-      <HintPath>..\packages\Chocolatey.NuGet.Versioning.3.0.0-alpha-20230219-156\lib\net472\Chocolatey.NuGet.Versioning.dll</HintPath>
+    <Reference Include="Chocolatey.NuGet.Versioning, Version=3.0.0.169, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
+      <HintPath>..\packages\Chocolatey.NuGet.Versioning.3.0.0-alpha-20230224-169\lib\net472\Chocolatey.NuGet.Versioning.dll</HintPath>
     </Reference>
     <Reference Include="log4net, Version=2.0.12.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
       <HintPath>..\packages\log4net.2.0.12\lib\net45\log4net.dll</HintPath>

--- a/src/chocolatey/infrastructure.app/nuget/NugetList.cs
+++ b/src/chocolatey/infrastructure.app/nuget/NugetList.cs
@@ -94,6 +94,12 @@ namespace chocolatey.infrastructure.app.nuget
             var cacheContext = new ChocolateySourceCacheContext(configuration);
 
             NuGetVersion version = !string.IsNullOrWhiteSpace(configuration.Version) ? NuGetVersion.Parse(configuration.Version) : null;
+
+            if (version != null)
+            {
+                searchFilter.OrderBy = SearchOrderBy.Version;
+            }
+
             var results = new HashSet<IPackageSearchMetadata>(new ComparePackageSearchMetadata());
             var thresholdLimit = 0;
 

--- a/src/chocolatey/packages.config
+++ b/src/chocolatey/packages.config
@@ -1,19 +1,19 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="AlphaFS" version="2.1.3" targetFramework="net40-Client" />
-  <package id="Chocolatey.NuGet.Commands" version="3.0.0-alpha-20230219-156" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.Common" version="3.0.0-alpha-20230219-156" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.Configuration" version="3.0.0-alpha-20230219-156" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.Credentials" version="3.0.0-alpha-20230219-156" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.DependencyResolver.Core" version="3.0.0-alpha-20230219-156" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.Frameworks" version="3.0.0-alpha-20230219-156" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.LibraryModel" version="3.0.0-alpha-20230219-156" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.PackageManagement" version="3.0.0-alpha-20230219-156" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.Packaging" version="3.0.0-alpha-20230219-156" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.ProjectModel" version="3.0.0-alpha-20230219-156" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.Protocol" version="3.0.0-alpha-20230219-156" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.Resolver" version="3.0.0-alpha-20230219-156" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.Versioning" version="3.0.0-alpha-20230219-156" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.Commands" version="3.0.0-alpha-20230224-169" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.Common" version="3.0.0-alpha-20230224-169" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.Configuration" version="3.0.0-alpha-20230224-169" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.Credentials" version="3.0.0-alpha-20230224-169" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.DependencyResolver.Core" version="3.0.0-alpha-20230224-169" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.Frameworks" version="3.0.0-alpha-20230224-169" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.LibraryModel" version="3.0.0-alpha-20230224-169" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.PackageManagement" version="3.0.0-alpha-20230224-169" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.Packaging" version="3.0.0-alpha-20230224-169" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.ProjectModel" version="3.0.0-alpha-20230224-169" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.Protocol" version="3.0.0-alpha-20230224-169" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.Resolver" version="3.0.0-alpha-20230224-169" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.Versioning" version="3.0.0-alpha-20230224-169" targetFramework="net48" />
   <package id="log4net" version="2.0.12" targetFramework="net48" />
   <package id="Microsoft.CodeAnalysis.BannedApiAnalyzers" version="3.3.3" targetFramework="net48" developmentDependency="true" />
   <package id="Microsoft.CSharp" version="4.3.0" targetFramework="net48" />


### PR DESCRIPTION
## Description Of Changes

This commit switches to using the new Version property in the NuGet.Client assemblies.

NOTE: In order for this change to work, an uplift to the NuGet.Client assemblies will be required. A PR is open to provide this functionality, and therefore hasn't been brought in yet.


## Motivation and Context

When searching for a specific version in Chocolatey 1.x, the orderby of the search was changed to be "Id,Version desc", and we want to use the same orderdy when using the new NuGet.Client assemblies.

## Testing

1. Testing steps are detailed in this PR - https://github.com/chocolatey/NuGet.Client/pull/28

### Operating Systems Testing

- Windows 10

## Change Types Made

* [ ] Bug fix (non-breaking change).
* [x] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [x] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue

- Relates to #508
- https://app.clickup.com/t/20540031/PROJ-511
