### PR TITLE
(maint) Add stale cleanup

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,48 @@
+name: 'Stale Issue and PR Cleanup'
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 4 * * *'
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v4.1.0
+        id: stale
+        with:
+          days-before-stale: 30
+          days-before-close: 14
+          exempt-all-assignees: false
+          exempt-draft-pr: true
+          stale-issue-label: "Pending Closure"
+          stale-pr-label: '0 - Waiting on User'
+          only-pr-labels: '0 - Waiting on User'
+          close-issue-label: "No Response / Stale"
+          close-pr-label: "No Response / Stale"
+          exempt-issue-labels: 'Security / CVE,0 - Backlog,1 - Ready for work,2 - Working,3 - Review,4 - Done,5 - Push required'
+          exempt-pr-labels: 'Security / CVE'
+          labels-to-remove-when-unstale: '0 - Wating on User,Pending closure'
+          stale-issue-message: |
+            Is this still relevant? If so, what is blocking it? Is there anything you can do to help move it forward?
+            This issue will be closed in 14 days if it continues to be inactive.
+          close-issue-message: |
+            Dear contributor,
+
+            As this issue seems to have been inactive for quite some time now, it has been automatically closed.
+            If you feel this is a valid issue, please feel free to re-open the issue if / when a pull request
+            has been added.
+            Thank you for your contribution.
+
+          close-pr-message: |
+            Dear contributor,
+
+            As this PR seems to have been inactive for 30 days after changes / additional information
+            was requested, it has been automatically closed.
+            If you feel the changes are still valid, please re-open the PR once all changes or additional information
+            that was requested has been added.
+            Thank you for your contribution.


### PR DESCRIPTION
## Description Of Changes
Added cleanup of stale issues and PR's with the '0 - Waiting On User' label..

## Motivation and Context
This will make it easier to manage the repository as stale issues will auotmatically be labelled, commented on and then closed if no follow-up work is done.

## Testing
N/A

### Operating Systems Testing
N/A

## Change Types Made
* [ ] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist
* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [ ] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?