### PR TITLE
(#508) Add Repository optimizations back into Chocolatey execution

### DIFF
--- a/src/chocolatey.tests.integration/chocolatey.tests.integration.csproj
+++ b/src/chocolatey.tests.integration/chocolatey.tests.integration.csproj
@@ -78,23 +78,23 @@
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Chocolatey.NuGet.Common, Version=3.0.0.169, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
-      <HintPath>..\packages\Chocolatey.NuGet.Common.3.0.0-alpha-20230224-169\lib\net472\Chocolatey.NuGet.Common.dll</HintPath>
+    <Reference Include="Chocolatey.NuGet.Common, Version=3.0.0.173, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
+      <HintPath>..\packages\Chocolatey.NuGet.Common.3.0.0-alpha-20230228-173\lib\net472\Chocolatey.NuGet.Common.dll</HintPath>
     </Reference>
-    <Reference Include="Chocolatey.NuGet.Configuration, Version=3.0.0.169, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
-      <HintPath>..\packages\Chocolatey.NuGet.Configuration.3.0.0-alpha-20230224-169\lib\net472\Chocolatey.NuGet.Configuration.dll</HintPath>
+    <Reference Include="Chocolatey.NuGet.Configuration, Version=3.0.0.173, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
+      <HintPath>..\packages\Chocolatey.NuGet.Configuration.3.0.0-alpha-20230228-173\lib\net472\Chocolatey.NuGet.Configuration.dll</HintPath>
     </Reference>
-    <Reference Include="Chocolatey.NuGet.Frameworks, Version=3.0.0.169, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
-      <HintPath>..\packages\Chocolatey.NuGet.Frameworks.3.0.0-alpha-20230224-169\lib\net472\Chocolatey.NuGet.Frameworks.dll</HintPath>
+    <Reference Include="Chocolatey.NuGet.Frameworks, Version=3.0.0.173, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
+      <HintPath>..\packages\Chocolatey.NuGet.Frameworks.3.0.0-alpha-20230228-173\lib\net472\Chocolatey.NuGet.Frameworks.dll</HintPath>
     </Reference>
-    <Reference Include="Chocolatey.NuGet.Packaging, Version=3.0.0.169, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
-      <HintPath>..\packages\Chocolatey.NuGet.Packaging.3.0.0-alpha-20230224-169\lib\net472\Chocolatey.NuGet.Packaging.dll</HintPath>
+    <Reference Include="Chocolatey.NuGet.Packaging, Version=3.0.0.173, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
+      <HintPath>..\packages\Chocolatey.NuGet.Packaging.3.0.0-alpha-20230228-173\lib\net472\Chocolatey.NuGet.Packaging.dll</HintPath>
     </Reference>
-    <Reference Include="Chocolatey.NuGet.Protocol, Version=3.0.0.169, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
-      <HintPath>..\packages\Chocolatey.NuGet.Protocol.3.0.0-alpha-20230224-169\lib\net472\Chocolatey.NuGet.Protocol.dll</HintPath>
+    <Reference Include="Chocolatey.NuGet.Protocol, Version=3.0.0.173, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
+      <HintPath>..\packages\Chocolatey.NuGet.Protocol.3.0.0-alpha-20230228-173\lib\net472\Chocolatey.NuGet.Protocol.dll</HintPath>
     </Reference>
-    <Reference Include="Chocolatey.NuGet.Versioning, Version=3.0.0.169, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
-      <HintPath>..\packages\Chocolatey.NuGet.Versioning.3.0.0-alpha-20230224-169\lib\net472\Chocolatey.NuGet.Versioning.dll</HintPath>
+    <Reference Include="Chocolatey.NuGet.Versioning, Version=3.0.0.173, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
+      <HintPath>..\packages\Chocolatey.NuGet.Versioning.3.0.0-alpha-20230228-173\lib\net472\Chocolatey.NuGet.Versioning.dll</HintPath>
     </Reference>
     <Reference Include="log4net, Version=2.0.12.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
       <HintPath>..\packages\log4net.2.0.12\lib\net45\log4net.dll</HintPath>

--- a/src/chocolatey.tests.integration/packages.config
+++ b/src/chocolatey.tests.integration/packages.config
@@ -1,11 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Chocolatey.NuGet.Common" version="3.0.0-alpha-20230224-169" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.Configuration" version="3.0.0-alpha-20230224-169" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.Frameworks" version="3.0.0-alpha-20230224-169" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.Packaging" version="3.0.0-alpha-20230224-169" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.Protocol" version="3.0.0-alpha-20230224-169" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.Versioning" version="3.0.0-alpha-20230224-169" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.Common" version="3.0.0-alpha-20230228-173" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.Configuration" version="3.0.0-alpha-20230228-173" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.Frameworks" version="3.0.0-alpha-20230228-173" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.Packaging" version="3.0.0-alpha-20230228-173" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.Protocol" version="3.0.0-alpha-20230228-173" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.Versioning" version="3.0.0-alpha-20230228-173" targetFramework="net48" />
   <package id="log4net" version="2.0.12" targetFramework="net48" />
   <package id="Microsoft.Web.Xdt" version="3.1.0" targetFramework="net48" />
   <package id="Moq" version="4.2.1402.2112" targetFramework="net40" />

--- a/src/chocolatey.tests/chocolatey.tests.csproj
+++ b/src/chocolatey.tests/chocolatey.tests.csproj
@@ -77,44 +77,44 @@
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Chocolatey.NuGet.Commands, Version=3.0.0.169, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
-      <HintPath>..\packages\Chocolatey.NuGet.Commands.3.0.0-alpha-20230224-169\lib\net472\Chocolatey.NuGet.Commands.dll</HintPath>
+    <Reference Include="Chocolatey.NuGet.Commands, Version=3.0.0.173, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
+      <HintPath>..\packages\Chocolatey.NuGet.Commands.3.0.0-alpha-20230228-173\lib\net472\Chocolatey.NuGet.Commands.dll</HintPath>
     </Reference>
-    <Reference Include="Chocolatey.NuGet.Common, Version=3.0.0.169, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
-      <HintPath>..\packages\Chocolatey.NuGet.Common.3.0.0-alpha-20230224-169\lib\net472\Chocolatey.NuGet.Common.dll</HintPath>
+    <Reference Include="Chocolatey.NuGet.Common, Version=3.0.0.173, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
+      <HintPath>..\packages\Chocolatey.NuGet.Common.3.0.0-alpha-20230228-173\lib\net472\Chocolatey.NuGet.Common.dll</HintPath>
     </Reference>
-    <Reference Include="Chocolatey.NuGet.Configuration, Version=3.0.0.169, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
-      <HintPath>..\packages\Chocolatey.NuGet.Configuration.3.0.0-alpha-20230224-169\lib\net472\Chocolatey.NuGet.Configuration.dll</HintPath>
+    <Reference Include="Chocolatey.NuGet.Configuration, Version=3.0.0.173, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
+      <HintPath>..\packages\Chocolatey.NuGet.Configuration.3.0.0-alpha-20230228-173\lib\net472\Chocolatey.NuGet.Configuration.dll</HintPath>
     </Reference>
-    <Reference Include="Chocolatey.NuGet.Credentials, Version=3.0.0.169, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
-      <HintPath>..\packages\Chocolatey.NuGet.Credentials.3.0.0-alpha-20230224-169\lib\net472\Chocolatey.NuGet.Credentials.dll</HintPath>
+    <Reference Include="Chocolatey.NuGet.Credentials, Version=3.0.0.173, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
+      <HintPath>..\packages\Chocolatey.NuGet.Credentials.3.0.0-alpha-20230228-173\lib\net472\Chocolatey.NuGet.Credentials.dll</HintPath>
     </Reference>
-    <Reference Include="Chocolatey.NuGet.DependencyResolver.Core, Version=3.0.0.169, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
-      <HintPath>..\packages\Chocolatey.NuGet.DependencyResolver.Core.3.0.0-alpha-20230224-169\lib\net472\Chocolatey.NuGet.DependencyResolver.Core.dll</HintPath>
+    <Reference Include="Chocolatey.NuGet.DependencyResolver.Core, Version=3.0.0.173, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
+      <HintPath>..\packages\Chocolatey.NuGet.DependencyResolver.Core.3.0.0-alpha-20230228-173\lib\net472\Chocolatey.NuGet.DependencyResolver.Core.dll</HintPath>
     </Reference>
-    <Reference Include="Chocolatey.NuGet.Frameworks, Version=3.0.0.169, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
-      <HintPath>..\packages\Chocolatey.NuGet.Frameworks.3.0.0-alpha-20230224-169\lib\net472\Chocolatey.NuGet.Frameworks.dll</HintPath>
+    <Reference Include="Chocolatey.NuGet.Frameworks, Version=3.0.0.173, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
+      <HintPath>..\packages\Chocolatey.NuGet.Frameworks.3.0.0-alpha-20230228-173\lib\net472\Chocolatey.NuGet.Frameworks.dll</HintPath>
     </Reference>
-    <Reference Include="Chocolatey.NuGet.LibraryModel, Version=3.0.0.169, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
-      <HintPath>..\packages\Chocolatey.NuGet.LibraryModel.3.0.0-alpha-20230224-169\lib\net472\Chocolatey.NuGet.LibraryModel.dll</HintPath>
+    <Reference Include="Chocolatey.NuGet.LibraryModel, Version=3.0.0.173, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
+      <HintPath>..\packages\Chocolatey.NuGet.LibraryModel.3.0.0-alpha-20230228-173\lib\net472\Chocolatey.NuGet.LibraryModel.dll</HintPath>
     </Reference>
-    <Reference Include="Chocolatey.NuGet.PackageManagement, Version=3.0.0.169, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
-      <HintPath>..\packages\Chocolatey.NuGet.PackageManagement.3.0.0-alpha-20230224-169\lib\net472\Chocolatey.NuGet.PackageManagement.dll</HintPath>
+    <Reference Include="Chocolatey.NuGet.PackageManagement, Version=3.0.0.173, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
+      <HintPath>..\packages\Chocolatey.NuGet.PackageManagement.3.0.0-alpha-20230228-173\lib\net472\Chocolatey.NuGet.PackageManagement.dll</HintPath>
     </Reference>
-    <Reference Include="Chocolatey.NuGet.Packaging, Version=3.0.0.169, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
-      <HintPath>..\packages\Chocolatey.NuGet.Packaging.3.0.0-alpha-20230224-169\lib\net472\Chocolatey.NuGet.Packaging.dll</HintPath>
+    <Reference Include="Chocolatey.NuGet.Packaging, Version=3.0.0.173, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
+      <HintPath>..\packages\Chocolatey.NuGet.Packaging.3.0.0-alpha-20230228-173\lib\net472\Chocolatey.NuGet.Packaging.dll</HintPath>
     </Reference>
-    <Reference Include="Chocolatey.NuGet.ProjectModel, Version=3.0.0.169, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
-      <HintPath>..\packages\Chocolatey.NuGet.ProjectModel.3.0.0-alpha-20230224-169\lib\net472\Chocolatey.NuGet.ProjectModel.dll</HintPath>
+    <Reference Include="Chocolatey.NuGet.ProjectModel, Version=3.0.0.173, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
+      <HintPath>..\packages\Chocolatey.NuGet.ProjectModel.3.0.0-alpha-20230228-173\lib\net472\Chocolatey.NuGet.ProjectModel.dll</HintPath>
     </Reference>
-    <Reference Include="Chocolatey.NuGet.Protocol, Version=3.0.0.169, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
-      <HintPath>..\packages\Chocolatey.NuGet.Protocol.3.0.0-alpha-20230224-169\lib\net472\Chocolatey.NuGet.Protocol.dll</HintPath>
+    <Reference Include="Chocolatey.NuGet.Protocol, Version=3.0.0.173, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
+      <HintPath>..\packages\Chocolatey.NuGet.Protocol.3.0.0-alpha-20230228-173\lib\net472\Chocolatey.NuGet.Protocol.dll</HintPath>
     </Reference>
-    <Reference Include="Chocolatey.NuGet.Resolver, Version=3.0.0.169, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
-      <HintPath>..\packages\Chocolatey.NuGet.Resolver.3.0.0-alpha-20230224-169\lib\net472\Chocolatey.NuGet.Resolver.dll</HintPath>
+    <Reference Include="Chocolatey.NuGet.Resolver, Version=3.0.0.173, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
+      <HintPath>..\packages\Chocolatey.NuGet.Resolver.3.0.0-alpha-20230228-173\lib\net472\Chocolatey.NuGet.Resolver.dll</HintPath>
     </Reference>
-    <Reference Include="Chocolatey.NuGet.Versioning, Version=3.0.0.169, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
-      <HintPath>..\packages\Chocolatey.NuGet.Versioning.3.0.0-alpha-20230224-169\lib\net472\Chocolatey.NuGet.Versioning.dll</HintPath>
+    <Reference Include="Chocolatey.NuGet.Versioning, Version=3.0.0.173, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
+      <HintPath>..\packages\Chocolatey.NuGet.Versioning.3.0.0-alpha-20230228-173\lib\net472\Chocolatey.NuGet.Versioning.dll</HintPath>
     </Reference>
     <Reference Include="log4net, Version=2.0.12.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
       <HintPath>..\packages\log4net.2.0.12\lib\net45\log4net.dll</HintPath>

--- a/src/chocolatey.tests/packages.config
+++ b/src/chocolatey.tests/packages.config
@@ -1,18 +1,18 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Chocolatey.NuGet.Commands" version="3.0.0-alpha-20230224-169" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.Common" version="3.0.0-alpha-20230224-169" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.Configuration" version="3.0.0-alpha-20230224-169" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.Credentials" version="3.0.0-alpha-20230224-169" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.DependencyResolver.Core" version="3.0.0-alpha-20230224-169" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.Frameworks" version="3.0.0-alpha-20230224-169" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.LibraryModel" version="3.0.0-alpha-20230224-169" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.PackageManagement" version="3.0.0-alpha-20230224-169" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.Packaging" version="3.0.0-alpha-20230224-169" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.ProjectModel" version="3.0.0-alpha-20230224-169" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.Protocol" version="3.0.0-alpha-20230224-169" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.Resolver" version="3.0.0-alpha-20230224-169" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.Versioning" version="3.0.0-alpha-20230224-169" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.Commands" version="3.0.0-alpha-20230228-173" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.Common" version="3.0.0-alpha-20230228-173" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.Configuration" version="3.0.0-alpha-20230228-173" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.Credentials" version="3.0.0-alpha-20230228-173" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.DependencyResolver.Core" version="3.0.0-alpha-20230228-173" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.Frameworks" version="3.0.0-alpha-20230228-173" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.LibraryModel" version="3.0.0-alpha-20230228-173" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.PackageManagement" version="3.0.0-alpha-20230228-173" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.Packaging" version="3.0.0-alpha-20230228-173" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.ProjectModel" version="3.0.0-alpha-20230228-173" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.Protocol" version="3.0.0-alpha-20230228-173" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.Resolver" version="3.0.0-alpha-20230228-173" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.Versioning" version="3.0.0-alpha-20230228-173" targetFramework="net48" />
   <package id="log4net" version="2.0.12" targetFramework="net48" />
   <package id="Microsoft.CSharp" version="4.3.0" targetFramework="net48" />
   <package id="Microsoft.Web.Xdt" version="3.1.0" targetFramework="net48" />

--- a/src/chocolatey/chocolatey.csproj
+++ b/src/chocolatey/chocolatey.csproj
@@ -101,44 +101,44 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\AlphaFS.2.1.3\lib\net40\AlphaFS.dll</HintPath>
     </Reference>
-    <Reference Include="Chocolatey.NuGet.Commands, Version=3.0.0.169, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
-      <HintPath>..\packages\Chocolatey.NuGet.Commands.3.0.0-alpha-20230224-169\lib\net472\Chocolatey.NuGet.Commands.dll</HintPath>
+    <Reference Include="Chocolatey.NuGet.Commands, Version=3.0.0.173, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
+      <HintPath>..\packages\Chocolatey.NuGet.Commands.3.0.0-alpha-20230228-173\lib\net472\Chocolatey.NuGet.Commands.dll</HintPath>
     </Reference>
-    <Reference Include="Chocolatey.NuGet.Common, Version=3.0.0.169, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
-      <HintPath>..\packages\Chocolatey.NuGet.Common.3.0.0-alpha-20230224-169\lib\net472\Chocolatey.NuGet.Common.dll</HintPath>
+    <Reference Include="Chocolatey.NuGet.Common, Version=3.0.0.173, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
+      <HintPath>..\packages\Chocolatey.NuGet.Common.3.0.0-alpha-20230228-173\lib\net472\Chocolatey.NuGet.Common.dll</HintPath>
     </Reference>
-    <Reference Include="Chocolatey.NuGet.Configuration, Version=3.0.0.169, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
-      <HintPath>..\packages\Chocolatey.NuGet.Configuration.3.0.0-alpha-20230224-169\lib\net472\Chocolatey.NuGet.Configuration.dll</HintPath>
+    <Reference Include="Chocolatey.NuGet.Configuration, Version=3.0.0.173, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
+      <HintPath>..\packages\Chocolatey.NuGet.Configuration.3.0.0-alpha-20230228-173\lib\net472\Chocolatey.NuGet.Configuration.dll</HintPath>
     </Reference>
-    <Reference Include="Chocolatey.NuGet.Credentials, Version=3.0.0.169, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
-      <HintPath>..\packages\Chocolatey.NuGet.Credentials.3.0.0-alpha-20230224-169\lib\net472\Chocolatey.NuGet.Credentials.dll</HintPath>
+    <Reference Include="Chocolatey.NuGet.Credentials, Version=3.0.0.173, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
+      <HintPath>..\packages\Chocolatey.NuGet.Credentials.3.0.0-alpha-20230228-173\lib\net472\Chocolatey.NuGet.Credentials.dll</HintPath>
     </Reference>
-    <Reference Include="Chocolatey.NuGet.DependencyResolver.Core, Version=3.0.0.169, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
-      <HintPath>..\packages\Chocolatey.NuGet.DependencyResolver.Core.3.0.0-alpha-20230224-169\lib\net472\Chocolatey.NuGet.DependencyResolver.Core.dll</HintPath>
+    <Reference Include="Chocolatey.NuGet.DependencyResolver.Core, Version=3.0.0.173, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
+      <HintPath>..\packages\Chocolatey.NuGet.DependencyResolver.Core.3.0.0-alpha-20230228-173\lib\net472\Chocolatey.NuGet.DependencyResolver.Core.dll</HintPath>
     </Reference>
-    <Reference Include="Chocolatey.NuGet.Frameworks, Version=3.0.0.169, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
-      <HintPath>..\packages\Chocolatey.NuGet.Frameworks.3.0.0-alpha-20230224-169\lib\net472\Chocolatey.NuGet.Frameworks.dll</HintPath>
+    <Reference Include="Chocolatey.NuGet.Frameworks, Version=3.0.0.173, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
+      <HintPath>..\packages\Chocolatey.NuGet.Frameworks.3.0.0-alpha-20230228-173\lib\net472\Chocolatey.NuGet.Frameworks.dll</HintPath>
     </Reference>
-    <Reference Include="Chocolatey.NuGet.LibraryModel, Version=3.0.0.169, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
-      <HintPath>..\packages\Chocolatey.NuGet.LibraryModel.3.0.0-alpha-20230224-169\lib\net472\Chocolatey.NuGet.LibraryModel.dll</HintPath>
+    <Reference Include="Chocolatey.NuGet.LibraryModel, Version=3.0.0.173, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
+      <HintPath>..\packages\Chocolatey.NuGet.LibraryModel.3.0.0-alpha-20230228-173\lib\net472\Chocolatey.NuGet.LibraryModel.dll</HintPath>
     </Reference>
-    <Reference Include="Chocolatey.NuGet.PackageManagement, Version=3.0.0.169, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
-      <HintPath>..\packages\Chocolatey.NuGet.PackageManagement.3.0.0-alpha-20230224-169\lib\net472\Chocolatey.NuGet.PackageManagement.dll</HintPath>
+    <Reference Include="Chocolatey.NuGet.PackageManagement, Version=3.0.0.173, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
+      <HintPath>..\packages\Chocolatey.NuGet.PackageManagement.3.0.0-alpha-20230228-173\lib\net472\Chocolatey.NuGet.PackageManagement.dll</HintPath>
     </Reference>
-    <Reference Include="Chocolatey.NuGet.Packaging, Version=3.0.0.169, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
-      <HintPath>..\packages\Chocolatey.NuGet.Packaging.3.0.0-alpha-20230224-169\lib\net472\Chocolatey.NuGet.Packaging.dll</HintPath>
+    <Reference Include="Chocolatey.NuGet.Packaging, Version=3.0.0.173, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
+      <HintPath>..\packages\Chocolatey.NuGet.Packaging.3.0.0-alpha-20230228-173\lib\net472\Chocolatey.NuGet.Packaging.dll</HintPath>
     </Reference>
-    <Reference Include="Chocolatey.NuGet.ProjectModel, Version=3.0.0.169, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
-      <HintPath>..\packages\Chocolatey.NuGet.ProjectModel.3.0.0-alpha-20230224-169\lib\net472\Chocolatey.NuGet.ProjectModel.dll</HintPath>
+    <Reference Include="Chocolatey.NuGet.ProjectModel, Version=3.0.0.173, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
+      <HintPath>..\packages\Chocolatey.NuGet.ProjectModel.3.0.0-alpha-20230228-173\lib\net472\Chocolatey.NuGet.ProjectModel.dll</HintPath>
     </Reference>
-    <Reference Include="Chocolatey.NuGet.Protocol, Version=3.0.0.169, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
-      <HintPath>..\packages\Chocolatey.NuGet.Protocol.3.0.0-alpha-20230224-169\lib\net472\Chocolatey.NuGet.Protocol.dll</HintPath>
+    <Reference Include="Chocolatey.NuGet.Protocol, Version=3.0.0.173, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
+      <HintPath>..\packages\Chocolatey.NuGet.Protocol.3.0.0-alpha-20230228-173\lib\net472\Chocolatey.NuGet.Protocol.dll</HintPath>
     </Reference>
-    <Reference Include="Chocolatey.NuGet.Resolver, Version=3.0.0.169, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
-      <HintPath>..\packages\Chocolatey.NuGet.Resolver.3.0.0-alpha-20230224-169\lib\net472\Chocolatey.NuGet.Resolver.dll</HintPath>
+    <Reference Include="Chocolatey.NuGet.Resolver, Version=3.0.0.173, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
+      <HintPath>..\packages\Chocolatey.NuGet.Resolver.3.0.0-alpha-20230228-173\lib\net472\Chocolatey.NuGet.Resolver.dll</HintPath>
     </Reference>
-    <Reference Include="Chocolatey.NuGet.Versioning, Version=3.0.0.169, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
-      <HintPath>..\packages\Chocolatey.NuGet.Versioning.3.0.0-alpha-20230224-169\lib\net472\Chocolatey.NuGet.Versioning.dll</HintPath>
+    <Reference Include="Chocolatey.NuGet.Versioning, Version=3.0.0.173, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
+      <HintPath>..\packages\Chocolatey.NuGet.Versioning.3.0.0-alpha-20230228-173\lib\net472\Chocolatey.NuGet.Versioning.dll</HintPath>
     </Reference>
     <Reference Include="log4net, Version=2.0.12.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
       <HintPath>..\packages\log4net.2.0.12\lib\net45\log4net.dll</HintPath>

--- a/src/chocolatey/infrastructure.app/nuget/NugetList.cs
+++ b/src/chocolatey/infrastructure.app/nuget/NugetList.cs
@@ -359,94 +359,18 @@ namespace chocolatey.infrastructure.app.nuget
                     return metadata;
                 }
             }
-
-            //If no packages found, then return nothing
-            return null;
-
-            /*
-            // use old method when newer method causes issues
-            if (!config.Features.UsePackageRepositoryOptimizations) return repository.FindPackage(packageName, version, config.Prerelease, allowUnlisted: false);
-
-            packageName = packageName.to_string().ToLower(CultureInfo.CurrentCulture);
-            // find the package based on version using older method
-            if (version != null) return repository.FindPackage(packageName, version, config.Prerelease, allowUnlisted: false);
-
-            // we should always be using an aggregate repository
-            var aggregateRepository = repository as AggregateRepository;
-            if (aggregateRepository != null)
             {
-                var packageResults = new List<IPackage>();
-
-                foreach (var packageRepository in aggregateRepository.Repositories.or_empty_list_if_null())
                 {
-                    try
+
                     {
-                        "chocolatey".Log().Debug("Using '" + packageRepository.Source + "'.");
-                        "chocolatey".Log().Debug("- Supports prereleases? '" + packageRepository.SupportsPrereleasePackages + "'.");
-                        "chocolatey".Log().Debug("- Is ServiceBased? '" + (packageRepository is IServiceBasedRepository) + "'.");
-
-                        // search based on lower case id - similar to PackageRepositoryExtensions.FindPackagesByIdCore()
-                        IQueryable<IPackage> combinedResults = packageRepository.GetPackages().Where(x => x.Id.ToLower() == packageName);
-
-                        if (config.Prerelease && packageRepository.SupportsPrereleasePackages)
-                        {
-                            combinedResults = combinedResults.Where(p => p.IsAbsoluteLatestVersion);
-                        }
-                        else
-                        {
-                            combinedResults = combinedResults.Where(p => p.IsLatestVersion);
-                        }
-
-                        if (!(packageRepository is IServiceBasedRepository))
-                        {
-                            combinedResults = combinedResults
-                                .Where(PackageExtensions.IsListed)
-                                .Where(p => config.Prerelease || p.IsReleaseVersion())
-                                .distinct_last(PackageEqualityComparer.Id, PackageComparer.Version)
-                                .AsQueryable();
-                        }
-
-                        var packageRepositoryResults = combinedResults.ToList();
-                        if (packageRepositoryResults.Count() != 0)
-                        {
-                            "chocolatey".Log().Debug("Package '{0}' found on source '{1}'".format_with(packageName, packageRepository.Source));
-                            packageResults.AddRange(packageRepositoryResults);
-                        }
                     }
-                    catch (Exception e)
-                    {
-                        "chocolatey".Log().Warn("Error retrieving packages from source '{0}':{1} {2}".format_with(packageRepository.Source, Environment.NewLine, e.Message));
-                    }
-                }
 
-                // get only one result, should be the latest - similar to TryFindLatestPackageById
-                return packageResults.OrderByDescending(x => x.Version).FirstOrDefault();
             }
 
-            // search based on lower case id - similar to PackageRepositoryExtensions.FindPackagesByIdCore()
-            IQueryable<IPackage> results = repository.GetPackages().Where(x => x.Id.ToLower() == packageName);
-
-            if (config.Prerelease && repository.SupportsPrereleasePackages)
             {
-                results = results.Where(p => p.IsAbsoluteLatestVersion);
-            }
-            else
-            {
-                results = results.Where(p => p.IsLatestVersion);
+
             }
 
-            if (!(repository is IServiceBasedRepository))
-            {
-                results = results
-                    .Where(PackageExtensions.IsListed)
-                    .Where(p => config.Prerelease || p.IsReleaseVersion())
-                    .distinct_last(PackageEqualityComparer.Id, PackageComparer.Version)
-                    .AsQueryable();
-            }
-
-            // get only one result, should be the latest - similar to TryFindLatestPackageById
-            return results.ToList().OrderByDescending(x => x.Version).FirstOrDefault();
-            */
         }
     }
 

--- a/src/chocolatey/infrastructure.app/services/NugetService.cs
+++ b/src/chocolatey/infrastructure.app/services/NugetService.cs
@@ -573,7 +573,7 @@ folder.");
                     latestPackageVersion = version;
                 }
 
-                var availablePackage = NugetList.find_package(packageName, config, _nugetLogger, sourceCacheContext, NugetCommon.GetRepositoryResource<PackageMetadataResource>(remoteRepositories).ToList(), latestPackageVersion);
+                var availablePackage = NugetList.find_package(packageName, config, _nugetLogger, sourceCacheContext, NugetCommon.GetRepositoryResource<PackageMetadataResource>(remoteRepositories).ToList(), NugetCommon.GetRepositoryResource<ListResource>(remoteRepositories).ToList(), latestPackageVersion);
 
                 if (availablePackage == null)
                 {
@@ -1042,7 +1042,7 @@ Please see https://docs.chocolatey.org/en-us/troubleshooting for more
                     config.Prerelease = true;
                 }
 
-                var availablePackage = NugetList.find_package(packageName, config, _nugetLogger, sourceCacheContext, NugetCommon.GetRepositoryResource<PackageMetadataResource>(remoteRepositories).ToList(), version);
+                var availablePackage = NugetList.find_package(packageName, config, _nugetLogger, sourceCacheContext, NugetCommon.GetRepositoryResource<PackageMetadataResource>(remoteRepositories).ToList(), NugetCommon.GetRepositoryResource<ListResource>(remoteRepositories).ToList(), version);
 
                 config.Prerelease = originalPrerelease;
 
@@ -1483,7 +1483,7 @@ Please see https://docs.chocolatey.org/en-us/troubleshooting for more
                     config.Prerelease = true;
                 }
 
-                var latestPackage = NugetList.find_package(packageName, config, _nugetLogger, sourceCacheContext, NugetCommon.GetRepositoryResource<PackageMetadataResource>(remoteRepositories).ToList());
+                var latestPackage = NugetList.find_package(packageName, config, _nugetLogger, sourceCacheContext, NugetCommon.GetRepositoryResource<PackageMetadataResource>(remoteRepositories).ToList(), NugetCommon.GetRepositoryResource<ListResource>(remoteRepositories).ToList());
 
                 if (latestPackage == null)
                 {

--- a/src/chocolatey/infrastructure.app/services/TemplateService.cs
+++ b/src/chocolatey/infrastructure.app/services/TemplateService.cs
@@ -281,7 +281,8 @@ namespace chocolatey.infrastructure.app.services
                     configuration,
                     _nugetLogger,
                     sourceCacheContext,
-                    NugetCommon.GetRepositoryResource<PackageMetadataResource>(packageRepositories));
+                    NugetCommon.GetRepositoryResource<PackageMetadataResource>(packageRepositories),
+                    NugetCommon.GetRepositoryResource<ListResource>(packageRepositories));
 
             var templateInstalledViaPackage = (pkg != null);
 

--- a/src/chocolatey/packages.config
+++ b/src/chocolatey/packages.config
@@ -1,19 +1,19 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="AlphaFS" version="2.1.3" targetFramework="net40-Client" />
-  <package id="Chocolatey.NuGet.Commands" version="3.0.0-alpha-20230224-169" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.Common" version="3.0.0-alpha-20230224-169" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.Configuration" version="3.0.0-alpha-20230224-169" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.Credentials" version="3.0.0-alpha-20230224-169" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.DependencyResolver.Core" version="3.0.0-alpha-20230224-169" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.Frameworks" version="3.0.0-alpha-20230224-169" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.LibraryModel" version="3.0.0-alpha-20230224-169" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.PackageManagement" version="3.0.0-alpha-20230224-169" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.Packaging" version="3.0.0-alpha-20230224-169" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.ProjectModel" version="3.0.0-alpha-20230224-169" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.Protocol" version="3.0.0-alpha-20230224-169" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.Resolver" version="3.0.0-alpha-20230224-169" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.Versioning" version="3.0.0-alpha-20230224-169" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.Commands" version="3.0.0-alpha-20230228-173" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.Common" version="3.0.0-alpha-20230228-173" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.Configuration" version="3.0.0-alpha-20230228-173" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.Credentials" version="3.0.0-alpha-20230228-173" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.DependencyResolver.Core" version="3.0.0-alpha-20230228-173" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.Frameworks" version="3.0.0-alpha-20230228-173" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.LibraryModel" version="3.0.0-alpha-20230228-173" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.PackageManagement" version="3.0.0-alpha-20230228-173" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.Packaging" version="3.0.0-alpha-20230228-173" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.ProjectModel" version="3.0.0-alpha-20230228-173" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.Protocol" version="3.0.0-alpha-20230228-173" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.Resolver" version="3.0.0-alpha-20230228-173" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.Versioning" version="3.0.0-alpha-20230228-173" targetFramework="net48" />
   <package id="log4net" version="2.0.12" targetFramework="net48" />
   <package id="Microsoft.CodeAnalysis.BannedApiAnalyzers" version="3.3.3" targetFramework="net48" developmentDependency="true" />
   <package id="Microsoft.CSharp" version="4.3.0" targetFramework="net48" />


### PR DESCRIPTION
## Description Of Changes

This commit changes the find_package method to make use of a new
PackageAsync method which has been added to the ListResource within the
NuGet.Clint assemblies, which provides this optimization.

In addition, this commit makes a slight refactoring to the code where
find_package is called, and removes unnecessary calls to the
GetAllVersionsAsync method.  This work is exactly the same as the work
done in the GetMetaDataAsync method of the find_package method, and
therefore not required.

## Motivation and Context

In order for the new Chocolatey CLI to function in the same way as the
previous 1.x versions, we need to take into account the
UsePackageRepositoryOptimizations feature.  WHen this is enabled, as
few queries as necessary should be used.  For example, when querying
for an exact package id, or checking to see if a new package version is
available, we can make a single query to a source via the Packages()
API, rather than doing multiple calls to the FindPackagesById endpoint.
 This greatly reduces the number of queries that are required overall.

## Testing

1. Testing steps are detailed in this PR - https://github.com/chocolatey/NuGet.Client/pull/29

### Operating Systems Testing

- Windows 10

## Change Types Made

* [ ] Bug fix (non-breaking change).
* [x] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [x] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue

- Relates to #508
- https://app.clickup.com/t/20540031/PROJ-506
