### PR TITLE
(#1092) Ensure chocolateyBeforeModify.ps1 is run for dependencies

### DIFF
--- a/src/chocolatey.tests.integration/chocolatey.tests.integration.csproj
+++ b/src/chocolatey.tests.integration/chocolatey.tests.integration.csproj
@@ -141,6 +141,54 @@
     <None Include="context\badpackage\2.0\tools\chocolateyUninstall.ps1">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
+    <None Include="context\dependenciesbeforemodify\hasdependencywithbeforemodify\1.0.0\hasdependencywithbeforemodify.nuspec">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Include="context\dependenciesbeforemodify\hasdependencywithbeforemodify\1.0.0\tools\chocolateyBeforeModify.ps1">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Include="context\dependenciesbeforemodify\hasdependencywithbeforemodify\1.0.0\tools\chocolateyinstall.ps1">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Include="context\dependenciesbeforemodify\hasdependencywithbeforemodify\1.0.0\tools\chocolateyuninstall.ps1">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Include="context\dependenciesbeforemodify\hasdependencywithbeforemodify\2.0.0\hasdependencywithbeforemodify.nuspec">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Include="context\dependenciesbeforemodify\hasdependencywithbeforemodify\2.0.0\tools\chocolateyBeforeModify.ps1">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Include="context\dependenciesbeforemodify\hasdependencywithbeforemodify\2.0.0\tools\chocolateyinstall.ps1">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Include="context\dependenciesbeforemodify\hasdependencywithbeforemodify\2.0.0\tools\chocolateyuninstall.ps1">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Include="context\dependenciesbeforemodify\isdependencywithbeforemodify\1.0.0\isdependencywithbeforemodify.nuspec">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Include="context\dependenciesbeforemodify\isdependencywithbeforemodify\1.0.0\tools\chocolateyBeforeModify.ps1">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Include="context\dependenciesbeforemodify\isdependencywithbeforemodify\1.0.0\tools\chocolateyinstall.ps1">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Include="context\dependenciesbeforemodify\isdependencywithbeforemodify\1.0.0\tools\chocolateyuninstall.ps1">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Include="context\dependenciesbeforemodify\isdependencywithbeforemodify\2.0.0\isdependencywithbeforemodify.nuspec">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Include="context\dependenciesbeforemodify\isdependencywithbeforemodify\2.0.0\tools\chocolateyBeforeModify.ps1">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Include="context\dependenciesbeforemodify\isdependencywithbeforemodify\2.0.0\tools\chocolateyinstall.ps1">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Include="context\dependenciesbeforemodify\isdependencywithbeforemodify\2.0.0\tools\chocolateyuninstall.ps1">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
     <None Include="context\dependencies\conflictingdependency\1.0.1\conflictingdependency.nuspec">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
@@ -661,6 +709,10 @@
     <None Include="context\upgradepackage\1.1.0\tools\graphical.exe">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
+    <Content Include="context\dependenciesbeforemodify\hasdependencywithbeforemodify\1.0.0\tools\purpose.txt" />
+    <Content Include="context\dependenciesbeforemodify\hasdependencywithbeforemodify\2.0.0\tools\purpose.txt" />
+    <Content Include="context\dependenciesbeforemodify\isdependencywithbeforemodify\1.0.0\tools\purpose.txt" />
+    <Content Include="context\dependenciesbeforemodify\isdependencywithbeforemodify\2.0.0\tools\purpose.txt" />
     <Content Include="context\exactpackage\exactpackage.dontfind\1.0.0\tools\purpose.txt">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>

--- a/src/chocolatey.tests.integration/context/dependenciesbeforemodify/hasdependencywithbeforemodify/1.0.0/hasdependencywithbeforemodify.nuspec
+++ b/src/chocolatey.tests.integration/context/dependenciesbeforemodify/hasdependencywithbeforemodify/1.0.0/hasdependencywithbeforemodify.nuspec
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+    <metadata>
+        <id>hasdependencywithbeforemodify</id>
+        <version>1.0.0</version>
+        <title>hasdependencywithbeforemodify</title>
+        <authors>__REPLACE_AUTHORS_OF_SOFTWARE__</authors>
+        <owners>__REPLACE_YOUR_NAME__</owners>
+        <requireLicenseAcceptance>false</requireLicenseAcceptance>
+        <description>__REPLACE__</description>
+        <summary>__REPLACE__</summary>
+        <releaseNotes />
+        <copyright />
+        <tags>hasdependencywithbeforemodify admin</tags>
+        <dependencies>
+            <dependency id="isdependencywithbeforemodify" version="[1.0.0, 2.0.0.0)" />
+        </dependencies>
+    </metadata>
+  <files>
+    <file src="tools\**" target="tools" />
+  </files>
+</package>

--- a/src/chocolatey.tests.integration/context/dependenciesbeforemodify/hasdependencywithbeforemodify/1.0.0/tools/chocolateyBeforeModify.ps1
+++ b/src/chocolatey.tests.integration/context/dependenciesbeforemodify/hasdependencywithbeforemodify/1.0.0/tools/chocolateyBeforeModify.ps1
@@ -1,0 +1,1 @@
+﻿Write-Output "Ran BeforeModify: $env:PackageName $env:PackageVersion"

--- a/src/chocolatey.tests.integration/context/dependenciesbeforemodify/hasdependencywithbeforemodify/1.0.0/tools/chocolateyinstall.ps1
+++ b/src/chocolatey.tests.integration/context/dependenciesbeforemodify/hasdependencywithbeforemodify/1.0.0/tools/chocolateyinstall.ps1
@@ -1,0 +1,1 @@
+﻿Write-Output "$env:PackageName $env:PackageVersion Installed"

--- a/src/chocolatey.tests.integration/context/dependenciesbeforemodify/hasdependencywithbeforemodify/1.0.0/tools/chocolateyuninstall.ps1
+++ b/src/chocolatey.tests.integration/context/dependenciesbeforemodify/hasdependencywithbeforemodify/1.0.0/tools/chocolateyuninstall.ps1
@@ -1,0 +1,1 @@
+﻿Write-Output "$env:PackageName $env:PackageVersion Uninstalled"

--- a/src/chocolatey.tests.integration/context/dependenciesbeforemodify/hasdependencywithbeforemodify/1.0.0/tools/purpose.txt
+++ b/src/chocolatey.tests.integration/context/dependenciesbeforemodify/hasdependencywithbeforemodify/1.0.0/tools/purpose.txt
@@ -1,0 +1,1 @@
+﻿This package is used to test out upgrade behaviour with beforeModify scripts in play for the main package and dependencies.

--- a/src/chocolatey.tests.integration/context/dependenciesbeforemodify/hasdependencywithbeforemodify/2.0.0/hasdependencywithbeforemodify.nuspec
+++ b/src/chocolatey.tests.integration/context/dependenciesbeforemodify/hasdependencywithbeforemodify/2.0.0/hasdependencywithbeforemodify.nuspec
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+    <metadata>
+        <id>hasdependencywithbeforemodify</id>
+        <version>2.0.0</version>
+        <title>hasdependencywithbeforemodify</title>
+        <authors>__REPLACE_AUTHORS_OF_SOFTWARE__</authors>
+        <owners>__REPLACE_YOUR_NAME__</owners>
+        <requireLicenseAcceptance>false</requireLicenseAcceptance>
+        <description>__REPLACE__</description>
+        <summary>__REPLACE__</summary>
+        <releaseNotes />
+        <copyright />
+        <tags>hasdependencywithbeforemodify admin</tags>
+        <dependencies>
+            <dependency id="isdependencywithbeforemodify" version="[2.0.0, 3.0.0.0)" />
+        </dependencies>
+    </metadata>
+  <files>
+    <file src="tools\**" target="tools" />
+  </files>
+</package>

--- a/src/chocolatey.tests.integration/context/dependenciesbeforemodify/hasdependencywithbeforemodify/2.0.0/tools/chocolateyBeforeModify.ps1
+++ b/src/chocolatey.tests.integration/context/dependenciesbeforemodify/hasdependencywithbeforemodify/2.0.0/tools/chocolateyBeforeModify.ps1
@@ -1,0 +1,1 @@
+﻿Write-Output "Ran BeforeModify: $env:PackageName $env:PackageVersion"

--- a/src/chocolatey.tests.integration/context/dependenciesbeforemodify/hasdependencywithbeforemodify/2.0.0/tools/chocolateyinstall.ps1
+++ b/src/chocolatey.tests.integration/context/dependenciesbeforemodify/hasdependencywithbeforemodify/2.0.0/tools/chocolateyinstall.ps1
@@ -1,0 +1,1 @@
+﻿Write-Output "$env:PackageName $env:PackageVersion Installed"

--- a/src/chocolatey.tests.integration/context/dependenciesbeforemodify/hasdependencywithbeforemodify/2.0.0/tools/chocolateyuninstall.ps1
+++ b/src/chocolatey.tests.integration/context/dependenciesbeforemodify/hasdependencywithbeforemodify/2.0.0/tools/chocolateyuninstall.ps1
@@ -1,0 +1,1 @@
+﻿Write-Output "$env:PackageName $env:PackageVersion Uninstalled"

--- a/src/chocolatey.tests.integration/context/dependenciesbeforemodify/hasdependencywithbeforemodify/2.0.0/tools/purpose.txt
+++ b/src/chocolatey.tests.integration/context/dependenciesbeforemodify/hasdependencywithbeforemodify/2.0.0/tools/purpose.txt
@@ -1,0 +1,1 @@
+﻿This package is used to test out upgrade behaviour with beforeModify scripts in play for the main package and dependencies.

--- a/src/chocolatey.tests.integration/context/dependenciesbeforemodify/isdependencywithbeforemodify/1.0.0/isdependencywithbeforemodify.nuspec
+++ b/src/chocolatey.tests.integration/context/dependenciesbeforemodify/isdependencywithbeforemodify/1.0.0/isdependencywithbeforemodify.nuspec
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+  <metadata>
+    <id>isdependencywithbeforemodify</id>
+    <version>1.0.0</version>
+    <title>isdependencywithbeforemodify</title>
+    <authors>__REPLACE_AUTHORS_OF_SOFTWARE__</authors>
+    <owners>__REPLACE_YOUR_NAME__</owners>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <description>__REPLACE__</description>
+    <summary>__REPLACE__</summary>
+    <releaseNotes />
+    <tags>isdependencywithbeforemodify admin</tags>
+  </metadata>
+  <files>
+    <file src="tools\**" target="tools" />
+  </files>
+</package>

--- a/src/chocolatey.tests.integration/context/dependenciesbeforemodify/isdependencywithbeforemodify/1.0.0/tools/chocolateyBeforeModify.ps1
+++ b/src/chocolatey.tests.integration/context/dependenciesbeforemodify/isdependencywithbeforemodify/1.0.0/tools/chocolateyBeforeModify.ps1
@@ -1,0 +1,1 @@
+﻿Write-Output "Ran BeforeModify: $env:PackageName $env:PackageVersion"

--- a/src/chocolatey.tests.integration/context/dependenciesbeforemodify/isdependencywithbeforemodify/1.0.0/tools/chocolateyinstall.ps1
+++ b/src/chocolatey.tests.integration/context/dependenciesbeforemodify/isdependencywithbeforemodify/1.0.0/tools/chocolateyinstall.ps1
@@ -1,0 +1,1 @@
+﻿Write-Output "$env:PackageName $env:PackageVersion Installed"

--- a/src/chocolatey.tests.integration/context/dependenciesbeforemodify/isdependencywithbeforemodify/1.0.0/tools/chocolateyuninstall.ps1
+++ b/src/chocolatey.tests.integration/context/dependenciesbeforemodify/isdependencywithbeforemodify/1.0.0/tools/chocolateyuninstall.ps1
@@ -1,0 +1,1 @@
+﻿Write-Output "$env:PackageName $env:PackageVersion Uninstalled"

--- a/src/chocolatey.tests.integration/context/dependenciesbeforemodify/isdependencywithbeforemodify/1.0.0/tools/purpose.txt
+++ b/src/chocolatey.tests.integration/context/dependenciesbeforemodify/isdependencywithbeforemodify/1.0.0/tools/purpose.txt
@@ -1,0 +1,1 @@
+﻿This package is used to test out upgrade behaviour with beforeModify scripts in play for the main package and dependencies.

--- a/src/chocolatey.tests.integration/context/dependenciesbeforemodify/isdependencywithbeforemodify/2.0.0/isdependencywithbeforemodify.nuspec
+++ b/src/chocolatey.tests.integration/context/dependenciesbeforemodify/isdependencywithbeforemodify/2.0.0/isdependencywithbeforemodify.nuspec
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+  <metadata>
+    <id>isdependencywithbeforemodify</id>
+    <version>2.0.0</version>
+    <title>isdependencywithbeforemodify</title>
+    <authors>__REPLACE_AUTHORS_OF_SOFTWARE__</authors>
+    <owners>__REPLACE_YOUR_NAME__</owners>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <description>__REPLACE__</description>
+    <summary>__REPLACE__</summary>
+    <releaseNotes />
+    <tags>isdependencywithbeforemodify admin</tags>
+  </metadata>
+  <files>
+    <file src="tools\**" target="tools" />
+  </files>
+</package>

--- a/src/chocolatey.tests.integration/context/dependenciesbeforemodify/isdependencywithbeforemodify/2.0.0/tools/chocolateyBeforeModify.ps1
+++ b/src/chocolatey.tests.integration/context/dependenciesbeforemodify/isdependencywithbeforemodify/2.0.0/tools/chocolateyBeforeModify.ps1
@@ -1,0 +1,1 @@
+﻿Write-Output "Ran BeforeModify: $env:PackageName $env:PackageVersion"

--- a/src/chocolatey.tests.integration/context/dependenciesbeforemodify/isdependencywithbeforemodify/2.0.0/tools/chocolateyinstall.ps1
+++ b/src/chocolatey.tests.integration/context/dependenciesbeforemodify/isdependencywithbeforemodify/2.0.0/tools/chocolateyinstall.ps1
@@ -1,0 +1,1 @@
+﻿Write-Output "$env:PackageName $env:PackageVersion Installed"

--- a/src/chocolatey.tests.integration/context/dependenciesbeforemodify/isdependencywithbeforemodify/2.0.0/tools/chocolateyuninstall.ps1
+++ b/src/chocolatey.tests.integration/context/dependenciesbeforemodify/isdependencywithbeforemodify/2.0.0/tools/chocolateyuninstall.ps1
@@ -1,0 +1,1 @@
+﻿Write-Output "$env:PackageName $env:PackageVersion Uninstalled"

--- a/src/chocolatey.tests.integration/context/dependenciesbeforemodify/isdependencywithbeforemodify/2.0.0/tools/purpose.txt
+++ b/src/chocolatey.tests.integration/context/dependenciesbeforemodify/isdependencywithbeforemodify/2.0.0/tools/purpose.txt
@@ -1,0 +1,1 @@
+﻿This package is used to test out upgrade behaviour with beforeModify scripts in play for the main package and dependencies.

--- a/src/chocolatey.tests.integration/scenarios/ListScenarios.cs
+++ b/src/chocolatey.tests.integration/scenarios/ListScenarios.cs
@@ -19,7 +19,6 @@ namespace chocolatey.tests.integration.scenarios
     using System.Collections.Generic;
     using System.Linq;
     using chocolatey.infrastructure.app;
-    using chocolatey.infrastructure.app.commands;
     using chocolatey.infrastructure.app.configuration;
     using chocolatey.infrastructure.app.services;
     using chocolatey.infrastructure.results;

--- a/src/chocolatey.tests.integration/scenarios/UninstallScenarios.cs
+++ b/src/chocolatey.tests.integration/scenarios/UninstallScenarios.cs
@@ -1316,5 +1316,91 @@ namespace chocolatey.tests.integration.scenarios
             }
         }
 
+        public class when_uninstalling_a_package_with_remove_dependencies_with_beforeModify : ScenariosBase
+        {
+            private const string TargetPackageName = "hasdependencywithbeforemodify";
+            private const string DependencyName = "isdependencywithbeforemodify";
+
+            public override void Context()
+            {
+                base.Context();
+
+                Scenario.add_packages_to_source_location(Configuration, "{0}.*".format_with(TargetPackageName) + Constants.PackageExtension);
+                Scenario.add_packages_to_source_location(Configuration, "{0}.*".format_with(DependencyName) + Constants.PackageExtension);
+                Scenario.install_package(Configuration, TargetPackageName, "1.0.0");
+                Scenario.install_package(Configuration, DependencyName, "1.0.0");
+
+                Configuration.PackageNames = Configuration.Input = TargetPackageName;
+                Configuration.ForceDependencies = true;
+            }
+
+            public override void Because()
+            {
+                Results = Service.uninstall_run(Configuration);
+            }
+
+            [Fact]
+            public void should_uninstall_the_package()
+            {
+                var packageFile = Path.Combine(Scenario.get_top_level(), "lib", TargetPackageName, "{0}.nupkg".format_with(TargetPackageName));
+                File.Exists(packageFile).ShouldBeFalse();
+            }
+
+            [Fact]
+            public void should_uninstall_the_dependency()
+            {
+                var packageFile = Path.Combine(Scenario.get_top_level(), "lib", DependencyName, "{0}.nupkg".format_with(DependencyName));
+                File.Exists(packageFile).ShouldBeFalse();
+            }
+
+            [Fact]
+            public void should_contain_a_message_that_everything_uninstalled_successfully()
+            {
+                MockLogger.contains_message("uninstalled 2/2", LogLevel.Warn).ShouldBeTrue();
+            }
+
+            [Fact]
+            [WindowsOnly]
+            [Platform(Exclude = "Mono")]
+            public void should_run_target_package_beforeModify()
+            {
+                MockLogger.contains_message("Ran BeforeModify: {0} {1}".format_with(TargetPackageName, "1.0.0"), LogLevel.Info).ShouldBeTrue();
+            }
+
+            [Fact]
+            [WindowsOnly]
+            [Platform(Exclude = "Mono")]
+            public void should_run_dependency_package_beforeModify()
+            {
+                MockLogger.contains_message("Ran BeforeModify: {0} {1}".format_with(DependencyName, "1.0.0"), LogLevel.Info).ShouldBeTrue();
+            }
+
+            [Fact]
+            public void should_have_a_successful_package_result()
+            {
+                foreach (var packageResult in Results)
+                {
+                    packageResult.Value.Success.ShouldBeTrue();
+                }
+            }
+
+            [Fact]
+            public void should_not_have_inconclusive_package_result()
+            {
+                foreach (var packageResult in Results)
+                {
+                    packageResult.Value.Inconclusive.ShouldBeFalse();
+                }
+            }
+
+            [Fact]
+            public void should_not_have_warning_package_result()
+            {
+                foreach (var packageResult in Results)
+                {
+                    packageResult.Value.Warning.ShouldBeFalse();
+                }
+            }
+        }
     }
 }

--- a/src/chocolatey.tests.integration/scenarios/UpgradeScenarios.cs
+++ b/src/chocolatey.tests.integration/scenarios/UpgradeScenarios.cs
@@ -3525,5 +3525,175 @@ namespace chocolatey.tests.integration.scenarios
                 MockLogger.contains_message("pre-beforemodify-all.ps1 hook ran for upgradepackage 1.1.0", LogLevel.Info).ShouldBeFalse();
             }
         }
+
+        public class when_upgrading_a_package_with_beforeModify_script_with_dependencies_with_beforeModify_scripts_and_hooks : ScenariosBase
+        {
+            private const string TargetPackageName = "hasdependencywithbeforemodify";
+            private const string DependencyName = "isdependencywithbeforemodify";
+
+            public override void Context()
+            {
+                base.Context();
+
+                Scenario.add_packages_to_source_location(Configuration, "{0}.*".format_with(TargetPackageName) + Constants.PackageExtension);
+                Scenario.add_packages_to_source_location(Configuration, "{0}.*".format_with(DependencyName) + Constants.PackageExtension);
+                Scenario.add_packages_to_source_location(Configuration, "scriptpackage.hook" + "*" + Constants.PackageExtension);
+                Scenario.install_package(Configuration, DependencyName, "1.0.0");
+                Scenario.install_package(Configuration, TargetPackageName, "1.0.0");
+                Scenario.install_package(Configuration, "scriptpackage.hook", "1.0.0");
+
+                Configuration.PackageNames = Configuration.Input = TargetPackageName;
+            }
+
+            public override void Because()
+            {
+                Results = Service.upgrade_run(Configuration);
+            }
+
+            [Fact]
+            public void should_upgrade_the_package()
+            {
+                var packageFile = Path.Combine(Scenario.get_top_level(), "lib", TargetPackageName, "{0}.nupkg".format_with(TargetPackageName));
+                var package = new OptimizedZipPackage(packageFile);
+                package.Version.Version.to_string().ShouldEqual("2.0.0.0");
+            }
+
+            [Fact]
+            public void should_upgrade_the_minimum_version_dependency()
+            {
+                var packageFile = Path.Combine(Scenario.get_top_level(), "lib", DependencyName, "{0}.nupkg".format_with(DependencyName));
+                var package = new OptimizedZipPackage(packageFile);
+                package.Version.Version.to_string().ShouldEqual("2.0.0.0");
+            }
+
+            [Fact]
+            public void should_contain_a_message_that_everything_upgraded_successfully()
+            {
+                MockLogger.contains_message("upgraded 2/2", LogLevel.Warn).ShouldBeTrue();
+            }
+
+            [Fact]
+            [WindowsOnly]
+            [Platform(Exclude = "Mono")]
+            public void should_run_beforemodify_hook_script_for_previous_version_of_target()
+            {
+                MockLogger.contains_message("pre-beforemodify-all.ps1 hook ran for {0} {1}".format_with(TargetPackageName, "1.0.0"), LogLevel.Info).ShouldBeTrue();
+            }
+
+            [Fact]
+            [WindowsOnly]
+            [Platform(Exclude = "Mono")]
+            public void should_run_already_installed_target_package_beforeModify()
+            {
+                MockLogger.contains_message("Ran BeforeModify: {0} {1}".format_with(TargetPackageName, "1.0.0"), LogLevel.Info).ShouldBeTrue();
+            }
+
+            [Fact]
+            [WindowsOnly]
+            [Platform(Exclude = "Mono")]
+            public void should_not_run_beforemodify_hook_script_for_upgrade_version_of_target()
+            {
+                MockLogger.contains_message("pre-beforemodify-all.ps1 hook ran for {0} {1}".format_with(TargetPackageName, "2.0.0"), LogLevel.Info).ShouldBeFalse();
+            }
+
+            [Fact]
+            [WindowsOnly]
+            [Platform(Exclude = "Mono")]
+            public void should_not_run_target_package_beforeModify_for_upgraded_version()
+            {
+                MockLogger.contains_message("Ran BeforeModify: {0} {1}".format_with(TargetPackageName, "2.0.0"), LogLevel.Info).ShouldBeFalse();
+            }
+
+            [Fact]
+            [WindowsOnly]
+            [Platform(Exclude = "Mono")]
+            public void should_run_pre_all_hook_script_for_upgraded_version_of_target()
+            {
+                MockLogger.contains_message("pre-install-all.ps1 hook ran for {0} {1}".format_with(TargetPackageName, "2.0.0"), LogLevel.Info).ShouldBeTrue();
+            }
+
+            [Fact]
+            [WindowsOnly]
+            [Platform(Exclude = "Mono")]
+            public void should_run_post_all_hook_script_for_upgraded_version_of_target()
+            {
+                MockLogger.contains_message("post-install-all.ps1 hook ran for {0} {1}".format_with(TargetPackageName, "2.0.0"), LogLevel.Info).ShouldBeTrue();
+            }
+
+            [Fact]
+            [WindowsOnly]
+            [Platform(Exclude = "Mono")]
+            public void should_run_beforemodify_hook_script_for_previous_version_of_dependency()
+            {
+                MockLogger.contains_message("pre-beforemodify-all.ps1 hook ran for {0} {1}".format_with(DependencyName, "1.0.0"), LogLevel.Info).ShouldBeTrue();
+            }
+
+            [Fact]
+            [WindowsOnly]
+            [Platform(Exclude = "Mono")]
+            public void should_run_already_installed_dependency_package_beforeModify()
+            {
+                MockLogger.contains_message("Ran BeforeModify: {0} {1}".format_with(DependencyName, "1.0.0"), LogLevel.Info).ShouldBeTrue();
+            }
+
+            [Fact]
+            [WindowsOnly]
+            [Platform(Exclude = "Mono")]
+            public void should_not_run_beforemodify_hook_script_for_upgrade_version_of_dependency()
+            {
+                MockLogger.contains_message("pre-beforemodify-all.ps1 hook ran for {0} {1}".format_with(DependencyName, "2.0.0"), LogLevel.Info).ShouldBeFalse();
+            }
+
+            [Fact]
+            [WindowsOnly]
+            [Platform(Exclude = "Mono")]
+            public void should_not_run_dependency_package_beforeModify_for_upgraded_version()
+            {
+                MockLogger.contains_message("Ran BeforeModify: {0} {1}".format_with(DependencyName, "2.0.0"), LogLevel.Info).ShouldBeFalse();
+            }
+
+            [Fact]
+            [WindowsOnly]
+            [Platform(Exclude = "Mono")]
+            public void should_run_pre_all_hook_script_for_upgraded_version_of_dependency()
+            {
+                MockLogger.contains_message("pre-install-all.ps1 hook ran for {0} {1}".format_with(DependencyName, "2.0.0"), LogLevel.Info).ShouldBeTrue();
+            }
+
+            [Fact]
+            [WindowsOnly]
+            [Platform(Exclude = "Mono")]
+            public void should_run_post_all_hook_script_for_upgraded_version_of_dependency()
+            {
+                MockLogger.contains_message("post-install-all.ps1 hook ran for {0} {1}".format_with(DependencyName, "2.0.0"), LogLevel.Info).ShouldBeTrue();
+            }
+
+            [Fact]
+            public void should_have_a_successful_package_result()
+            {
+                foreach (var packageResult in Results)
+                {
+                    packageResult.Value.Success.ShouldBeTrue();
+                }
+            }
+
+            [Fact]
+            public void should_not_have_inconclusive_package_result()
+            {
+                foreach (var packageResult in Results)
+                {
+                    packageResult.Value.Inconclusive.ShouldBeFalse();
+                }
+            }
+
+            [Fact]
+            public void should_not_have_warning_package_result()
+            {
+                foreach (var packageResult in Results)
+                {
+                    packageResult.Value.Warning.ShouldBeFalse();
+                }
+            }
+        }
     }
 }

--- a/src/chocolatey.tests/infrastructure.app/services/ChocolateyPackageServiceSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/services/ChocolateyPackageServiceSpecs.cs
@@ -88,9 +88,9 @@ namespace chocolatey.tests.infrastructure.app.services
                 var expectedResult = new ConcurrentDictionary<string, PackageResult>();
                 expectedResult.TryAdd("test-feature", new PackageResult(package.Object, "windowsfeatures", null));
 
-                FeaturesRunner.Setup(r => r.install_run(It.IsAny<ChocolateyConfiguration>(), It.IsAny<Action<PackageResult>>()))
+                FeaturesRunner.Setup(r => r.install_run(It.IsAny<ChocolateyConfiguration>(), It.IsAny<Action<PackageResult>>(), It.IsAny<Action<PackageResult>>()))
                     .Returns(expectedResult);
-                NormalRunner.Setup(r => r.install_run(It.IsAny<ChocolateyConfiguration>(), It.IsAny<Action<PackageResult>>()))
+                NormalRunner.Setup(r => r.install_run(It.IsAny<ChocolateyConfiguration>(), It.IsAny<Action<PackageResult>>(), It.IsAny<Action<PackageResult>>()))
                     .Returns(new ConcurrentDictionary<string, PackageResult>());
                 SourceRunners.AddRange(new[] { NormalRunner.Object, FeaturesRunner.Object });
 
@@ -125,20 +125,20 @@ namespace chocolatey.tests.infrastructure.app.services
             [Test]
             public void should_have_called_runner_for_windows_features_source()
             {
-                FeaturesRunner.Verify(r => r.install_run(It.Is<ChocolateyConfiguration>(c => c.PackageNames == "test-feature"), It.IsAny<Action<PackageResult>>()), Times.Once);
+                FeaturesRunner.Verify(r => r.install_run(It.Is<ChocolateyConfiguration>(c => c.PackageNames == "test-feature"), It.IsAny<Action<PackageResult>>(), It.IsAny<Action<PackageResult>>()), Times.Once);
             }
 
             [Test]
             public void should_not_have_called_runner_for_windows_features_source_with_other_package_names()
             {
-                FeaturesRunner.Verify(r => r.install_run(It.Is<ChocolateyConfiguration>(c => c.PackageNames != "test-feature"), It.IsAny<Action<PackageResult>>()), Times.Never);
+                FeaturesRunner.Verify(r => r.install_run(It.Is<ChocolateyConfiguration>(c => c.PackageNames != "test-feature"), It.IsAny<Action<PackageResult>>(), It.IsAny<Action<PackageResult>>()), Times.Never);
             }
 
             [Test]
             public void should_not_have_called_normal_source_runner_for_non_empty_packages()
             {
                 // The normal source runners will be called with an argument
-                NormalRunner.Verify(r => r.install_run(It.Is<ChocolateyConfiguration>(c => c.PackageNames != string.Empty), It.IsAny<Action<PackageResult>>()), Times.Never);
+                NormalRunner.Verify(r => r.install_run(It.Is<ChocolateyConfiguration>(c => c.PackageNames != string.Empty), It.IsAny<Action<PackageResult>>(), It.IsAny<Action<PackageResult>>()), Times.Never);
             }
         }
     }

--- a/src/chocolatey/infrastructure.app/services/ChocolateyPackageService.cs
+++ b/src/chocolatey/infrastructure.app/services/ChocolateyPackageService.cs
@@ -606,7 +606,8 @@ package '{0}' - stopping further execution".format_with(packageResult.Name));
                         action = (packageResult) => handle_package_result(packageResult, packageConfig, CommandNameType.install);
                     }
 
-                    var results = perform_source_runner_function(packageConfig, r => r.install_run(packageConfig, action));
+                    var beforeModifyAction = new Action<PackageResult>(packageResult => before_package_modify(packageResult, config));
+                    var results = perform_source_runner_function(packageConfig, r => r.install_run(packageConfig, action, beforeModifyAction));
 
                     foreach (var result in results)
                     {

--- a/src/chocolatey/infrastructure.app/services/CygwinService.cs
+++ b/src/chocolatey/infrastructure.app/services/CygwinService.cs
@@ -235,6 +235,11 @@ namespace chocolatey.infrastructure.app.services
 
         public ConcurrentDictionary<string, PackageResult> install_run(ChocolateyConfiguration config, Action<PackageResult> continueAction)
         {
+            return install_run(config, continueAction, beforeModifyAction: null);
+        }
+
+        public ConcurrentDictionary<string, PackageResult> install_run(ChocolateyConfiguration config, Action<PackageResult> continueAction, Action<PackageResult> beforeModifyAction)
+        {
             var args = build_args(config, _installArguments);
             var packageResults = new ConcurrentDictionary<string, PackageResult>(StringComparer.InvariantCultureIgnoreCase);
 

--- a/src/chocolatey/infrastructure.app/services/ISourceRunner.cs
+++ b/src/chocolatey/infrastructure.app/services/ISourceRunner.cs
@@ -78,6 +78,15 @@ namespace chocolatey.infrastructure.app.services
         ConcurrentDictionary<string, PackageResult> install_run(ChocolateyConfiguration config, Action<PackageResult> continueAction);
 
         /// <summary>
+        ///   Installs packages from the source feed
+        /// </summary>
+        /// <param name="config">The configuration.</param>
+        /// <param name="continueAction">The action to continue with when install is successful.</param>
+        /// <param name="beforeModifyAction">The action (if any) to run on any currently installed package dependencies before triggering the install or updating those dependencies.</param>
+        /// <returns>results of installs</returns>
+        ConcurrentDictionary<string, PackageResult> install_run(ChocolateyConfiguration config, Action<PackageResult> continueAction, Action<PackageResult> beforeModifyAction);
+
+        /// <summary>
         ///   Run upgrade in noop mode
         /// </summary>
         /// <param name="config">The configuration.</param>
@@ -89,7 +98,7 @@ namespace chocolatey.infrastructure.app.services
         /// </summary>
         /// <param name="config">The configuration.</param>
         /// <param name="continueAction">The action to continue with when upgrade is successful.</param>
-        /// <param name="beforeUpgradeAction">The action (if any) to run on any currently installed package before triggering the upgrade.</param>
+        /// <param name="beforeUpgradeAction">The action (if any) to run on any currently installed package or its dependencies before triggering the upgrade.</param>
         /// <returns>results of installs</returns>
         ConcurrentDictionary<string, PackageResult> upgrade_run(ChocolateyConfiguration config, Action<PackageResult> continueAction, Action<PackageResult> beforeUpgradeAction = null);
 

--- a/src/chocolatey/infrastructure.app/services/NugetService.cs
+++ b/src/chocolatey/infrastructure.app/services/NugetService.cs
@@ -385,6 +385,11 @@ folder.");
 
         public virtual ConcurrentDictionary<string, PackageResult> install_run(ChocolateyConfiguration config, Action<PackageResult> continueAction)
         {
+            return install_run(config, continueAction, beforeModifyAction: null);
+        }
+
+        public virtual ConcurrentDictionary<string, PackageResult> install_run(ChocolateyConfiguration config, Action<PackageResult> continueAction, Action<PackageResult> beforeModifyAction)
+        {
             _fileSystem.create_directory_if_not_exists(ApplicationParameters.PackagesLocation);
             var packageInstalls = new ConcurrentDictionary<string, PackageResult>(StringComparer.InvariantCultureIgnoreCase);
 

--- a/src/chocolatey/infrastructure.app/services/NugetService.cs
+++ b/src/chocolatey/infrastructure.app/services/NugetService.cs
@@ -392,6 +392,7 @@ folder.");
         {
             _fileSystem.create_directory_if_not_exists(ApplicationParameters.PackagesLocation);
             var packageInstalls = new ConcurrentDictionary<string, PackageResult>(StringComparer.InvariantCultureIgnoreCase);
+            var packagesModified = new ConcurrentDictionary<string, PackageResult>(StringComparer.InvariantCultureIgnoreCase);
 
             //todo: #23 handle all
 
@@ -450,6 +451,21 @@ folder.");
                     },
                 uninstallSuccessAction: null,
                 addUninstallHandler: true);
+
+            EventHandler<PackageOperationEventArgs> beforeModifyHandler = (sender, eventArgs) =>
+            {
+                // Soundness: any code called here must avoid calling packageManager methods for
+                // InstallPackage() and UninstallPackage(), or in some other way handle the
+                // unbounded recursion doing so would create.
+                // Additionally, errors thrown during here have been known to cause very strange
+                // NuGet / LINQ exceptions to be thrown during later calls to seemingly unrelated
+                // code paths. Debug this event handler if you see strange errors, such as
+                // complaints about InternalsVisibleTo and strong name signing.
+                backup_and_before_modify(eventArgs.Package, config, beforeModifyAction, packagesModified);
+            };
+
+            packageManager.PackageUninstalling += beforeModifyHandler;
+            packageManager.PackageInstalling += beforeModifyHandler;
 
             config.start_backup();
 
@@ -518,10 +534,7 @@ Please see https://docs.chocolatey.org/en-us/troubleshooting for more
                 {
                     var forcedResult = packageInstalls.GetOrAdd(packageName, new PackageResult(availablePackage, _fileSystem.combine_paths(ApplicationParameters.PackagesLocation, availablePackage.Id)));
                     forcedResult.Messages.Add(new ResultMessage(ResultType.Note, "Backing up and removing old version"));
-
-                    remove_rollback_directory_if_exists(packageName);
-                    backup_existing_version(config, installedPackage, _packageInfoService.get_package_information(installedPackage));
-
+                    
                     try
                     {
                         packageManager.UninstallPackage(installedPackage, forceRemove: config.Force, removeDependencies: config.ForceDependencies);
@@ -617,6 +630,7 @@ Please see https://docs.chocolatey.org/en-us/troubleshooting for more
         {
             _fileSystem.create_directory_if_not_exists(ApplicationParameters.PackagesLocation);
             var packageInstalls = new ConcurrentDictionary<string, PackageResult>(StringComparer.InvariantCultureIgnoreCase);
+            var packagesModified = new ConcurrentDictionary<string, PackageResult>(StringComparer.InvariantCultureIgnoreCase);
 
             SemanticVersion version = !string.IsNullOrWhiteSpace(config.Version) ? new SemanticVersion(config.Version) : null;
             if (config.Force) config.AllowDowngrade = true;
@@ -636,6 +650,21 @@ Please see https://docs.chocolatey.org/en-us/troubleshooting for more
                     },
                 uninstallSuccessAction: null,
                 addUninstallHandler: false);
+
+            EventHandler<PackageOperationEventArgs> beforeModifyHandler = (sender, eventArgs) =>
+            {
+                // Soundness: any code called here must avoid calling packageManager methods for
+                // InstallPackage() and UninstallPackage(), or in some other way handle the
+                // unbounded recursion doing so would create.
+                // Additionally, errors thrown during here have been known to cause very strange
+                // NuGet / LINQ exceptions to be thrown during later calls to seemingly unrelated
+                // code paths. Debug this event handler if you see strange errors, such as
+                // complaints about InternalsVisibleTo and strong name signing.
+                backup_and_before_modify(eventArgs.Package, config, beforeUpgradeAction, packagesModified);
+            };
+
+            packageManager.PackageUninstalling += beforeModifyHandler;
+            packageManager.PackageInstalling += beforeModifyHandler;
 
             var configIgnoreDependencies = config.IgnoreDependencies;
             set_package_names_if_all_is_specified(config, () => { config.IgnoreDependencies = true; });
@@ -685,7 +714,7 @@ Please see https://docs.chocolatey.org/en-us/troubleshooting for more
                     }
                     else
                     {
-                        var installResults = install_run(config, continueAction);
+                        var installResults = install_run(config, continueAction, beforeUpgradeAction);
                         foreach (var result in installResults)
                         {
                             packageInstalls.GetOrAdd(result.Key, result.Value);
@@ -850,17 +879,15 @@ Please see https://docs.chocolatey.org/en-us/troubleshooting for more
                                 packageName,
                                 version == null ? null : version.ToString()))
                             {
-                                if (beforeUpgradeAction != null)
-                                {
-                                    var currentPackageResult = new PackageResult(installedPackage, get_install_directory(config, installedPackage));
-                                    beforeUpgradeAction(currentPackageResult);
-                                }
-
-                                remove_rollback_directory_if_exists(packageName);
-                                ensure_package_files_have_compatible_attributes(config, installedPackage, pkgInfo);
-                                rename_legacy_package_version(config, installedPackage, pkgInfo);
-                                backup_existing_version(config, installedPackage, pkgInfo);
-                                remove_shim_directors(config, installedPackage, pkgInfo);
+                                // Take a backup before trying to update anything.
+                                // 1. If we're taking the '--force' route we don't use UninstallPackage() here as we don't really want
+                                //    to treat this as a proper uninstall, but we DO want to take backups and be able to run a beforeModify.
+                                // 2. If we're taking the UpdatePackage route, we need to pre-emptively take a backup in case the new
+                                //    version of the package doesn't have necessary dependencies available, in which case the upgrade will
+                                //    actually fail BEFORE we do any backups or beforeModify to the main package. Without this pre-step,
+                                //    we can accidentally flag the already-installed package as "bad" since the upgrade failed, and there
+                                //    needs to be a backup to restore from.
+                                backup_and_before_modify(installedPackage, config, beforeUpgradeAction, packagesModified);
                                 if (config.Force && (installedPackage.Version == availablePackage.Version))
                                 {
                                     FaultTolerance.try_catch_with_logging_exception(
@@ -876,6 +903,7 @@ Please see https://docs.chocolatey.org/en-us/troubleshooting for more
                                 {
                                     packageManager.UpdatePackage(availablePackage, updateDependencies: !config.IgnoreDependencies, allowPrereleaseVersions: config.Prerelease);
                                 }
+
                                 remove_nuget_cache_for_package(availablePackage);
                             }
                         }
@@ -1219,7 +1247,7 @@ Side by side installations are deprecated and is pending removal in v2.0.0".form
         /// <param name="config">The configuration.</param>
         /// <param name="installedPackage">The installed package.</param>
         /// <param name="pkgInfo">The package information.</param>
-        private void remove_shim_directors(ChocolateyConfiguration config, IPackage installedPackage, ChocolateyPackageInformation pkgInfo)
+        private void remove_shim_directors(ChocolateyConfiguration config, IPackage installedPackage)
         {
             var pkgInstallPath = get_install_directory(config, installedPackage);
 
@@ -1290,21 +1318,35 @@ Side by side installations are deprecated and is pending removal in v2.0.0".form
         public virtual ConcurrentDictionary<string, PackageResult> uninstall_run(ChocolateyConfiguration config, Action<PackageResult> continueAction, bool performAction, Action<PackageResult> beforeUninstallAction = null)
         {
             var packageUninstalls = new ConcurrentDictionary<string, PackageResult>(StringComparer.InvariantCultureIgnoreCase);
+            var packagesModified = new ConcurrentDictionary<string, PackageResult>(StringComparer.InvariantCultureIgnoreCase);
 
             SemanticVersion version = config.Version != null ? new SemanticVersion(config.Version) : null;
-            var packageManager = NugetCommon.GetPackageManager(config, _nugetLogger, _packageDownloader,
-                                                               installSuccessAction: null,
-                                                               uninstallSuccessAction: (e) =>
-                                                                   {
-                                                                       var pkg = e.Package;
-                                                                       "chocolatey".Log().Info(ChocolateyLoggers.Important, " {0} has been successfully uninstalled.".format_with(pkg.Id));
-                                                                   },
-                                                               addUninstallHandler: true);
-
-            var loopCount = 0;
-            packageManager.PackageUninstalling += (s, e) =>
+            var packageManager = NugetCommon.GetPackageManager(
+                config,
+                _nugetLogger,
+                _packageDownloader,
+                installSuccessAction: null,
+                uninstallSuccessAction: (e) =>
                 {
                     var pkg = e.Package;
+                    "chocolatey".Log().Info(ChocolateyLoggers.Important, " {0} has been successfully uninstalled.".format_with(pkg.Id));
+                },
+                addUninstallHandler: true);
+
+            var loopCount = 0;
+
+            packageManager.PackageUninstalling += (s, e) =>
+                {
+                    // Soundness: any code called here must avoid calling packageManager methods for
+                    // InstallPackage() and UninstallPackage(), or in some other way handle the
+                    // unbounded recursion doing so would create.
+                    var pkg = e.Package;
+
+                    // Errors thrown during here have been known to cause very strange
+                    // NuGet / LINQ exceptions to be thrown during later calls to seemingly unrelated
+                    // code paths. Debug this event handler if you see strange errors, such as
+                    // complaints about InternalsVisibleTo and strong name signing.
+                    backup_and_before_modify(pkg, config, beforeUninstallAction, packagesModified);
 
                     // TODO: Removal special handling for SxS packages once we hit v2.0.0
 
@@ -1331,8 +1373,8 @@ Side by side installations are deprecated and is pending removal in v2.0.0".form
                     }
 
                     // is this the latest version, have you passed --sxs, or is this a side-by-side install? This is the only way you get through to the continue action.
-                    var latestVersion = packageManager.LocalRepository.FindPackage(e.Package.Id);
-                    var pkgInfo = _packageInfoService.get_package_information(e.Package);
+                    var latestVersion = packageManager.LocalRepository.FindPackage(pkg.Id);
+                    var pkgInfo = _packageInfoService.get_package_information(pkg);
                     if (latestVersion.Version == pkg.Version || config.AllowMultipleVersions || (pkgInfo != null && pkgInfo.IsSideBySide))
                     {
                         packageResult.Messages.Add(new ResultMessage(ResultType.Debug, ApplicationParameters.Messages.ContinueChocolateyAction));
@@ -1343,6 +1385,16 @@ Side by side installations are deprecated and is pending removal in v2.0.0".form
                         //todo: #2578 allow cleaning of pkgstore files
                     }
                 };
+
+            packageManager.PackageUninstalled += (sender, eventArgs) =>
+            {
+                var pkg = eventArgs.Package;
+                var pkgInfo = _packageInfoService.get_package_information(pkg);
+
+                ensure_nupkg_is_removed(pkg, pkgInfo);
+                remove_installation_files(pkg, pkgInfo);
+                remove_cache_for_package(config, pkg);
+            };
 
             // if we are uninstalling a package and not forcing dependencies,
             // look to see if the user is missing the actual package they meant
@@ -1500,21 +1552,7 @@ Side by side installations are deprecated and is pending removal in v2.0.0".form
                                 packageVersion.Id, packageVersion.Version.to_string())
                                 )
                             {
-                                if (beforeUninstallAction != null)
-                                {
-                                    // guessing this is not added so that it doesn't fail the action if an error is recorded?
-                                    //var currentPackageResult = packageUninstalls.GetOrAdd(packageName, new PackageResult(packageVersion, get_install_directory(config, packageVersion)));
-                                    var currentPackageResult = new PackageResult(packageVersion, get_install_directory(config, packageVersion));
-                                    beforeUninstallAction(currentPackageResult);
-                                }
-                                ensure_package_files_have_compatible_attributes(config, packageVersion, pkgInfo);
-                                rename_legacy_package_version(config, packageVersion, pkgInfo);
-                                remove_rollback_directory_if_exists(packageName);
-                                backup_existing_version(config, packageVersion, pkgInfo);
                                 packageManager.UninstallPackage(packageVersion.Id.to_lower(), forceRemove: config.Force, removeDependencies: config.ForceDependencies, version: packageVersion.Version);
-                                ensure_nupkg_is_removed(packageVersion, pkgInfo);
-                                remove_installation_files(packageVersion, pkgInfo);
-                                remove_cache_for_package(config, packageVersion);
                             }
                         }
                         catch (Exception ex)
@@ -1546,6 +1584,87 @@ Side by side installations are deprecated and is pending removal in v2.0.0".form
             config.reset_config(removeBackup: true);
 
             return packageUninstalls;
+        }
+
+        /// <summary>
+        /// This method should be called before any modifications are made to a package.
+        /// Typically this should be injected into the IPackageManager's Installing and Uninstalling events
+        /// in order to handle both installation and uninstallation of dependencies as well as the primary
+        /// packages.
+        /// </summary>
+        /// <param name="package">The package currently being modified. For IPackageManager event handlers, this will be the eventArgs.Package property.</param>
+        /// <param name="config">The current configuration.</param>
+        /// <param name="beforeModifyAction">Any action to run before performing backup operations. Typically this is an invocation of the chocolateyBeforeModify script.</param>
+        /// <param name="packagesModified">Dictionary to add any modified packages' packageResults to.</param>
+        protected virtual void backup_and_before_modify(
+            IPackage package,
+            ChocolateyConfiguration config,
+            Action<PackageResult> beforeModifyAction,
+            ConcurrentDictionary<string, PackageResult> packagesModified)
+        {
+            try
+            {
+                var installDirectory = get_install_directory(config, package);
+
+                if (installDirectory != null && !packagesModified.ContainsKey(package.Id))
+                {
+                    // Ensure we have the correct package metadata to pass to the beforeModify handlers.
+                    // The given IPackage can have the wrong version if NuGet is running InstallPackage()
+                    // without first running UninstallPackage(), it will pass in the package being installed
+                    // or upgraded to, not the package it's installing over the top of. This has been
+                    // observed when calling `choco install` and an already-installed dependency needs to
+                    // be upgraded to satisfy the new package's dependency requirements.
+                    var nugetFileSystem = NugetCommon.GetNuGetFileSystem(config, _nugetLogger);
+                    var localPackage = NugetCommon
+                        .GetLocalRepository(NugetCommon.GetPathResolver(config, nugetFileSystem), nugetFileSystem, _nugetLogger)
+                        .FindPackagesById(package.Id)
+                        .OrderByDescending(p => p.Version)
+                        .FirstOrDefault();
+                    var packageResult = new PackageResult(localPackage, installDirectory);
+
+                    // Only run the beforeModify / backup if this handler was the one to add the result to the dictionary,
+                    // so we ensure it doesn't run duplicate actions.
+                    if (packagesModified.TryAdd(package.Id, packageResult))
+                    {
+                        // if this is an already installed package we're modifying, ensure we run its beforeModify script and back it up properly.
+                        // Check the package ID isn't already in the dictionary of packages that we've modified so we don't run a beforeModify
+                        // more than once.
+                        if (beforeModifyAction != null)
+                        {
+                            "chocolatey".Log().Debug("Running beforeModify step for '{0}'", package.Id);
+                            beforeModifyAction(packageResult);
+                        }
+
+                        "chocolatey".Log().Debug("Backing up package files for '{0}'", package.Id);
+
+                        backup_existing_package_files(config, package);
+                    }
+                }
+            }
+            catch (Exception error)
+            {
+                // If there's failures here, NuGet might report very strange things when it tries to run other operations.
+                // Try starting here and placing breakpoints to determine if we're causing errors here.
+                "chocolatey".Log().Error("Failed to run backup or beforeModify steps for package '{0}': {1}", package.Id, error.Message);
+                "chocolatey".Log().Trace(error.StackTrace);
+            }
+        }
+
+        /// <summary>
+        /// Takes a backup of the existing package files, optionally pre-checking the file attributes and any locked files.
+        /// </summary>
+        /// <param name="config"></param>
+        /// <param name="package"></param>
+        /// <param name="ignoreAttributes"></param>
+        private void backup_existing_package_files(ChocolateyConfiguration config, IPackage package)
+        {
+            var packageInformation = _packageInfoService.get_package_information(package);
+
+            remove_rollback_directory_if_exists(package.Id);
+            ensure_package_files_have_compatible_attributes(config, package, packageInformation);
+            rename_legacy_package_version(config, package, packageInformation);
+            backup_existing_version(config, package, packageInformation);
+            remove_shim_directors(config, package);
         }
 
         /// <summary>

--- a/src/chocolatey/infrastructure.app/services/PythonService.cs
+++ b/src/chocolatey/infrastructure.app/services/PythonService.cs
@@ -338,6 +338,11 @@ namespace chocolatey.infrastructure.app.services
 
         public ConcurrentDictionary<string, PackageResult> install_run(ChocolateyConfiguration config, Action<PackageResult> continueAction)
         {
+            return install_run(config, continueAction, beforeModifyAction: null);
+        }
+
+        public ConcurrentDictionary<string, PackageResult> install_run(ChocolateyConfiguration config, Action<PackageResult> continueAction, Action<PackageResult> beforeModifyAction)
+        {
             set_executable_path_if_not_set();
             var args = build_args(config, _installArguments);
             var packageResults = new ConcurrentDictionary<string, PackageResult>(StringComparer.InvariantCultureIgnoreCase);

--- a/src/chocolatey/infrastructure.app/services/RubyGemsService.cs
+++ b/src/chocolatey/infrastructure.app/services/RubyGemsService.cs
@@ -197,6 +197,11 @@ namespace chocolatey.infrastructure.app.services
 
         public ConcurrentDictionary<string, PackageResult> install_run(ChocolateyConfiguration config, Action<PackageResult> continueAction)
         {
+            return install_run(config, continueAction, beforeModifyAction: null);
+        }
+
+        public ConcurrentDictionary<string, PackageResult> install_run(ChocolateyConfiguration config, Action<PackageResult> continueAction, Action<PackageResult> beforeModifyAction)
+        {
             var packageResults = new ConcurrentDictionary<string, PackageResult>(StringComparer.InvariantCultureIgnoreCase);
             var args = ExternalCommandArgsBuilder.build_arguments(config, _installArguments);
 

--- a/src/chocolatey/infrastructure.app/services/WebPiService.cs
+++ b/src/chocolatey/infrastructure.app/services/WebPiService.cs
@@ -215,6 +215,11 @@ The `webpi` source is deprecated and will be removed in Chocolatey v2.0.0.
 
         public ConcurrentDictionary<string, PackageResult> install_run(ChocolateyConfiguration config, Action<PackageResult> continueAction)
         {
+            return install_run(config, continueAction, beforeModifyAction: null);
+        }
+
+        public ConcurrentDictionary<string, PackageResult> install_run(ChocolateyConfiguration config, Action<PackageResult> continueAction, Action<PackageResult> beforeModifyAction)
+        {
             write_deprecation_warning();
             var packageResults = new ConcurrentDictionary<string, PackageResult>(StringComparer.InvariantCultureIgnoreCase);
             var args = ExternalCommandArgsBuilder.build_arguments(config, _installArguments);

--- a/src/chocolatey/infrastructure.app/services/WindowsFeatureService.cs
+++ b/src/chocolatey/infrastructure.app/services/WindowsFeatureService.cs
@@ -259,6 +259,11 @@ namespace chocolatey.infrastructure.app.services
 
         public ConcurrentDictionary<string, PackageResult> install_run(ChocolateyConfiguration config, Action<PackageResult> continueAction)
         {
+            return install_run(config, continueAction, beforeModifyAction: null);
+        }
+
+        public ConcurrentDictionary<string, PackageResult> install_run(ChocolateyConfiguration config, Action<PackageResult> continueAction, Action<PackageResult> beforeModifyAction)
+        {
             set_executable_path_if_not_set();
             var args = build_args(config, _installArguments);
             var packageResults = new ConcurrentDictionary<string, PackageResult>(StringComparer.InvariantCultureIgnoreCase);


### PR DESCRIPTION
## Description Of Changes

- Remove manual backup of package files and run of beforeModify script for the target package
- Inject backup and beforeModify actions into the IPackageManager's Installing and Uninstalling actions to ensure that these happen for every package being changed, even for dependencies which are changing during a `choco install` operation.

## Motivation and Context

This improves the overall soundness of our package operations, and fixes an issue where updating Chocolatey licensed packages can trip over the chocolatey-agent package if it ends up being updated during processing of dependencies (for instance, by updating one of _its_ dependencies outside of its currently permitted version range, while a newer agent package is available that will work with the newer dependency version.

## Testing

1. Run the unit tests
2. Test out the failing test case with chocolatey-agent upgrade from choco 1.x (this PR build) and current stable agent, licensed extension, GUI, and gui extension to choco v2.x alpha and alpha releases of licensed components and GUI by upgrading the `chocolateygui.extension` package. With this change, the upgrade should correctly run the chocolatey-agent beforeModify script and succeed smoothly.

There are a couple unit tests I'd still like to add, but the currently-added ones cover the main priority here at the moment.

### Operating Systems Testing

Win10, Win11

## Change Types Made
<!-- Tick the boxes for the type of changes that have been made -->

* [x] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [x] Tests to cover my changes, have been added.
* [x] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue

Fixes #1092

<!-- PLEASE REMOVE ALL COMMENTS BEFORE SUBMITTING -->
