### PR TITLE
(maint) Use specific version for dependencies

### DIFF
--- a/src/chocolatey.tests.integration/context/dependencies/hasdependency/2.0.1/hasdependency.nuspec
+++ b/src/chocolatey.tests.integration/context/dependencies/hasdependency/2.0.1/hasdependency.nuspec
@@ -13,7 +13,7 @@
     <copyright />
     <tags>hasdependency admin</tags>
     <dependencies>
-      <dependency id="isdependency" />
+      <dependency id="isdependency" version="1.0.0" />
     </dependencies>
   </metadata>
   <files>

--- a/tests/chocolatey-tests/commands/testnuspecs/basic-dependencies/basic-dependencies.nuspec
+++ b/tests/chocolatey-tests/commands/testnuspecs/basic-dependencies/basic-dependencies.nuspec
@@ -7,7 +7,7 @@
     <authors>Author</authors>
     <description>Not empty</description>
     <dependencies>
-      <dependency id="basic" />
+      <dependency id="basic" version="1.0.0" />
     </dependencies>
   </metadata>
   <files />

--- a/tests/chocolatey-tests/commands/testnuspecs/cdata/cdata.nuspec
+++ b/tests/chocolatey-tests/commands/testnuspecs/cdata/cdata.nuspec
@@ -10,7 +10,7 @@
     be valid even when & and < is being used.
     ]]></description>
     <dependencies>
-      <dependency id="basic" />
+      <dependency id="basic" version="1.0.0" />
     </dependencies>
   </metadata>
   <files />

--- a/tests/chocolatey-tests/commands/testnuspecs/description-long.nuspec
+++ b/tests/chocolatey-tests/commands/testnuspecs/description-long.nuspec
@@ -20,7 +20,7 @@ Nulla facilisi nullam vehicula ipsum a arcu cursus vitae. Netus et malesuada fam
 Leo vel orci porta non pulvinar neque laoreet suspendisse. Sagittis eu volutpat odio facilisis mauris. Sollicitudin ac orci phasellus egestas tellus rutrum tellus. Tellus integer feugiat scelerisque varius morbi. Tincidunt praesent semper feugiat nibh. Enim nec dui nunc mattis enim ut. Sit amet nisl purus in mollis. Eget duis at tellus at urna condimentum mattis pellentesque. Amet mattis vulputate enim nulla aliquet porttitor lacus luctus. Porttitor lacus luctus accumsan tortor posuere ac. Tristique senectus et netus et malesuada fames. Auctor urna nunc id cursus metus aliquam eleifend. Amet porttitor eget dolor morbi non arcu risus quis. Eu non diam phasellus vestibulum lorem sed risus ultricies tristique. Facilisis gravida neque convallis a cras semper auctor neque. Praesent semper feugiat nibh sed pulvinar proin gravida hendrerit. Sit amet massa vitae tortor.
 </description>
     <dependencies>
-      <dependency id="basic" />
+      <dependency id="basic" version="1.0.0" />
     </dependencies>
   </metadata>
   <files />

--- a/tests/chocolatey-tests/commands/testnuspecs/empty-requireLicenseAcceptance.nuspec
+++ b/tests/chocolatey-tests/commands/testnuspecs/empty-requireLicenseAcceptance.nuspec
@@ -8,7 +8,7 @@
     <requireLicenseAcceptance></requireLicenseAcceptance>
     <description>Not empty</description>
     <dependencies>
-      <dependency id="basic" />
+      <dependency id="basic" version="1.0.0" />
     </dependencies>
   </metadata>
   <files />

--- a/tests/chocolatey-tests/commands/testnuspecs/empty.nuspec
+++ b/tests/chocolatey-tests/commands/testnuspecs/empty.nuspec
@@ -14,7 +14,7 @@
     <bugTrackerUrl></bugTrackerUrl>
     <description>Test Description</description>
     <dependencies>
-      <dependency id="basic" />
+      <dependency id="basic" version="1.0.0" />
     </dependencies>
   </metadata>
   <files />

--- a/tests/chocolatey-tests/commands/testnuspecs/invalid-bugtrackerurl.nuspec
+++ b/tests/chocolatey-tests/commands/testnuspecs/invalid-bugtrackerurl.nuspec
@@ -8,7 +8,7 @@
     <bugTrackerUrl>invalid bug tracker url</bugTrackerUrl>
     <description>Test Description</description>
     <dependencies>
-      <dependency id="basic" />
+      <dependency id="basic" version="1.0.0" />
     </dependencies>
   </metadata>
   <files />

--- a/tests/chocolatey-tests/commands/testnuspecs/invalid-character-and.nuspec
+++ b/tests/chocolatey-tests/commands/testnuspecs/invalid-character-and.nuspec
@@ -7,7 +7,7 @@
     <authors>Author</authors>
     <description>This metadata file contains the invalid character &.</description>
     <dependencies>
-      <dependency id="basic" />
+      <dependency id="basic" version="1.0.0" />
     </dependencies>
   </metadata>
   <files />

--- a/tests/chocolatey-tests/commands/testnuspecs/invalid-character-lesser.nuspec
+++ b/tests/chocolatey-tests/commands/testnuspecs/invalid-character-lesser.nuspec
@@ -7,7 +7,7 @@
     <authors>Author</authors>
     <description>This metadata file contains the invalid character <.</description>
     <dependencies>
-      <dependency id="basic" />
+      <dependency id="basic" version="1.0.0" />
     </dependencies>
   </metadata>
   <files />

--- a/tests/chocolatey-tests/commands/testnuspecs/invalid-docsurl.nuspec
+++ b/tests/chocolatey-tests/commands/testnuspecs/invalid-docsurl.nuspec
@@ -8,7 +8,7 @@
     <docsUrl>invalid docs url</docsUrl>
     <description>Test Description</description>
     <dependencies>
-      <dependency id="basic" />
+      <dependency id="basic" version="1.0.0" />
     </dependencies>
   </metadata>
   <files />

--- a/tests/chocolatey-tests/commands/testnuspecs/invalid-iconurl.nuspec
+++ b/tests/chocolatey-tests/commands/testnuspecs/invalid-iconurl.nuspec
@@ -8,7 +8,7 @@
     <iconUrl>invalid icon url</iconUrl>
     <description>Test Description</description>
     <dependencies>
-      <dependency id="basic" />
+      <dependency id="basic" version="1.0.0" />
     </dependencies>
   </metadata>
   <files />

--- a/tests/chocolatey-tests/commands/testnuspecs/invalid-id.nuspec
+++ b/tests/chocolatey-tests/commands/testnuspecs/invalid-id.nuspec
@@ -7,7 +7,7 @@
     <authors>Author</authors>
     <description>Not empty</description>
     <dependencies>
-      <dependency id="basic" />
+      <dependency id="basic" version="1.0.0" />
     </dependencies>
   </metadata>
   <files />

--- a/tests/chocolatey-tests/commands/testnuspecs/invalid-licenseUrl.nuspec
+++ b/tests/chocolatey-tests/commands/testnuspecs/invalid-licenseUrl.nuspec
@@ -8,7 +8,7 @@
     <licenseUrl>invalid license url</licenseUrl>
     <description>Test Description</description>
     <dependencies>
-      <dependency id="basic" />
+      <dependency id="basic" version="1.0.0" />
     </dependencies>
   </metadata>
   <files />

--- a/tests/chocolatey-tests/commands/testnuspecs/invalid-mailinglisturl.nuspec
+++ b/tests/chocolatey-tests/commands/testnuspecs/invalid-mailinglisturl.nuspec
@@ -8,7 +8,7 @@
     <mailingListUrl>invalid mailing list url</mailingListUrl>
     <description>Test Description</description>
     <dependencies>
-      <dependency id="basic" />
+      <dependency id="basic" version="1.0.0" />
     </dependencies>
   </metadata>
   <files />

--- a/tests/chocolatey-tests/commands/testnuspecs/invalid-projectsourceurl.nuspec
+++ b/tests/chocolatey-tests/commands/testnuspecs/invalid-projectsourceurl.nuspec
@@ -8,7 +8,7 @@
     <projectSourceUrl>invalid project source url</projectSourceUrl>
     <description>Test Description</description>
     <dependencies>
-      <dependency id="basic" />
+      <dependency id="basic" version="1.0.0" />
     </dependencies>
   </metadata>
   <files />

--- a/tests/chocolatey-tests/commands/testnuspecs/invalid-projecturl.nuspec
+++ b/tests/chocolatey-tests/commands/testnuspecs/invalid-projecturl.nuspec
@@ -8,7 +8,7 @@
     <projectUrl>invalid project url</projectUrl>
     <description>Test Description</description>
     <dependencies>
-      <dependency id="basic" />
+      <dependency id="basic" version="1.0.0" />
     </dependencies>
   </metadata>
   <files />

--- a/tests/chocolatey-tests/commands/testnuspecs/invalid-requireLicenseAcceptance.nuspec
+++ b/tests/chocolatey-tests/commands/testnuspecs/invalid-requireLicenseAcceptance.nuspec
@@ -8,7 +8,7 @@
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <description>Test Description</description>
     <dependencies>
-      <dependency id="basic" />
+      <dependency id="basic" version="1.0.0" />
     </dependencies>
   </metadata>
   <files />

--- a/tests/chocolatey-tests/commands/testnuspecs/invalid-version.nuspec
+++ b/tests/chocolatey-tests/commands/testnuspecs/invalid-version.nuspec
@@ -7,7 +7,7 @@
     <authors>Author</authors>
     <description>Not empty</description>
     <dependencies>
-      <dependency id="basic" />
+      <dependency id="basic" version="1.0.0" />
     </dependencies>
   </metadata>
   <files />

--- a/tests/chocolatey-tests/commands/testnuspecs/missing.nuspec
+++ b/tests/chocolatey-tests/commands/testnuspecs/missing.nuspec
@@ -3,7 +3,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <dependencies>
-      <dependency id="basic" />
+      <dependency id="basic" version="1.0.0" />
     </dependencies>
   </metadata>
   <files />

--- a/tests/chocolatey-tests/commands/testnuspecs/required.nuspec
+++ b/tests/chocolatey-tests/commands/testnuspecs/required.nuspec
@@ -7,7 +7,7 @@
     <authors></authors>
     <description></description>
     <dependencies>
-      <dependency id="basic" />
+      <dependency id="basic" version="1.0.0" />
     </dependencies>
   </metadata>
   <files />

--- a/tests/chocolatey-tests/commands/testpackages/chocolatey-dummy-package/1.0.0/chocolatey-dummy-package.nuspec
+++ b/tests/chocolatey-tests/commands/testpackages/chocolatey-dummy-package/1.0.0/chocolatey-dummy-package.nuspec
@@ -12,7 +12,7 @@
     <summary>This is a purposely empty dummy package for testing choco push functionality</summary>
     <description>This is a purposely empty dummy package for testing choco push functionality</description>
     <dependencies>
-      <dependency id="chocolatey" />
+      <dependency id="chocolatey" version="0.10.15" />
     </dependencies>
   </metadata>
 </package>

--- a/tests/chocolatey-tests/commands/testpackages/too-long-description/1.0.0/too-long-description.nuspec
+++ b/tests/chocolatey-tests/commands/testpackages/too-long-description/1.0.0/too-long-description.nuspec
@@ -24,7 +24,7 @@ Nulla facilisi nullam vehicula ipsum a arcu cursus vitae. Netus et malesuada fam
 
 Leo vel orci porta non pulvinar neque laoreet suspendisse. Sagittis eu volutpat odio facilisis mauris. Sollicitudin ac orci phasellus egestas tellus rutrum tellus. Tellus integer feugiat scelerisque varius morbi. Tincidunt praesent semper feugiat nibh. Enim nec dui nunc mattis enim ut. Sit amet nisl purus in mollis. Eget duis at tellus at urna condimentum mattis pellentesque. Amet mattis vulputate enim nulla aliquet porttitor lacus luctus. Porttitor lacus luctus accumsan tortor posuere ac. Tristique senectus et netus et malesuada fames. Auctor urna nunc id cursus metus aliquam eleifend. Amet porttitor eget dolor morbi non arcu risus quis. Eu non diam phasellus vestibulum lorem sed risus ultricies tristique. Facilisis gravida neque convallis a cras semper auctor neque. Praesent semper feugiat nibh sed pulvinar proin gravida hendrerit. Sit amet massa vitae tortor.</description>
     <dependencies>
-      <dependency id="chocolatey" />
+      <dependency id="chocolatey" version="0.10.15" />
     </dependencies>
   </metadata>
 </package>

--- a/tests/chocolatey-tests/commands/testpackages/too-long-title/1.0.0/too-long-title.nuspec
+++ b/tests/chocolatey-tests/commands/testpackages/too-long-title/1.0.0/too-long-title.nuspec
@@ -12,7 +12,7 @@
     <summary>This is a purposely empty dummy package for testing choco push functionality</summary>
     <description>This is a purposely empty dummy package for testing choco push functionality</description>
     <dependencies>
-      <dependency id="chocolatey" />
+      <dependency id="chocolatey" version="0.10.15" />
     </dependencies>
   </metadata>
 </package>

--- a/tests/packages/circulardependency1/circulardependency1.nuspec
+++ b/tests/packages/circulardependency1/circulardependency1.nuspec
@@ -10,7 +10,7 @@
     <description>Circular dependencies are not supported by Chocolatey. `choco install` should fail when it encounters them.
     </description>
     <dependencies>
-      <dependency id="circulardependency2" />
+      <dependency id="circulardependency2" version="0.0.1" />
     </dependencies>
   </metadata>
 </package>

--- a/tests/packages/circulardependency2/circulardependency2.nuspec
+++ b/tests/packages/circulardependency2/circulardependency2.nuspec
@@ -10,7 +10,7 @@
     <description>Circular dependencies are not supported by Chocolatey. `choco install` should fail when it encounters them.
     </description>
     <dependencies>
-      <dependency id="circulardependency1" />
+      <dependency id="circulardependency1" version="0.0.1" />
     </dependencies>
   </metadata>
 </package>


### PR DESCRIPTION
## Description Of Changes

This commit adds a specific version number in each dependency in each of the nuspec files.  This is necessary, since moving into new NuGet.Client assemblies, the version number is a required field in the dependency element, and we have found issues where repository managers don't correctly show/find the dependencies on a V3 feed, when a version isn't available in this element.  There may be other work that needs to be done in Chocolatey to account for this new requirement, but updating all our internal testing packages to have a version number for each dependency will ensure that some automated tests work as expected.

## Motivation and Context

Some end to end tests are failing when using the V3 feed, since not all dependencies are known, and therefore fail to be installed.

## Testing

Once pushed, these new packages will be part of the Test-Kitchen execution, and will be tested there.

### Operating Systems Testing

N/A

## Change Types Made

* [x] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [ ] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue

N/A