### PR TITLE
(maint) Fix logical operation to shortcircuit

### DIFF
--- a/src/chocolatey/infrastructure.app/nuget/NugetList.cs
+++ b/src/chocolatey/infrastructure.app/nuget/NugetList.cs
@@ -188,8 +188,8 @@ namespace chocolatey.infrastructure.app.nuget
                     }
                     else
                     {
-                        configuration.Prerelease |= version != null && version.IsPrerelease;
-                        configuration.AllVersions |= version != null;
+                        configuration.Prerelease = configuration.Prerelease || (version != null && version.IsPrerelease);
+                        configuration.AllVersions = configuration.AllVersions || (version != null);
 
                         var tempResults = await repositoryResources.listResource.ListAsync(searchTermLower, configuration.Prerelease, configuration.AllVersions, false, nugetLogger, CancellationToken.None);
                         var enumerator = tempResults.GetEnumeratorAsync();


### PR DESCRIPTION
## Description Of Changes

This merge request fixes a logical operation that had previously been
added to make use of the short circuit variant of the same logical
expression. It changes the compound assignment of `|=` (which is equivalent to `x = x | y|) to make use of the short circuit logic `x = x || y` instead.

## Motivation and Context

This is done to prevent the need to evaluate both of the statements
on each side of the or operator in the cases where pre release is already
marked as true, or when all versions is true already.

## Testing

There are no functional difference in the results in this case, as such no additional testing has been done.

### Operating Systems Testing

- Windows 10/11

## Change Types Made

* [x] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [ ] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue

N/A
