### PR TITLE
(#508) Control packages used for requiredPackageIds

### DIFF
--- a/src/chocolatey.tests.integration/scenarios/UpgradeScenarios.cs
+++ b/src/chocolatey.tests.integration/scenarios/UpgradeScenarios.cs
@@ -3398,6 +3398,329 @@ namespace chocolatey.tests.integration.scenarios
             }
         }
 
+        public class when_upgrading_a_dependency_with_parent_being_pinned_and_depends_on_a_range_less_than_upgrade_version : ScenariosBase
+        {
+            public override void Context()
+            {
+                base.Context();
+                Configuration.PackageNames = Configuration.Input = "isdependency";
+                Scenario.add_packages_to_source_location(Configuration, "hasdependency.*" + NuGetConstants.PackageExtension);
+                Scenario.add_packages_to_source_location(Configuration, "isdependency.*" + NuGetConstants.PackageExtension);
+                Scenario.add_packages_to_source_location(Configuration, "isexactversiondependency*" + NuGetConstants.PackageExtension);
+                Scenario.install_package(Configuration, "isdependency", "1.0.0");
+                Configuration.PinPackage = true;
+                Scenario.install_package(Configuration, "hasdependency", "1.0.0");
+                Configuration.PinPackage = false;
+            }
+
+            public override void Because()
+            {
+                Results = Service.upgrade_run(Configuration);
+            }
+
+            [Fact]
+            public void should_upgrade_the_package_to_highest_version_in_range()
+            {
+                var packageFile = Path.Combine(Scenario.get_top_level(), "lib", "isdependency", "isdependency.nupkg");
+                using (var packageReader = new PackageArchiveReader(packageFile))
+                {
+                    packageReader.NuspecReader.GetVersion().to_string().ShouldEqual("1.1.0");
+                }
+            }
+
+            [Fact]
+            public void should_not_upgrade_parent_package()
+            {
+                var packageFile = Path.Combine(Scenario.get_top_level(), "lib", "hasdependency", "hasdependency.nupkg");
+                using (var packageReader = new PackageArchiveReader(packageFile))
+                {
+                    packageReader.NuspecReader.GetVersion().to_string().ShouldEqual("1.0.0");
+                }
+            }
+
+            [Fact]
+            public void should_not_upgrade_the_exact_version_dependency()
+            {
+                var packageFile = Path.Combine(Scenario.get_top_level(), "lib", "isexactversiondependency", "isexactversiondependency.nupkg");
+                using (var packageReader = new PackageArchiveReader(packageFile))
+                {
+                    packageReader.NuspecReader.GetVersion().to_string().ShouldEqual("1.0.0");
+                }
+            }
+
+            [Fact]
+            public void should_contain_a_message_that_everything_upgraded_successfully()
+            {
+                bool expectedMessage = false;
+                foreach (var message in MockLogger.MessagesFor(LogLevel.Warn).or_empty_list_if_null())
+                {
+                    if (message.Contains("upgraded 1/1")) expectedMessage = true;
+                }
+
+                expectedMessage.ShouldBeTrue();
+            }
+
+            [Fact]
+            public void should_have_a_successful_package_result()
+            {
+                foreach (var packageResult in Results)
+                {
+                    packageResult.Value.Success.ShouldBeTrue();
+                }
+            }
+
+            [Fact]
+            public void should_not_have_inconclusive_package_result()
+            {
+                foreach (var packageResult in Results)
+                {
+                    packageResult.Value.Inconclusive.ShouldBeFalse();
+                }
+            }
+
+            [Fact]
+            public void should_not_have_warning_package_result()
+            {
+                foreach (var packageResult in Results)
+                {
+                    packageResult.Value.Warning.ShouldBeFalse();
+                }
+            }
+
+            [Fact]
+            public void should_have_outputted_conflicting_upgrade_message()
+            {
+                bool expectedMessage = false;
+                foreach (var message in MockLogger.MessagesFor(LogLevel.Warn).or_empty_list_if_null())
+                {
+                    if (message.Contains("One or more unresolved package dependency constraints detected in the Chocolatey lib folder")
+                        && message.Contains("hasdependency 1.0.0 constraint: isdependency (>= 1.0.0 && < 2.0.0)"))
+                    {
+                        expectedMessage = true;
+                    }
+                }
+
+                expectedMessage.ShouldBeTrue();
+            }
+        }
+
+        public class when_upgrading_a_dependency_with_parent_being_pinned_and_depends_on_a_range_less_than_upgrade_version_and_has_missing_dependency : ScenariosBase
+        {
+            public override void Context()
+            {
+                base.Context();
+                Configuration.PackageNames = Configuration.Input = "isdependency";
+                Scenario.add_packages_to_source_location(Configuration, "hasdependency.*" + NuGetConstants.PackageExtension);
+                Scenario.add_packages_to_source_location(Configuration, "isdependency.*" + NuGetConstants.PackageExtension);
+                Scenario.add_packages_to_source_location(Configuration, "isexactversiondependency*" + NuGetConstants.PackageExtension);
+                Scenario.install_package(Configuration, "isdependency", "1.0.0");
+                Configuration.PinPackage = true;
+                Configuration.IgnoreDependencies = true;
+                Scenario.install_package(Configuration, "hasdependency", "1.0.0");
+                Configuration.PinPackage = false;
+                Configuration.IgnoreDependencies = false;
+            }
+
+            public override void Because()
+            {
+                Results = Service.upgrade_run(Configuration);
+            }
+
+            [Fact]
+            public void should_upgrade_the_package_to_highest_version_in_range()
+            {
+                var packageFile = Path.Combine(Scenario.get_top_level(), "lib", "isdependency", "isdependency.nupkg");
+                using (var packageReader = new PackageArchiveReader(packageFile))
+                {
+                    packageReader.NuspecReader.GetVersion().to_string().ShouldEqual("1.1.0");
+                }
+            }
+
+            [Fact]
+            public void should_not_upgrade_parent_package()
+            {
+                var packageFile = Path.Combine(Scenario.get_top_level(), "lib", "hasdependency", "hasdependency.nupkg");
+                using (var packageReader = new PackageArchiveReader(packageFile))
+                {
+                    packageReader.NuspecReader.GetVersion().to_string().ShouldEqual("1.0.0");
+                }
+            }
+
+            [Fact]
+            public void should_not_upgrade_the_exact_version_dependency()
+            {
+                var packageFile = Path.Combine(Scenario.get_top_level(), "lib", "isexactversiondependency", "isexactversiondependency.nupkg");
+                using (var packageReader = new PackageArchiveReader(packageFile))
+                {
+                    packageReader.NuspecReader.GetVersion().to_string().ShouldEqual("1.0.0");
+                }
+            }
+
+            [Fact]
+            public void should_contain_a_message_that_everything_upgraded_successfully()
+            {
+                bool expectedMessage = false;
+                foreach (var message in MockLogger.MessagesFor(LogLevel.Warn).or_empty_list_if_null())
+                {
+                    if (message.Contains("upgraded 2/2")) expectedMessage = true;
+                }
+
+                expectedMessage.ShouldBeTrue();
+            }
+
+            [Fact]
+            public void should_have_a_successful_package_result()
+            {
+                foreach (var packageResult in Results)
+                {
+                    packageResult.Value.Success.ShouldBeTrue();
+                }
+            }
+
+            [Fact]
+            public void should_not_have_inconclusive_package_result()
+            {
+                foreach (var packageResult in Results)
+                {
+                    packageResult.Value.Inconclusive.ShouldBeFalse();
+                }
+            }
+
+            [Fact]
+            public void should_not_have_warning_package_result()
+            {
+                foreach (var packageResult in Results)
+                {
+                    packageResult.Value.Warning.ShouldBeFalse();
+                }
+            }
+
+            [Fact]
+            public void should_have_outputted_conflicting_upgrade_message()
+            {
+                bool expectedMessage = false;
+                foreach (var message in MockLogger.MessagesFor(LogLevel.Warn).or_empty_list_if_null())
+                {
+                    if (message.Contains("One or more unresolved package dependency constraints detected in the Chocolatey lib folder")
+                        && message.Contains("hasdependency 1.0.0 constraint: isexactversiondependency (= 1.0.0)")
+                        && message.Contains("hasdependency 1.0.0 constraint: isdependency (>= 1.0.0 && < 2.0.0)"))
+                    {
+                        expectedMessage = true;
+                    }
+                }
+
+                expectedMessage.ShouldBeTrue();
+            }
+        }
+
+        public class when_upgrading_a_dependency_with_parent_has_different_pinned_dependency_and_depends_on_a_range_less_than_upgrade_version : ScenariosBase
+        {
+            public override void Context()
+            {
+                base.Context();
+                Configuration.PackageNames = Configuration.Input = "isdependency";
+                Scenario.add_packages_to_source_location(Configuration, "hasdependency.*" + NuGetConstants.PackageExtension);
+                Scenario.add_packages_to_source_location(Configuration, "isdependency.*" + NuGetConstants.PackageExtension);
+                Scenario.add_packages_to_source_location(Configuration, "isexactversiondependency*" + NuGetConstants.PackageExtension);
+                Scenario.install_package(Configuration, "isdependency", "1.0.0");
+                Configuration.PinPackage = true;
+                Scenario.install_package(Configuration, "isexactversiondependency", "1.0.0");
+                Configuration.PinPackage = false;
+                Scenario.install_package(Configuration, "hasdependency", "1.0.0");
+                Scenario.remove_packages_from_destination_location(Configuration, "hasdependency.2.0.1" + NuGetConstants.PackageExtension);
+            }
+
+            public override void Because()
+            {
+                Results = Service.upgrade_run(Configuration);
+            }
+
+            [Fact]
+            public void should_upgrade_the_package_to_highest_version_in_range()
+            {
+                var packageFile = Path.Combine(Scenario.get_top_level(), "lib", "isdependency", "isdependency.nupkg");
+                using (var packageReader = new PackageArchiveReader(packageFile))
+                {
+                    packageReader.NuspecReader.GetVersion().to_string().ShouldEqual("1.1.0");
+                }
+            }
+
+            [Fact]
+            public void should_not_upgrade_parent_package()
+            {
+                var packageFile = Path.Combine(Scenario.get_top_level(), "lib", "hasdependency", "hasdependency.nupkg");
+                using (var packageReader = new PackageArchiveReader(packageFile))
+                {
+                    packageReader.NuspecReader.GetVersion().to_string().ShouldEqual("1.0.0");
+                }
+            }
+
+            [Fact]
+            public void should_not_upgrade_the_exact_version_dependency()
+            {
+                var packageFile = Path.Combine(Scenario.get_top_level(), "lib", "isexactversiondependency", "isexactversiondependency.nupkg");
+                using (var packageReader = new PackageArchiveReader(packageFile))
+                {
+                    packageReader.NuspecReader.GetVersion().to_string().ShouldEqual("1.0.0");
+                }
+            }
+
+            [Fact]
+            public void should_contain_a_message_that_everything_upgraded_successfully()
+            {
+                bool expectedMessage = false;
+                foreach (var message in MockLogger.MessagesFor(LogLevel.Warn).or_empty_list_if_null())
+                {
+                    if (message.Contains("upgraded 1/1")) expectedMessage = true;
+                }
+
+                expectedMessage.ShouldBeTrue();
+            }
+
+            [Fact]
+            public void should_have_a_successful_package_result()
+            {
+                foreach (var packageResult in Results)
+                {
+                    packageResult.Value.Success.ShouldBeTrue();
+                }
+            }
+
+            [Fact]
+            public void should_not_have_inconclusive_package_result()
+            {
+                foreach (var packageResult in Results)
+                {
+                    packageResult.Value.Inconclusive.ShouldBeFalse();
+                }
+            }
+
+            [Fact]
+            public void should_not_have_warning_package_result()
+            {
+                foreach (var packageResult in Results)
+                {
+                    packageResult.Value.Warning.ShouldBeFalse();
+                }
+            }
+
+            [Fact]
+            public void should_have_outputted_conflicting_upgrade_message()
+            {
+                bool expectedMessage = false;
+                foreach (var message in MockLogger.MessagesFor(LogLevel.Warn).or_empty_list_if_null())
+                {
+                    if (message.Contains("One or more unresolved package dependency constraints detected in the Chocolatey lib folder")
+                        && message.Contains("hasdependency 1.0.0 constraint: isdependency (>= 1.0.0 && < 2.0.0)"))
+                    {
+                        expectedMessage = true;
+                    }
+                }
+
+                expectedMessage.ShouldBeTrue();
+            }
+        }
+
         public class when_upgrading_a_legacy_folder_dependency_with_parent_that_depends_on_a_range_less_than_upgrade_version : ScenariosBase
         {
             public override void Context()

--- a/src/chocolatey.tests.integration/scenarios/UpgradeScenarios.cs
+++ b/src/chocolatey.tests.integration/scenarios/UpgradeScenarios.cs
@@ -3721,6 +3721,109 @@ namespace chocolatey.tests.integration.scenarios
             }
         }
 
+        public class when_upgrading_a_dependency_while_ignoring_dependencies_and_parent_package_is_pinned : ScenariosBase
+        {
+            public override void Context()
+            {
+                base.Context();
+                Configuration.PackageNames = Configuration.Input = "isdependency";
+                Scenario.add_packages_to_source_location(Configuration, "hasdependency.*" + NuGetConstants.PackageExtension);
+                Scenario.add_packages_to_source_location(Configuration, "isdependency.*" + NuGetConstants.PackageExtension);
+                Scenario.add_packages_to_source_location(Configuration, "isexactversiondependency*" + NuGetConstants.PackageExtension);
+                Scenario.install_package(Configuration, "isdependency", "1.0.0");
+                Configuration.PinPackage = true;
+                Scenario.install_package(Configuration, "hasdependency", "1.0.0");
+                Configuration.PinPackage = false;
+                Configuration.IgnoreDependencies = true;
+            }
+
+            public override void Because()
+            {
+                Results = Service.upgrade_run(Configuration);
+            }
+
+            [Fact]
+            public void should_not_upgrade_the_package()
+            {
+                var packageFile = Path.Combine(Scenario.get_top_level(), "lib", "isdependency", "isdependency.nupkg");
+                using (var packageReader = new PackageArchiveReader(packageFile))
+                {
+                    packageReader.NuspecReader.GetVersion().to_string().ShouldEqual("1.0.0");
+                }
+            }
+
+            [Fact]
+            public void should_not_upgrade_parent_package()
+            {
+                var packageFile = Path.Combine(Scenario.get_top_level(), "lib", "hasdependency", "hasdependency.nupkg");
+                using (var packageReader = new PackageArchiveReader(packageFile))
+                {
+                    packageReader.NuspecReader.GetVersion().to_string().ShouldEqual("1.0.0");
+                }
+            }
+
+            [Fact]
+            public void should_not_upgrade_the_exact_version_dependency()
+            {
+                var packageFile = Path.Combine(Scenario.get_top_level(), "lib", "isexactversiondependency", "isexactversiondependency.nupkg");
+                using (var packageReader = new PackageArchiveReader(packageFile))
+                {
+                    packageReader.NuspecReader.GetVersion().to_string().ShouldEqual("1.0.0");
+                }
+            }
+
+            [Fact]
+            public void should_contain_a_message_that_nothing_was_upgraded()
+            {
+                bool expectedMessage = false;
+                foreach (var message in MockLogger.MessagesFor(LogLevel.Warn).or_empty_list_if_null())
+                {
+                    if (message.Contains("upgraded 0/1")) expectedMessage = true;
+                }
+
+                expectedMessage.ShouldBeTrue();
+            }
+
+            [Fact]
+            public void should_have_an_error_package_result()
+            {
+                foreach (var packageResult in Results)
+                {
+                    packageResult.Value.Success.ShouldBeFalse();
+                }
+            }
+
+            [Fact]
+            public void should_not_have_inconclusive_package_result()
+            {
+                foreach (var packageResult in Results)
+                {
+                    packageResult.Value.Inconclusive.ShouldBeFalse();
+                }
+            }
+
+            [Fact]
+            public void should_not_have_warning_package_result()
+            {
+                foreach (var packageResult in Results)
+                {
+                    packageResult.Value.Warning.ShouldBeFalse();
+                }
+            }
+
+            [Fact]
+            public void should_have_outputted_expected_error_message()
+            {
+                bool expectedMessage = false;
+                foreach (var message in MockLogger.MessagesFor(LogLevel.Error).or_empty_list_if_null())
+                {
+                    if (message.Contains("Unable to resolve dependency chain. This may be caused by a parent package depending on this package, try specifying a specific version to use or don't ignore any dependencies!")) expectedMessage = true;
+                }
+
+                expectedMessage.ShouldBeTrue();
+            }
+        }
+
         public class when_upgrading_a_legacy_folder_dependency_with_parent_that_depends_on_a_range_less_than_upgrade_version : ScenariosBase
         {
             public override void Context()


### PR DESCRIPTION
## Description Of Changes

This commit aims to address this problem by only passing the packages to the resolver context where there are no missing dependencies. This has fixed the issue mentioned above, and also the integration tests which were previously failing when the last attempt was made to address this problem:

https://github.com/chocolatey/choco/commit/6a13edc49de1c5627bf239f5a63eb37b0f297d62

## Motivation and Context

When resolving what packages need to be upgraded/installed, we were previously passing in a list of the currently installed local packages. This was used as an attempt to ensure that these packages remained being installed, after the operation was performed.  The side effect of this though was that the install/upgrade operation was too aggressive, and failed the installation/upgrade if an unrelated dependency was missing.

For example, if you were to install Chocolatey GUI (which takes a dependency on dotnetfx), and then you were to manually delete the dotnetfx package, and then attempt the installation of git (which doesn't take a dependency on dotnetfx), the install would fail saying that there was a missing constraint. However, this is an unrelated constraint to the package that is being installed, and therefore shouldn't happen like this.  The current production version of Chocolatey correctly installs git, without erroring on the lack of the dotnetfx package.

## Testing

1. Install Chocolatey GUI package
2. Manually delete the dotnetfx package
3. Install git package
4. This should succeed
5. Run all integration and unit tests

### Operating Systems Testing

- Windows 10

## Change Types Made

* [x] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [x] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue

- Relates to #508
- https://app.clickup.com/t/20540031/PROJ-494