### PR TITLE
(#508) Fix broken tests and tests marked as broken

### DIFF
--- a/src/chocolatey.tests.integration/scenarios/InstallScenarios.cs
+++ b/src/chocolatey.tests.integration/scenarios/InstallScenarios.cs
@@ -1327,7 +1327,7 @@ namespace chocolatey.tests.integration.scenarios
                 packageResult.Name.ShouldEqual(Configuration.Input);
             }
 
-            [Fact, Pending("Current version of the NuGet client library changes this to 1.0"), Broken]
+            [Fact]
             public void should_have_a_version_of_one_dot_zero_dot_zero()
             {
                 packageResult.Version.ShouldEqual("1.0.0");

--- a/src/chocolatey/infrastructure.app/nuget/NugetList.cs
+++ b/src/chocolatey/infrastructure.app/nuget/NugetList.cs
@@ -340,11 +340,14 @@ namespace chocolatey.infrastructure.app.nuget
             {
                 if (version is null)
                 {
+                    // We only need to force a lower case package name when we
+                    // are using our own repository optimization queries.
+                    var packageNameLower = packageName.to_lower();
                     var metadataList = new HashSet<IPackageSearchMetadata>();
 
                     foreach (var listResource in listResources)
                     {
-                        var package = listResource.PackageAsync(packageName, config.Prerelease, nugetLogger, CancellationToken.None).GetAwaiter().GetResult();
+                        var package = listResource.PackageAsync(packageNameLower, config.Prerelease, nugetLogger, CancellationToken.None).GetAwaiter().GetResult();
                         if (package != null)
                         {
                             metadataList.Add(package);

--- a/tests/chocolatey-tests/chocolatey.Tests.ps1
+++ b/tests/chocolatey-tests/chocolatey.Tests.ps1
@@ -189,7 +189,7 @@ Describe "Ensuring Chocolatey is correctly installed" -Tag Environment, Chocolat
     }
 
     # This is skipped when not run in CI because it modifies the local system.
-    Context 'License warning is worded properly' -Tag FossOnly, Broken -Skip:((-not $env:TEST_KITCHEN) -or (-not (Test-ChocolateyVersionEqualOrHigherThan '1.0.0'))) {
+    Context 'License warning is worded properly' -Tag FossOnly -Skip:((-not $env:TEST_KITCHEN) -or (-not (Test-ChocolateyVersionEqualOrHigherThan '1.0.0'))) {
         BeforeAll {
             $null = Invoke-Choco install chocolatey-license-business -y
             $Output = Invoke-Choco list -lo

--- a/tests/chocolatey-tests/commands/choco-install.Tests.ps1
+++ b/tests/chocolatey-tests/commands/choco-install.Tests.ps1
@@ -1570,6 +1570,110 @@ To install a local, or remote file, you may use:
         }
     }
 
+    Context 'Installing a package while passing in an uppercase letter as the identifier' {
+        BeforeAll {
+            Restore-ChocolateyInstallSnapshot
+
+            $Output = Invoke-Choco install IsDependency --confirm
+        }
+
+        It 'Exits with Success (0)' {
+            $Output.ExitCode | Should -Be 0
+        }
+
+        It 'Installs package to expected directory' {
+            "$env:ChocolateyInstall\lib\isdependency\isdependency.nuspec" | Should -Exist
+        }
+
+        It 'Outputs installation was successful' {
+            $Output.Lines | Should -Contain 'The install of isdependency was successful.' -Because $Output.String
+        }
+
+        It "Installs the expected version of the package" {
+            "$env:ChocolateyInstall\lib\isdependency\isdependency.nuspec" | Should -Exist
+            [xml]$XML = Get-Content "$env:ChocolateyInstall\lib\isdependency\isdependency.nuspec"
+            $XML.package.metadata.version | Should -Be "2.1.0"
+        }
+    }
+
+    Context 'Installing a package while passing in an uppercase letter as the identifier (Repository optimization disabled)' {
+        BeforeAll {
+            Restore-ChocolateyInstallSnapshot
+
+            $Output = Invoke-Choco install IsDependency --confirm --disable-repository-optimizations
+        }
+
+        It 'Exits with Success (0)' {
+            $Output.ExitCode | Should -Be 0
+        }
+
+        It 'Installs package to expected directory' {
+            "$env:ChocolateyInstall\lib\isdependency\isdependency.nuspec" | Should -Exist
+        }
+
+        It 'Outputs installation was successful' {
+            $Output.Lines | Should -Contain 'The install of isdependency was successful.' -Because $Output.String
+        }
+
+        It "Installs the expected version of the package" {
+            "$env:ChocolateyInstall\lib\isdependency\isdependency.nuspec" | Should -Exist
+            [xml]$XML = Get-Content "$env:ChocolateyInstall\lib\isdependency\isdependency.nuspec"
+            $XML.package.metadata.version | Should -Be "2.1.0"
+        }
+    }
+
+    Context 'Installing a package while passing in an uppercase letter as the identifier and specific version' {
+        BeforeAll {
+            Restore-ChocolateyInstallSnapshot
+
+            $Output = Invoke-Choco install IsDependency --confirm --disable-repository-optimizations --version 1.0.0
+        }
+
+        It 'Exits with Success (0)' {
+            $Output.ExitCode | Should -Be 0
+        }
+
+        It 'Installs package to expected directory' {
+            "$env:ChocolateyInstall\lib\isdependency\isdependency.nuspec" | Should -Exist
+        }
+
+        It 'Outputs installation was successful' {
+            $Output.Lines | Should -Contain 'The install of isdependency was successful.' -Because $Output.String
+        }
+
+        It "Installs the expected version of the package" {
+            "$env:ChocolateyInstall\lib\isdependency\isdependency.nuspec" | Should -Exist
+            [xml]$XML = Get-Content "$env:ChocolateyInstall\lib\isdependency\isdependency.nuspec"
+            $XML.package.metadata.version | Should -Be "1.0.0"
+        }
+    }
+
+    Context 'Installing a package while passing in an uppercase letter as the identifier and specific version (Repository optimization disabled)' {
+        BeforeAll {
+            Restore-ChocolateyInstallSnapshot
+
+            $Output = Invoke-Choco install IsDependency --confirm --disable-repository-optimizations --version 1.0.0
+        }
+
+        It 'Exits with Success (0)' {
+            $Output.ExitCode | Should -Be 0
+        }
+
+        It 'Installs package to expected directory' {
+            "$env:ChocolateyInstall\lib\isdependency\isdependency.nuspec" | Should -Exist
+        }
+
+        It 'Outputs installation was successful' {
+            $Output.Lines | Should -Contain 'The install of isdependency was successful.' -Because $Output.String
+        }
+
+        It "Installs the expected version of the package" {
+            "$env:ChocolateyInstall\lib\isdependency\isdependency.nuspec" | Should -Exist
+            [xml]$XML = Get-Content "$env:ChocolateyInstall\lib\isdependency\isdependency.nuspec"
+            $XML.package.metadata.version | Should -Be "1.0.0"
+        }
+    }
+
     # This needs to be the last test in this block, to ensure NuGet configurations aren't being created.
     # Any tests after this block are expected to generate the configuration as they're explicitly using the NuGet CLI
     Test-NuGetPaths

--- a/tests/chocolatey-tests/commands/choco-install.Tests.ps1
+++ b/tests/chocolatey-tests/commands/choco-install.Tests.ps1
@@ -1385,8 +1385,8 @@ To install a local, or remote file, you may use:
         }
 
         It "should identify a circular dependency" {
-            $result1.Lines | Should -Contain "Circular dependency detected 'circulardependency1 0.0.1 => circulardependency2 0.0.1 => circulardependency1 0.0.1'."
-            $result2.Lines | Should -Contain "Circular dependency detected 'circulardependency1 0.0.1 => circulardependency2 0.0.1 => circulardependency1 0.0.1'."
+            $result1.Lines | Should -Contain "Unable to resolve dependency 'circulardependency1': Circular dependency detected 'circulardependency1 0.0.1 => circulardependency2 0.0.1 => circulardependency1 0.0.1'." -Because $result1.String
+            $result2.Lines | Should -Contain "Unable to resolve dependency 'circulardependency1': Circular dependency detected 'circulardependency1 0.0.1 => circulardependency2 0.0.1 => circulardependency1 0.0.1'." -Because $result2.String
         }
     }
 

--- a/tests/chocolatey-tests/commands/choco-list.Tests.ps1
+++ b/tests/chocolatey-tests/commands/choco-list.Tests.ps1
@@ -111,9 +111,7 @@ Describe "choco <_>" -ForEach $Command -Tag Chocolatey, ListCommand, SearchComma
         }
     }
 
-    # TODO: Using All versions and pre release together is currently broken
-    # in vNext of Chocolatey CLI.
-    Context "Searching all available packages (allowing prerelease)" -Tag Broken {
+    Context "Searching all available packages (allowing prerelease)" -Tag Testing {
         BeforeAll {
             $Output = Invoke-Choco $_ --AllVersions --PreRelease
         }


### PR DESCRIPTION
## Description Of Changes

This pull request fixes tests that is failing on our internal testing environment, and re-enables tests that are no longer broken.

## Motivation and Context

To make things work again.

## Testing

1. Run `build.bat --testExecutionType=all --shouldRunopenCover=false`
2. Ensure no failures are reported
3. Run E2E tests and make sure all succeed.

### Operating Systems Testing

- Windows 11
- Windows Server 2019

## Change Types Made
<!-- Tick the boxes for the type of changes that have been made -->

* [x] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [ ] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue
<!-- Make sure you have raised an issue for this pull request before
continuing. -->

#508  
https://app.clickup.com/t/20540031/PROJ-519

<!-- PLEASE REMOVE ALL COMMENTS BEFORE SUBMITTING -->
