### PR TITLE
(maint) Fix test executions after internal changes

### DIFF
--- a/tests/chocolatey-tests/chocolatey.Tests.ps1
+++ b/tests/chocolatey-tests/chocolatey.Tests.ps1
@@ -197,6 +197,8 @@ Describe "Ensuring Chocolatey is correctly installed" -Tag Environment, Chocolat
     # This is skipped when not run in CI because it modifies the local system.
     Context 'License warning is worded properly' -Tag FossOnly,ListCommand,License -Skip:((-not $env:TEST_KITCHEN) -or (-not (Test-ChocolateyVersionEqualOrHigherThan '1.0.0'))) {
         BeforeAll {
+            Restore-ChocolateyInstallSnapshot
+            $null = Enable-ChocolateySource 'hermes-setup'
             $null = Invoke-Choco install chocolatey-license-business -y
             $Output = Invoke-Choco list
         }
@@ -216,10 +218,12 @@ Describe "Ensuring Chocolatey is correctly installed" -Tag Environment, Chocolat
     # This is skipped when not run in CI because it modifies the local system.
     Context 'PowerShell Profile comments updated correctly' -Tag ListCommand, Profile -Skip:((-not $env:TEST_KITCHEN) -or (-not (Test-ChocolateyVersionEqualOrHigherThan '1.0.0'))) {
         BeforeAll {
+            Restore-ChocolateyInstallSnapshot
             Remove-Item $Profile.CurrentUserCurrentHost -ErrorAction Ignore
             New-Item $Profile.CurrentUserCurrentHost -Force
             $chocolatey = (Invoke-Choco list chocolatey -r --exact).Lines | ConvertFrom-ChocolateyOutput -Command List
             Enable-ChocolateySource -Name local
+            Enable-ChocolateySource -Name hermes-setup
             $null = Invoke-Choco install chocolatey -f --version $chocolatey.Version
         }
 
@@ -243,6 +247,7 @@ Describe "Ensuring Chocolatey is correctly installed" -Tag Environment, Chocolat
     # This is skipped when not run in CI because it modifies the local system.
     Context 'PowerShell Profile properly updated when Windows thinks a 5 byte file is signed' -Tag ListCommand, Profile -Skip:((-not $env:TEST_KITCHEN) -or (-not (Test-ChocolateyVersionEqualOrHigherThan '1.1.0'))) {
         BeforeAll {
+            Restore-ChocolateyInstallSnapshot
             New-Item $Profile.CurrentUserCurrentHost -Force
             "" | Set-Content -Path $Profile.CurrentUserCurrentHost -Encoding UTF8
             $chocolatey = (Invoke-Choco list chocolatey -r --exact).Lines | ConvertFrom-ChocolateyOutput -Command List
@@ -278,6 +283,7 @@ Describe "Ensuring Chocolatey is correctly installed" -Tag Environment, Chocolat
         }
     ) {
         BeforeAll {
+            Restore-ChocolateyInstallSnapshot
             $chocolatey = (Invoke-Choco list chocolatey -r --exact).Lines | ConvertFrom-ChocolateyOutput -Command List
 
             foreach ($shim in $RemovedShims) {
@@ -292,6 +298,7 @@ Describe "Ensuring Chocolatey is correctly installed" -Tag Environment, Chocolat
             }
 
             Enable-ChocolateySource -Name local
+            Enable-ChocolateySource -Name hermes-setup
             $Output = Invoke-Choco install chocolatey -f --version $chocolatey.Version --no-progress
         }
 
@@ -310,6 +317,7 @@ Describe "Ensuring Chocolatey is correctly installed" -Tag Environment, Chocolat
 
     Context 'Ensure a corrupted config file does not cause errors' -Tag ConfigFile -Skip:(-not (Test-ChocolateyVersionEqualOrHigherThan '1.1.0')) {
         BeforeAll {
+            Restore-ChocolateyInstallSnapshot
             $ChocolateyConfigLocation = "$env:ChocolateyInstall/config/chocolatey.config"
             $BadContent = "<chocolatey></chocolatey>BadFile"
             # Make sure we have a chocolatey config file
@@ -333,9 +341,9 @@ Describe "Ensuring Chocolatey is correctly installed" -Tag Environment, Chocolat
         'powershell'
     ) -Skip:((-not $env:TEST_KITCHEN) -or (-not (Test-ChocolateyVersionEqualOrHigherThan '1.1.0'))) {
         BeforeAll {
-            New-ChocolateyInstallSnapshot
-            # TODO: Internalize pwsh and powershell packages...
-            $pwshInstall = Invoke-Choco install $_ -y -s https://community.chocolatey.org/api/v2/
+            Restore-ChocolateyInstallSnapshot
+            Enable-ChocolateySource -Name hermes-setup
+            $pwshInstall = Invoke-Choco install $_ -y
             $ChocoUnzipped = "$(Get-TempDirectory)$(New-Guid)"
             $modulePath = "$ChocoUnzipped/tools/chocolateySetup.psm1"
 
@@ -364,7 +372,7 @@ Describe "Ensuring Chocolatey is correctly installed" -Tag Environment, Chocolat
             if (Test-Path $ChocoUnzipped) {
                 Remove-Item $ChocoUnzipped -Force -Recurse
             }
-            $null = Invoke-Choco uninstall $_ -y -s https://community.chocolatey.org/api/v2/ --force-dependencies
+            $null = Invoke-Choco uninstall $_ -y --force-dependencies
             Remove-ChocolateyInstallSnapshot
         }
 

--- a/tests/chocolatey-tests/commands/choco-install.Tests.ps1
+++ b/tests/chocolatey-tests/commands/choco-install.Tests.ps1
@@ -1723,8 +1723,6 @@ To install a local, or remote file, you may use:
             $nuspec | Set-Content -Path $nuspecPath
             "readme content" | Set-Content -Path "$tempPath/$packageName/readme.md"
 
-            Enable-ChocolateySource -Name hermes-setup
-
             $null = Invoke-Choco install nuget.commandline
             $null = & "$env:ChocolateyInstall/bin/nuget.exe" pack $nuspecPath
 

--- a/tests/chocolatey-tests/commands/choco-install.Tests.ps1
+++ b/tests/chocolatey-tests/commands/choco-install.Tests.ps1
@@ -1320,7 +1320,7 @@ To install a local, or remote file, you may use:
 
     Context "Installing commercial package with custom commandlets" -Tag FossOnly {
         BeforeAll {
-            New-ChocolateyInstallSnapshot
+            Restore-ChocolateyInstallSnapshot
 
             $Output = Invoke-Choco install get-chocolateyunzip-licensed --confirm
         }
@@ -1332,7 +1332,8 @@ To install a local, or remote file, you may use:
 
     Context "Installing license only package on open source" -Tag FossOnly {
         BeforeAll {
-            New-ChocolateyInstallSnapshot
+            Restore-ChocolateyInstallSnapshot
+            Enable-ChocolateySource -Name hermes-setup
 
             $Output = Invoke-Choco install business-only-license --confirm
         }
@@ -1456,7 +1457,6 @@ To install a local, or remote file, you may use:
     Context "Installing package that makes use of new Get Chocolatey Path helper" {
         BeforeAll {
             Restore-ChocolateyInstallSnapshot
-            Enable-ChocolateySource -Name 'local'
 
             $Output = Invoke-Choco install test-chocolateypath -y
         }
@@ -1723,8 +1723,12 @@ To install a local, or remote file, you may use:
             $nuspec | Set-Content -Path $nuspecPath
             "readme content" | Set-Content -Path "$tempPath/$packageName/readme.md"
 
+            Enable-ChocolateySource -Name hermes-setup
+
             $null = Invoke-Choco install nuget.commandline
             $null = & "$env:ChocolateyInstall/bin/nuget.exe" pack $nuspecPath
+
+            Disable-ChocolateySource -Name hermes-setup
 
             $Output = Invoke-Choco install $packageName --source .
         }


### PR DESCRIPTION
## Description Of Changes

This merge request updates the tests we have for open source
Chocolatey CLI after the changes we expect to need to be
made in our internal structure to make sure they still
are able to pass.

## Motivation and Context

We have a need to change our internal structure, as such we need to make minor changes to the tests as well to make sure they are still valid and have not been broken.

## Testing

1. Run through test kitchen

### Operating Systems Testing

- Windows Server 2019

## Change Types Made
<!-- Tick the boxes for the type of changes that have been made -->

* [ ] Bug fix (non-breaking change).
* [x] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [ ] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue

- https://app.clickup.com/t/20540031/PROJ-532