### PR TITLE
(#2986) Strip `config list` down to just config

### DIFF
--- a/src/chocolatey/infrastructure.app/commands/ChocolateyConfigCommand.cs
+++ b/src/chocolatey/infrastructure.app/commands/ChocolateyConfigCommand.cs
@@ -33,14 +33,6 @@ namespace chocolatey.infrastructure.app.commands
     {
         private readonly IChocolateyConfigSettingsService _configSettingsService;
 
-        internal const string DeprecatedConfigListResultsMessage = @"
-Starting in v2.0.0, the `config list` command will only list the
- configuration values, instead of also listing the configured features
- and sources.
- Use the `choco feature` or `choco source` commands to list and interact
- with these values.
-";
-
         public ChocolateyConfigCommand(IChocolateyConfigSettingsService configSettingsService)
         {
             _configSettingsService = configSettingsService;
@@ -105,9 +97,6 @@ Chocolatey will allow you to interact with the configuration file settings.
 
 NOTE: Available in 0.9.9.9+.
 ");
-
-            this.Log().Warn(ChocolateyLoggers.Important, "DEPRECATION NOTICE");
-            this.Log().Warn(DeprecatedConfigListResultsMessage);
 
             "chocolatey".Log().Info(ChocolateyLoggers.Important, "Usage");
             "chocolatey".Log().Info(@"

--- a/src/chocolatey/infrastructure.app/services/ChocolateyConfigSettingsService.cs
+++ b/src/chocolatey/infrastructure.app/services/ChocolateyConfigSettingsService.cs
@@ -370,26 +370,6 @@ namespace chocolatey.infrastructure.app.services
             {
                 this.Log().Info(() => "{0} = {1} | {2}".format_with(config.Key, config.Value, config.Description));
             }
-
-            this.Log().Info("");
-            this.Log().Info(ChocolateyLoggers.Important, "Sources");
-            this.Log().Warn(ChocolateyLoggers.Important, "DEPRECATION NOTICE");
-            this.Log().Warn(ChocolateyConfigCommand.DeprecatedConfigListResultsMessage);
-            source_list(configuration);
-            this.Log().Info("");
-            this.Log().Info(@"NOTE: Use choco source to interact with sources.");
-            this.Log().Info("");
-            this.Log().Info(ChocolateyLoggers.Important, "Features");
-            this.Log().Warn(ChocolateyLoggers.Important, "DEPRECATION NOTICE");
-            this.Log().Warn(ChocolateyConfigCommand.DeprecatedConfigListResultsMessage);
-            feature_list(configuration);
-            this.Log().Info("");
-            this.Log().Info(@"NOTE: Use choco feature to interact with features.");
-            ;
-            this.Log().Info("");
-            this.Log().Info(ChocolateyLoggers.Important, "API Keys");
-            this.Log().Info(@"NOTE: Api Keys are not shown through this command.
- Use choco apikey to interact with API keys.");
         }
 
         public void config_get(ChocolateyConfiguration configuration)

--- a/tests/chocolatey-tests/commands/choco-config.Tests.ps1
+++ b/tests/chocolatey-tests/commands/choco-config.Tests.ps1
@@ -102,37 +102,16 @@ Describe "choco config" -Tag Chocolatey, ConfigCommand {
             $Output.Lines | Should -Contain "Settings"
         }
 
-        It "Displays Sources section" {
-            $Output.Lines | Should -Contain "Sources"
+        It "Does not display Sources section" {
+            $Output.Lines | Should  -Not -Contain "Sources"
         }
 
-        It "Displays Features" {
-            $Output.Lines | Should -Contain "Features"
+        It "Does not display Features" {
+            $Output.Lines | Should -Not -Contain "Features"
         }
 
-        It "Displays API Keys section" {
-            $Output.Lines | Should -Contain "API Keys"
-        }
-
-        It "Displays note about choco <_>" -ForEach @(
-            "source"
-            "feature"
-        ) {
-            $Output.Lines | Should -Contain "NOTE: Use choco $_ to interact with $($_)s."
-        }
-
-        It "Displays note about choco apikey" {
-            $Output.Lines | Should -Contain "NOTE: Api Keys are not shown through this command."
-            $Output.Lines | Should -Contain "Use choco apikey to interact with API keys."
-        }
-
-        It "Displays deprecation note about sources and features" {
-            $pattern = @(
-                'Starting in v2.0.0, the `config list` command will only list the'
-                ' configuration values, instead of also listing the configured features'
-                ' and sources.'
-            ) -join "\r?\n"
-            $Output.String | Should -Match $pattern
+        It "Does not display API Keys section" {
+            $Output.Lines | Should -Not -Contain "API Keys"
         }
 
         It "Displays Available Setting <_>" -ForEach @(


### PR DESCRIPTION
## Description Of Changes

- Remove deprecation messages regarding `config list` as they are no longer relevant
- Remove non-config-related output from the config command and service.

## Motivation and Context

We have other commands for listing features, sources, apikeys, etc. Config can finally just be config. Long-awaited deprecation.

## Testing

1. Build and run with `config list`
2. Ensure only config values and nothing else is listed
3. Run ConfigCommand tests and ensure nothing breaks

### Operating Systems Testing

Tested on Win11

## Change Types Made
<!-- Tick the boxes for the type of changes that have been made -->

* [ ] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [x] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [x] Requires a change to the documentation.
   * I don't think this will happen until the 2.x stable release though?
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [x] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue

Fixes #2986
