### PR TITLE
(#2776) Fix AssemblyFileExtractor spelling error

### DIFF
--- a/src/chocolatey/infrastructure/extractors/AssemblyFileExtractor.cs
+++ b/src/chocolatey/infrastructure/extractors/AssemblyFileExtractor.cs
@@ -66,8 +66,8 @@ namespace chocolatey.infrastructure.extractors
         /// <param name="overwriteExisting">
         ///   if set to <c>true</c> [overwrite existing].
         /// </param>
-        /// <param name="throwEror">Throw an error if there are issues</param>
-        public static void extract_binary_file_from_assembly(IFileSystem fileSystem, IAssembly assembly, string manifestLocation, string filePath, bool overwriteExisting = false, bool throwEror = true)
+        /// <param name="throwError">Throw an error if there are issues</param>
+        public static void extract_binary_file_from_assembly(IFileSystem fileSystem, IAssembly assembly, string manifestLocation, string filePath, bool overwriteExisting = false, bool throwError = true)
         {
             if (overwriteExisting || !fileSystem.file_exists(filePath))
             {
@@ -78,10 +78,10 @@ namespace chocolatey.infrastructure.extractors
                         fileSystem.write_file(filePath, () => assembly.get_manifest_stream(manifestLocation));
                     },
                    errorMessage:"Unable to extract binary",
-                   throwError: throwEror,
+                   throwError: throwError,
                    logWarningInsteadOfError: false,
-                   logDebugInsteadOfError: !throwEror,
-                   isSilent: !throwEror);
+                   logDebugInsteadOfError: !throwError,
+                   isSilent: !throwError);
             }
         }
 


### PR DESCRIPTION
## Description Of Changes

- Rename method parameter to `throwError`

## Motivation and Context

Speling is important! :)

## Testing

Apart from the fact it's technically a public API change, if it compiles we're good; there are zero functional changes here.

### Operating Systems Testing

Win11

## Change Types Made
<!-- Tick the boxes for the type of changes that have been made -->

* [ ] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [x] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [x] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue
<!-- Make sure you have raised an issue for this pull request before
continuing. -->

Fixes #2776

<!-- PLEASE REMOVE ALL COMMENTS BEFORE SUBMITTING -->
