### PR TITLE
(#158) Split out list command to its own command class

### DIFF
--- a/src/chocolatey.resources/helpers/ChocolateyTabExpansion.ps1
+++ b/src/chocolatey.resources/helpers/ChocolateyTabExpansion.ps1
@@ -40,6 +40,7 @@ $script:someCommands = @('-?', 'search', 'list', 'info', 'install', 'outdated', 
 # ensure these all have a space to start, or they will cause issues
 $allcommands = " --debug --verbose --trace --noop --help --accept-license --confirm --limit-output --no-progress --log-file='' --execution-timeout='' --cache-location='' --proxy='' --proxy-user='' --proxy-password='' --proxy-bypass-list='' --proxy-bypass-on-local --force --no-color --skip-compatibility-checks"
 $proListOptions = " --audit --use-self-service"
+$proSearchOptions = " --use-self-service"
 $proInfoOptions = " --use-self-service"
 $proInstallUpgradeOptions = " --install-directory='' --package-parameters-sensitive='' --max-download-rate='' --install-arguments-sensitive='' --skip-download-cache --use-download-cache --skip-virus-check --virus-check --virus-positives-minimum='' --deflate-package-size --no-deflate-package-size --deflate-nupkg-only --use-self-service"
 $proUpgradeOptions = " --exclude-chocolatey-packages-during-upgrade-all --include-chocolatey-packages-during-upgrade-all --use-self-service"
@@ -50,8 +51,8 @@ $proOutdatedOptions = " --use-self-service"
 $proPushOptions = " --use-self-service"
 
 $commandOptions = @{
-    list      = "--lo --id-only --pre --exact --by-id-only --id-starts-with --detailed --approved-only --not-broken --source='' --user='' --password='' --local-only --prerelease --include-programs --page='' --page-size='' --order-by-popularity --download-cache-only --disable-package-repository-optimizations" + $proListOptions + $allcommands
-    search    = "--pre --exact --by-id-only --id-starts-with --detailed --approved-only --not-broken --source='' --user='' --password='' --local-only --prerelease --include-programs --page='' --page-size='' --order-by-popularity --download-cache-only --disable-package-repository-optimizations" + $proListOptions + $allcommands
+    list      = "--id-only --pre --exact --by-id-only --id-starts-with --detailed --prerelease --include-programs --page='' --page-size=''" + $proListOptions + $allcommands
+    search    = "--pre --exact --by-id-only --id-starts-with --detailed --approved-only --not-broken --source='' --user='' --password='' --prerelease --page='' --page-size='' --order-by-popularity --download-cache-only --disable-package-repository-optimizations" + $proSearchOptions + $allcommands
     info      = "--pre --lo --source='' --user='' --password='' --local-only --prerelease --disable-package-repository-optimizations" + $proInfoOptions + $allcommands
     install   = "-y -whatif -? --pre --version= --params='' --install-arguments='' --override-arguments --ignore-dependencies --source='' --source='windowsfeatures' --user='' --password='' --prerelease --forcex86 --not-silent --package-parameters='' --exit-when-reboot-detected --ignore-detected-reboot --allow-downgrade --force-dependencies --require-checksums --use-package-exit-codes --ignore-package-exit-codes --skip-automation-scripts --allow-multiple-versions --ignore-checksums --allow-empty-checksums --allow-empty-checksums-secure --download-checksum='' --download-checksum-type='' --download-checksum-x64='' --download-checksum-type-x64='' --stop-on-first-package-failure --disable-package-repository-optimizations --pin" + $proInstallUpgradeOptions + $allcommands
     pin       = "--name='' --version='' -?" + $proPinOptions + $allcommands
@@ -71,6 +72,7 @@ $commandOptions = @{
     export    = "--include-version-numbers --output-file-path='' -?" + $allcommands
     template  = "--name=''" + $allcommands
 }
+$commandOptions['find'] = $commandOptions['search']
 
 try {
     # if license exists
@@ -98,14 +100,14 @@ function script:chocoLocalPackages($filter) {
     if ($filter -ne $null -and $filter.StartsWith(".")) {
         return;
     } #file search
-    @(& $script:choco list $filter -lo -r --id-starts-with) | ForEach-Object { $_.Split('|')[0] }
+    @(& $script:choco list $filter -r --id-starts-with) | ForEach-Object { $_.Split('|')[0] }
 }
 
 function script:chocoLocalPackagesUpgrade($filter) {
     if ($filter -ne $null -and $filter.StartsWith(".")) {
         return;
     } #file search
-    @('all|') + @(& $script:choco list $filter -lo -r --id-starts-with) |
+    @('all|') + @(& $script:choco list $filter -r --id-starts-with) |
         Where-Object { $_ -like "$filter*" } |
         ForEach-Object { $_.Split('|')[0] }
 }
@@ -144,7 +146,7 @@ function ChocolateyTabExpansion($lastBlock) {
         }
 
         # Handles list/search first tab
-        "^(list|search)\s+(?<subcommand>[^-\s]*)$" {
+        "^(list|search|find)\s+(?<subcommand>[^-\s]*)$" {
             @('<filter>', '-?') | Where-Object { $_ -like "$($matches['subcommand'])*" }
         }
 

--- a/src/chocolatey.tests.integration/Scenario.cs
+++ b/src/chocolatey.tests.integration/Scenario.cs
@@ -349,10 +349,10 @@ namespace chocolatey.tests.integration
             return config;
         }
 
-        public static ChocolateyConfiguration list()
+        public static ChocolateyConfiguration search()
         {
             var config = baseline_configuration();
-            config.CommandName = "list";
+            config.CommandName = "search";
 
             return config;
         }

--- a/src/chocolatey.tests.integration/Scenario.cs
+++ b/src/chocolatey.tests.integration/Scenario.cs
@@ -349,6 +349,14 @@ namespace chocolatey.tests.integration
             return config;
         }
 
+        public static ChocolateyConfiguration list()
+        {
+            var config = baseline_configuration();
+            config.CommandName = "list";
+
+            return config;
+        }
+
         public static ChocolateyConfiguration search()
         {
             var config = baseline_configuration();

--- a/src/chocolatey.tests.integration/chocolatey.tests.integration.csproj
+++ b/src/chocolatey.tests.integration/chocolatey.tests.integration.csproj
@@ -156,7 +156,7 @@
     <Compile Include="Scenario.cs" />
     <Compile Include="scenarios\InfoScenarios.cs" />
     <Compile Include="scenarios\InstallScenarios.cs" />
-    <Compile Include="scenarios\ListScenarios.cs" />
+    <Compile Include="scenarios\SearchScenarios.cs" />
     <Compile Include="scenarios\PackScenarios.cs" />
     <Compile Include="scenarios\PinScenarios.cs" />
     <Compile Include="scenarios\UninstallScenarios.cs" />

--- a/src/chocolatey.tests.integration/chocolatey.tests.integration.csproj
+++ b/src/chocolatey.tests.integration/chocolatey.tests.integration.csproj
@@ -156,6 +156,7 @@
     <Compile Include="Scenario.cs" />
     <Compile Include="scenarios\InfoScenarios.cs" />
     <Compile Include="scenarios\InstallScenarios.cs" />
+    <Compile Include="scenarios\ListScenarios.cs" />
     <Compile Include="scenarios\SearchScenarios.cs" />
     <Compile Include="scenarios\PackScenarios.cs" />
     <Compile Include="scenarios\PinScenarios.cs" />

--- a/src/chocolatey.tests.integration/scenarios/ListScenarios.cs
+++ b/src/chocolatey.tests.integration/scenarios/ListScenarios.cs
@@ -1,0 +1,251 @@
+﻿// Copyright © 2023-Present Chocolatey Software, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace chocolatey.tests.integration.scenarios
+{
+    using System.Collections.Generic;
+    using System.Linq;
+    using chocolatey.infrastructure.app.configuration;
+    using chocolatey.infrastructure.app.services;
+    using chocolatey.infrastructure.results;
+    using NuGet.Configuration;
+    using Should;
+
+    public class ListScenarios
+    {
+        [ConcernFor("list")]
+        public abstract class ScenariosBase : TinySpec
+        {
+            protected IList<PackageResult> Results;
+            protected ChocolateyConfiguration Configuration;
+            protected IChocolateyPackageService Service;
+
+            public override void Context()
+            {
+                Configuration = Scenario.list();
+                Scenario.reset(Configuration);
+                Scenario.add_packages_to_source_location(Configuration, Configuration.Input + "*" + NuGetConstants.PackageExtension);
+                Scenario.add_packages_to_source_location(Configuration, "installpackage*" + NuGetConstants.PackageExtension);
+                Scenario.install_package(Configuration, "installpackage", "1.0.0");
+                Scenario.install_package(Configuration, "upgradepackage", "1.0.0");
+
+                Service = NUnitSetup.Container.GetInstance<IChocolateyPackageService>();
+                Configuration.ListCommand.LocalOnly = true;
+            }
+        }
+
+        public class when_listing_local_packages : ScenariosBase
+        {
+            public override void Context()
+            {
+                base.Context();
+            }
+
+            public override void Because()
+            {
+                MockLogger.reset();
+                Results = Service.list_run(Configuration).ToList();
+            }
+
+            [Fact]
+            public void should_contain_packages_and_versions_with_a_space_between_them()
+            {
+                MockLogger.contains_message("upgradepackage 1.0.0").ShouldBeTrue(userMessage: "Warnings: " + string.Join("\n", MockLogger.Messages["Info"]));
+            }
+
+            [Fact]
+            public void should_not_contain_packages_and_versions_with_a_pipe_between_them()
+            {
+                MockLogger.contains_message("upgradepackage|1.0.0").ShouldBeFalse();
+            }
+
+            [Fact]
+            public void should_contain_a_summary()
+            {
+                MockLogger.contains_message("packages installed").ShouldBeTrue();
+            }
+
+            [Fact]
+            public void should_contain_debugging_messages()
+            {
+                MockLogger.contains_message("Searching for package information", LogLevel.Debug).ShouldBeTrue();
+                MockLogger.contains_message("Running list with the following filter", LogLevel.Debug).ShouldBeTrue();
+                MockLogger.contains_message("Start of List", LogLevel.Debug).ShouldBeTrue();
+                MockLogger.contains_message("End of List", LogLevel.Debug).ShouldBeTrue();
+            }
+        }
+
+        public class when_listing_local_packages_with_id_only : ScenariosBase
+        {
+            public override void Context()
+            {
+                base.Context();
+                Configuration.ListCommand.IdOnly = true;
+            }
+
+            public override void Because()
+            {
+                MockLogger.reset();
+                Results = Service.list_run(Configuration).ToList();
+            }
+
+            [Fact]
+            public void should_contain_package_name()
+            {
+                MockLogger.contains_message("upgradepackage").ShouldBeTrue();
+            }
+
+            [Fact]
+            public void should_not_contain_any_version_number()
+            {
+                MockLogger.contains_message(".0").ShouldBeFalse();
+            }
+        }
+
+        public class when_listing_local_packages_limiting_output : ScenariosBase
+        {
+            public override void Context()
+            {
+                base.Context();
+
+                Configuration.RegularOutput = false;
+            }
+
+            public override void Because()
+            {
+                MockLogger.reset();
+                Results = Service.list_run(Configuration).ToList();
+            }
+
+            [Fact]
+            public void should_contain_packages_and_versions_with_a_pipe_between_them()
+            {
+                MockLogger.contains_message("upgradepackage|1.0.0").ShouldBeTrue();
+            }
+
+            [Fact]
+            public void should_only_have_messages_related_to_package_information()
+            {
+                var count = MockLogger.Messages.SelectMany(messageLevel => messageLevel.Value.or_empty_list_if_null()).Count();
+                count.ShouldEqual(2);
+            }
+
+            [Fact]
+            public void should_not_contain_packages_and_versions_with_a_space_between_them()
+            {
+                MockLogger.contains_message("upgradepackage 1.0.0").ShouldBeFalse();
+            }
+
+            [Fact]
+            public void should_not_contain_a_summary()
+            {
+                MockLogger.contains_message("packages installed").ShouldBeFalse();
+            }
+
+            [Fact]
+            public void should_not_contain_debugging_messages()
+            {
+                MockLogger.contains_message("Searching for package information", LogLevel.Debug).ShouldBeFalse();
+                MockLogger.contains_message("Running list with the following filter", LogLevel.Debug).ShouldBeFalse();
+                MockLogger.contains_message("Start of List", LogLevel.Debug).ShouldBeFalse();
+                MockLogger.contains_message("End of List", LogLevel.Debug).ShouldBeFalse();
+            }
+        }
+
+        public class when_listing_local_packages_limiting_output_with_id_only : ScenariosBase
+        {
+            public override void Context()
+            {
+                base.Context();
+
+                Configuration.ListCommand.IdOnly = true;
+                Configuration.RegularOutput = false;
+            }
+
+            public override void Because()
+            {
+                MockLogger.reset();
+                Results = Service.list_run(Configuration).ToList();
+            }
+
+            [Fact]
+            public void should_contain_packages_id()
+            {
+                MockLogger.contains_message("upgradepackage").ShouldBeTrue();
+            }
+
+            [Fact]
+            public void should_not_contain_any_version_number()
+            {
+                MockLogger.contains_message(".0").ShouldBeFalse();
+            }
+
+            [Fact]
+            public void should_not_contain_pipe()
+            {
+                MockLogger.contains_message("|").ShouldBeFalse();
+            }
+        }
+
+        public class when_listing_local_packages_with_uppercase_id_package_installed : ScenariosBase
+        {
+            public override void Context()
+            {
+                base.Context();
+                Scenario.add_packages_to_source_location(Configuration, "UpperCase" + "*" + NuGetConstants.PackageExtension);
+                Scenario.install_package(Configuration, "UpperCase", "1.1.0");
+            }
+
+            public override void Because()
+            {
+                MockLogger.reset();
+                Results = Service.list_run(Configuration).ToList();
+            }
+
+            [Fact]
+            public void should_contain_packages_and_versions_with_a_space_between_them()
+            {
+                MockLogger.contains_message("upgradepackage 1.0.0").ShouldBeTrue();
+            }
+
+            [Fact]
+            public void should_contain_uppercase_id_package()
+            {
+                MockLogger.contains_message("UpperCase 1.1.0").ShouldBeTrue();
+            }
+
+            [Fact]
+            public void should_not_contain_packages_and_versions_with_a_pipe_between_them()
+            {
+                MockLogger.contains_message("upgradepackage|1.0.0").ShouldBeFalse();
+            }
+
+            [Fact]
+            public void should_contain_a_summary()
+            {
+                MockLogger.contains_message("packages installed").ShouldBeTrue();
+            }
+
+            [Fact]
+            public void should_contain_debugging_messages()
+            {
+                MockLogger.contains_message("Searching for package information", LogLevel.Debug).ShouldBeTrue();
+                MockLogger.contains_message("Running list with the following filter", LogLevel.Debug).ShouldBeTrue();
+                MockLogger.contains_message("Start of List", LogLevel.Debug).ShouldBeTrue();
+                MockLogger.contains_message("End of List", LogLevel.Debug).ShouldBeTrue();
+            }
+        }
+    }
+}

--- a/src/chocolatey.tests.integration/scenarios/SearchScenarios.cs
+++ b/src/chocolatey.tests.integration/scenarios/SearchScenarios.cs
@@ -28,9 +28,9 @@ namespace chocolatey.tests.integration.scenarios
     using NUnit.Framework;
     using Should;
 
-    public class ListScenarios
+    public class SearchScenarios
     {
-        [ConcernFor("list")]
+        [ConcernFor("search")]
         public abstract class ScenariosBase : TinySpec
         {
             protected IList<PackageResult> Results;
@@ -39,7 +39,7 @@ namespace chocolatey.tests.integration.scenarios
 
             public override void Context()
             {
-                Configuration = Scenario.list();
+                Configuration = Scenario.search();
                 Scenario.reset(Configuration);
                 Scenario.add_packages_to_source_location(Configuration, Configuration.Input + "*" + NuGetConstants.PackageExtension);
                 Scenario.add_packages_to_source_location(Configuration, "installpackage*" + NuGetConstants.PackageExtension);
@@ -553,7 +553,7 @@ namespace chocolatey.tests.integration.scenarios
         {
             public override void Context()
             {
-                Configuration = Scenario.list();
+                Configuration = Scenario.search();
                 Scenario.reset(Configuration);
                 Scenario.add_packages_to_source_location(Configuration, "exactpackage*" + NuGetConstants.PackageExtension);
                 Service = NUnitSetup.Container.GetInstance<IChocolateyPackageService>();
@@ -612,7 +612,7 @@ namespace chocolatey.tests.integration.scenarios
         {
             public override void Context()
             {
-                Configuration = Scenario.list();
+                Configuration = Scenario.search();
                 Scenario.reset(Configuration);
                 Scenario.add_packages_to_source_location(Configuration, "exactpackage*" + NuGetConstants.PackageExtension);
                 Service = NUnitSetup.Container.GetInstance<IChocolateyPackageService>();
@@ -667,7 +667,7 @@ namespace chocolatey.tests.integration.scenarios
         {
             public override void Context()
             {
-                Configuration = Scenario.list();
+                Configuration = Scenario.search();
                 Scenario.reset(Configuration);
                 Scenario.add_packages_to_source_location(Configuration, "exactpackage*" + NuGetConstants.PackageExtension);
                 Service = NUnitSetup.Container.GetInstance<IChocolateyPackageService>();
@@ -714,7 +714,7 @@ namespace chocolatey.tests.integration.scenarios
         {
             public override void Context()
             {
-                Configuration = Scenario.list();
+                Configuration = Scenario.search();
                 Scenario.reset(Configuration);
                 Scenario.add_packages_to_source_location(Configuration, "exactpackage*" + NuGetConstants.PackageExtension);
                 Service = NUnitSetup.Container.GetInstance<IChocolateyPackageService>();

--- a/src/chocolatey.tests.integration/scenarios/SearchScenarios.cs
+++ b/src/chocolatey.tests.integration/scenarios/SearchScenarios.cs
@@ -1,4 +1,4 @@
-// Copyright © 2017 - 2021 Chocolatey Software, Inc
+// Copyright © 2017 - Present Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,10 +17,7 @@
 namespace chocolatey.tests.integration.scenarios
 {
     using System.Collections.Generic;
-    using System.IO;
     using System.Linq;
-    using chocolatey.infrastructure.app;
-    using chocolatey.infrastructure.app.commands;
     using chocolatey.infrastructure.app.configuration;
     using chocolatey.infrastructure.app.services;
     using chocolatey.infrastructure.results;
@@ -361,167 +358,6 @@ namespace chocolatey.tests.integration.scenarios
             }
         }
 
-        public class when_listing_local_packages : ScenariosBase
-        {
-            public override void Context()
-            {
-                base.Context();
-                Configuration.ListCommand.LocalOnly = true;
-                Configuration.Sources = ApplicationParameters.PackagesLocation;
-            }
-
-            public override void Because()
-            {
-                MockLogger.reset();
-                Results = Service.list_run(Configuration).ToList();
-            }
-
-            [Fact]
-            public void should_contain_packages_and_versions_with_a_space_between_them()
-            {
-                MockLogger.contains_message("upgradepackage 1.0.0").ShouldBeTrue();
-            }
-
-            [Fact]
-            public void should_not_contain_packages_and_versions_with_a_pipe_between_them()
-            {
-                MockLogger.contains_message("upgradepackage|1.0.0").ShouldBeFalse();
-            }
-
-            [Fact]
-            public void should_contain_a_summary()
-            {
-                MockLogger.contains_message("packages installed").ShouldBeTrue();
-            }
-
-            [Fact]
-            public void should_contain_debugging_messages()
-            {
-                MockLogger.contains_message("Searching for package information", LogLevel.Debug).ShouldBeTrue();
-                MockLogger.contains_message("Running list with the following filter", LogLevel.Debug).ShouldBeTrue();
-                MockLogger.contains_message("Start of List", LogLevel.Debug).ShouldBeTrue();
-                MockLogger.contains_message("End of List", LogLevel.Debug).ShouldBeTrue();
-            }
-        }
-
-        public class when_listing_local_packages_with_id_only : ScenariosBase
-        {
-            public override void Context()
-            {
-                base.Context();
-                Configuration.ListCommand.LocalOnly = true;
-                Configuration.ListCommand.IdOnly = true;
-                Configuration.Sources = ApplicationParameters.PackagesLocation;
-            }
-
-            public override void Because()
-            {
-                MockLogger.reset();
-                Results = Service.list_run(Configuration).ToList();
-            }
-
-            [Fact]
-            public void should_contain_package_name()
-            {
-                MockLogger.contains_message("upgradepackage").ShouldBeTrue();
-            }
-
-            [Fact]
-            public void should_not_contain_any_version_number()
-            {
-                MockLogger.contains_message(".0").ShouldBeFalse();
-            }
-        }
-
-        public class when_listing_local_packages_limiting_output : ScenariosBase
-        {
-            public override void Context()
-            {
-                base.Context();
-
-                Configuration.ListCommand.LocalOnly = true;
-                Configuration.Sources = ApplicationParameters.PackagesLocation;
-                Configuration.RegularOutput = false;
-            }
-
-            public override void Because()
-            {
-                MockLogger.reset();
-                Results = Service.list_run(Configuration).ToList();
-            }
-
-            [Fact]
-            public void should_contain_packages_and_versions_with_a_pipe_between_them()
-            {
-                MockLogger.contains_message("upgradepackage|1.0.0").ShouldBeTrue();
-            }
-
-            [Fact]
-            public void should_only_have_messages_related_to_package_information()
-            {
-                var count = MockLogger.Messages.SelectMany(messageLevel => messageLevel.Value.or_empty_list_if_null()).Count();
-                count.ShouldEqual(2);
-            }
-
-            [Fact]
-            public void should_not_contain_packages_and_versions_with_a_space_between_them()
-            {
-                MockLogger.contains_message("upgradepackage 1.0.0").ShouldBeFalse();
-            }
-
-            [Fact]
-            public void should_not_contain_a_summary()
-            {
-                MockLogger.contains_message("packages installed").ShouldBeFalse();
-            }
-
-            [Fact]
-            public void should_not_contain_debugging_messages()
-            {
-                MockLogger.contains_message("Searching for package information", LogLevel.Debug).ShouldBeFalse();
-                MockLogger.contains_message("Running list with the following filter", LogLevel.Debug).ShouldBeFalse();
-                MockLogger.contains_message("Start of List", LogLevel.Debug).ShouldBeFalse();
-                MockLogger.contains_message("End of List", LogLevel.Debug).ShouldBeFalse();
-            }
-        }
-
-        public class when_listing_local_packages_limiting_output_with_id_only : ScenariosBase
-        {
-            public override void Context()
-            {
-                base.Context();
-
-                Configuration.ListCommand.LocalOnly = true;
-                Configuration.ListCommand.IdOnly = true;
-                Configuration.Sources = ApplicationParameters.PackagesLocation;
-                Configuration.RegularOutput = false;
-            }
-
-            public override void Because()
-            {
-                MockLogger.reset();
-                Results = Service.list_run(Configuration).ToList();
-            }
-
-            [Fact]
-            public void should_contain_packages_id()
-            {
-                MockLogger.contains_message("upgradepackage").ShouldBeTrue();
-            }
-
-            [Fact]
-            public void should_not_contain_any_version_number()
-            {
-                MockLogger.contains_message(".0").ShouldBeFalse();
-            }
-
-            [Fact]
-            public void should_not_contain_pipe()
-            {
-                MockLogger.contains_message("|").ShouldBeFalse();
-            }
-        }
-
         public class when_listing_packages_with_no_sources_enabled : ScenariosBase
         {
             public override void Context()
@@ -757,58 +593,6 @@ namespace chocolatey.tests.integration.scenarios
                 Results[0].PackageMetadata.Version.ToNormalizedString().ShouldEqual("1.0.0");
                 Results[1].PackageMetadata.Version.ToNormalizedString().ShouldEqual("1.0.0-beta1");
                 Results[2].PackageMetadata.Version.ToNormalizedString().ShouldEqual("0.9.0");
-            }
-        }
-
-        public class when_listing_local_packages_with_uppercase_id_package_installed : ScenariosBase
-        {
-            public override void Context()
-            {
-                base.Context();
-                Scenario.add_packages_to_source_location(Configuration, "UpperCase" + "*" + NuGetConstants.PackageExtension);
-                Scenario.install_package(Configuration, "UpperCase", "1.1.0");
-
-                Configuration.ListCommand.LocalOnly = true;
-                Configuration.Sources = ApplicationParameters.PackagesLocation;
-            }
-
-            public override void Because()
-            {
-                MockLogger.reset();
-                Results = Service.list_run(Configuration).ToList();
-            }
-
-            [Fact]
-            public void should_contain_packages_and_versions_with_a_space_between_them()
-            {
-                MockLogger.contains_message("upgradepackage 1.0.0").ShouldBeTrue();
-            }
-
-            [Fact]
-            public void should_contain_uppercase_id_package()
-            {
-                MockLogger.contains_message("UpperCase 1.1.0").ShouldBeTrue();
-            }
-
-            [Fact]
-            public void should_not_contain_packages_and_versions_with_a_pipe_between_them()
-            {
-                MockLogger.contains_message("upgradepackage|1.0.0").ShouldBeFalse();
-            }
-
-            [Fact]
-            public void should_contain_a_summary()
-            {
-                MockLogger.contains_message("packages installed").ShouldBeTrue();
-            }
-
-            [Fact]
-            public void should_contain_debugging_messages()
-            {
-                MockLogger.contains_message("Searching for package information", LogLevel.Debug).ShouldBeTrue();
-                MockLogger.contains_message("Running list with the following filter", LogLevel.Debug).ShouldBeTrue();
-                MockLogger.contains_message("Start of List", LogLevel.Debug).ShouldBeTrue();
-                MockLogger.contains_message("End of List", LogLevel.Debug).ShouldBeTrue();
             }
         }
     }

--- a/src/chocolatey.tests/chocolatey.tests.csproj
+++ b/src/chocolatey.tests/chocolatey.tests.csproj
@@ -157,6 +157,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="infrastructure.app\attributes\CommandForAttributeSpecs.cs" />
+    <Compile Include="infrastructure.app\commands\ChocolateyListCommandSpecs.cs" />
     <Compile Include="infrastructure.app\commands\ChocolateyApiKeyCommandSpecs.cs" />
     <Compile Include="infrastructure.app\commands\ChocolateyConfigCommandSpecs.cs" />
     <Compile Include="infrastructure.app\commands\ChocolateyTemplateCommandSpecs.cs" />

--- a/src/chocolatey.tests/chocolatey.tests.csproj
+++ b/src/chocolatey.tests/chocolatey.tests.csproj
@@ -165,7 +165,7 @@
     <Compile Include="infrastructure.app\commands\ChocolateyInfoCommandSpecs.cs" />
     <Compile Include="infrastructure.app\commands\ChocolateyInstallCommandSpecs.cs" />
     <Compile Include="infrastructure.app\commands\ChocolateyHelpCommandSpecs.cs" />
-    <Compile Include="infrastructure.app\commands\ChocolateyListCommandSpecs.cs" />
+    <Compile Include="infrastructure.app\commands\ChocolateySearchCommandSpecs.cs" />
     <Compile Include="infrastructure.app\commands\ChocolateyNewCommandSpecs.cs" />
     <Compile Include="infrastructure.app\commands\ChocolateyOutdatedCommandSpecs.cs" />
     <Compile Include="infrastructure.app\commands\ChocolateyPackCommandSpecs.cs" />

--- a/src/chocolatey.tests/infrastructure.app/commands/ChocolateyListCommandSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/commands/ChocolateyListCommandSpecs.cs
@@ -1,0 +1,206 @@
+﻿// Copyright © 2023-Present Chocolatey Software, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace chocolatey.tests.infrastructure.app.commands
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using chocolatey.infrastructure.app.attributes;
+    using chocolatey.infrastructure.app.commands;
+    using chocolatey.infrastructure.app.configuration;
+    using chocolatey.infrastructure.app.services;
+    using chocolatey.infrastructure.commandline;
+    using Moq;
+    using Should;
+
+    public static class ChocolateyListCommandSpecs
+    {
+        [ConcernFor("list")]
+        public abstract class ChocolateyListCommandSpecsBase : TinySpec
+        {
+            protected ChocolateyListCommand command;
+            protected Mock<IChocolateyPackageService> packageService = new Mock<IChocolateyPackageService>();
+            protected ChocolateyConfiguration configuration = new ChocolateyConfiguration();
+
+            public override void Context()
+            {
+                command = new ChocolateyListCommand(packageService.Object);
+            }
+        }
+
+        public class when_implementing_command_for : ChocolateyListCommandSpecsBase
+        {
+            private List<string> results;
+
+            public override void Because()
+            {
+                results = command.GetType().GetCustomAttributes(typeof(CommandForAttribute), false).Cast<CommandForAttribute>().Select(a => a.CommandName).ToList();
+            }
+
+            [Fact]
+            public void should_implement_list()
+            {
+                results.ShouldContain("list");
+            }
+
+            [Fact]
+            public void should_not_implement_search()
+            {
+                results.ShouldNotContain("search");
+            }
+
+            [Fact]
+            public void should_not_implement_find()
+            {
+                results.ShouldNotContain("find");
+            }
+
+            public class when_configurating_the_argument_parser : ChocolateyListCommandSpecsBase
+            {
+                private OptionSet optionSet;
+
+                public override void Context()
+                {
+                    base.Context();
+                    optionSet = new OptionSet();
+                }
+
+                public override void Because()
+                {
+                    command.configure_argument_parser(optionSet, configuration);
+                }
+
+                [NUnit.Framework.TestCase("prerelease")]
+                [NUnit.Framework.TestCase("pre")]
+                [NUnit.Framework.TestCase("includeprograms")]
+                [NUnit.Framework.TestCase("i")]
+                public void should_add_to_option_set(string option)
+                {
+                    optionSet.Contains(option).ShouldBeTrue();
+                }
+
+                [NUnit.Framework.TestCase("source")]
+                [NUnit.Framework.TestCase("s")]
+                [NUnit.Framework.TestCase("localonly")]
+                [NUnit.Framework.TestCase("l")]
+                [NUnit.Framework.TestCase("user")]
+                [NUnit.Framework.TestCase("u")]
+                [NUnit.Framework.TestCase("password")]
+                [NUnit.Framework.TestCase("p")]
+                [NUnit.Framework.TestCase("allversions")]
+                [NUnit.Framework.TestCase("a")]
+                public void should_not_add_to_option_set(string option)
+                {
+                    optionSet.Contains(option).ShouldBeFalse();
+                }
+            }
+
+            public class when_handling_additional_argument_parsing : ChocolateyListCommandSpecsBase
+            {
+                private readonly IList<string> unparsedArgs = new List<string>();
+                private readonly string source = "https://somewhereoutthere";
+                private Action because;
+
+                public override void Context()
+                {
+                    base.Context();
+                    unparsedArgs.Add("pkg1");
+                    unparsedArgs.Add("pkg2");
+                    unparsedArgs.Add("-l");
+                    unparsedArgs.Add("--local-only");
+                    unparsedArgs.Add("--localonly");
+                    configuration.Sources = source;
+                }
+
+                public override void Because()
+                {
+                    because = () => command.handle_additional_argument_parsing(unparsedArgs, configuration);
+                }
+
+                [Fact]
+                public void should_set_unparsed_arguments_to_configuration_input()
+                {
+                    because();
+                    configuration.Input.ShouldEqual("pkg1 pkg2");
+                }
+
+                [NUnit.Framework.TestCase("-l")]
+                [NUnit.Framework.TestCase("--local-only")]
+                [NUnit.Framework.TestCase("--localonly")]
+                public void should_output_warning_message_about_unsupported_argument(string argument)
+                {
+                    because();
+                    MockLogger.Messages.Keys.ShouldContain("Warn");
+                    MockLogger.Messages["Warn"].ShouldContain(@"
+UNSUPPORTED ARGUMENT: Ignoring the argument {0}. This argument is unsupported for locally installed packages, and will be treated as a package name in Chocolatey CLI v3!".format_with(argument));
+                }
+            }
+
+            public class when_noop_is_called_with_list_command : ChocolateyListCommandSpecsBase
+            {
+                public override void Context()
+                {
+                    base.Context();
+                    configuration.CommandName = "search";
+                    configuration.ListCommand.LocalOnly = false;
+                }
+
+                public override void Because()
+                {
+                    command.noop(configuration);
+                }
+
+                [Fact]
+                public void should_call_service_list_noop()
+                {
+                    packageService.Verify(c => c.list_noop(configuration), Times.Once);
+                }
+
+                [Fact]
+                public void should_not_report_any_warning_messages()
+                {
+                    MockLogger.Messages.Keys.ShouldNotContain("Warn");
+                }
+            }
+
+            public class when_run_is_called_with_search_command_and_local_only : ChocolateyListCommandSpecsBase
+            {
+                public override void Context()
+                {
+                    base.Context();
+                    configuration.CommandName = "list";
+                }
+
+                public override void Because()
+                {
+                    command.run(configuration);
+                }
+
+                [Fact]
+                public void should_call_service_list_run()
+                {
+                    packageService.Verify(c => c.list_run(configuration), Times.Once);
+                }
+
+                [Fact]
+                public void should_not_report_any_warning_messages()
+                {
+                    MockLogger.Messages.Keys.ShouldNotContain("Warn");
+                }
+            }
+        }
+    }
+}

--- a/src/chocolatey.tests/infrastructure.app/commands/ChocolateySearchCommandSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/commands/ChocolateySearchCommandSpecs.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -27,23 +27,23 @@ namespace chocolatey.tests.infrastructure.app.commands
     using Moq;
     using Should;
 
-    public class ChocolateyListCommandSpecs
+    public class ChocolateySearchCommandSpecs
     {
-        [ConcernFor("list")]
-        public abstract class ChocolateyListCommandSpecsBase : TinySpec
+        [ConcernFor("search")]
+        public abstract class ChocolateySearchCommandSpecsBase : TinySpec
         {
-            protected ChocolateyListCommand command;
+            protected ChocolateySearchCommand command;
             protected Mock<IChocolateyPackageService> packageService = new Mock<IChocolateyPackageService>();
             protected ChocolateyConfiguration configuration = new ChocolateyConfiguration();
 
             public override void Context()
             {
                 configuration.Sources = "bob";
-                command = new ChocolateyListCommand(packageService.Object);
+                command = new ChocolateySearchCommand(packageService.Object);
             }
         }
 
-        public class when_implementing_command_for : ChocolateyListCommandSpecsBase
+        public class when_implementing_command_for : ChocolateySearchCommandSpecsBase
         {
             private List<string> results;
 
@@ -53,9 +53,9 @@ namespace chocolatey.tests.infrastructure.app.commands
             }
 
             [Fact]
-            public void should_implement_list()
+            public void should_not_implement_list()
             {
-                results.ShouldContain("list");
+                results.ShouldNotContain("list");
             }
 
             [Fact]
@@ -71,7 +71,7 @@ namespace chocolatey.tests.infrastructure.app.commands
             }
         }
 
-        public class when_configurating_the_argument_parser_for_list_command : ChocolateyListCommandSpecsBase
+        public class when_configurating_the_argument_parser_for_search_command : ChocolateySearchCommandSpecsBase
         {
             private OptionSet optionSet;
 
@@ -79,7 +79,7 @@ namespace chocolatey.tests.infrastructure.app.commands
             {
                 base.Context();
                 optionSet = new OptionSet();
-                configuration.CommandName = "list";
+                configuration.CommandName = "search";
             }
 
             public override void Because()
@@ -174,7 +174,7 @@ namespace chocolatey.tests.infrastructure.app.commands
 
         [NUnit.Framework.TestFixture("search")]
         [NUnit.Framework.TestFixture("find")]
-        public class when_configurating_the_argument_parser : ChocolateyListCommandSpecsBase
+        public class when_configurating_the_argument_parser : ChocolateySearchCommandSpecsBase
         {
             private OptionSet optionSet;
 
@@ -279,7 +279,7 @@ namespace chocolatey.tests.infrastructure.app.commands
             }
         }
 
-        public class when_handling_additional_argument_parsing : ChocolateyListCommandSpecsBase
+        public class when_handling_additional_argument_parsing : ChocolateySearchCommandSpecsBase
         {
             private readonly IList<string> unparsedArgs = new List<string>();
             private readonly string source = "https://somewhereoutthere";
@@ -314,12 +314,12 @@ namespace chocolatey.tests.infrastructure.app.commands
             }
         }
 
-        public class when_noop_is_called_with_list_command : ChocolateyListCommandSpecsBase
+        public class when_noop_is_called_with_search_command : ChocolateySearchCommandSpecsBase
         {
             public override void Context()
             {
                 base.Context();
-                configuration.CommandName = "list";
+                configuration.CommandName = "search";
             }
 
             public override void Because()
@@ -344,12 +344,12 @@ Repository).");
             }
         }
 
-        public class when_noop_is_called_with_list_command_and_local_only : ChocolateyListCommandSpecsBase
+        public class when_noop_is_called_with_search_command_and_local_only : ChocolateySearchCommandSpecsBase
         {
             public override void Context()
             {
                 base.Context();
-                configuration.CommandName = "list";
+                configuration.CommandName = "search";
                 configuration.ListCommand.LocalOnly = true;
             }
 
@@ -371,7 +371,7 @@ Repository).");
             }
         }
 
-        public class when_noop_is_called : ChocolateyListCommandSpecsBase
+        public class when_noop_is_called : ChocolateySearchCommandSpecsBase
         {
             public override void Because()
             {
@@ -391,12 +391,12 @@ Repository).");
             }
         }
 
-        public class when_run_is_called_with_list_command : ChocolateyListCommandSpecsBase
+        public class when_run_is_called_with_search_command : ChocolateySearchCommandSpecsBase
         {
             public override void Context()
             {
                 base.Context();
-                configuration.CommandName = "list";
+                configuration.CommandName = "search";
             }
 
             public override void Because()
@@ -421,12 +421,12 @@ Repository).");
             }
         }
 
-        public class when_run_is_called_with_list_command_and_local_only : ChocolateyListCommandSpecsBase
+        public class when_run_is_called_with_search_command_and_local_only : ChocolateySearchCommandSpecsBase
         {
             public override void Context()
             {
                 base.Context();
-                configuration.CommandName = "list";
+                configuration.CommandName = "search";
                 configuration.ListCommand.LocalOnly = true;
             }
 
@@ -448,7 +448,7 @@ Repository).");
             }
         }
 
-        public class when_run_is_called : ChocolateyListCommandSpecsBase
+        public class when_run_is_called : ChocolateySearchCommandSpecsBase
         {
             public override void Because()
             {
@@ -470,7 +470,7 @@ Repository).");
 
         [NUnit.Framework.TestFixture("search")]
         [NUnit.Framework.TestFixture("find")]
-        public class when_outputting_help_message : ChocolateyListCommandSpecsBase
+        public class when_outputting_help_message : ChocolateySearchCommandSpecsBase
         {
             public when_outputting_help_message(string commandName)
             {

--- a/src/chocolatey.tests/infrastructure.app/commands/ChocolateySearchCommandSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/commands/ChocolateySearchCommandSpecs.cs
@@ -99,18 +99,6 @@ namespace chocolatey.tests.infrastructure.app.commands
                 optionSet.Contains("s").ShouldBeTrue();
             }
 
-            [Fact, Obsolete("Local Only will be removed in v2.0.0 for the list command")]
-            public void should_add_localonly_to_the_option_set()
-            {
-                optionSet.Contains("localonly").ShouldBeTrue();
-            }
-
-            [Fact, Obsolete("Local Only will be removed in v2.0.0 for the list command")]
-            public void should_add_short_version_of_localonly_to_the_option_set()
-            {
-                optionSet.Contains("l").ShouldBeTrue();
-            }
-
             [Fact]
             public void should_add_prerelease_to_the_option_set()
             {
@@ -147,25 +135,25 @@ namespace chocolatey.tests.infrastructure.app.commands
                 optionSet.Contains("a").ShouldBeTrue();
             }
 
-            [Fact, Obsolete("Will be removed in v2.0.0")]
+            [Fact]
             public void should_add_user_to_the_option_set()
             {
                 optionSet.Contains("user").ShouldBeTrue();
             }
 
-            [Fact, Obsolete("Will be removed in v2.0.0")]
+            [Fact]
             public void should_add_short_version_of_user_to_the_option_set()
             {
                 optionSet.Contains("u").ShouldBeTrue();
             }
 
-            [Fact, Obsolete("Will be removed in v2.0.0")]
+            [Fact]
             public void should_add_password_to_the_option_set()
             {
                 optionSet.Contains("password").ShouldBeTrue();
             }
 
-            [Fact, Obsolete("Will be removed in v2.0.0")]
+            [Fact]
             public void should_add_short_version_of_password_to_the_option_set()
             {
                 optionSet.Contains("p").ShouldBeTrue();
@@ -204,18 +192,6 @@ namespace chocolatey.tests.infrastructure.app.commands
             public void should_add_short_version_of_source_to_the_option_set()
             {
                 optionSet.Contains("s").ShouldBeTrue();
-            }
-
-            [Fact]
-            public void should_add_localonly_to_the_option_set()
-            {
-                optionSet.Contains("localonly").ShouldBeTrue();
-            }
-
-            [Fact]
-            public void should_add_short_version_of_localonly_to_the_option_set()
-            {
-                optionSet.Contains("l").ShouldBeTrue();
             }
 
             [Fact]
@@ -332,43 +308,6 @@ namespace chocolatey.tests.infrastructure.app.commands
             {
                 packageService.Verify(c => c.list_noop(configuration), Times.Once);
             }
-
-            [Fact]
-            public void should_report_deprecation_of_remote_sources()
-            {
-                MockLogger.Messages.Keys.ShouldContain("Warn");
-                MockLogger.Messages["Warn"].ShouldContain(@"Using the list command with remote sources is deprecated and will be made
-to only list locally installed packages in v2.0.0. Use the search, or find,
-command to find packages on remote sources (such as the Chocolatey Community
-Repository).");
-            }
-        }
-
-        public class when_noop_is_called_with_search_command_and_local_only : ChocolateySearchCommandSpecsBase
-        {
-            public override void Context()
-            {
-                base.Context();
-                configuration.CommandName = "search";
-                configuration.ListCommand.LocalOnly = true;
-            }
-
-            public override void Because()
-            {
-                command.noop(configuration);
-            }
-
-            [Fact]
-            public void should_call_service_list_noop()
-            {
-                packageService.Verify(c => c.list_noop(configuration), Times.Once);
-            }
-
-            [Fact]
-            public void should_not_report_any_warning_messages()
-            {
-                MockLogger.Messages.Keys.ShouldNotContain("Warn");
-            }
         }
 
         public class when_noop_is_called : ChocolateySearchCommandSpecsBase
@@ -408,43 +347,6 @@ Repository).");
             public void should_call_service_list_run()
             {
                 packageService.Verify(c => c.list_run(configuration), Times.Once);
-            }
-
-            [Fact]
-            public void should_report_deprecation_of_remote_sources()
-            {
-                MockLogger.Messages.Keys.ShouldContain("Warn");
-                MockLogger.Messages["Warn"].ShouldContain(@"Using the list command with remote sources is deprecated and will be made
-to only list locally installed packages in v2.0.0. Use the search, or find,
-command to find packages on remote sources (such as the Chocolatey Community
-Repository).");
-            }
-        }
-
-        public class when_run_is_called_with_search_command_and_local_only : ChocolateySearchCommandSpecsBase
-        {
-            public override void Context()
-            {
-                base.Context();
-                configuration.CommandName = "search";
-                configuration.ListCommand.LocalOnly = true;
-            }
-
-            public override void Because()
-            {
-                command.run(configuration);
-            }
-
-            [Fact]
-            public void should_call_service_list_run()
-            {
-                packageService.Verify(c => c.list_run(configuration), Times.Once);
-            }
-
-            [Fact]
-            public void should_not_report_any_warning_messages()
-            {
-                MockLogger.Messages.Keys.ShouldNotContain("Warn");
             }
         }
 

--- a/src/chocolatey/chocolatey.csproj
+++ b/src/chocolatey/chocolatey.csproj
@@ -404,7 +404,7 @@
     <Compile Include="infrastructure.app\domain\SourceType.cs" />
     <Compile Include="infrastructure\extractors\AssemblyFileExtractor.cs" />
     <Compile Include="infrastructure.app\builders\ConfigurationBuilder.cs" />
-    <Compile Include="infrastructure.app\commands\ChocolateyListCommand.cs" />
+    <Compile Include="infrastructure.app\commands\ChocolateySearchCommand.cs" />
     <Compile Include="infrastructure.app\commands\ChocolateyUnpackSelfCommand.cs" />
     <Compile Include="infrastructure.app\attributes\CommandForAttribute.cs" />
     <Compile Include="infrastructure.app\domain\CommandNameType.cs" />

--- a/src/chocolatey/chocolatey.csproj
+++ b/src/chocolatey/chocolatey.csproj
@@ -200,6 +200,7 @@
     </Compile>
     <Compile Include="AssemblyExtensions.cs" />
     <Compile Include="infrastructure.app\attributes\MultiServiceAttribute.cs" />
+    <Compile Include="infrastructure.app\commands\ChocolateyListCommand.cs" />
     <Compile Include="infrastructure.app\commands\ChocolateyTemplateCommand.cs" />
     <Compile Include="infrastructure.app\domain\ApiKeyCommandType.cs" />
     <Compile Include="infrastructure.app\domain\SourceTypes.cs" />

--- a/src/chocolatey/infrastructure.app/commands/ChocolateyInfoCommand.cs
+++ b/src/chocolatey/infrastructure.app/commands/ChocolateyInfoCommand.cs
@@ -24,7 +24,7 @@ namespace chocolatey.infrastructure.app.commands
     using services;
 
     [CommandFor("info", "retrieves package information. Shorthand for choco search pkgname --exact --verbose")]
-    public class ChocolateyInfoCommand : ChocolateyListCommand
+    public class ChocolateyInfoCommand : ChocolateySearchCommand
     {
         public ChocolateyInfoCommand(IChocolateyPackageService packageService)
             : base(packageService)

--- a/src/chocolatey/infrastructure.app/commands/ChocolateyListCommand.cs
+++ b/src/chocolatey/infrastructure.app/commands/ChocolateyListCommand.cs
@@ -1,0 +1,219 @@
+﻿// Copyright © 2023-Present Chocolatey Software, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace chocolatey.infrastructure.app.commands
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using chocolatey.infrastructure.app.attributes;
+    using chocolatey.infrastructure.app.configuration;
+    using chocolatey.infrastructure.app.services;
+    using chocolatey.infrastructure.commandline;
+    using chocolatey.infrastructure.commands;
+    using chocolatey.infrastructure.logging;
+    using chocolatey.infrastructure.results;
+
+    [CommandFor("list", "lists local packages")]
+    public class ChocolateyListCommand : IListCommand<PackageResult>
+    {
+        private readonly IChocolateyPackageService _packageService;
+
+        [Obsolete("Remove unsupported argument in V3!")]
+        private readonly string[] _unsupportedArguments = new[]
+        {
+            "l",
+            "lo",
+            "local",
+            "localonly",
+            "local-only",
+            "a",
+            "all",
+            "allversions",
+            "all-versions",
+            "order-by-popularity"
+        };
+
+        public ChocolateyListCommand(IChocolateyPackageService packageService)
+        {
+            _packageService = packageService ?? throw new ArgumentNullException(nameof(packageService));
+        }
+
+        public virtual void configure_argument_parser(OptionSet optionSet, ChocolateyConfiguration configuration)
+        {
+            optionSet
+                .Add("idonly|id-only",
+                     "Id Only - Only return Package Ids in the list results. Available in 0.10.6+.",
+                     option => configuration.ListCommand.IdOnly = option != null)
+                .Add("pre|prerelease",
+                     "Prerelease - Include Prereleases? Defaults to false.",
+                     option => configuration.Prerelease = option != null)
+                .Add("i|includeprograms|include-programs",
+                     "IncludePrograms - Used in conjunction with LocalOnly, filters out apps chocolatey has listed as packages and includes those in the list. Defaults to false.",
+                     option => configuration.ListCommand.IncludeRegistryPrograms = option != null)
+                .Add("version=",
+                     "Version - Specific version of a package to return.",
+                     option => configuration.Version = option.remove_surrounding_quotes())
+                .Add("page=",
+                     "Page - the 'page' of results to return. Defaults to return all results. Available in 0.9.10+.",
+                     option =>
+                     {
+                         if (int.TryParse(option, out var page))
+                         {
+                             configuration.ListCommand.Page = page;
+                         }
+                         else
+                         {
+                             configuration.ListCommand.Page = null;
+                         }
+                     })
+                .Add("page-size=", // Does it make sense to have paging on local packages?
+                     "Page Size - the amount of package results to return per page. Defaults to 25. Available in 0.9.10+.",
+                     option =>
+                     {
+                         configuration.ListCommand.PageSize = int.Parse(option);
+                         configuration.ListCommand.ExplicitPageSize = true;
+                     })
+                .Add("e|exact",
+                     "Exact - Only return packages with this exact name. Available in 0.9.10+.",
+                     option => configuration.ListCommand.Exact = option != null)
+                .Add("by-id-only",
+                     "ByIdOnly - Only return packages where the id contains the search filter. Available in 0.9.10+.",
+                     option => configuration.ListCommand.ByIdOnly = option != null)
+                 .Add("by-tag-only|by-tags-only",
+                     "ByTagOnly - Only return packages where the search filter matches on the tags. Available in 0.10.6+.",
+                     option => configuration.ListCommand.ByTagOnly = option != null)
+                 .Add("id-starts-with",
+                     "IdStartsWith - Only return packages where the id starts with the search filter. Available in 0.9.10+.",
+                     option => configuration.ListCommand.IdStartsWith = option != null)
+                 .Add("detail|detailed",
+                     "Detailed - Alias for verbose. Available in 0.9.10+.",
+                     option => configuration.Verbose = option != null);
+        }
+
+        public virtual int count(ChocolateyConfiguration config)
+        {
+            config.ListCommand.LocalOnly = true;
+            config.QuietOutput = true;
+
+            return _packageService.count_run(config);
+        }
+
+        public virtual void handle_additional_argument_parsing(IList<string> unparsedArguments, ChocolateyConfiguration configuration)
+        {
+            var argumentsWithoutLocalOnly = new List<string>(unparsedArguments.Count);
+
+            foreach (var argument in unparsedArguments)
+            {
+                if (_unsupportedArguments.Contains(argument.TrimStart('-'), StringComparer.OrdinalIgnoreCase))
+                {
+                    this.Log().Warn(ChocolateyLoggers.Important, @"
+UNSUPPORTED ARGUMENT: Ignoring the argument {0}. This argument is unsupported for locally installed packages, and will be treated as a package name in Chocolatey CLI v3!", argument);
+                }
+                else
+                {
+                    argumentsWithoutLocalOnly.Add(argument);
+                }
+            }
+
+            configuration.Input = string.Join(" ", argumentsWithoutLocalOnly);
+        }
+
+        public virtual void handle_validation(ChocolateyConfiguration configuration)
+        {
+            // There is nothing to validate.
+        }
+
+        public virtual void help_message(ChocolateyConfiguration configuration)
+        {
+            this.Log().Info(ChocolateyLoggers.Important, "List Command");
+            this.Log().Info(string.Empty);
+
+            this.Log().Info(ChocolateyLoggers.Important, "Usage");
+            this.Log().Info(@"
+    choco {0} <filter> [<options/switches>]
+".format_with(configuration.CommandName));
+
+            this.Log().Info(ChocolateyLoggers.Important, "Examples");
+            this.Log().Info(@"
+    choco {0} --local-only
+    choco {0} --local-only --include-programs
+
+NOTE: See scripting in the command reference (`choco -?`) for how to
+ write proper scripts and integrations.
+
+".format_with(configuration.CommandName));
+
+            this.Log().Info(ChocolateyLoggers.Important, "Exit Codes");
+            this.Log().Info(@"
+Exit codes that normally result from running this command.
+
+Normal:
+ - 0: operation was successful, no issues detected
+ - -1 or 1: an error has occurred
+
+Enhanced:
+ - 0: operation was successful, no issues detected
+ - -1 or 1: an error has occurred
+ - 2: no results (enhanced)
+
+NOTE: Starting in v0.10.12, if you have the feature '{0}'
+ turned on, then choco will provide enhanced exit codes that allow
+ better integration and scripting.
+
+If you find other exit codes that we have not yet documented, please
+ file a ticket so we can document it at
+ https://github.com/chocolatey/choco/issues/new/choose.
+
+".format_with(ApplicationParameters.Features.UseEnhancedExitCodes));
+
+            this.Log().Info(ChocolateyLoggers.Important, "Options and Switches");
+        }
+
+        public virtual IEnumerable<PackageResult> list(ChocolateyConfiguration config)
+        {
+            config.ListCommand.LocalOnly = true;
+            config.QuietOutput = true;
+
+            return _packageService.list_run(config);
+        }
+
+        public virtual bool may_require_admin_access()
+        {
+            return false;
+        }
+
+        public virtual void noop(ChocolateyConfiguration configuration)
+        {
+            configuration.ListCommand.LocalOnly = true;
+
+            _packageService.list_noop(configuration);
+        }
+
+        public virtual void run(ChocolateyConfiguration config)
+        {
+            config.ListCommand.LocalOnly = true;
+
+            // note: you must leave the .ToList() here or else the method won't be evaluated!
+            var packageResults = _packageService.list_run(config).ToList();
+
+            // if there are no results, exit with a 2 if enhanced exit codes is enabled.
+            if (config.Features.UseEnhancedExitCodes && packageResults.Count == 0 && Environment.ExitCode == 0)
+            {
+                Environment.ExitCode = 2;
+            }
+        }
+    }
+}

--- a/src/chocolatey/infrastructure.app/commands/ChocolateyListCommand.cs
+++ b/src/chocolatey/infrastructure.app/commands/ChocolateyListCommand.cs
@@ -34,16 +34,16 @@ namespace chocolatey.infrastructure.app.commands
         [Obsolete("Remove unsupported argument in V3!")]
         private readonly string[] _unsupportedArguments = new[]
         {
-            "l",
-            "lo",
-            "local",
-            "localonly",
-            "local-only",
-            "a",
-            "all",
-            "allversions",
-            "all-versions",
-            "order-by-popularity"
+            "-l",
+            "-lo",
+            "--local",
+            "--localonly",
+            "--local-only",
+            "-a",
+            "--all",
+            "--allversions",
+            "--all-versions",
+            "--order-by-popularity"
         };
 
         public ChocolateyListCommand(IChocolateyPackageService packageService)
@@ -117,7 +117,7 @@ namespace chocolatey.infrastructure.app.commands
 
             foreach (var argument in unparsedArguments)
             {
-                if (_unsupportedArguments.Contains(argument.TrimStart('-'), StringComparer.OrdinalIgnoreCase))
+                if (_unsupportedArguments.Contains(argument, StringComparer.OrdinalIgnoreCase))
                 {
                     this.Log().Warn(ChocolateyLoggers.Important, @"
 UNSUPPORTED ARGUMENT: Ignoring the argument {0}. This argument is unsupported for locally installed packages, and will be treated as a package name in Chocolatey CLI v3!", argument);

--- a/src/chocolatey/infrastructure.app/commands/ChocolateySearchCommand.cs
+++ b/src/chocolatey/infrastructure.app/commands/ChocolateySearchCommand.cs
@@ -40,27 +40,17 @@ namespace chocolatey.infrastructure.app.commands
 
         public virtual void configure_argument_parser(OptionSet optionSet, ChocolateyConfiguration configuration)
         {
-            var localOnlyDescription = configuration.CommandName.is_equal_to("list")
-                ? "LocalOnly - Only search against local machine items. Ignores --source if provided.. (DEPRECATION NOTICE: Will be removed and enabled by default in v2.0.0 and removed.)"
-                : "LocalOnly - Only search against local machine items. Ignores --source if provided..";
-            var deprecationNotice = configuration.CommandName.is_equal_to("list")
-                ? " (DEPRECATION NOTICE: Will be removed for list command in v2.0.0)"
-                : string.Empty;
-
             optionSet
                 .Add("s=|source=",
-                     "Source - Source location for install. Can use special 'windowsfeatures', 'ruby', 'cygwin', or 'python' sources. Defaults to sources." + deprecationNotice,
+                     "Source - Source location for install. Can use special 'windowsfeatures', 'ruby', 'cygwin', or 'python' sources. Defaults to sources.",
                      option => configuration.Sources = option.remove_surrounding_quotes())
-                .Add("l|lo|local|localonly|local-only",
-                     localOnlyDescription,
-                     option => configuration.ListCommand.LocalOnly = option != null)
                 .Add("idonly|id-only",
                      "Id Only - Only return Package Ids in the list results. Available in 0.10.6+.",
                      option => configuration.ListCommand.IdOnly = option != null)
                 .Add("pre|prerelease",
                      "Prerelease - Include Prereleases? Defaults to false.",
                      option => configuration.Prerelease = option != null)
-                .Add("i|includeprograms|include-programs",
+                .Add("i|includeprograms|include-programs", // Should this parameter be deprecated on Search?
                      "IncludePrograms - Used in conjunction with LocalOnly, filters out apps chocolatey has listed as packages and includes those in the list. Defaults to false.",
                      option => configuration.ListCommand.IncludeRegistryPrograms = option != null)
                 .Add("a|all|allversions|all-versions",
@@ -70,16 +60,16 @@ namespace chocolatey.infrastructure.app.commands
                      "Version - Specific version of a package to return.",
                      option => configuration.Version = option.remove_surrounding_quotes())
                 .Add("u=|user=",
-                     "User - used with authenticated feeds. Defaults to empty." + deprecationNotice,
+                     "User - used with authenticated feeds. Defaults to empty.",
                      option => configuration.SourceCommand.Username = option.remove_surrounding_quotes())
                 .Add("p=|password=",
-                     "Password - the user's password to the source. Defaults to empty." + deprecationNotice,
+                     "Password - the user's password to the source. Defaults to empty.",
                      option => configuration.SourceCommand.Password = option.remove_surrounding_quotes())
                 .Add("cert=",
-                     "Client certificate - PFX pathname for an x509 authenticated feeds. Defaults to empty. Available in 0.9.10+." + deprecationNotice,
+                     "Client certificate - PFX pathname for an x509 authenticated feeds. Defaults to empty. Available in 0.9.10+.",
                      option => configuration.SourceCommand.Certificate = option.remove_surrounding_quotes())
                 .Add("cp=|certpassword=",
-                     "Certificate Password - the client certificate's password to the source. Defaults to empty. Available in 0.9.10+." + deprecationNotice,
+                     "Certificate Password - the client certificate's password to the source. Defaults to empty. Available in 0.9.10+.",
                      option => configuration.SourceCommand.CertificatePassword = option.remove_surrounding_quotes())
                 .Add("page=",
                      "Page - the 'page' of results to return. Defaults to return all results. Available in 0.9.10+.",
@@ -118,20 +108,20 @@ namespace chocolatey.infrastructure.app.commands
                      "OrderByPopularity - Sort by package results by popularity. Available in 0.9.10+.",
                      option => configuration.ListCommand.OrderByPopularity = option != null)
                  .Add("approved-only",
-                    "ApprovedOnly - Only return approved packages - this option will filter out results not from the community repository. Available in 0.9.10+." + deprecationNotice,
+                    "ApprovedOnly - Only return approved packages - this option will filter out results not from the community repository. Available in 0.9.10+.",
                      option => configuration.ListCommand.ApprovedOnly = option != null)
                  .Add("download-cache|download-cache-only",
-                     "DownloadCacheAvailable - Only return packages that have a download cache available - this option will filter out results not from the community repository. Available in 0.9.10+." + deprecationNotice,
+                     "DownloadCacheAvailable - Only return packages that have a download cache available - this option will filter out results not from the community repository. Available in 0.9.10+.",
                      option => configuration.ListCommand.DownloadCacheAvailable = option != null)
                  .Add("not-broken",
-                     "NotBroken - Only return packages that are not failing testing - this option only filters out failing results from the community feed. It will not filter against other sources. Available in 0.9.10+." + deprecationNotice,
+                     "NotBroken - Only return packages that are not failing testing - this option only filters out failing results from the community feed. It will not filter against other sources. Available in 0.9.10+.",
                      option => configuration.ListCommand.NotBroken = option != null)
                   .Add("detail|detailed",
                      "Detailed - Alias for verbose. Available in 0.9.10+.",
                      option => configuration.Verbose = option != null)
                   .Add("disable-repository-optimizations|disable-package-repository-optimizations",
-                    "Disable Package Repository Optimizations - Do not use optimizations for reducing bandwidth with repository queries during package install/upgrade/outdated operations. Should not generally be used, unless a repository needs to support older methods of query. When disabled, this makes queries similar to the way they were done in Chocolatey v0.10.11 and before. Overrides the default feature '{0}' set to '{1}'. Available in 0.10.14+.{2}".format_with
-                        (ApplicationParameters.Features.UsePackageRepositoryOptimizations, configuration.Features.UsePackageRepositoryOptimizations.to_string(), deprecationNotice),
+                    "Disable Package Repository Optimizations - Do not use optimizations for reducing bandwidth with repository queries during package install/upgrade/outdated operations. Should not generally be used, unless a repository needs to support older methods of query. When disabled, this makes queries similar to the way they were done in Chocolatey v0.10.11 and before. Overrides the default feature '{0}' set to '{1}'. Available in 0.10.14+.".format_with
+                        (ApplicationParameters.Features.UsePackageRepositoryOptimizations, configuration.Features.UsePackageRepositoryOptimizations.to_string()),
                     option =>
                     {
                         if (option != null)
@@ -165,7 +155,7 @@ namespace chocolatey.infrastructure.app.commands
 
         public virtual void help_message(ChocolateyConfiguration configuration)
         {
-            this.Log().Info(ChocolateyLoggers.Important, "List/Search Command");
+            this.Log().Info(ChocolateyLoggers.Important, "Search Command");
             this.Log().Info(@"
 Chocolatey will perform a search for a package local or remote.
 
@@ -180,19 +170,16 @@ NOTE: 100% compatible with older Chocolatey client (0.9.8.x and below)
             // coding the names?
             "chocolatey".Log().Info(@"
     choco find <filter> [<options/switches>]
-    choco list <filter> [<options/switches>]
     choco search <filter> [<options/switches>]
 ");
 
             "chocolatey".Log().Info(ChocolateyLoggers.Important, "Examples");
             "chocolatey".Log().Info(@"
-    choco list --local-only (DEPRECATED: will be default for list in v2.0.0)
-    choco list -li
-    choco list -lai
-    choco list --page=0 --page-size=25
     choco search git
     choco search git --source=""'https://somewhere/out/there'""
     choco search bob -s ""'https://somewhere/protected'"" -u user -p pass
+    choco search --page=0 --page-size=25
+    choco search 7zip --all-versions --exact
 
 NOTE: See scripting in the command reference (`choco -?`) for how to
  write proper scripts and integrations.
@@ -229,36 +216,16 @@ choco {0}: https://raw.githubusercontent.com/wiki/chocolatey/choco/images/gifs/c
 ".format_with(configuration.CommandName));
             "chocolatey".Log().Info(ChocolateyLoggers.Important, "Alternative Sources");
 
-            if (configuration.CommandName.is_equal_to("list"))
-            {
-                "chocolatey".Log().Warn(@"
-Will be removed for the list command in v2.0.0.");
-            }
-
-            "chocolatey".Log().Info(@"
-Available in 0.9.10+.
-
-Windows Features
-This specifies that the source is a Windows Feature and we should
- install via the Deployment Image Servicing and Management tool (DISM)
- on the local machine.
- e.g. `choco {0} --source windowsfeatures`
-".format_with(configuration.CommandName));
-
             "chocolatey".Log().Info(ChocolateyLoggers.Important, "Options and Switches");
         }
 
         public virtual void noop(ChocolateyConfiguration configuration)
         {
-            log_deprecation_warning(configuration);
-
             _packageService.list_noop(configuration);
         }
 
         public virtual void run(ChocolateyConfiguration configuration)
         {
-            log_deprecation_warning(configuration);
-
             _packageService.ensure_source_app_installed(configuration);
             // note: you must leave the .ToList() here or else the method won't be evaluated!
             var packageResults = _packageService.list_run(configuration).ToList();
@@ -286,28 +253,6 @@ This specifies that the source is a Windows Feature and we should
         public virtual bool may_require_admin_access()
         {
             return false;
-        }
-
-        // Marked as obsolete on purpose so we remember to remove
-        // this method when we make list local only, currently this
-        // is planned for v2.0.0, with #158.
-        [Obsolete("Remove once list is made local only!")]
-        private void log_deprecation_warning(ChocolateyConfiguration configuration)
-        {
-            if (configuration.CommandName.is_equal_to("list") && !configuration.ListCommand.LocalOnly)
-            {
-                var logger = ChocolateyLoggers.LogFileOnly;
-
-                if (configuration.RegularOutput)
-                {
-                    logger = ChocolateyLoggers.Normal;
-                }
-
-                this.Log().Warn(logger, @"Using the list command with remote sources is deprecated and will be made
-to only list locally installed packages in v2.0.0. Use the search, or find,
-command to find packages on remote sources (such as the Chocolatey Community
-Repository).");
-            }
         }
     }
 }

--- a/src/chocolatey/infrastructure.app/commands/ChocolateySearchCommand.cs
+++ b/src/chocolatey/infrastructure.app/commands/ChocolateySearchCommand.cs
@@ -27,14 +27,13 @@ namespace chocolatey.infrastructure.app.commands
     using results;
     using services;
 
-    [CommandFor("list", "lists remote or local packages")]
-    [CommandFor("search", "searches remote or local packages")]
-    [CommandFor("find", "searches remote or local packages (alias for search)")]
-    public class ChocolateyListCommand : IListCommand<PackageResult>
+    [CommandFor("search", "searches remote packages")]
+    [CommandFor("find", "searches remote packages (alias for search)")]
+    public class ChocolateySearchCommand : IListCommand<PackageResult>
     {
         private readonly IChocolateyPackageService _packageService;
 
-        public ChocolateyListCommand(IChocolateyPackageService packageService)
+        public ChocolateySearchCommand(IChocolateyPackageService packageService)
         {
             _packageService = packageService;
         }

--- a/tests/chocolatey-tests/chocolatey.Tests.ps1
+++ b/tests/chocolatey-tests/chocolatey.Tests.ps1
@@ -198,7 +198,7 @@ Describe "Ensuring Chocolatey is correctly installed" -Tag Environment, Chocolat
     Context 'License warning is worded properly' -Tag FossOnly -Skip:((-not $env:TEST_KITCHEN) -or (-not (Test-ChocolateyVersionEqualOrHigherThan '1.0.0'))) {
         BeforeAll {
             $null = Invoke-Choco install chocolatey-license-business -y
-            $Output = Invoke-Choco list -lo
+            $Output = Invoke-Choco search -lo
         }
 
         AfterAll {
@@ -218,7 +218,7 @@ Describe "Ensuring Chocolatey is correctly installed" -Tag Environment, Chocolat
         BeforeAll {
             Remove-Item $Profile.CurrentUserCurrentHost -ErrorAction Ignore
             New-Item $Profile.CurrentUserCurrentHost -Force
-            $chocolatey = (Invoke-Choco list chocolatey -lo -r --exact).Lines | ConvertFrom-ChocolateyOutput -Command List
+            $chocolatey = (Invoke-Choco search chocolatey -lo -r --exact).Lines | ConvertFrom-ChocolateyOutput -Command Search
             Enable-ChocolateySource -Name local
             $null = Invoke-Choco install chocolatey -f --version $chocolatey.Version
         }
@@ -245,7 +245,7 @@ Describe "Ensuring Chocolatey is correctly installed" -Tag Environment, Chocolat
         BeforeAll {
             New-Item $Profile.CurrentUserCurrentHost -Force
             "" | Set-Content -Path $Profile.CurrentUserCurrentHost -Encoding UTF8
-            $chocolatey = (Invoke-Choco list chocolatey -lo -r --exact).Lines | ConvertFrom-ChocolateyOutput -Command List
+            $chocolatey = (Invoke-Choco search chocolatey -lo -r --exact).Lines | ConvertFrom-ChocolateyOutput -Command Search
         }
 
         AfterAll {
@@ -278,7 +278,7 @@ Describe "Ensuring Chocolatey is correctly installed" -Tag Environment, Chocolat
         }
     ) {
         BeforeAll {
-            $chocolatey = (Invoke-Choco list chocolatey -lo -r --exact).Lines | ConvertFrom-ChocolateyOutput -Command List
+            $chocolatey = (Invoke-Choco search chocolatey -lo -r --exact).Lines | ConvertFrom-ChocolateyOutput -Command Search
 
             foreach ($shim in $RemovedShims) {
                 $shimToRemove = "$env:ChocolateyInstall$shim"

--- a/tests/chocolatey-tests/chocolatey.Tests.ps1
+++ b/tests/chocolatey-tests/chocolatey.Tests.ps1
@@ -195,10 +195,10 @@ Describe "Ensuring Chocolatey is correctly installed" -Tag Environment, Chocolat
     }
 
     # This is skipped when not run in CI because it modifies the local system.
-    Context 'License warning is worded properly' -Tag FossOnly -Skip:((-not $env:TEST_KITCHEN) -or (-not (Test-ChocolateyVersionEqualOrHigherThan '1.0.0'))) {
+    Context 'License warning is worded properly' -Tag FossOnly,ListCommand,License -Skip:((-not $env:TEST_KITCHEN) -or (-not (Test-ChocolateyVersionEqualOrHigherThan '1.0.0'))) {
         BeforeAll {
             $null = Invoke-Choco install chocolatey-license-business -y
-            $Output = Invoke-Choco search -lo
+            $Output = Invoke-Choco list
         }
 
         AfterAll {
@@ -214,11 +214,11 @@ Describe "Ensuring Chocolatey is correctly installed" -Tag Environment, Chocolat
     }
 
     # This is skipped when not run in CI because it modifies the local system.
-    Context 'PowerShell Profile comments updated correctly' -Skip:((-not $env:TEST_KITCHEN) -or (-not (Test-ChocolateyVersionEqualOrHigherThan '1.0.0'))) {
+    Context 'PowerShell Profile comments updated correctly' -Tag ListCommand,Profile -Skip:((-not $env:TEST_KITCHEN) -or (-not (Test-ChocolateyVersionEqualOrHigherThan '1.0.0'))) {
         BeforeAll {
             Remove-Item $Profile.CurrentUserCurrentHost -ErrorAction Ignore
             New-Item $Profile.CurrentUserCurrentHost -Force
-            $chocolatey = (Invoke-Choco search chocolatey -lo -r --exact).Lines | ConvertFrom-ChocolateyOutput -Command Search
+            $chocolatey = (Invoke-Choco list chocolatey -r --exact).Lines | ConvertFrom-ChocolateyOutput -Command List
             Enable-ChocolateySource -Name local
             $null = Invoke-Choco install chocolatey -f --version $chocolatey.Version
         }
@@ -241,11 +241,11 @@ Describe "Ensuring Chocolatey is correctly installed" -Tag Environment, Chocolat
     }
 
     # This is skipped when not run in CI because it modifies the local system.
-    Context 'PowerShell Profile properly updated when Windows thinks a 5 byte file is signed' -Skip:((-not $env:TEST_KITCHEN) -or (-not (Test-ChocolateyVersionEqualOrHigherThan '1.1.0'))) {
+    Context 'PowerShell Profile properly updated when Windows thinks a 5 byte file is signed', ListCommand,Profile -Skip:((-not $env:TEST_KITCHEN) -or (-not (Test-ChocolateyVersionEqualOrHigherThan '1.1.0'))) {
         BeforeAll {
             New-Item $Profile.CurrentUserCurrentHost -Force
             "" | Set-Content -Path $Profile.CurrentUserCurrentHost -Encoding UTF8
-            $chocolatey = (Invoke-Choco search chocolatey -lo -r --exact).Lines | ConvertFrom-ChocolateyOutput -Command Search
+            $chocolatey = (Invoke-Choco list chocolatey -r --exact).Lines | ConvertFrom-ChocolateyOutput -Command List
         }
 
         AfterAll {
@@ -265,7 +265,7 @@ Describe "Ensuring Chocolatey is correctly installed" -Tag Environment, Chocolat
     }
 
     # This is skipped when not run in CI because it requires signed executables
-    Context 'Ensure we <Removal> shims during upgrade' -Skip:((-not $env:TEST_KITCHEN) -or (-not (Test-ChocolateyVersionEqualOrHigherThan '1.0.0'))) -ForEach @(
+    Context 'Ensure we <Removal> shims during upgrade' -Tag ListCommand,Shims -Skip:((-not $env:TEST_KITCHEN) -or (-not (Test-ChocolateyVersionEqualOrHigherThan '1.0.0'))) -ForEach @(
         @{
             RemovedShims = $RemovedShims
             Signed       = $true
@@ -278,7 +278,7 @@ Describe "Ensuring Chocolatey is correctly installed" -Tag Environment, Chocolat
         }
     ) {
         BeforeAll {
-            $chocolatey = (Invoke-Choco search chocolatey -lo -r --exact).Lines | ConvertFrom-ChocolateyOutput -Command Search
+            $chocolatey = (Invoke-Choco list chocolatey -r --exact).Lines | ConvertFrom-ChocolateyOutput -Command List
 
             foreach ($shim in $RemovedShims) {
                 $shimToRemove = "$env:ChocolateyInstall$shim"

--- a/tests/chocolatey-tests/chocolatey.Tests.ps1
+++ b/tests/chocolatey-tests/chocolatey.Tests.ps1
@@ -214,7 +214,7 @@ Describe "Ensuring Chocolatey is correctly installed" -Tag Environment, Chocolat
     }
 
     # This is skipped when not run in CI because it modifies the local system.
-    Context 'PowerShell Profile comments updated correctly' -Tag ListCommand,Profile -Skip:((-not $env:TEST_KITCHEN) -or (-not (Test-ChocolateyVersionEqualOrHigherThan '1.0.0'))) {
+    Context 'PowerShell Profile comments updated correctly' -Tag ListCommand, Profile -Skip:((-not $env:TEST_KITCHEN) -or (-not (Test-ChocolateyVersionEqualOrHigherThan '1.0.0'))) {
         BeforeAll {
             Remove-Item $Profile.CurrentUserCurrentHost -ErrorAction Ignore
             New-Item $Profile.CurrentUserCurrentHost -Force
@@ -241,7 +241,7 @@ Describe "Ensuring Chocolatey is correctly installed" -Tag Environment, Chocolat
     }
 
     # This is skipped when not run in CI because it modifies the local system.
-    Context 'PowerShell Profile properly updated when Windows thinks a 5 byte file is signed', ListCommand,Profile -Skip:((-not $env:TEST_KITCHEN) -or (-not (Test-ChocolateyVersionEqualOrHigherThan '1.1.0'))) {
+    Context 'PowerShell Profile properly updated when Windows thinks a 5 byte file is signed' -Tag ListCommand, Profile -Skip:((-not $env:TEST_KITCHEN) -or (-not (Test-ChocolateyVersionEqualOrHigherThan '1.1.0'))) {
         BeforeAll {
             New-Item $Profile.CurrentUserCurrentHost -Force
             "" | Set-Content -Path $Profile.CurrentUserCurrentHost -Encoding UTF8
@@ -265,7 +265,7 @@ Describe "Ensuring Chocolatey is correctly installed" -Tag Environment, Chocolat
     }
 
     # This is skipped when not run in CI because it requires signed executables
-    Context 'Ensure we <Removal> shims during upgrade' -Tag ListCommand,Shims -Skip:((-not $env:TEST_KITCHEN) -or (-not (Test-ChocolateyVersionEqualOrHigherThan '1.0.0'))) -ForEach @(
+    Context 'Ensure we <Removal> shims during upgrade' -Tag ListCommand, Shims -Skip:((-not $env:TEST_KITCHEN) -or (-not (Test-ChocolateyVersionEqualOrHigherThan '1.0.0'))) -ForEach @(
         @{
             RemovedShims = $RemovedShims
             Signed       = $true

--- a/tests/chocolatey-tests/commands/choco-list.Tests.ps1
+++ b/tests/chocolatey-tests/commands/choco-list.Tests.ps1
@@ -15,7 +15,6 @@ Describe "choco list" -Tag Chocolatey, ListCommand {
         Remove-ChocolateyTestInstall
     }
 
-    # TODO: Extract to separate list file
     Context "Listing local packages" {
         BeforeAll {
             $Output = Invoke-Choco list
@@ -38,7 +37,6 @@ Describe "choco list" -Tag Chocolatey, ListCommand {
         }
     }
 
-    # TODO: Separate to separate list file
     Context "Listing local packages (limiting output)" {
         BeforeAll {
             $Output = Invoke-Choco list --LimitOutput
@@ -61,7 +59,6 @@ Describe "choco list" -Tag Chocolatey, ListCommand {
         }
     }
 
-    # TODO: Separate to separate list file
     Context "Listing local packages (limiting output, ID only)" {
         BeforeAll {
             $Output = Invoke-Choco list --IdOnly

--- a/tests/chocolatey-tests/commands/choco-list.Tests.ps1
+++ b/tests/chocolatey-tests/commands/choco-list.Tests.ps1
@@ -1,0 +1,118 @@
+Import-Module helpers/common-helpers
+
+Describe "choco list" -Tag Chocolatey, ListCommand {
+    BeforeAll {
+        Remove-NuGetPaths
+        Initialize-ChocolateyTestInstall -Source $PSScriptRoot\testpackages
+        Invoke-Choco install installpackage --version 1.0.0 --confirm
+        Invoke-Choco install upgradepackage --version 1.0.0 --confirm
+        $VersionRegex = "[^v]\d+\.\d+\.\d+"
+        # Ensure that we remove any compatibility package before running the tests
+        $null = Invoke-Choco uninstall chocolatey-compatibility.extension -y --force
+    }
+
+    AfterAll {
+        Remove-ChocolateyTestInstall
+    }
+
+    # TODO: Extract to separate list file
+    Context "Listing local packages" {
+        BeforeAll {
+            $Output = Invoke-Choco list
+        }
+
+        It "Exits with Success (0)" {
+            $Output.ExitCode | Should -Be 0
+        }
+
+        It "Should contain packages and version with a space between them" {
+            $Output.Lines | Should -Contain "upgradepackage 1.0.0"
+        }
+
+        It "Should not contain pipe-delimited packages and versions" {
+            $Output.Lines | Should -Not -Contain "upgradepackage|1.0.0"
+        }
+
+        It "Should contain a summary" {
+            $Output.String | Should -Match "\d+ packages installed"
+        }
+    }
+
+    # TODO: Separate to separate list file
+    Context "Listing local packages (limiting output)" {
+        BeforeAll {
+            $Output = Invoke-Choco list --LimitOutput
+        }
+
+        It "Exits with Success (0)" {
+            $Output.ExitCode | Should -Be 0
+        }
+
+        It "Should not contain packages and version with a space between them" {
+            $Output.Lines | Should -Not -Contain "upgradepackage 1.0.0"
+        }
+
+        It "Should contain pipe-delimited packages and versions" {
+            $Output.Lines | Should -Contain "upgradepackage|1.0.0"
+        }
+
+        It "Should not contain a summary" {
+            $Output.String | Should -Not -Match "\d+ packages installed"
+        }
+    }
+
+    # TODO: Separate to separate list file
+    Context "Listing local packages (limiting output, ID only)" {
+        BeforeAll {
+            $Output = Invoke-Choco list --IdOnly
+        }
+
+        It "Exits with Success (0)" {
+            $Output.ExitCode | Should -Be 0
+        }
+
+        It "Should contain package name(s)" {
+            $Output.Lines | Should -Contain "upgradepackage"
+        }
+
+        It "Should not contain any version numbers" {
+            $Output.String | Should -Not -Match $VersionRegex
+        }
+    }
+
+    Context "Listing local packages with paging" {
+        BeforeAll {
+            Restore-ChocolateyInstallSnapshot
+
+            $null = Invoke-Choco install hasdependency --confirm
+
+            $Output = Invoke-Choco list dependency --page 1 --page-size 2 --id-only
+        }
+
+        It "Exits with Success (0)" {
+            $Output.ExitCode | Should -Be 0
+        }
+
+        It "Should contain package isexactversiondependency" {
+            $Output.Lines | Should -Contain isexactversiondependency
+        }
+
+        It "Should not contain package <_>" -Foreach @('isdependency', 'hasdependency') {
+            $Output.Lines | Should -Not -Contain $_
+        }
+    }
+
+    Context "Listing local packages with unsupported argument outputs warning" -ForEach @('-l', '-lo', '--lo', '--local', '--localonly', '--local-only', '--order-by-popularity', '-a', '--all', '--allversions', '--all-versions') {
+        BeforeAll {
+            $Output = Invoke-Choco list $_
+        }
+
+        It "Exits with Success (0)" {
+            $Output.ExitCode | Should -Be 0
+        }
+
+        It "Should contain expected warning message" {
+            $Output.Lines | Should -Contain "UNSUPPORTED ARGUMENT: Ignoring the argument $_. This argument is unsupported for locally installed packages, and will be treated as a package name in Chocolatey CLI v3!"
+        }
+    }
+}

--- a/tests/chocolatey-tests/commands/choco-search.Tests.ps1
+++ b/tests/chocolatey-tests/commands/choco-search.Tests.ps1
@@ -1,14 +1,13 @@
 ﻿<#
     .Synopsis
-        Tests for `choco list` and aliases
+        Tests for `choco search` and aliases
 
     .Link
-        https://github.com/chocolatey/choco/blob/master/src/chocolatey.tests.integration/scenarios/ListScenarios.cs
+        https://github.com/chocolatey/choco/blob/master/src/chocolatey.tests.integration/scenarios/SearchScenarios.cs
 #>
 param(
-    # Which command to test (used for testing aliases instead of the base command, 'list')
+    # Which command to test (used for testing aliases instead of the base command, 'search')
     [string[]]$Command = @(
-        "list"
         "find"
         "search"
     )
@@ -16,7 +15,7 @@ param(
 
 Import-Module helpers/common-helpers
 
-Describe "choco <_>" -ForEach $Command -Tag Chocolatey, ListCommand, SearchCommand, FindCommand {
+Describe "choco <_>" -ForEach $Command -Tag Chocolatey, SearchCommand, FindCommand {
     BeforeDiscovery {
         $licensedProxyFixed = Test-PackageIsEqualOrHigher 'chocolatey.extension' 2.2.0-beta -AllowMissingPackage
     }
@@ -185,6 +184,7 @@ Describe "choco <_>" -ForEach $Command -Tag Chocolatey, ListCommand, SearchComma
         }
     }
 
+    # TODO: Extract to separate list file
     Context "Listing local packages" {
         BeforeAll {
             $Output = Invoke-Choco $_ --LocalOnly
@@ -207,6 +207,7 @@ Describe "choco <_>" -ForEach $Command -Tag Chocolatey, ListCommand, SearchComma
         }
     }
 
+    # TODO: Separate to separate list file
     Context "Listing local packages (limiting output)" {
         BeforeAll {
             $Output = Invoke-Choco $_ --LocalOnly --LimitOutput
@@ -229,6 +230,7 @@ Describe "choco <_>" -ForEach $Command -Tag Chocolatey, ListCommand, SearchComma
         }
     }
 
+    # TODO: Separate to separate list file
     Context "Listing local packages (limiting output, ID only)" {
         BeforeAll {
             $Output = Invoke-Choco $_ --LocalOnly --IdOnly
@@ -247,7 +249,7 @@ Describe "choco <_>" -ForEach $Command -Tag Chocolatey, ListCommand, SearchComma
         }
     }
 
-    Context "Listing packages with no sources enabled" {
+    Context "Searching packages with no sources enabled" {
         BeforeAll {
             Disable-ChocolateySource -All
 
@@ -313,7 +315,7 @@ Describe "choco <_>" -ForEach $Command -Tag Chocolatey, ListCommand, SearchComma
     }
 
     # Issue: https://gitlab.com/chocolatey/collaborators/choco-licensed/-/issues/530 (NOTE: Proxy bypassing also works on Chocolatey FOSS)
-    Context "Listing packages on source using proxy and proxy bypass list" -Skip:(!$licensedProxyFixed) {
+    Context "Searching packages on source using proxy and proxy bypass list" -Skip:(!$licensedProxyFixed) {
         BeforeAll {
             Restore-ChocolateyInstallSnapshot
             $null = Invoke-Choco config set --name=proxy --value="https://invalid.chocolatey.org/"
@@ -336,7 +338,7 @@ Describe "choco <_>" -ForEach $Command -Tag Chocolatey, ListCommand, SearchComma
     }
 
     # Issue: https://gitlab.com/chocolatey/collaborators/choco-licensed/-/issues/530 (NOTE: Proxy bypassing also works on Chocolatey FOSS)
-    Context "Listing packages on source using proxy and proxy bypass list on command" -Skip:(!$licensedProxyFixed) {
+    Context "Searching packages on source using proxy and proxy bypass list on command" -Skip:(!$licensedProxyFixed) {
         BeforeAll {
             Restore-ChocolateyInstallSnapshot
             $null = Invoke-Choco config set --name=proxy --value="https://invalid.chocolatey.org/"
@@ -358,7 +360,7 @@ Describe "choco <_>" -ForEach $Command -Tag Chocolatey, ListCommand, SearchComma
     }
 
     # Issue: https://github.com/chocolatey/choco/issues/2304
-    Context "Listing packages with exact and all version displayed without pre-release argument" -Skip:(-Not (Test-ChocolateyVersionEqualOrHigherThan "0.10.16-beta-233")) {
+    Context "Searching packages with exact and all version displayed without pre-release argument" -Skip:(-Not (Test-ChocolateyVersionEqualOrHigherThan "0.10.16-beta-233")) {
         BeforeAll {
             Restore-ChocolateyInstallSnapshot
 
@@ -378,7 +380,7 @@ Describe "choco <_>" -ForEach $Command -Tag Chocolatey, ListCommand, SearchComma
         }
     }
 
-    Context "Listing packages with exact, all versions and pre-release arguments" -Skip:(-Not (Test-ChocolateyVersionEqualOrHigherThan "0.10.16-beta-233")) {
+    Context "Searching packages with exact, all versions and pre-release arguments" -Skip:(-Not (Test-ChocolateyVersionEqualOrHigherThan "0.10.16-beta-233")) {
         BeforeAll {
             Restore-ChocolateyInstallSnapshot
 

--- a/tests/chocolatey-tests/commands/choco-search.Tests.ps1
+++ b/tests/chocolatey-tests/commands/choco-search.Tests.ps1
@@ -50,7 +50,7 @@ Describe "choco <_>" -ForEach $Command -Tag Chocolatey, SearchCommand, FindComma
         }
 
         It "Contains packages and versions with a space between them" {
-            $Output.Lines | Should -Contain "upgradepackage 1.1.0"
+            $Output.Lines | Should -Contain "upgradepackage 1.1.0" -Because $Output.String
         }
 
         It "Should not contain pipe-delimited values" {
@@ -181,71 +181,6 @@ Describe "choco <_>" -ForEach $Command -Tag Chocolatey, SearchCommand, FindComma
 
         It "Should contain a summary" {
             $Output.String | Should -Match "\d+ packages found."
-        }
-    }
-
-    # TODO: Extract to separate list file
-    Context "Listing local packages" {
-        BeforeAll {
-            $Output = Invoke-Choco $_ --LocalOnly
-        }
-
-        It "Exits with Success (0)" {
-            $Output.ExitCode | Should -Be 0
-        }
-
-        It "Should contain packages and version with a space between them" {
-            $Output.Lines | Should -Contain "upgradepackage 1.0.0"
-        }
-
-        It "Should not contain pipe-delimited packages and versions" {
-            $Output.Lines | Should -Not -Contain "upgradepackage|1.0.0"
-        }
-
-        It "Should contain a summary" {
-            $Output.String | Should -Match "\d+ packages installed"
-        }
-    }
-
-    # TODO: Separate to separate list file
-    Context "Listing local packages (limiting output)" {
-        BeforeAll {
-            $Output = Invoke-Choco $_ --LocalOnly --LimitOutput
-        }
-
-        It "Exits with Success (0)" {
-            $Output.ExitCode | Should -Be 0
-        }
-
-        It "Should not contain packages and version with a space between them" {
-            $Output.Lines | Should -Not -Contain "upgradepackage 1.0.0"
-        }
-
-        It "Should contain pipe-delimited packages and versions" {
-            $Output.Lines | Should -Contain "upgradepackage|1.0.0"
-        }
-
-        It "Should not contain a summary" {
-            $Output.String | Should -Not -Match "\d+ packages installed"
-        }
-    }
-
-    # TODO: Separate to separate list file
-    Context "Listing local packages (limiting output, ID only)" {
-        BeforeAll {
-            $Output = Invoke-Choco $_ --LocalOnly --IdOnly
-        }
-
-        It "Exits with Success (0)" {
-            $Output.ExitCode | Should -Be 0
-        }
-
-        It "Should contain package name(s)" {
-            $Output.Lines | Should -Contain "upgradepackage"
-        }
-
-        It "Should not contain any version numbers" {
-            $Output.String | Should -Not -Match $VersionRegex
         }
     }
 
@@ -493,6 +428,21 @@ Describe "choco <_>" -ForEach $Command -Tag Chocolatey, SearchCommand, FindComma
 
         It "Should output the amount of packages found" {
             $Output.Lines | Should -Contain "1 packages found." -Because $Output.String
+        }
+    }
+
+    Context "Searching with '--local-only' searches for package with the name" {
+        BeforeAll {
+            # This test will need to be updated if we start caching search results
+            $Output = Invoke-Choco $currentCommand --local-only --verbose
+        }
+
+        It "Exits with Success (0)" {
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
+        }
+
+        It "Uses search term '--local-only'" {
+            $Output.String | Should -BeLike "*searchTerm='--local-only'*"
         }
     }
 

--- a/tests/helpers/common/Chocolatey/ConvertFrom-ChocolateyOutput.ps1
+++ b/tests/helpers/common/Chocolatey/ConvertFrom-ChocolateyOutput.ps1
@@ -4,7 +4,7 @@
             Converts from Chocolatey's --LimitOutput (-r) to PowerShell object
 
         .Example
-            (Invoke-Choco list -lo -r).Lines | ConvertFrom-ChocolateyOutput -Command List
+            (Invoke-Choco list -r).Lines | ConvertFrom-ChocolateyOutput -Command List
 
         .Example
             (Invoke-Choco pin list -r).Lines | ConvertFrom-ChocolateyOutput -Command PinList

--- a/tests/helpers/common/Chocolatey/Get-ChocolateyLicense.ps1
+++ b/tests/helpers/common/Chocolatey/Get-ChocolateyLicense.ps1
@@ -3,7 +3,7 @@
         return $script:LicenseType
     }
 
-    $package = (Invoke-Choco list --local-only --limitoutput).Lines |
+    $package = (Invoke-Choco list --limitoutput).Lines |
         ConvertFrom-ChocolateyOutput -Command List |
         Where-Object Name -Match "^chocolatey-license-" |
         Select-Object -First 1 # We only expect one package, so we only take the first result

--- a/tests/helpers/common/Chocolatey/Get-ExpectedChocolateyHeader.ps1
+++ b/tests/helpers/common/Chocolatey/Get-ExpectedChocolateyHeader.ps1
@@ -1,5 +1,5 @@
 ﻿function Get-ExpectedChocolateyHeader {
-    $packages = (Invoke-Choco list --local-only --limitoutput).Lines |
+    $packages = (Invoke-Choco list --limitoutput).Lines |
         Where-Object { $_ -NotMatch 'please upgrade' } |
         ConvertFrom-ChocolateyOutput -Command List
 

--- a/tests/helpers/common/Chocolatey/Test-ChocolateyVersionEqualOrHigherThan.ps1
+++ b/tests/helpers/common/Chocolatey/Test-ChocolateyVersionEqualOrHigherThan.ps1
@@ -10,7 +10,7 @@
     param(
         [NuGet.Versioning.NuGetVersion]$Version
     )
-    $installedVersion = ((Invoke-Choco list -lo -r).Lines | ConvertFrom-ChocolateyOutput -Command List | Where-Object Name -EQ 'chocolatey').Version
+    $installedVersion = ((Invoke-Choco list -r).Lines | ConvertFrom-ChocolateyOutput -Command List | Where-Object Name -EQ 'chocolatey').Version
 
     return Test-VersionEqualOrHigher -InstalledVersion $installedVersion -CompareVersion $Version
 }

--- a/tests/helpers/common/Chocolatey/Test-PackageIsEqualOrHigher.ps1
+++ b/tests/helpers/common/Chocolatey/Test-PackageIsEqualOrHigher.ps1
@@ -10,7 +10,7 @@ function Test-PackageIsEqualOrHigher {
         [switch]$AllowMissingPackage
     )
 
-    $package = (Invoke-Choco list --local-only --limitoutput).Lines |
+    $package = (Invoke-Choco list --limitoutput).Lines |
         Where-Object { $_ -notmatch 'please upgrade' } |
         ConvertFrom-ChocolateyOutput -Command List |
         Where-Object Name -EQ $PackageName


### PR DESCRIPTION
## Description Of Changes

This pull requests splits out the list command to be its own command in the source codes, which can only handle local packages and not remote sources.
In this move, all arguments that had been deprecated for the list command have been completely removed from the list command, and a few remote only arguments will be warning about that they are unsupported (this won't do anything at all).

The tab completion file has also been updated with this new logic, with an adition that remote searches have had their local arguments removed from the tab completion.

## Motivation and Context

To make list searching only local packages, while using search and find will be for remote sources.

## Testing

1. Run `choco list`
2. Verify only locally installed packages is shown
3. Run `choco search` against a feed not containing 1 or more of the installed pakcages
3. Verify the packages only available locally is not shown
4. Run `choco list --local-only`
5. Verify a warning is outputted (purple) about the argument being unsupported
6. Run `choco search --local-only --verbose`
7. Verify the console mentions it used a query with the search term `--local-only`
9. Run `choco info chocolatey --local-only`
10. Verify information is shown about the local package, and no warning about unsupported argument.
11. Run `choco info upgradepackage` (against internal repository source)
12. Verify the remote package information is shown
12. (Optional) Run test kitchen against the tags `ListCommand`,`SearchCommand` and `InfoCommand`

### Operating Systems Testing

- Windows 11
- Windows Server 2019

## Change Types Made

* [ ] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [x] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [ ] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue

- Fixes #158
- https://app.clickup.com/t/20540031/PROJ-526
