### PR TITLE
(#2623) Remove Get-BinRoot alias

### DIFF
--- a/src/chocolatey.resources/helpers/functions/Get-ToolsLocation.ps1
+++ b/src/chocolatey.resources/helpers/functions/Get-ToolsLocation.ps1
@@ -30,10 +30,6 @@ into the same directory as the tool. Having that all combined in the
 same package directory could get tricky.
 
 .NOTES
-This is the successor to the poorly named `Get-BinRoot`. Available as
-`Get-ToolsLocation` in 0.9.10+. The Alias `Get-BinRoot` will be removed
-in version 2.0.0.
-
 Sets an environment variable called `ChocolateyToolsLocation`. If the
 older `ChocolateyBinRoot` is set, it uses the value from that and
 removes the older variable.
@@ -47,10 +43,6 @@ None
 
     $invocation = $MyInvocation
     Write-FunctionCallLogMessage -Invocation $invocation -Parameters $PSBoundParameters
-
-    if ($invocation -ne $null -and $invocation.InvocationName -ne $null -and $invocation.InvocationName.ToLower() -eq 'get-binroot') {
-        Write-Warning "Get-BinRoot was deprecated in v1 and will be removed in v2. It has been replaced with Get-ToolsLocation (starting with v0.9.10), however many packages no longer require a special separate directory since package folders no longer have versions on them. Some do though and should continue to use Get-ToolsLocation."
-    }
 
     $toolsLocation = $env:ChocolateyToolsLocation
 
@@ -96,5 +88,3 @@ None
 
     return $toolsLocation
 }
-
-Set-Alias Get-BinRoot Get-ToolsLocation -Force -Scope Global -Option AllScope

--- a/tests/chocolatey-tests/commands/choco-deprecated.Tests.ps1
+++ b/tests/chocolatey-tests/commands/choco-deprecated.Tests.ps1
@@ -52,34 +52,3 @@ Describe "choco deprecated shims" -Skip:(-not (Test-ChocolateyVersionEqualOrHigh
         }
     }
 }
-
-Describe "Deprecated Chocolatey Helper Commands" -Skip:(-not (Test-ChocolateyVersionEqualOrHigherThan "1.0.0")) -Tag Chocolatey, DeprecatedHelpers {
-    BeforeAll {
-        Initialize-ChocolateyTestInstall
-        New-ChocolateyInstallSnapshot
-
-        $PackageName = New-Guid
-        $HelperUnderTest = "Get-BinRoot"
-        $null = Invoke-Choco new $PackageName --version 1.0.0
-        $TemplateOutput = Get-ChildItem -Path $PackageName -Recurse | Select-String -Pattern 'Get-BinRoot'
-        $HelperUnderTest > "$PackageName/tools/chocolateyInstall.ps1"
-        $null = Invoke-Choco pack "$PackageName/$PackageName.nuspec"
-        $Output = Invoke-Choco install $PackageName --source . -y
-    }
-
-    AfterAll {
-        Remove-Item "./$PackageName" -Recurse -Force -ErrorAction Ignore
-        Remove-ChocolateyTestInstall
-    }
-    It 'should not mention Get-BinRoot in any of the generated files' {
-        $TemplateOutput | Should -BeNullOrEmpty -Because 'Get-BinRoot has been deprecated and removed from the template'
-    }
-
-    It 'should exit success (0)' {
-        $Output.ExitCode | Should -Be 0
-    }
-
-    It 'should warn that Get-BinRoot is deprecated' {
-        $Output.Lines | Should -Contain 'WARNING: Get-BinRoot was deprecated in v1 and will be removed in v2. It has been replaced with Get-ToolsLocation (starting with v0.9.10), however many packages no longer require a special separate directory since package folders no longer have versions on them. Some do though and should continue to use Get-ToolsLocation.'
-    }
-}

--- a/tests/chocolatey-tests/commands/choco-removed.Tests.ps1
+++ b/tests/chocolatey-tests/commands/choco-removed.Tests.ps1
@@ -17,6 +17,7 @@ Describe "Ensuring removed things are removed" -Tag Removed, Chocolatey {
         @{ FunctionName = 'Write-ChocolateySuccess' }
         @{ FunctionName = 'Write-ChocolateyFailure' }
         @{ FunctionName = 'Install-ChocolateyDesktopLink' }
+        @{ FunctionName = 'Get-BinRoot' }
     ) {
         BeforeAll {
             $TestScript = @'

--- a/tests/packages/msi.template/templates/ReadMe.md
+++ b/tests/packages/msi.template/templates/ReadMe.md
@@ -46,7 +46,7 @@ functions that you can use, these are sometimes called the helpers.
 https://chocolatey.org/docs/helpers-reference
 
 A note about a couple:
-* Get-BinRoot - this is a horribly named function that doesn't do what new folks think it does. It gets you the 'tools' root, which by default is set to 'c:\tools', not the chocolateyInstall bin folder - see https://chocolatey.org/docs/helpers-get-tools-location
+
 * Install-BinFile - used for non-exe files - executables are automatically shimmed... - see https://chocolatey.org/docs/helpers-install-bin-file
 * Uninstall-BinFile - used for non-exe files - executables are automatically shimmed - see https://chocolatey.org/docs/helpers-uninstall-bin-file
 

--- a/tests/packages/zip.template/templates/ReadMe.md
+++ b/tests/packages/zip.template/templates/ReadMe.md
@@ -46,7 +46,7 @@ functions that you can use, these are sometimes called the helpers.
 https://chocolatey.org/docs/helpers-reference
 
 A note about a couple:
-* Get-BinRoot - this is a horribly named function that doesn't do what new folks think it does. It gets you the 'tools' root, which by default is set to 'c:\tools', not the chocolateyInstall bin folder - see https://chocolatey.org/docs/helpers-get-tools-location
+
 * Install-BinFile - used for non-exe files - executables are automatically shimmed... - see https://chocolatey.org/docs/helpers-install-bin-file
 * Uninstall-BinFile - used for non-exe files - executables are automatically shimmed - see https://chocolatey.org/docs/helpers-uninstall-bin-file
 


### PR DESCRIPTION
## Description Of Changes

- Remove Get-BinRoot alias
- Remove all mention of it from documentation, template readmes, etc.
- Update tests to ensure it is removed and no longer present

## Motivation and Context

Excising the sins of our past. (It wasn't _that_ bad, but man some of the comments we left behind when we first deprecated it sound _very_ disgruntled 😂 )

## Testing

Run Invoke-Tests.ps1 and ensure the removal tests pass

### Operating Systems Testing

Win11

## Change Types Made
<!-- Tick the boxes for the type of changes that have been made -->

* [ ] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [x] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [x] Tests to cover my changes, have been added.
* [x] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue

Fixes #2623

<!-- PLEASE REMOVE ALL COMMENTS BEFORE SUBMITTING -->
