### PR TITLE
(test) Remove Features/Sources from Config tests

### DIFF
--- a/tests/chocolatey-tests/commands/choco-config.Tests.ps1
+++ b/tests/chocolatey-tests/commands/choco-config.Tests.ps1
@@ -13,35 +13,6 @@ Describe "choco config" -Tag Chocolatey, ConfigCommand {
     BeforeDiscovery {
         $isLicensed = Test-PackageIsEqualOrHigher "chocolatey.extension" "0.0.0"
 
-        $TestedFeatures = @(
-            "checksumFiles"
-            "autoUninstaller"
-            "allowGlobalConfirmation"
-            "failOnAutoUninstaller"
-            "failOnStandardError"
-            "allowEmptyChecksums"
-            "allowEmptyChecksumsSecure"
-            "powershellHost"
-            "logEnvironmentValues"
-            "virusCheck"
-            "failOnInvalidOrMissingLicense"
-            "ignoreInvalidOptionsSwitches"
-            "usePackageExitCodes"
-            "useEnhancedExitCodes"
-            "exitOnRebootDetected"
-            "useFipsCompliantChecksums"
-            "showNonElevatedWarnings"
-            "showDownloadProgress"
-            "stopOnFirstPackageFailure"
-            "useRememberedArgumentsForUpgrades"
-            "ignoreUnfoundPackagesOnUpgradeOutdated"
-            "skipPackageUpgradesWhenNotInstalled"
-            "removePackageInformationOnUninstall"
-            "logWithoutColor"
-            "logValidationResultsOnWarnings"
-            "usePackageRepositoryOptimizations"
-        )
-
         $TestedConfigs = @(
             "cacheLocation"
             "containsLegacyPackageInstalls"
@@ -128,26 +99,6 @@ Describe "choco config" -Tag Chocolatey, ConfigCommand {
             "defaultTemplateName =  |"
         ) {
             $Output.String | Should -MatchExactly ([Regex]::Escape($_))
-        }
-
-        # Only community repository URL will be set on 0.10.16 and above
-        # Issue: https://github.com/chocolatey/choco/issues/2231
-        It "Displays Available Sources <Name> - <Source>" -ForEach @(
-            @{
-                Name   = "chocolatey"
-                Source = if (Test-ChocolateyVersionEqualOrHigherThan "0.10.16-beta") {
-                    "https://community.chocolatey.org/api/v2/"
-                }
-                else {
-                    "https://chocolatey.org/api/v2/"
-                }
-            }
-        ) {
-            $Output.String | Should -MatchExactly "$Name( \[Disabled\])? - $([Regex]::Escape($Source))\s*\|"
-        }
-
-        It "Displays Available Feature <_>" -ForEach $TestedFeatures {
-            $Output.String | Should -Match "\[[ x]\] $_ -"
         }
     }
 


### PR DESCRIPTION
## Description Of Changes

Update Pester tests to remove the Feature and Source output checks.

## Motivation and Context

The config command no longer outputs these.

## Testing

1. Run through Test Kitchen with the "ConfigCommand" tag.

### Operating Systems Testing

Windows Server 2016/9

## Change Types Made

* [ ] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.
* [x] End to End Pester Tests

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [x] Tests to cover my changes, have been added.
* [x] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue

N/A