### PR TITLE
(#158) Add all possible unsupported argument permutations

### DIFF
--- a/src/chocolatey/infrastructure.app/commands/ChocolateyListCommand.cs
+++ b/src/chocolatey/infrastructure.app/commands/ChocolateyListCommand.cs
@@ -36,13 +36,21 @@ namespace chocolatey.infrastructure.app.commands
         {
             "-l",
             "-lo",
+            "--lo",
+            "-local",
             "--local",
+            "-localonly",
             "--localonly",
+            "-local-only",
             "--local-only",
             "-a",
+            "-all",
             "--all",
+            "-allversions",
             "--allversions",
+            "-all-versions",
             "--all-versions",
+            "-order-by-popularity",
             "--order-by-popularity"
         };
 


### PR DESCRIPTION
## Description Of Changes

Add all of the possible permutations for the no longer supported list command arguments

## Motivation and Context

When the list of unsupported arguments was created, we missed adding the single-dash variants to the list as well as the double-dash variants.

## Testing

1. Build Chocolatey CLI
2. Run `choco list -lo` and `choco list --lo` ensure that warning is emitted both times.
3. Run `choco list -all` and `choco list --all` ensure that warning is emitted both times. 

### Operating Systems Testing

- Windows 10

## Change Types Made

* [x] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [ ] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue

Fixes #158
