### PR TITLE
(#2642) Ensure unsigned shims aren't removed.

### DIFF
--- a/nuspec/chocolatey/chocolatey/tools/chocolateysetup.psm1
+++ b/nuspec/chocolatey/chocolatey/tools/chocolateysetup.psm1
@@ -1,4 +1,4 @@
-﻿$thisScriptFolder = (Split-Path -Parent $MyInvocation.MyCommand.Definition)
+$thisScriptFolder = (Split-Path -Parent $MyInvocation.MyCommand.Definition)
 $chocoInstallVariableName = "ChocolateyInstall"
 $sysDrive = $env:SystemDrive
 $tempDir = $env:TEMP
@@ -78,7 +78,7 @@ function Remove-ShimWithAuthenticodeSignature {
 function Remove-UnsupportedShimFiles {
     param([string[]]$Paths)
 
-    $shims = @("cpack.exe", "cver.exe")
+    $shims = @("cpack.exe", "cver.exe", "chocolatey.exe", "cinst.exe", "clist.exe", "cpush.exe", "cuninst.exe", "cup.exe")
 
     $Paths | ForEach-Object {
         $path = $_


### PR DESCRIPTION
## Description Of Changes

Add removed shims to list of shims to only remove if signed.

## Motivation and Context

Pester tests failures. Also we shouldn't be removing unsigned shims.

## Testing

Will run these through Test Kitchen after merge.

### Operating Systems Testing

None

## Change Types Made

* [x] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [ ] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue

Fixes #2642