### PR TITLE
(maint) Update Pester tests for the 2.0.0 release.

### DIFF
--- a/tests/chocolatey-tests/commands/choco-config.Tests.ps1
+++ b/tests/chocolatey-tests/commands/choco-config.Tests.ps1
@@ -69,10 +69,6 @@ Describe "choco config" -Tag Chocolatey, ConfigCommand {
             $Output.Lines | Should -Contain $expectedLicenseHeader
         }
 
-        It "Displays Settings section" {
-            $Output.Lines | Should -Contain "Settings"
-        }
-
         It "Does not display Sources section" {
             $Output.Lines | Should  -Not -Contain "Sources"
         }

--- a/tests/chocolatey-tests/commands/choco-removed.Tests.ps1
+++ b/tests/chocolatey-tests/commands/choco-removed.Tests.ps1
@@ -64,7 +64,7 @@ exit $command.Count
             $null = Invoke-Choco new testPackage --version 1.0.0
             $null = Invoke-Choco pack testPackage/testPackage.nuspec
             $null = Invoke-Choco apikey add -s https://chocolatey.org -k None
-            $Output = Invoke-Choco push ./testPackage.1.0.0.nupkg
+            $Output = Invoke-Choco push ./testPackage.1.0.0.nupkg --source https://push.chocolatey.org/
         }
 
         It 'Exits with Failure (1)' {
@@ -109,7 +109,7 @@ exit $command.Count
     Context 'Ensure WebPI source removal' -Skip:(-not (Test-ChocolateyVersionEqualOrHigherThan '1.999.999')) {
 
         BeforeAll {
-            $Output = Invoke-Choco list --source webpi
+            $Output = Invoke-Choco search --source webpi
         }
 
         It 'Exits with Failure (1)' {
@@ -137,7 +137,7 @@ exit $command.Count
 
     Context 'Ensure --allow-multiple removed from Chocolatey' -Tag InstallCommand, UpgradeCommand, UninstallCommand, AllowMultiple -Foreach @(
         @{ Command = 'install' }
-        @{ Command = 'update' }
+        @{ Command = 'upgrade' }
         @{ Command = 'uninstall' }
     ){
         BeforeAll {


### PR DESCRIPTION
## Description Of Changes

Update a few tests for some slight changes in the 2.0.0 release.

## Motivation and Context

Some slight changes mean that some of the tests needed to change.

## Testing

1. Manually ran Test Kitchen against these.
2. Ran Team City Test Kitchen against this branch.

### Operating Systems Testing

- Server 2019
- Server 2016

## Change Types Made

* [ ] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.
* [x] Pester end to end tests

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [ ] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue

N/A These are tests that fail due to the test not the code.