### PR TITLE
(#2902)(#2585) Update TLS protocol handling

### DIFF
--- a/src/chocolatey/infrastructure.app/runners/GenericRunner.cs
+++ b/src/chocolatey/infrastructure.app/runners/GenericRunner.cs
@@ -146,7 +146,7 @@ Chocolatey is not an official build (bypassed with --allow-unofficial).
             }
 
             FailOnMissingOrInvalidLicenseIfFeatureSet(config);
-            SecurityProtocol.SetProtocol(provideWarning: true);
+            SecurityProtocol.SetProtocol(config);
             EventManager.Publish(new PreRunMessage(config));
 
             try
@@ -230,7 +230,7 @@ Chocolatey is not an official build (bypassed with --allow-unofficial).
             }
 
             FailOnMissingOrInvalidLicenseIfFeatureSet(config);
-            SecurityProtocol.SetProtocol(provideWarning: true);
+            SecurityProtocol.SetProtocol(config);
             EventManager.Publish(new PreRunMessage(config));
 
             try
@@ -266,7 +266,7 @@ Chocolatey is not an official build (bypassed with --allow-unofficial).
         public int Count(ChocolateyConfiguration config, Container container, bool isConsole, Action<ICommand> parseArgs)
         {
             FailOnMissingOrInvalidLicenseIfFeatureSet(config);
-            SecurityProtocol.SetProtocol(provideWarning: true);
+            SecurityProtocol.SetProtocol(config);
 
             var command = FindCommand(config, container, isConsole, parseArgs) as IListCommand;
             if (command == null)

--- a/src/chocolatey/infrastructure.app/services/PowershellService.cs
+++ b/src/chocolatey/infrastructure.app/services/PowershellService.cs
@@ -540,7 +540,7 @@ namespace chocolatey.infrastructure.app.services
                 }
             }
 
-            SecurityProtocol.SetProtocol(provideWarning: false);
+            SecurityProtocol.SetProtocol(configuration);
         }
 
         private ResolveEventHandler _handler = null;


### PR DESCRIPTION
## Description Of Changes

This updates the TLS protocols that Chocolatey sets now that Chocolatey is built with .NET 4.8.

First, this removes the fallback and warning about being unable to set TLS 1.2, as .NET 4.8 will always have TLS 1.2 available. Second, it uses the TLS 1.2 definition directly available in the system libraries. Third, it removes the provideWarning bool in the method definition, as the warning is no longer applicable.

Finally, an OS version check is added, so the system default will be used on Windows 8/Server 2012 and newer, as per Microsoft guidance, but explicitly enabling TLS 1.2 on older operating systems. See code comments for links to documentation.

## Motivation and Context

Keeping current with TLS protocols available is important for security reasons, for example this allows TLS v1.3 on Windows 11 / Server 2022

## Testing

TODO

### Operating Systems Testing
- Windows 10 22H2

## Change Types Made

* [ ] Bug fix (non-breaking change).
* [x] Feature / Enhancement (non-breaking change).
* [x] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [x] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue

Fixes #2902
Fixes #2585 by removing the need for the warning

