### PR TITLE
(tests) Fix end to end proxy test failures

### DIFF
--- a/tests/chocolatey-tests/chocolatey.Tests.ps1
+++ b/tests/chocolatey-tests/chocolatey.Tests.ps1
@@ -1,4 +1,4 @@
-Import-Module helpers/common-helpers
+﻿Import-Module helpers/common-helpers
 
 Describe "Ensuring Chocolatey is correctly installed" -Tag Environment, Chocolatey {
     BeforeDiscovery {
@@ -334,8 +334,7 @@ Describe "Ensuring Chocolatey is correctly installed" -Tag Environment, Chocolat
     ) -Skip:((-not $env:TEST_KITCHEN) -or (-not (Test-ChocolateyVersionEqualOrHigherThan '1.1.0'))) {
         BeforeAll {
             New-ChocolateyInstallSnapshot
-            # TODO: Internalize pwsh and powershell packages...
-            $pwshInstall = Invoke-Choco install $_ -y -s https://community.chocolatey.org/api/v2/
+            $pwshInstall = Invoke-Choco install $_ -y
             $ChocoUnzipped = "$(Get-TempDirectory)$(New-Guid)"
             $modulePath = "$ChocoUnzipped/tools/chocolateySetup.psm1"
 

--- a/tests/chocolatey-tests/commands/choco-config.Tests.ps1
+++ b/tests/chocolatey-tests/commands/choco-config.Tests.ps1
@@ -82,19 +82,19 @@ Describe "choco config" -Tag Chocolatey, ConfigCommand {
         }
 
         It "Displays Available Setting <_>" -ForEach @(
-            "cacheLocation =  |"
-            "containsLegacyPackageInstalls = true |"
-            "commandExecutionTimeoutSeconds = 2700 |"
-            "proxy =  |"
-            "proxyUser =  |"
-            "proxyPassword =  |"
-            "webRequestTimeoutSeconds = 30 |"
-            "proxyBypassList =  |"
-            "proxyBypassOnLocal = true |"
-            "upgradeAllExceptions =  |"
-            "defaultTemplateName =  |"
+            "cacheLocation =  \|"
+            "containsLegacyPackageInstalls = true \|"
+            "commandExecutionTimeoutSeconds = 2700 \|"
+            "proxy = [^|]* \|"
+            "proxyUser = [^|]* \|"
+            "proxyPassword = [^|]* \|"
+            "webRequestTimeoutSeconds = 30 \|"
+            "proxyBypassList =  \|"
+            "proxyBypassOnLocal = true \|"
+            "upgradeAllExceptions =  \|"
+            "defaultTemplateName =  \|"
         ) {
-            $Output.String | Should -MatchExactly ([Regex]::Escape($_))
+            $Output.String | Should -MatchExactly $_
         }
     }
 

--- a/tests/chocolatey-tests/commands/choco-info.Tests.ps1
+++ b/tests/chocolatey-tests/commands/choco-info.Tests.ps1
@@ -1,4 +1,4 @@
-Import-Module helpers/common-helpers
+﻿Import-Module helpers/common-helpers
 
 Describe "choco info" -Tag Chocolatey, InfoCommand {
     BeforeDiscovery {
@@ -81,6 +81,7 @@ Describe "choco info" -Tag Chocolatey, InfoCommand {
     }
 
     # Issue: https://gitlab.com/chocolatey/collaborators/choco-licensed/-/issues/530 (NOTE: Proxy bypassing also works on Chocolatey FOSS)
+    # These are skipped on Proxy tests because the proxy server can't be bypassed in that test environment.
     Context "Listing package information when using proxy and proxy bypass list in config" -Tag ProxySkip -Skip:(!$licensedProxyFixed) {
         BeforeDiscovery {
             $infoItems = @(
@@ -114,6 +115,7 @@ Describe "choco info" -Tag Chocolatey, InfoCommand {
     }
 
     # Issue: https://gitlab.com/chocolatey/collaborators/choco-licensed/-/issues/530 (NOTE: Proxy bypassing also works on Chocolatey FOSS)
+    # These are skipped on Proxy tests because the proxy server can't be bypassed in that test environment.
     Context "Listing package information when using proxy and proxy bypass list on command" -Tag ProxySkip -Skip:(!$licensedProxyFixed) {
         BeforeDiscovery {
             $infoItems = @(

--- a/tests/chocolatey-tests/commands/choco-info.Tests.ps1
+++ b/tests/chocolatey-tests/commands/choco-info.Tests.ps1
@@ -81,7 +81,7 @@ Describe "choco info" -Tag Chocolatey, InfoCommand {
     }
 
     # Issue: https://gitlab.com/chocolatey/collaborators/choco-licensed/-/issues/530 (NOTE: Proxy bypassing also works on Chocolatey FOSS)
-    Context "Listing package information when using proxy and proxy bypass list in config" -Skip:(!$licensedProxyFixed) {
+    Context "Listing package information when using proxy and proxy bypass list in config" -Tag ProxySkip -Skip:(!$licensedProxyFixed) {
         BeforeDiscovery {
             $infoItems = @(
                 @{ Title = "Tags"; Value = "mvcmusicstore db" }
@@ -114,7 +114,7 @@ Describe "choco info" -Tag Chocolatey, InfoCommand {
     }
 
     # Issue: https://gitlab.com/chocolatey/collaborators/choco-licensed/-/issues/530 (NOTE: Proxy bypassing also works on Chocolatey FOSS)
-    Context "Listing package information when using proxy and proxy bypass list on command" -Skip:(!$licensedProxyFixed) {
+    Context "Listing package information when using proxy and proxy bypass list on command" -Tag ProxySkip -Skip:(!$licensedProxyFixed) {
         BeforeDiscovery {
             $infoItems = @(
                 @{ Title = "Tags"; Value = "mvcmusicstore db" }

--- a/tests/chocolatey-tests/commands/choco-install.Tests.ps1
+++ b/tests/chocolatey-tests/commands/choco-install.Tests.ps1
@@ -1210,7 +1210,7 @@ To install a local, or remote file, you may use:
     }
 
     # Issue: https://gitlab.com/chocolatey/collaborators/choco-licensed/-/issues/530 (NOTE: Proxy bypassing also works on Chocolatey FOSS)
-    Context "Installing a Package with proxy and proxy bypass list" -Skip:(!$licensedProxyFixed) {
+    Context "Installing a Package with proxy and proxy bypass list" -Tag ProxySkip -Skip:(!$licensedProxyFixed) {
         BeforeAll {
             Restore-ChocolateyInstallSnapshot
             $null = Invoke-Choco config set --name=proxy --value="https://invalid.chocolatey.org/"
@@ -1229,7 +1229,7 @@ To install a local, or remote file, you may use:
     }
 
     # Issue: https://gitlab.com/chocolatey/collaborators/choco-licensed/-/issues/530 (NOTE: Proxy bypassing also works on Chocolatey FOSS)
-    Context "Installing a Package with proxy and proxy bypass list on command" -Skip:(!$licensedProxyFixed) {
+    Context "Installing a Package with proxy and proxy bypass list on command" -Tag ProxySkip -Skip:(!$licensedProxyFixed) {
         BeforeAll {
             Restore-ChocolateyInstallSnapshot
             $null = Invoke-Choco config set --name=proxy --value="https://invalid.chocolatey.org/"
@@ -1350,7 +1350,7 @@ To install a local, or remote file, you may use:
         }
     }
 
-    Context "Installing package with beforeInstall scriptblock defined" -Skip:(!$hasBeforeInstallBlock) {
+    Context "Installing package with beforeInstall scriptblock defined" -Tag ProxySkip -Skip:(!$hasBeforeInstallBlock) {
         BeforeAll {
             New-ChocolateyInstallSnapshot
             Remove-Item "$env:ChocolateyInstall\logs\*" -ErrorAction Ignore

--- a/tests/chocolatey-tests/commands/choco-install.Tests.ps1
+++ b/tests/chocolatey-tests/commands/choco-install.Tests.ps1
@@ -1210,6 +1210,7 @@ To install a local, or remote file, you may use:
     }
 
     # Issue: https://gitlab.com/chocolatey/collaborators/choco-licensed/-/issues/530 (NOTE: Proxy bypassing also works on Chocolatey FOSS)
+    # These are skipped on Proxy tests because the proxy server can't be bypassed in that test environment.
     Context "Installing a Package with proxy and proxy bypass list" -Tag ProxySkip -Skip:(!$licensedProxyFixed) {
         BeforeAll {
             Restore-ChocolateyInstallSnapshot
@@ -1229,6 +1230,7 @@ To install a local, or remote file, you may use:
     }
 
     # Issue: https://gitlab.com/chocolatey/collaborators/choco-licensed/-/issues/530 (NOTE: Proxy bypassing also works on Chocolatey FOSS)
+    # These are skipped on Proxy tests because the proxy server can't be bypassed in that test environment.
     Context "Installing a Package with proxy and proxy bypass list on command" -Tag ProxySkip -Skip:(!$licensedProxyFixed) {
         BeforeAll {
             Restore-ChocolateyInstallSnapshot
@@ -1350,6 +1352,7 @@ To install a local, or remote file, you may use:
         }
     }
 
+    # These are skipped in the Proxy Test environment because the beforeInstall reaches out to GitHub which is not permitted through our proxy.
     Context "Installing package with beforeInstall scriptblock defined" -Tag ProxySkip -Skip:(!$hasBeforeInstallBlock) {
         BeforeAll {
             New-ChocolateyInstallSnapshot

--- a/tests/chocolatey-tests/commands/choco-push.Tests.ps1
+++ b/tests/chocolatey-tests/commands/choco-push.Tests.ps1
@@ -1,5 +1,6 @@
 ﻿Import-Module helpers/common-helpers
 
+# These are skipped in the Proxy Test environment because they push to a port outside of 8443 which is not allowed by our proxy.
 Describe "choco push" -Tag Chocolatey, PushCommand, ProxySkip -Skip:($null -eq $env:API_KEY -or $null -eq $env:PUSH_REPO) {
     BeforeAll {
         Remove-NuGetPaths

--- a/tests/chocolatey-tests/commands/choco-push.Tests.ps1
+++ b/tests/chocolatey-tests/commands/choco-push.Tests.ps1
@@ -1,6 +1,6 @@
 ﻿Import-Module helpers/common-helpers
 
-Describe "choco push" -Tag Chocolatey, PushCommand -Skip:($null -eq $env:API_KEY -or $null -eq $env:PUSH_REPO) {
+Describe "choco push" -Tag Chocolatey, PushCommand, ProxySkip -Skip:($null -eq $env:API_KEY -or $null -eq $env:PUSH_REPO) {
     BeforeAll {
         Remove-NuGetPaths
         $ApiKey = $env:API_KEY

--- a/tests/chocolatey-tests/commands/choco-search.Tests.ps1
+++ b/tests/chocolatey-tests/commands/choco-search.Tests.ps1
@@ -250,7 +250,7 @@ Describe "choco <_>" -ForEach $Command -Tag Chocolatey, SearchCommand, FindComma
     }
 
     # Issue: https://gitlab.com/chocolatey/collaborators/choco-licensed/-/issues/530 (NOTE: Proxy bypassing also works on Chocolatey FOSS)
-    Context "Searching packages on source using proxy and proxy bypass list" -Skip:(!$licensedProxyFixed) {
+    Context "Searching packages on source using proxy and proxy bypass list" -Tag ProxySkip -Skip:(!$licensedProxyFixed) {
         BeforeAll {
             Restore-ChocolateyInstallSnapshot
             $null = Invoke-Choco config set --name=proxy --value="https://invalid.chocolatey.org/"
@@ -273,7 +273,7 @@ Describe "choco <_>" -ForEach $Command -Tag Chocolatey, SearchCommand, FindComma
     }
 
     # Issue: https://gitlab.com/chocolatey/collaborators/choco-licensed/-/issues/530 (NOTE: Proxy bypassing also works on Chocolatey FOSS)
-    Context "Searching packages on source using proxy and proxy bypass list on command" -Skip:(!$licensedProxyFixed) {
+    Context "Searching packages on source using proxy and proxy bypass list on command" -Tag ProxySkip -Skip:(!$licensedProxyFixed) {
         BeforeAll {
             Restore-ChocolateyInstallSnapshot
             $null = Invoke-Choco config set --name=proxy --value="https://invalid.chocolatey.org/"

--- a/tests/chocolatey-tests/commands/choco-search.Tests.ps1
+++ b/tests/chocolatey-tests/commands/choco-search.Tests.ps1
@@ -250,6 +250,7 @@ Describe "choco <_>" -ForEach $Command -Tag Chocolatey, SearchCommand, FindComma
     }
 
     # Issue: https://gitlab.com/chocolatey/collaborators/choco-licensed/-/issues/530 (NOTE: Proxy bypassing also works on Chocolatey FOSS)
+    # These are skipped on Proxy tests because the proxy server can't be bypassed in that test environment.
     Context "Searching packages on source using proxy and proxy bypass list" -Tag ProxySkip -Skip:(!$licensedProxyFixed) {
         BeforeAll {
             Restore-ChocolateyInstallSnapshot
@@ -273,6 +274,7 @@ Describe "choco <_>" -ForEach $Command -Tag Chocolatey, SearchCommand, FindComma
     }
 
     # Issue: https://gitlab.com/chocolatey/collaborators/choco-licensed/-/issues/530 (NOTE: Proxy bypassing also works on Chocolatey FOSS)
+    # These are skipped on Proxy tests because the proxy server can't be bypassed in that test environment.
     Context "Searching packages on source using proxy and proxy bypass list on command" -Tag ProxySkip -Skip:(!$licensedProxyFixed) {
         BeforeAll {
             Restore-ChocolateyInstallSnapshot

--- a/tests/chocolatey-tests/features/PythonSource.Tests.ps1
+++ b/tests/chocolatey-tests/features/PythonSource.Tests.ps1
@@ -1,7 +1,7 @@
 ﻿Import-Module helpers/common-helpers
 
 # This is skipped when not run in CI because it modifies the local system.
-Describe "Python Source" -Tag Chocolatey, UpgradeCommand, PythonSource -Skip:(-not $env:TEST_KITCHEN) {
+Describe "Python Source" -Tag Chocolatey, UpgradeCommand, PythonSource, ProxySkip -Skip:(-not $env:TEST_KITCHEN) {
     BeforeAll {
         Initialize-ChocolateyTestInstall
         New-ChocolateyInstallSnapshot

--- a/tests/chocolatey-tests/features/PythonSource.Tests.ps1
+++ b/tests/chocolatey-tests/features/PythonSource.Tests.ps1
@@ -5,8 +5,7 @@ Describe "Python Source" -Tag Chocolatey, UpgradeCommand, PythonSource, ProxySki
     BeforeAll {
         Initialize-ChocolateyTestInstall
         New-ChocolateyInstallSnapshot
-        # TODO: Internalize Python and most dependencies. (KB perhaps not internalized due to excessive size...)
-        $null = Invoke-Choco install python3 --source https://community.chocolatey.org/api/v2/
+        $null = Invoke-Choco install python3
     }
 
     AfterAll {

--- a/tests/chocolatey-tests/features/PythonSource.Tests.ps1
+++ b/tests/chocolatey-tests/features/PythonSource.Tests.ps1
@@ -1,6 +1,7 @@
 ﻿Import-Module helpers/common-helpers
 
 # This is skipped when not run in CI because it modifies the local system.
+# This is skipped on Proxy as Python needs to reach out to pypi which our proxy server does not allow.
 Describe "Python Source" -Tag Chocolatey, UpgradeCommand, PythonSource, ProxySkip -Skip:(-not $env:TEST_KITCHEN) {
     BeforeAll {
         Initialize-ChocolateyTestInstall


### PR DESCRIPTION
## Description Of Changes

Tag tests that will not work in our Test Kitchen Proxy testing environment as `ProxySkip`.

## Motivation and Context

To get a handle on what things work with a proxy and what don't, we need tests that will work in the proxy testing environment.

## Testing

1. Ran multiple Test Kitchen runs targeting this branch and various Proxy configurations.
2. Ensured they all worked as expected.

### Operating Systems Testing

- Windows Server 2016
- Windows Server 2019

## Change Types Made

* [ ] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.
* [x] End to End Pester tests

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [x] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue

* PROJ-522
