### PR TITLE
(tests) Fix end to end proxy test failures (stable branch)

### DIFF
--- a/tests/chocolatey-tests/chocolatey.Tests.ps1
+++ b/tests/chocolatey-tests/chocolatey.Tests.ps1
@@ -328,8 +328,7 @@ Describe "Ensuring Chocolatey is correctly installed" -Tag Environment, Chocolat
     ) -Skip:((-not $env:TEST_KITCHEN) -or (-not (Test-ChocolateyVersionEqualOrHigherThan '1.1.0'))) {
         BeforeAll {
             New-ChocolateyInstallSnapshot
-            # TODO: Internalize pwsh and powershell packages...
-            $pwshInstall = Invoke-Choco install $_ -y -s https://community.chocolatey.org/api/v2/
+            $pwshInstall = Invoke-Choco install $_ -y
             $ChocoUnzipped = "$(Get-TempDirectory)$(New-Guid)"
             $modulePath = "$ChocoUnzipped/tools/chocolateySetup.psm1"
 

--- a/tests/chocolatey-tests/commands/choco-config.Tests.ps1
+++ b/tests/chocolatey-tests/commands/choco-config.Tests.ps1
@@ -135,19 +135,19 @@ Describe "choco config" -Tag Chocolatey, ConfigCommand {
         }
 
         It "Displays Available Setting <_>" -ForEach @(
-            "cacheLocation =  |"
-            "containsLegacyPackageInstalls = true |"
-            "commandExecutionTimeoutSeconds = 2700 |"
-            "proxy =  |"
-            "proxyUser =  |"
-            "proxyPassword =  |"
-            "webRequestTimeoutSeconds = 30 |"
-            "proxyBypassList =  |"
-            "proxyBypassOnLocal = true |"
-            "upgradeAllExceptions =  |"
-            "defaultTemplateName =  |"
+            "cacheLocation =  \|"
+            "containsLegacyPackageInstalls = true \|"
+            "commandExecutionTimeoutSeconds = 2700 \|"
+            "proxy = [^|]* \|"
+            "proxyUser = [^|]* \|"
+            "proxyPassword = [^|]* \|"
+            "webRequestTimeoutSeconds = 30 \|"
+            "proxyBypassList =  \|"
+            "proxyBypassOnLocal = true \|"
+            "upgradeAllExceptions =  \|"
+            "defaultTemplateName =  \|"
         ) {
-            $Output.String | Should -MatchExactly ([Regex]::Escape($_))
+            $Output.String | Should -MatchExactly $_
         }
 
         # Only community repository URL will be set on 0.10.16 and above

--- a/tests/chocolatey-tests/commands/choco-info.Tests.ps1
+++ b/tests/chocolatey-tests/commands/choco-info.Tests.ps1
@@ -79,7 +79,7 @@ Describe "choco info" -Tag Chocolatey, InfoCommand {
     }
 
     # Issue: https://gitlab.com/chocolatey/collaborators/choco-licensed/-/issues/530 (NOTE: Proxy bypassing also works on Chocolatey FOSS)
-    Context "Listing package information when using proxy and proxy bypass list in config" -Skip:(!$licensedProxyFixed) {
+    Context "Listing package information when using proxy and proxy bypass list in config" -Tag ProxySkip -Skip:(!$licensedProxyFixed) {
         BeforeDiscovery {
             $infoItems = @(
                 @{ Title = "Tags"; Value = "mvcmusicstore db" }
@@ -112,7 +112,7 @@ Describe "choco info" -Tag Chocolatey, InfoCommand {
     }
 
     # Issue: https://gitlab.com/chocolatey/collaborators/choco-licensed/-/issues/530 (NOTE: Proxy bypassing also works on Chocolatey FOSS)
-    Context "Listing package information when using proxy and proxy bypass list on command" -Skip:(!$licensedProxyFixed) {
+    Context "Listing package information when using proxy and proxy bypass list on command" -Tag ProxySkip -Skip:(!$licensedProxyFixed) {
         BeforeDiscovery {
             $infoItems = @(
                 @{ Title = "Tags"; Value = "mvcmusicstore db" }

--- a/tests/chocolatey-tests/commands/choco-info.Tests.ps1
+++ b/tests/chocolatey-tests/commands/choco-info.Tests.ps1
@@ -79,6 +79,7 @@ Describe "choco info" -Tag Chocolatey, InfoCommand {
     }
 
     # Issue: https://gitlab.com/chocolatey/collaborators/choco-licensed/-/issues/530 (NOTE: Proxy bypassing also works on Chocolatey FOSS)
+    # These are skipped on Proxy tests because the proxy server can't be bypassed in that test environment.
     Context "Listing package information when using proxy and proxy bypass list in config" -Tag ProxySkip -Skip:(!$licensedProxyFixed) {
         BeforeDiscovery {
             $infoItems = @(
@@ -112,6 +113,7 @@ Describe "choco info" -Tag Chocolatey, InfoCommand {
     }
 
     # Issue: https://gitlab.com/chocolatey/collaborators/choco-licensed/-/issues/530 (NOTE: Proxy bypassing also works on Chocolatey FOSS)
+    # These are skipped on Proxy tests because the proxy server can't be bypassed in that test environment.
     Context "Listing package information when using proxy and proxy bypass list on command" -Tag ProxySkip -Skip:(!$licensedProxyFixed) {
         BeforeDiscovery {
             $infoItems = @(

--- a/tests/chocolatey-tests/commands/choco-install.Tests.ps1
+++ b/tests/chocolatey-tests/commands/choco-install.Tests.ps1
@@ -1341,6 +1341,7 @@ Describe "choco install" -Tag Chocolatey, InstallCommand {
     }
 
     # Issue: https://gitlab.com/chocolatey/collaborators/choco-licensed/-/issues/530 (NOTE: Proxy bypassing also works on Chocolatey FOSS)
+    # These are skipped on Proxy tests because the proxy server can't be bypassed in that test environment.
     Context "Installing a Package with proxy and proxy bypass list" -Tag ProxySkip -Skip:(!$licensedProxyFixed) {
         BeforeAll {
             Restore-ChocolateyInstallSnapshot
@@ -1360,6 +1361,7 @@ Describe "choco install" -Tag Chocolatey, InstallCommand {
     }
 
     # Issue: https://gitlab.com/chocolatey/collaborators/choco-licensed/-/issues/530 (NOTE: Proxy bypassing also works on Chocolatey FOSS)
+    # These are skipped on Proxy tests because the proxy server can't be bypassed in that test environment.
     Context "Installing a Package with proxy and proxy bypass list on command" -Tag ProxySkip -Skip:(!$licensedProxyFixed) {
         BeforeAll {
             Restore-ChocolateyInstallSnapshot
@@ -1481,6 +1483,7 @@ Describe "choco install" -Tag Chocolatey, InstallCommand {
         }
     }
 
+    # These are skipped in the Proxy Test environment because the beforeInstall reaches out to GitHub which is not permitted through our proxy.
     Context "Installing package with beforeInstall scriptblock defined" -Tag ProxySkip -Skip:(!$hasBeforeInstallBlock) {
         BeforeAll {
             New-ChocolateyInstallSnapshot

--- a/tests/chocolatey-tests/commands/choco-install.Tests.ps1
+++ b/tests/chocolatey-tests/commands/choco-install.Tests.ps1
@@ -1341,7 +1341,7 @@ Describe "choco install" -Tag Chocolatey, InstallCommand {
     }
 
     # Issue: https://gitlab.com/chocolatey/collaborators/choco-licensed/-/issues/530 (NOTE: Proxy bypassing also works on Chocolatey FOSS)
-    Context "Installing a Package with proxy and proxy bypass list" -Skip:(!$licensedProxyFixed) {
+    Context "Installing a Package with proxy and proxy bypass list" -Tag ProxySkip -Skip:(!$licensedProxyFixed) {
         BeforeAll {
             Restore-ChocolateyInstallSnapshot
             $null = Invoke-Choco config set --name=proxy --value="https://invalid.chocolatey.org/"
@@ -1360,7 +1360,7 @@ Describe "choco install" -Tag Chocolatey, InstallCommand {
     }
 
     # Issue: https://gitlab.com/chocolatey/collaborators/choco-licensed/-/issues/530 (NOTE: Proxy bypassing also works on Chocolatey FOSS)
-    Context "Installing a Package with proxy and proxy bypass list on command" -Skip:(!$licensedProxyFixed) {
+    Context "Installing a Package with proxy and proxy bypass list on command" -Tag ProxySkip -Skip:(!$licensedProxyFixed) {
         BeforeAll {
             Restore-ChocolateyInstallSnapshot
             $null = Invoke-Choco config set --name=proxy --value="https://invalid.chocolatey.org/"
@@ -1481,7 +1481,7 @@ Describe "choco install" -Tag Chocolatey, InstallCommand {
         }
     }
 
-    Context "Installing package with beforeInstall scriptblock defined" -Skip:(!$hasBeforeInstallBlock) {
+    Context "Installing package with beforeInstall scriptblock defined" -Tag ProxySkip -Skip:(!$hasBeforeInstallBlock) {
         BeforeAll {
             New-ChocolateyInstallSnapshot
             Remove-Item "$env:ChocolateyInstall\logs\*" -ErrorAction Ignore

--- a/tests/chocolatey-tests/commands/choco-list.Tests.ps1
+++ b/tests/chocolatey-tests/commands/choco-list.Tests.ps1
@@ -334,7 +334,7 @@ Describe "choco <_>" -ForEach $Command -Tag Chocolatey, ListCommand, SearchComma
     }
 
     # Issue: https://gitlab.com/chocolatey/collaborators/choco-licensed/-/issues/530 (NOTE: Proxy bypassing also works on Chocolatey FOSS)
-    Context "Listing packages on source using proxy and proxy bypass list" -Skip:(!$licensedProxyFixed) {
+    Context "Listing packages on source using proxy and proxy bypass list" -Tag ProxySkip -Skip:(!$licensedProxyFixed) {
         BeforeAll {
             Restore-ChocolateyInstallSnapshot
             $null = Invoke-Choco config set --name=proxy --value="https://invalid.chocolatey.org/"
@@ -357,7 +357,7 @@ Describe "choco <_>" -ForEach $Command -Tag Chocolatey, ListCommand, SearchComma
     }
 
     # Issue: https://gitlab.com/chocolatey/collaborators/choco-licensed/-/issues/530 (NOTE: Proxy bypassing also works on Chocolatey FOSS)
-    Context "Listing packages on source using proxy and proxy bypass list on command" -Skip:(!$licensedProxyFixed) {
+    Context "Listing packages on source using proxy and proxy bypass list on command" -Tag ProxySkip -Skip:(!$licensedProxyFixed) {
         BeforeAll {
             Restore-ChocolateyInstallSnapshot
             $null = Invoke-Choco config set --name=proxy --value="https://invalid.chocolatey.org/"

--- a/tests/chocolatey-tests/commands/choco-list.Tests.ps1
+++ b/tests/chocolatey-tests/commands/choco-list.Tests.ps1
@@ -334,6 +334,7 @@ Describe "choco <_>" -ForEach $Command -Tag Chocolatey, ListCommand, SearchComma
     }
 
     # Issue: https://gitlab.com/chocolatey/collaborators/choco-licensed/-/issues/530 (NOTE: Proxy bypassing also works on Chocolatey FOSS)
+    # These are skipped on Proxy tests because the proxy server can't be bypassed in that test environment.
     Context "Listing packages on source using proxy and proxy bypass list" -Tag ProxySkip -Skip:(!$licensedProxyFixed) {
         BeforeAll {
             Restore-ChocolateyInstallSnapshot
@@ -357,6 +358,7 @@ Describe "choco <_>" -ForEach $Command -Tag Chocolatey, ListCommand, SearchComma
     }
 
     # Issue: https://gitlab.com/chocolatey/collaborators/choco-licensed/-/issues/530 (NOTE: Proxy bypassing also works on Chocolatey FOSS)
+    # These are skipped on Proxy tests because the proxy server can't be bypassed in that test environment.
     Context "Listing packages on source using proxy and proxy bypass list on command" -Tag ProxySkip -Skip:(!$licensedProxyFixed) {
         BeforeAll {
             Restore-ChocolateyInstallSnapshot

--- a/tests/chocolatey-tests/commands/choco-push.Tests.ps1
+++ b/tests/chocolatey-tests/commands/choco-push.Tests.ps1
@@ -1,6 +1,6 @@
 ﻿Import-Module helpers/common-helpers
 
-Describe "choco push" -Tag Chocolatey, PushCommand -Skip:($null -eq $env:API_KEY) {
+Describe "choco push" -Tag Chocolatey, PushCommand, ProxySkip -Skip:($null -eq $env:API_KEY) {
     BeforeDiscovery {
         $isLicensed30OrMissingVersion = Test-PackageIsEqualOrHigher 'chocolatey.extension' '3.0.0-beta' -AllowMissingPackage
         $licensedProxyFixed = Test-PackageIsEqualOrHigher 'chocolatey.extension' 2.2.0-beta -AllowMissingPackage

--- a/tests/chocolatey-tests/commands/choco-push.Tests.ps1
+++ b/tests/chocolatey-tests/commands/choco-push.Tests.ps1
@@ -1,5 +1,6 @@
 ﻿Import-Module helpers/common-helpers
 
+# These are skipped in the Proxy Test environment because they push to a port outside of 8443 which is not allowed by our proxy.
 Describe "choco push" -Tag Chocolatey, PushCommand, ProxySkip -Skip:($null -eq $env:API_KEY) {
     BeforeDiscovery {
         $isLicensed30OrMissingVersion = Test-PackageIsEqualOrHigher 'chocolatey.extension' '3.0.0-beta' -AllowMissingPackage

--- a/tests/chocolatey-tests/features/PythonSource.Tests.ps1
+++ b/tests/chocolatey-tests/features/PythonSource.Tests.ps1
@@ -1,7 +1,7 @@
 ﻿Import-Module helpers/common-helpers
 
 # This is skipped when not run in CI because it modifies the local system.
-Describe "Python Source" -Tag Chocolatey, UpgradeCommand, PythonSource -Skip:(-not $env:TEST_KITCHEN) {
+Describe "Python Source" -Tag Chocolatey, UpgradeCommand, PythonSource, ProxySkip -Skip:(-not $env:TEST_KITCHEN) {
     BeforeAll {
         Initialize-ChocolateyTestInstall
         New-ChocolateyInstallSnapshot

--- a/tests/chocolatey-tests/features/PythonSource.Tests.ps1
+++ b/tests/chocolatey-tests/features/PythonSource.Tests.ps1
@@ -1,4 +1,4 @@
-Import-Module helpers/common-helpers
+﻿Import-Module helpers/common-helpers
 
 # This is skipped when not run in CI because it modifies the local system.
 # This is skipped on Proxy as Python needs to reach out to pypi which our proxy server does not allow.
@@ -6,8 +6,7 @@ Describe "Python Source" -Tag Chocolatey, UpgradeCommand, PythonSource, ProxySki
     BeforeAll {
         Initialize-ChocolateyTestInstall
         New-ChocolateyInstallSnapshot
-        # TODO: Internalize Python and most dependencies. (KB perhaps not internalized due to excessive size...)
-        $null = Invoke-Choco install python3 --source https://community.chocolatey.org/api/v2/
+        $null = Invoke-Choco install python3
     }
 
     AfterAll {

--- a/tests/chocolatey-tests/features/PythonSource.Tests.ps1
+++ b/tests/chocolatey-tests/features/PythonSource.Tests.ps1
@@ -1,6 +1,7 @@
-﻿Import-Module helpers/common-helpers
+Import-Module helpers/common-helpers
 
 # This is skipped when not run in CI because it modifies the local system.
+# This is skipped on Proxy as Python needs to reach out to pypi which our proxy server does not allow.
 Describe "Python Source" -Tag Chocolatey, UpgradeCommand, PythonSource, ProxySkip -Skip:(-not $env:TEST_KITCHEN) {
     BeforeAll {
         Initialize-ChocolateyTestInstall


### PR DESCRIPTION
## Description Of Changes

Tag tests that will not work in our Test Kitchen Proxy testing environment as `ProxySkip`.

## Motivation and Context

To get a handle on what things work with a proxy and what don't, we need tests that will work in the proxy testing environment.

## Testing

1. Ran multiple Test Kitchen runs targeting this branch and various Proxy configurations.
2. Ensured they all worked as expected.

### Operating Systems Testing

- Windows Server 2016
- Windows Server 2019

## Change Types Made

* [ ] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.
* [x] End to End Pester tests

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [x] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue

* PROJ-522
