### PR TITLE
(#1720) Ensure documented proxy settings are used

### DIFF
--- a/src/chocolatey.tests.integration/Scenario.cs
+++ b/src/chocolatey.tests.integration/Scenario.cs
@@ -389,6 +389,21 @@ namespace chocolatey.tests.integration
             return config;
         }
 
+        public static ChocolateyConfiguration proxy()
+        {
+            return baseline_configuration();
+        }
+
+        public static void set_configuration_file_setting(string name, string value)
+        {
+            var config = baseline_configuration();
+            config.ConfigCommand.Name = name;
+            config.ConfigCommand.ConfigValue = value;
+            config.ConfigCommand.Command = ConfigCommandType.Set;
+            var configService = NUnitSetup.Container.GetInstance<IChocolateyConfigSettingsService>();
+            configService.SetConfig(config);
+        }
+
         private static void delete_test_package_directories()
         {
             var topDirectory = get_top_level();

--- a/src/chocolatey.tests.integration/chocolatey.tests.integration.csproj
+++ b/src/chocolatey.tests.integration/chocolatey.tests.integration.csproj
@@ -146,6 +146,7 @@
     <Reference Include="WindowsBase" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="infrastructure.app\builders\ConfigurationBuilderSpecs.cs" />
     <Compile Include="infrastructure.app\services\FilesServiceSpecs.cs" />
     <Compile Include="infrastructure\commands\CommandExecutorSpecs.cs" />
     <Compile Include="infrastructure\cryptography\CryptoHashProviderSpecs.cs" />

--- a/src/chocolatey.tests.integration/infrastructure.app/builders/ConfigurationBuilderSpecs.cs
+++ b/src/chocolatey.tests.integration/infrastructure.app/builders/ConfigurationBuilderSpecs.cs
@@ -1,0 +1,238 @@
+// Copyright © 2017 - 2023 Chocolatey Software, Inc
+// Copyright © 2011 - 2017 RealDimensions Software, LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace chocolatey.tests.integration.infrastructure.app.builders
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Configuration;
+    using chocolatey.infrastructure.adapters;
+    using chocolatey.infrastructure.app;
+    using ConfigurationBuilder = chocolatey.infrastructure.app.builders.ConfigurationBuilder;
+    using chocolatey.infrastructure.app.configuration;
+    using chocolatey.infrastructure.app.domain;
+    using chocolatey.infrastructure.app.services;
+    using chocolatey.infrastructure.licensing;
+    using Moq;
+    using NUnit.Framework;
+    using Container = SimpleInjector.Container;
+    using License = System.ComponentModel.License;
+    using chocolatey.infrastructure.registration;
+    using Microsoft.Win32;
+    using scenarios;
+    using Should;
+
+    public class ConfigurationBuilderSpecs
+    {
+        private const string IgnoreSystemProxyReason = "System Proxy not mockable";
+
+        public abstract class ProxyConfigurationBase : TinySpec
+        {
+            protected bool SystemSet = false;
+            protected bool EnvironmentVariableSet = false;
+            protected bool ConfigSet = false;
+            protected bool ArgumentSet = false;
+            protected const string ConfigurationFileProxySettingName = "proxy";
+            protected const string ConfigurationFileProxyBypassSettingName = "proxyBypassList";
+            protected const string EnvironmentVariableProxyValue = "EnvironmentVariableSet";
+            protected const string CommandArgumentProxyValue = "CommandArgumentSet";
+            protected const string ConfigurationFileProxyValue = "ConfigurationFileSet";
+            protected const string SystemLevelProxyValue = "SystemLevelSet";
+            protected ChocolateyConfiguration Configuration;
+            protected Container Container;
+            protected ChocolateyLicense License;
+            protected Mock<IEnvironment> Environment;
+            protected List<string> ArgumentsList = new List<string>();
+
+            public ProxyConfigurationBase(bool systemSet, bool environmentVariableSet, bool configSet, bool argumentSet)
+            {
+                SystemSet = systemSet;
+                EnvironmentVariableSet = environmentVariableSet;
+                ConfigSet = configSet;
+                ArgumentSet = argumentSet;
+            }
+
+            public override void Context()
+            {
+                Configuration = Scenario.proxy();
+                Scenario.set_configuration_file_setting(ConfigurationFileProxySettingName, string.Empty);
+                Scenario.set_configuration_file_setting(ConfigurationFileProxyBypassSettingName, string.Empty);
+                Scenario.reset(Configuration);
+                Container = NUnitSetup.Container;
+                License = new ChocolateyLicense();
+                Environment = new Mock<IEnvironment>();
+                ConfigurationBuilder.InitializeWith(new Lazy<IEnvironment>(() => Environment.Object));
+                Environment.Setup(e => e.GetEnvironmentVariable(It.IsAny<string>())).Returns(string.Empty);
+                ArgumentsList.Clear();
+            }
+
+            public override void Because()
+            {
+                ConfigurationBuilder.SetupConfiguration(ArgumentsList, Configuration, Container, License, null);
+            }
+        }
+
+        // System and Configuration File and Environment Variable and CLI Argument
+        [TestFixture(false, false, false, false, TestName = "No Proxy Set")]
+        [TestFixture(true, false, false, false, TestName = "System Set", IgnoreReason = IgnoreSystemProxyReason)]
+        [TestFixture(true, true, false, false, TestName = "System and Environment Set", IgnoreReason = IgnoreSystemProxyReason)]
+        [TestFixture(true, true, true, false, TestName = "System and Environment and Configuration Set", IgnoreReason = IgnoreSystemProxyReason)]
+        [TestFixture(true, true, true, true, TestName = "System and Environment and Configuration and Argument Set", IgnoreReason = IgnoreSystemProxyReason)]
+        [TestFixture(true, false, true, false, TestName = "System and Configuration Set", IgnoreReason = IgnoreSystemProxyReason)]
+        [TestFixture(true, false, true, true, TestName = "System and Configuration and Argument Set", IgnoreReason = IgnoreSystemProxyReason)]
+        [TestFixture(true, false, false, true, TestName = "System and Argument Set", IgnoreReason = IgnoreSystemProxyReason)]
+        [TestFixture(true, true, false, true, TestName = "System and Environment and Argument Set", IgnoreReason = IgnoreSystemProxyReason)]
+        [TestFixture(false, true, false, false, TestName = "Environment Set")]
+        [TestFixture(false, true, true, false, TestName = "Environment and Configuration Set")]
+        [TestFixture(false, true, false, true, TestName = "Environment and Argument Set")]
+        [TestFixture(false, true, true, true, TestName = "Environment and Configuration and Argument Set")]
+        [TestFixture(false, false, true, false, TestName = "Configuration Set")]
+        [TestFixture(false, false, true, true, TestName = "Configuration and Argument Set")]
+        [TestFixture(false, false, false, true, TestName = "Argument Set")]
+        public class WhenProxyConfigurationTests : ProxyConfigurationBase
+        {
+            public WhenProxyConfigurationTests(bool system, bool environment, bool config, bool argument) : base(system, environment, config, argument) {}
+            public override void Context()
+            {
+                base.Context();
+
+                if (SystemSet)
+                {
+                    // Do System Level things
+                }
+
+                if (EnvironmentVariableSet)
+                {
+                    Environment.Setup(e => e.GetEnvironmentVariable(It.IsIn("http_proxy", "https_proxy"))).Returns(EnvironmentVariableProxyValue);
+                }
+                else
+                {
+                    Environment.Setup(e => e.GetEnvironmentVariable(It.IsIn("http_proxy", "https_proxy"))).Returns(string.Empty);
+                }
+
+                if (ConfigSet)
+                {
+                    Scenario.set_configuration_file_setting(ConfigurationFileProxySettingName, ConfigurationFileProxyValue);
+                }
+
+                if (ArgumentSet)
+                {
+                    ArgumentsList.Add("--proxy='{0}'".FormatWith(CommandArgumentProxyValue));
+                }
+            }
+
+            [Fact]
+            public void ShouldHaveProxyConfiguration()
+            {
+                if (!SystemSet && !ArgumentSet && !ConfigSet &&
+                    !EnvironmentVariableSet)
+                {
+                    Configuration.Proxy.Location.ShouldEqual(string.Empty);
+                    return;
+                }
+
+                if (ArgumentSet)
+                {
+                    Configuration.Proxy.Location.ShouldEqual(CommandArgumentProxyValue);
+                    return;
+                }
+
+                if (ConfigSet)
+                {
+                    Configuration.Proxy.Location.ShouldEqual(ConfigurationFileProxyValue);
+                    return;
+                }
+
+                if (EnvironmentVariableSet)
+                {
+                    Configuration.Proxy.Location.ShouldEqual(EnvironmentVariableProxyValue);
+                    return;
+                }
+
+                if (SystemSet)
+                {
+                    Configuration.Proxy.Location.ShouldEqual(SystemLevelProxyValue);
+                    return;
+                }
+            }
+        }
+
+        [TestFixture(false, false, false, false, TestName = "No Bypass Set")]
+        [TestFixture(false, true, false, false, TestName = "Config Bypass Set")]
+        [TestFixture(false, true, true, false, TestName = "Config and Environment Variable Bypass Set")]
+        [TestFixture(false, true, true, true, TestName = "Config and Environment Variable and Argument Bypass Set")]
+        [TestFixture(false, true, false, true, TestName = "Config and Argument Bypass Set")]
+        [TestFixture(false, false, true, false, TestName = "Environment Variable Bypass Set")]
+        [TestFixture(false, false, true, true, TestName = "Environment Variable and Argument Bypass Set")]
+        public class WhenProxyBypassConfigurationTests : ProxyConfigurationBase
+        {
+            public WhenProxyBypassConfigurationTests(bool system, bool environment, bool config, bool argument) : base(system, environment, config, argument) { }
+
+            public override void Context()
+            {
+                base.Context();
+
+                if (ConfigSet)
+                {
+                    Scenario.set_configuration_file_setting(ConfigurationFileProxyBypassSettingName, ConfigurationFileProxyValue);
+                }
+
+                if (EnvironmentVariableSet)
+                {
+                    Environment.Setup(e => e.GetEnvironmentVariable("no_proxy")).Returns(EnvironmentVariableProxyValue);
+                }
+                else
+                {
+                    Environment.Setup(e => e.GetEnvironmentVariable("no_proxy")).Returns(string.Empty);
+                }
+
+                if (ArgumentSet)
+                {
+                    ArgumentsList.Add("--proxy-bypass-list='{0}'".FormatWith(CommandArgumentProxyValue));
+                }
+            }
+
+            [Fact]
+            public void ShouldBypassProxy()
+            {
+                if (!ArgumentSet && !ConfigSet &&
+                    !EnvironmentVariableSet)
+                {
+                    Configuration.Proxy.BypassList.ShouldEqual(string.Empty);
+                    return;
+                }
+
+                if (ArgumentSet)
+                {
+                    Configuration.Proxy.BypassList.ShouldEqual(CommandArgumentProxyValue);
+                    return;
+                }
+
+                if (ConfigSet)
+                {
+                    Configuration.Proxy.BypassList.ShouldEqual(ConfigurationFileProxyValue);
+                    return;
+                }
+
+                if (EnvironmentVariableSet)
+                {
+                    Configuration.Proxy.BypassList.ShouldEqual(EnvironmentVariableProxyValue);
+                    return;
+                }
+            }
+        }
+    }
+}

--- a/src/chocolatey.tests.integration/scenarios/ListScenarios.cs
+++ b/src/chocolatey.tests.integration/scenarios/ListScenarios.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2023-Present Chocolatey Software, Inc
+// Copyright © 2023-Present Chocolatey Software, Inc
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -138,7 +138,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_only_have_messages_related_to_package_information()
             {
-                var count = MockLogger.Messages.SelectMany(messageLevel => messageLevel.Value.OrEmpty()).Count();
+                var count = MockLogger.MessagesFor(LogLevel.Info).OrEmpty().Count();
                 count.ShouldEqual(2);
             }
 

--- a/tests/chocolatey-tests/commands/choco-removed.Tests.ps1
+++ b/tests/chocolatey-tests/commands/choco-removed.Tests.ps1
@@ -135,7 +135,7 @@ exit $command.Count
         }
     }
 
-    Context 'Ensure --allow-multiple removed from Chocolatey' -Tag InstallCommand, UpgradeCommand, UninstallCommand, AllowMultiple -Foreach @(
+    Context 'Ensure --allow-multiple removed from Chocolatey <Command> command' -Tag InstallCommand, UpgradeCommand, UninstallCommand, AllowMultiple, cory -Foreach @(
         @{ Command = 'install' }
         @{ Command = 'upgrade' }
         @{ Command = 'uninstall' }
@@ -156,11 +156,13 @@ exit $command.Count
             $Output = Invoke-Choco $Command $package @options
         }
 
-        It 'Exits with Success (0)' {
+        # Skipping on Upgrade as that exits with -1 due to the BeforeModify script.
+        It 'Exits with Success (0)' -Skip:($Command -eq 'upgrade') {
             $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
-        It 'Does not use a versioned package folder' -Skip:($Command -eq 'upgrade') {
+        # Skipping on uninstall because there shouldn't be a folder after uninstall.
+        It 'Does not use a versioned package folder' -Skip:($Command -eq 'uninstall') {
             $expectedPath = Join-Path $env:ChocolateyInstall -ChildPath 'lib' |
                 Join-Path -ChildPath $package
 

--- a/tests/chocolatey-tests/features/Proxy.Tests.ps1
+++ b/tests/chocolatey-tests/features/Proxy.Tests.ps1
@@ -1,0 +1,236 @@
+Import-Module helpers/common-helpers
+
+$TestCases = @(
+    @{
+        Name = 'None'
+        ConfigurationsToTest = @{
+            System = $false
+            EnvironmentVariable = $false
+            ConfigFile = $false
+            CliArgument = $false
+        }
+    }
+    @{
+        Name = 'System'
+        ConfigurationsToTest = @{
+            System = $true
+            EnvironmentVariable = $false
+            ConfigFile = $false
+            CliArgument = $false
+        }
+    }
+    @{
+        Name = 'SystemConfig'
+        ConfigurationsToTest = @{
+            System = $true
+            EnvironmentVariable = $false
+            ConfigFile = $true
+            CliArgument = $false
+        }
+    }
+    @{
+        Name = 'SystemEnvironmentVariable'
+        ConfigurationsToTest = @{
+            System = $true
+            EnvironmentVariable = $true
+            ConfigFile = $false
+            CliArgument = $false
+        }
+    }
+    @{
+        Name = 'SystemCliArgument'
+        ConfigurationsToTest = @{
+            System = $true
+            EnvironmentVariable = $true
+            ConfigFile = $false
+            CliArgument = $false
+        }
+    }
+    @{
+        Name = 'SystemConfigFileEnvironmentVariable'
+        ConfigurationsToTest = @{
+            System = $true
+            EnvironmentVariable = $true
+            ConfigFile = $true
+            CliArgument = $false
+        }
+    }
+    @{
+        Name = 'SystemConfigFileCliArgument'
+        ConfigurationsToTest = @{
+            System = $true
+            EnvironmentVariable = $false
+            ConfigFile = $true
+            CliArgument = $true
+        }
+    }
+    @{
+        Name = 'SystemEnvironmentVariableCliAgrument'
+        ConfigurationsToTest = @{
+            System = $true
+            EnvironmentVariable = $true
+            ConfigFile = $false
+            CliArgument = $true
+        }
+    }
+    @{
+        Name = 'SystemConfigFileEnvironmentVariableCliArgument'
+        ConfigurationsToTest = @{
+            System = $true
+            EnvironmentVariable = $true
+            ConfigFile = $true
+            CliArgument = $true
+        }
+    }
+    @{
+        Name = 'ConfigFile'
+        ConfigurationsToTest = @{
+            System = $false
+            EnvironmentVariable = $false
+            ConfigFile = $true
+            CliArgument = $false
+        }
+    }
+    @{
+        Name = 'ConfigFileEnvironmentVariable'
+        ConfigurationsToTest = @{
+            System = $false
+            EnvironmentVariable = $true
+            ConfigFile = $true
+            CliArgument = $false
+        }
+    }
+    @{
+        Name = 'ConfigFileCliArgument'
+        ConfigurationsToTest = @{
+            System = $false
+            EnvironmentVariable = $false
+            ConfigFile = $true
+            CliArgument = $true
+        }
+    }
+    @{
+        Name = 'ConfigFileEnvironmentVariableCliArgument'
+        ConfigurationsToTest = @{
+            System = $false
+            EnvironmentVariable = $true
+            ConfigFile = $true
+            CliArgument = $true
+        }
+    }
+    @{
+        Name = 'EnvironmentVariable'
+        ConfigurationsToTest = @{
+            System = $false
+            EnvironmentVariable = $true
+            ConfigFile = $false
+            CliArgument = $false
+        }
+    }
+    @{
+        Name = 'EnvironmentVariableCliArgument'
+        ConfigurationsToTest = @{
+            System = $false
+            EnvironmentVariable = $true
+            ConfigFile = $false
+            CliArgument = $true
+        }
+    }
+    @{
+        Name = 'CliArgument'
+        ConfigurationsToTest = @{
+            System = $false
+            EnvironmentVariable = $false
+            ConfigFile = $false
+            CliArgument = $true
+        }
+    }
+)
+
+$CommandsToTest = @(
+    @{ Command = 'install'; ExtraArguments = @('dummypackage') }
+    @{ Command = 'upgrade'; ExtraArguments = @('dummypackage') }
+    @{ Command = 'search'; ExtraArguments = @('') }
+    @{ Command = 'find'; ExtraArguments = @('') }
+    @{ Command = 'outdated'; ExtraArguments = @('') }
+    @{ Command = 'push'; ExtraArguments = @("--source='https://example.com'", "--api-key='my-key'") }
+)
+
+# Skip when not on Test Kitchen as this changes the system proxy
+# Skip when run in Proxy Test Kitchen as the Proxy test kitchen sets some of these...
+Describe "Proxy configuration (<Name>)" -Tag Proxy, ProxySkip -ForEach $TestCases -Skip:(-not $env:TEST_KITCHEN) {
+    BeforeAll {
+        Initialize-ChocolateyTestInstall
+        New-ChocolateyInstallSnapshot
+        $arguments = $null
+
+        $SystemSet = "SystemSetProxy"
+        $ConfigFileSet = "ConfigFileSetProxy"
+        $EnvironmentVariableSet = "EnvironmentVariableSetProxy"
+        $CliArgumentSet = "CliArgumentSetProxy"
+
+        if ($ConfigurationsToTest.System) {
+            Set-ItemProperty -Path 'HKCU:/Software/Microsoft/Windows/CurrentVersion/Internet Settings' -name ProxyServer -Value $SystemSet
+            Set-ItemProperty -Path 'HKCU:/Software/Microsoft/Windows/CurrentVersion/Internet Settings' -name ProxyEnable -Value 1
+        }
+
+        if ($ConfigurationsToTest.ConfigFile) {
+            Invoke-Choco config set proxy $ConfigFileSet
+            Invoke-Choco config set proxyBypassList $ConfigFileSet
+        }
+
+        if ($ConfigurationsToTest.EnvironmentVariable) {
+            $env:https_proxy = $EnvironmentVariableSet
+            $env:no_proxy = $EnvironmentVariableSet
+        }
+
+        if ($ConfigurationsToTest.CliArgument) {
+            $arguments = @("--proxy='$CliArgumentSet'", "--proxy-bypass-list='$CliArgumentSet'")
+        }
+    }
+
+    AfterAll {
+        Remove-ChocolateyTestInstall
+        Remove-ItemProperty -Path 'HKCU:/Software/Microsoft/Windows/CurrentVersion/Internet Settings' -name ProxyServer -ErrorAction Ignore
+        Remove-ItemProperty -Path 'HKCU:/Software/Microsoft/Windows/CurrentVersion/Internet Settings' -name ProxyEnable -ErrorAction Ignore
+        $env:https_proxy = $null
+    }
+
+    Context "Configured for command (<Command>)" -ForEach $CommandsToTest {
+        BeforeAll {
+            $Output = Invoke-Choco $Command @arguments @ExtraArguments --debug --verbose --noop
+        }
+
+        It "Should output the correct Proxy setting" {
+            switch ($true) {
+                $ConfigurationsToTest.CliArgument {
+                    $Output.String | Should -MatchExactly "Proxy\.Location='$CliArgumentSet'"
+                    $Output.String | Should -MatchExactly "Proxy\.BypassList='$CliArgumentSet'"
+                    continue
+                }
+
+                $ConfigurationsToTest.ConfigFile {
+                    $Output.String | Should -MatchExactly "Proxy\.Location='$ConfigFileSet'"
+                    $Output.String | Should -MatchExactly "Proxy\.BypassList='$ConfigFileSet'"
+                    continue
+                }
+
+                $ConfigurationsToTest.EnvironmentVariable {
+                    $Output.String | Should -MatchExactly "Proxy\.Location='$EnvironmentVariableSet'"
+                    $Output.String | Should -MatchExactly "Proxy\.BypassList='$EnvironmentVariableSet'"
+                    continue
+                }
+
+                $ConfigurationsToTest.System {
+                    $Output.String | Should -MatchExactly "Proxy\.Location='$SystemSet'"
+                    continue
+                }
+
+                default {
+                    $Output.String | Should -Not -Match "Proxy\.Location"
+                    $Output.String | Should -Not -Match "Proxy\.BypassList"
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Description Of Changes

Read in system configured and environment variable set proxy information.

## Motivation and Context

With the uplift of the NuGet libraries, the Proxy configurations were not being honoured. 

## Testing

1. Update `Vagrantfile` in the `tests` directory to set `$env:TEST_KITCHEN` to `1` (uncomment line 62)
2. Run `vagrant up` from the `tests` directory
  * To run just the newly added tests you can add `Tag = 'Proxy'` to the `Invoke-Tests.ps1` file after line 119
4. Ensure that all Proxy related tests pass

Tests also run in Test Kitchen on Team City.

### Operating Systems Testing

- Windows Server 2022
- Windows Server 2019
- Windows Server 2016

## Change Types Made

* [ ] Bug fix (non-breaking change).
* [x] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [x] Tests to cover my changes, have been added.
* [x] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue

* PROJ-536
* #1720
