### PR TITLE
(maint) Make NuGetVersion extension methods public

### DIFF
--- a/src/chocolatey/NuGetVersionExtensions.cs
+++ b/src/chocolatey/NuGetVersionExtensions.cs
@@ -22,8 +22,7 @@ namespace chocolatey
     /// Helper methods for dealing with the the nuget version returned by
     /// the NuGet.Client libraries to ensure they can be easily used.
     /// </summary>
-    /// <remarks>The class is marked as internal on purpose to ensure it will not be part of the public API</remarks>
-    internal static class NuGetVersionExtensions
+    public static class NuGetVersionExtensions
     {
 #pragma warning disable RS0030 // Do not used banned APIs
         /// <summary>


### PR DESCRIPTION
## Description Of Changes

- Make `NuGetVersionExtensions` static class `public`

## Motivation and Context

These extension methods aren't widely used, but we would prefer to be able to use them in the licensed extension directly rather than duplicating code.

## Testing

N/A, no functional change from here, just making a thing public so we have an easier time in CLE.

### Operating Systems Testing

Win11

## Change Types Made
<!-- Tick the boxes for the type of changes that have been made -->

* [ ] Bug fix (non-breaking change).
* [x] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [x] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue

N/A
