### PR TITLE
(maint) Fix null config value throwing exception

### DIFF
--- a/src/chocolatey/infrastructure.app/configuration/ChocolateyConfiguration.cs
+++ b/src/chocolatey/infrastructure.app/configuration/ChocolateyConfiguration.cs
@@ -205,6 +205,14 @@ NOTE: Hiding sensitive configuration data! Please double and triple
                         AppendOutput(propertyValues, output);
                     }
                 }
+                else if (objectValue is null)
+                {
+                    var output = "{0}{1}={{null}}".FormatWith(
+                        string.IsNullOrWhiteSpace(prepend) ? "" : prepend + ".",
+                        propertyInfo.Name);
+
+                    AppendOutput(propertyValues, output);
+                }
                 else
                 {
                     OutputToString(propertyValues, propertyInfo.PropertyType.GetProperties(), objectValue, propertyInfo.Name);


### PR DESCRIPTION
## Description Of Changes

The changes in this PR validate whether a custom object is null before trying to recursively set its properties.
If the object is null, we'll just make that as part of the output string instead of trying to set any of the properties on the object.

## Motivation and Context

We don't want any null custom object values to prevent the running of the application, and/or unit tests.

## Testing

1. Build and copy changes into debug version of Chocolatey Licensed Extension.
2. Run unit tests
3. No failures are expected.

### Operating Systems Testing

- Windows 10/11

## Change Types Made

* [x] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [ ] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue

N/A 