### PR TITLE
(#2887) Fix tab completion in v2, tests, and add `support` to tab completion

### DIFF
--- a/src/chocolatey.resources/helpers/ChocolateyTabExpansion.ps1
+++ b/src/chocolatey.resources/helpers/ChocolateyTabExpansion.ps1
@@ -63,7 +63,7 @@ $commandOptions = @{
 $commandOptions['find'] = $commandOptions['search']
 
 try {
-    $licenseFile = Get-Item -Path "$env:ChocolateyInstall\license\chocolatey.license.xml" -ErrorAction Ignore
+    $licenseFile = Get-Item -Path "$env:ChocolateyInstall\license\chocolatey.license.xml" -ErrorAction SilentlyContinue
 
     if ($licenseFile) {
         # Add pro-only commands
@@ -94,6 +94,7 @@ try {
             # Add business-only commands
             $script:chocoCommands = @(
                 $script:chocoCommands
+                'support'
                 'sync'
             )
 
@@ -117,7 +118,7 @@ foreach ($key in @($commandOptions.Keys)) {
 }
 
 # Consistent ordering for commands so the added pro commands aren't weirdly out of order
-$script:chocoCommands = $script:chocoCommands | Sort-Object -Property { $_ -replace '[^a-z]' }
+$script:chocoCommands = $script:chocoCommands | Sort-Object -Property { $_ -replace '[^a-z](.*$)', '$1--' }
 
 function script:chocoCommands($filter) {
     $cmdList = @()


### PR DESCRIPTION
## Description Of Changes

- Fix issue for PSv2 where `Ignore` is not a valid ErrorActionPreference
- Fix test to check for commands correctly, and actually ensure all the commands are listed by fixing up and repurposing the commented-out portion of the tab completion test
- Add missing `support` command to tab completion for folks with a Business license (which I discovered was missing when I fixed this test, woO!)

## Motivation and Context

PSv2 compat is, apparently, still vaguely important, I guess. And also tab completion tests were broken. Must fix.

## Testing

- Run the invoke-tests.ps1 script. Maybe set the tag to `Profile` if you just wanna run these ones.

### Operating Systems Testing

I tested on win11, but this has previously been tested on PSv2 and this was the only issue we're aware of there. Would be good to re-check PSv2 if possible.

## Change Types Made
<!-- Tick the boxes for the type of changes that have been made -->

* [x] Bug fix (non-breaking change).
* [x] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [x] Tests to cover my changes, have been added.
* [x] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue

Related to changes made for #2887

<!-- PLEASE REMOVE ALL COMMENTS BEFORE SUBMITTING -->
