### PR TITLE
Add tests for missing lib directory

### DIFF
--- a/tests/chocolatey-tests/chocolatey.Tests.ps1
+++ b/tests/chocolatey-tests/chocolatey.Tests.ps1
@@ -444,4 +444,29 @@ exit $error.count
             $Output.Lines | Should -Contain '.NET 4.8 is not installed or may need a reboot to complete installation.'
         }
     }
+
+
+    Context 'Chocolatey lib directory missing' {
+        BeforeAll {
+            New-ChocolateyInstallSnapshot
+            Remove-Item -Path $env:ChocolateyInstall/lib/ -Recurse -Force
+            $Output = Invoke-Choco list
+        }
+
+        AfterAll {
+            Remove-ChocolateyInstallSnapshot
+        }
+
+        It 'Exits with success (0)' {
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
+        }
+
+        It 'Emits a warning about the missing directory' {
+            $Output.Lines | Should -Contain "Directory '$($env:ChocolateyInstall)\lib' does not exist." -Because $Output.String
+        }
+
+        It 'Does not emit a NuGet error for the missing directory and fall over' {
+            $Output.Lines | Should -Not -Contain "The path '$($env:ChocolateyInstall)\lib' for the selected source could not be resolved."
+        }
+    }
 }


### PR DESCRIPTION
## Description Of Changes

- Add test for `choco list` with a missing `lib` directory

## Motivation and Context

In CLE, there are cases where having a missing lib directory will break some commands.

However, the behaviour still needs to be asserted for CLI to ensure that we have the correct test here, and we will also run these tests under CLE in order to ensure that adding the extension does not break this edge case anymore.

## Testing

1. Run test
2. Test does not fail.

### Operating Systems Testing

Win11

## Change Types Made
<!-- Tick the boxes for the type of changes that have been made -->

* [ ] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [x] Tests to cover my changes, have been added.
* [x] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue

N/A, tests only

<!-- PLEASE REMOVE ALL COMMENTS BEFORE SUBMITTING -->
