### PR TITLE
(#158) Add handling for -li option

### DIFF
--- a/src/chocolatey.tests/infrastructure.app/commands/ChocolateyListCommandSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/commands/ChocolateyListCommandSpecs.cs
@@ -31,56 +31,56 @@ namespace chocolatey.tests.infrastructure.app.commands
         [ConcernFor("list")]
         public abstract class ChocolateyListCommandSpecsBase : TinySpec
         {
-            protected ChocolateyListCommand command;
-            protected Mock<IChocolateyPackageService> packageService = new Mock<IChocolateyPackageService>();
-            protected ChocolateyConfiguration configuration = new ChocolateyConfiguration();
+            protected ChocolateyListCommand Command;
+            protected Mock<IChocolateyPackageService> PackageService = new Mock<IChocolateyPackageService>();
+            protected ChocolateyConfiguration Configuration = new ChocolateyConfiguration();
 
             public override void Context()
             {
-                command = new ChocolateyListCommand(packageService.Object);
+                Command = new ChocolateyListCommand(PackageService.Object);
             }
         }
 
         public class When_implementing_command_for : ChocolateyListCommandSpecsBase
         {
-            private List<string> results;
+            private List<string> _results;
 
             public override void Because()
             {
-                results = command.GetType().GetCustomAttributes(typeof(CommandForAttribute), false).Cast<CommandForAttribute>().Select(a => a.CommandName).ToList();
+                _results = Command.GetType().GetCustomAttributes(typeof(CommandForAttribute), false).Cast<CommandForAttribute>().Select(a => a.CommandName).ToList();
             }
 
             [Fact]
             public void Should_implement_list()
             {
-                results.ShouldContain("list");
+                _results.ShouldContain("list");
             }
 
             [Fact]
             public void Should_not_implement_search()
             {
-                results.ShouldNotContain("search");
+                _results.ShouldNotContain("search");
             }
 
             [Fact]
             public void Should_not_implement_find()
             {
-                results.ShouldNotContain("find");
+                _results.ShouldNotContain("find");
             }
 
             public class When_configurating_the_argument_parser : ChocolateyListCommandSpecsBase
             {
-                private OptionSet optionSet;
+                private OptionSet _optionSet;
 
                 public override void Context()
                 {
                     base.Context();
-                    optionSet = new OptionSet();
+                    _optionSet = new OptionSet();
                 }
 
                 public override void Because()
                 {
-                    command.ConfigureArgumentParser(optionSet, configuration);
+                    Command.ConfigureArgumentParser(_optionSet, Configuration);
                 }
 
                 [NUnit.Framework.TestCase("prerelease")]
@@ -89,7 +89,7 @@ namespace chocolatey.tests.infrastructure.app.commands
                 [NUnit.Framework.TestCase("i")]
                 public void Should_add_to_option_set(string option)
                 {
-                    optionSet.Contains(option).ShouldBeTrue();
+                    _optionSet.Contains(option).ShouldBeTrue();
                 }
 
                 [NUnit.Framework.TestCase("source")]
@@ -104,37 +104,37 @@ namespace chocolatey.tests.infrastructure.app.commands
                 [NUnit.Framework.TestCase("a")]
                 public void Should_not_add_to_option_set(string option)
                 {
-                    optionSet.Contains(option).ShouldBeFalse();
+                    _optionSet.Contains(option).ShouldBeFalse();
                 }
             }
 
             public class When_handling_additional_argument_parsing : ChocolateyListCommandSpecsBase
             {
-                private readonly IList<string> unparsedArgs = new List<string>();
-                private readonly string source = "https://somewhereoutthere";
-                private Action because;
+                private readonly IList<string> _unparsedArgs = new List<string>();
+                private readonly string _source = "https://somewhereoutthere";
+                private Action _because;
 
                 public override void Context()
                 {
                     base.Context();
-                    unparsedArgs.Add("pkg1");
-                    unparsedArgs.Add("pkg2");
-                    unparsedArgs.Add("-l");
-                    unparsedArgs.Add("--local-only");
-                    unparsedArgs.Add("--localonly");
-                    configuration.Sources = source;
+                    _unparsedArgs.Add("pkg1");
+                    _unparsedArgs.Add("pkg2");
+                    _unparsedArgs.Add("-l");
+                    _unparsedArgs.Add("--local-only");
+                    _unparsedArgs.Add("--localonly");
+                    Configuration.Sources = _source;
                 }
 
                 public override void Because()
                 {
-                    because = () => command.ParseAdditionalArguments(unparsedArgs, configuration);
+                    _because = () => Command.ParseAdditionalArguments(_unparsedArgs, Configuration);
                 }
 
                 [Fact]
                 public void Should_set_unparsed_arguments_to_configuration_input()
                 {
-                    because();
-                    configuration.Input.ShouldEqual("pkg1 pkg2");
+                    _because();
+                    Configuration.Input.ShouldEqual("pkg1 pkg2");
                 }
 
                 [NUnit.Framework.TestCase("-l")]
@@ -142,7 +142,7 @@ namespace chocolatey.tests.infrastructure.app.commands
                 [NUnit.Framework.TestCase("--localonly")]
                 public void Should_output_warning_message_about_unsupported_argument(string argument)
                 {
-                    because();
+                    _because();
                     MockLogger.Messages.Keys.ShouldContain("Warn");
                     MockLogger.Messages["Warn"].ShouldContain(@"
 UNSUPPORTED ARGUMENT: Ignoring the argument {0}. This argument is unsupported for locally installed packages, and will be treated as a package name in Chocolatey CLI v3!".FormatWith(argument));
@@ -154,19 +154,19 @@ UNSUPPORTED ARGUMENT: Ignoring the argument {0}. This argument is unsupported fo
                 public override void Context()
                 {
                     base.Context();
-                    configuration.CommandName = "search";
-                    configuration.ListCommand.LocalOnly = false;
+                    Configuration.CommandName = "search";
+                    Configuration.ListCommand.LocalOnly = false;
                 }
 
                 public override void Because()
                 {
-                    command.DryRun(configuration);
+                    Command.DryRun(Configuration);
                 }
 
                 [Fact]
                 public void Should_call_service_list_noop()
                 {
-                    packageService.Verify(c => c.ListDryRun(configuration), Times.Once);
+                    PackageService.Verify(c => c.ListDryRun(Configuration), Times.Once);
                 }
 
                 [Fact]
@@ -181,18 +181,18 @@ UNSUPPORTED ARGUMENT: Ignoring the argument {0}. This argument is unsupported fo
                 public override void Context()
                 {
                     base.Context();
-                    configuration.CommandName = "list";
+                    Configuration.CommandName = "list";
                 }
 
                 public override void Because()
                 {
-                    command.Run(configuration);
+                    Command.Run(Configuration);
                 }
 
                 [Fact]
                 public void Should_call_service_list_run()
                 {
-                    packageService.Verify(c => c.List(configuration), Times.Once);
+                    PackageService.Verify(c => c.List(Configuration), Times.Once);
                 }
 
                 [Fact]

--- a/src/chocolatey.tests/infrastructure.app/commands/ChocolateyListCommandSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/commands/ChocolateyListCommandSpecs.cs
@@ -122,6 +122,8 @@ namespace chocolatey.tests.infrastructure.app.commands
                     _unparsedArgs.Add("-l");
                     _unparsedArgs.Add("--local-only");
                     _unparsedArgs.Add("--localonly");
+                    _unparsedArgs.Add("-li");
+                    _unparsedArgs.Add("-lai");
                     Configuration.Sources = _source;
                 }
 
@@ -146,6 +148,17 @@ namespace chocolatey.tests.infrastructure.app.commands
                     MockLogger.Messages.Keys.ShouldContain("Warn");
                     MockLogger.Messages["Warn"].ShouldContain(@"
 UNSUPPORTED ARGUMENT: Ignoring the argument {0}. This argument is unsupported for locally installed packages, and will be treated as a package name in Chocolatey CLI v3!".FormatWith(argument));
+                }
+
+                [NUnit.Framework.TestCase("-li")]
+                [NUnit.Framework.TestCase("-lai")]
+                public void Should_output_warning_message_about_unsupported_argument_and_set_include_programs(string argument)
+                {
+                    _because();
+                    MockLogger.Messages.Keys.ShouldContain("Warn");
+                    MockLogger.Messages["Warn"].ShouldContain(@"
+UNSUPPORTED ARGUMENT: Ignoring the argument {0}. This argument is unsupported for locally installed packages, and will be treated as a package name in Chocolatey CLI v3!".FormatWith(argument));
+                    Configuration.ListCommand.IncludeRegistryPrograms.ShouldBeTrue();
                 }
             }
 

--- a/src/chocolatey/infrastructure.app/commands/ChocolateyListCommand.cs
+++ b/src/chocolatey/infrastructure.app/commands/ChocolateyListCommand.cs
@@ -54,6 +54,24 @@ namespace chocolatey.infrastructure.app.commands
             "--order-by-popularity"
         };
 
+        /// <summary>
+        /// These options have been chosen since these are the examples that were listed on docs.chocolatey.org
+        /// - choco list -li
+        /// - choco list -lai
+        /// </summary>
+        [Obsolete("Remove unsupported argument in V3!")]
+        private readonly string[] _unsupportedIncludeRegistryProgramsArguments = new[]
+        {
+            "-li",
+            "-il",
+            "-lai",
+            "-lia",
+            "-ali",
+            "-ail",
+            "-ial",
+            "-ila"
+        };
+
         public ChocolateyListCommand(IChocolateyPackageService packageService)
         {
             _packageService = packageService ?? throw new ArgumentNullException(nameof(packageService));
@@ -129,6 +147,12 @@ namespace chocolatey.infrastructure.app.commands
                 {
                     this.Log().Warn(ChocolateyLoggers.Important, @"
 UNSUPPORTED ARGUMENT: Ignoring the argument {0}. This argument is unsupported for locally installed packages, and will be treated as a package name in Chocolatey CLI v3!", argument);
+                }
+                else if (_unsupportedIncludeRegistryProgramsArguments.Contains(argument, StringComparer.OrdinalIgnoreCase))
+                {
+                    this.Log().Warn(ChocolateyLoggers.Important, @"
+UNSUPPORTED ARGUMENT: Ignoring the argument {0}. This argument is unsupported for locally installed packages, and will be treated as a package name in Chocolatey CLI v3!", argument);
+                    configuration.ListCommand.IncludeRegistryPrograms = true;
                 }
                 else
                 {

--- a/src/chocolatey/infrastructure.app/commands/ChocolateyListCommand.cs
+++ b/src/chocolatey/infrastructure.app/commands/ChocolateyListCommand.cs
@@ -180,13 +180,13 @@ UNSUPPORTED ARGUMENT: Ignoring the argument {0}. This argument is unsupported fo
 
             this.Log().Info(ChocolateyLoggers.Important, "Examples");
             this.Log().Info(@"
-    choco {0} --local-only
-    choco {0} --local-only --include-programs
+    choco list -i
+    choco list --include-programs
 
 NOTE: See scripting in the command reference (`choco -?`) for how to
  write proper scripts and integrations.
 
-".FormatWith(configuration.CommandName));
+");
 
             this.Log().Info(ChocolateyLoggers.Important, "Exit Codes");
             this.Log().Info(@"

--- a/tests/chocolatey-tests/commands/choco-list.Tests.ps1
+++ b/tests/chocolatey-tests/commands/choco-list.Tests.ps1
@@ -99,7 +99,7 @@ Describe "choco list" -Tag Chocolatey, ListCommand {
         }
     }
 
-    Context "Listing local packages with unsupported argument outputs warning" -ForEach @('-l', '-lo', '--lo', '--local', '--localonly', '--local-only', '--order-by-popularity', '-a', '--all', '--allversions', '--all-versions') {
+    Context "Listing local packages with unsupported argument outputs warning" -ForEach @('-l', '-lo', '--lo', '--local', '--localonly', '--local-only', '--order-by-popularity', '-a', '--all', '--allversions', '--all-versions', '-li', '-il', '-lai', '-lia', '-ali', '-ail', '-ial', '-ila') {
         BeforeAll {
             $Output = Invoke-Choco list $_
         }


### PR DESCRIPTION
## Description Of Changes

This PR addresses this by adding specific handling for the option
combinations that were previously documented on our site, showing a
warning when they are used, and directly setting the
IncludeRegistryPrograms configuration value when required.

This code will be removed in a future version of Chocolatey, most
likely in V3.

## Motivation and Context

When the work was done to change the behaviour of choco list to only
include information about local packages, we missed the ability to run
a command like choco list -li.  Historically, this command would have
listed all locally installed packages, as well as information about
applications that have been directly installed outside of Chocolatey.
This was due to the fact that since -l is no longer a parsed argument.
the argument parser doesn't interpret the other options.

## Testing

1. Ran all unit, integration and Pester tests
2. Everything passed

### Operating Systems Testing

- Windows 10

## Change Types Made

* [x] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [x] Requires a change to the documentation.
* [x] Documentation has been updated.
* [x] Tests to cover my changes, have been added.
* [x] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue

- Relates to #158 
- https://app.clickup.com/t/20540031/PROJ-573