### PR TITLE
(#2219) Defer errors from defaultpushsource until validation for ChocolateyPushCommand

### DIFF
--- a/src/chocolatey.tests/infrastructure.app/commands/ChocolateyPushCommandSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/commands/ChocolateyPushCommandSpecs.cs
@@ -34,102 +34,102 @@ namespace chocolatey.tests.infrastructure.app.commands
         [ConcernFor("push")]
         public abstract class ChocolateyPushCommandSpecsBase : TinySpec
         {
-            protected ChocolateyPushCommand command;
-            protected Mock<IChocolateyPackageService> packageService = new Mock<IChocolateyPackageService>();
-            protected Mock<IChocolateyConfigSettingsService> configSettingsService = new Mock<IChocolateyConfigSettingsService>();
-            protected ChocolateyConfiguration configuration = new ChocolateyConfiguration();
+            protected ChocolateyPushCommand Command;
+            protected Mock<IChocolateyPackageService> PackageService = new Mock<IChocolateyPackageService>();
+            protected Mock<IChocolateyConfigSettingsService> ConfigSettingsService = new Mock<IChocolateyConfigSettingsService>();
+            protected ChocolateyConfiguration Configuration = new ChocolateyConfiguration();
 
             public override void Context()
             {
-                configuration.Sources = "https://localhost/somewhere/out/there";
-                command = new ChocolateyPushCommand(packageService.Object, configSettingsService.Object);
+                Configuration.Sources = "https://localhost/somewhere/out/there";
+                Command = new ChocolateyPushCommand(PackageService.Object, ConfigSettingsService.Object);
             }
         }
 
         public class When_implementing_command_for : ChocolateyPushCommandSpecsBase
         {
-            private List<string> results;
+            private List<string> _results;
 
             public override void Because()
             {
-                results = command.GetType().GetCustomAttributes(typeof(CommandForAttribute), false).Cast<CommandForAttribute>().Select(a => a.CommandName).ToList();
+                _results = Command.GetType().GetCustomAttributes(typeof(CommandForAttribute), false).Cast<CommandForAttribute>().Select(a => a.CommandName).ToList();
             }
 
             [Fact]
             public void Should_implement_push()
             {
-                results.ShouldContain("push");
+                _results.ShouldContain("push");
             }
         }
 
         //Yes, configurating [sic]
         public class When_configurating_the_argument_parser : ChocolateyPushCommandSpecsBase
         {
-            private OptionSet optionSet;
+            private OptionSet _optionSet;
 
             public override void Context()
             {
                 base.Context();
-                optionSet = new OptionSet();
+                _optionSet = new OptionSet();
             }
 
             public override void Because()
             {
-                command.ConfigureArgumentParser(optionSet, configuration);
+                Command.ConfigureArgumentParser(_optionSet, Configuration);
             }
 
             [Fact]
             public void Should_clear_previously_set_Source()
             {
-                configuration.Sources.ShouldBeNull();
+                Configuration.Sources.ShouldBeNull();
             }
 
             [Fact]
             public void Should_add_source_to_the_option_set()
             {
-                optionSet.Contains("source").ShouldBeTrue();
+                _optionSet.Contains("source").ShouldBeTrue();
             }
 
             [Fact]
             public void Should_add_short_version_of_source_to_the_option_set()
             {
-                optionSet.Contains("s").ShouldBeTrue();
+                _optionSet.Contains("s").ShouldBeTrue();
             }
 
             [Fact]
             public void Should_add_apikey_to_the_option_set()
             {
-                optionSet.Contains("apikey").ShouldBeTrue();
+                _optionSet.Contains("apikey").ShouldBeTrue();
             }
 
             [Fact]
             public void Should_add_short_version_of_apikey_to_the_option_set()
             {
-                optionSet.Contains("k").ShouldBeTrue();
+                _optionSet.Contains("k").ShouldBeTrue();
             }
 
             [Fact]
             public void Should_not_add_short_version_of_timeout_to_the_option_set()
             {
-                optionSet.Contains("t").ShouldBeFalse();
+                _optionSet.Contains("t").ShouldBeFalse();
             }
         }
 
         public class When_handling_additional_argument_parsing : ChocolateyPushCommandSpecsBase
         {
-            private readonly IList<string> unparsedArgs = new List<string>();
-            private const string apiKey = "bobdaf";
-            private Action because;
+            private readonly IList<string> _unparsedArgs = new List<string>();
+            private const string ApiKey = "bobdaf";
+            private Action _because;
 
             public override void Because()
             {
-                because = () => command.ParseAdditionalArguments(unparsedArgs, configuration);
+                _because = () => Command.ParseAdditionalArguments(_unparsedArgs, Configuration);
             }
 
             public void Reset()
             {
-                unparsedArgs.Clear();
-                configSettingsService.ResetCalls();
+                _unparsedArgs.Clear();
+                ConfigSettingsService.ResetCalls();
             }
 
             [Fact]
@@ -137,46 +137,46 @@ namespace chocolatey.tests.infrastructure.app.commands
             {
                 Reset();
                 string nupkgPath = "./some/path/to.nupkg";
-                unparsedArgs.Add(nupkgPath);
-                because();
-                configuration.Input.ShouldEqual(nupkgPath);
+                _unparsedArgs.Add(nupkgPath);
+                _because();
+                Configuration.Input.ShouldEqual(nupkgPath);
             }
 
             [Fact]
             public void Should_set_the_source_to_defaultpushsource_if_set_and_no_explicit_source()
             {
                 Reset();
-                configuration.Sources = "";
-                configuration.PushCommand.DefaultSource = "https://localhost/default/source";
-                because();
+                Configuration.Sources = "";
+                Configuration.PushCommand.DefaultSource = "https://localhost/default/source";
+                _because();
 
-                configuration.Sources.ShouldEqual("https://localhost/default/source");
+                Configuration.Sources.ShouldEqual("https://localhost/default/source");
             }
 
             [Fact]
             public void Should_not_override_explicit_source_if_defaultpushsource_is_set()
             {
                 Reset();
-                configuration.Sources = "https://localhost/somewhere/out/there";
-                configuration.PushCommand.DefaultSource = "https://localhost/default/source";
-                because();
+                Configuration.Sources = "https://localhost/somewhere/out/there";
+                Configuration.PushCommand.DefaultSource = "https://localhost/default/source";
+                _because();
 
-                configuration.Sources.ShouldEqual("https://localhost/somewhere/out/there");
+                Configuration.Sources.ShouldEqual("https://localhost/somewhere/out/there");
             }
 
             [Fact]
             public void Should_throw_when_defaultpushsource_is_not_set_and_no_explicit_sources()
             {
                 Reset();
-                configuration.PushCommand.DefaultSource = "";
-                configuration.Sources = "";
+                Configuration.PushCommand.DefaultSource = "";
+                Configuration.Sources = "";
 
                 var errorred = false;
                 Exception error = null;
 
                 try
                 {
-                    because();
+                    _because();
                 }
                 catch (Exception ex)
                 {
@@ -194,74 +194,74 @@ namespace chocolatey.tests.infrastructure.app.commands
             public void Should_continue_when_defaultpushsource_is_not_set_and_explicit_sources_passed()
             {
                 Reset();
-                configuration.Sources = "https://somewhere/out/there";
-                configuration.PushCommand.Key = "bob";
-                configuration.PushCommand.DefaultSource = "";
-                because();
+                Configuration.Sources = "https://somewhere/out/there";
+                Configuration.PushCommand.Key = "bob";
+                Configuration.PushCommand.DefaultSource = "";
+                _because();
             }
 
             [Fact]
             public void Should_not_set_the_apiKey_if_source_is_not_found()
             {
                 Reset();
-                configSettingsService.Setup(c => c.GetApiKey(configuration, null)).Returns("");
-                configuration.PushCommand.Key = "";
-                configuration.Sources = "https://localhost/somewhere/out/there";
-                because();
+                ConfigSettingsService.Setup(c => c.GetApiKey(Configuration, null)).Returns("");
+                Configuration.PushCommand.Key = "";
+                Configuration.Sources = "https://localhost/somewhere/out/there";
+                _because();
 
-                configuration.PushCommand.Key.ShouldEqual("");
+                Configuration.PushCommand.Key.ShouldEqual("");
             }
 
             [Fact]
             public void Should_not_try_to_determine_the_key_if_passed_in_as_an_argument()
             {
                 Reset();
-                configSettingsService.Setup(c => c.GetApiKey(configuration, null)).Returns("");
-                configuration.PushCommand.Key = "bob";
-                configuration.Sources = "https://localhost/somewhere/out/there";
-                because();
+                ConfigSettingsService.Setup(c => c.GetApiKey(Configuration, null)).Returns("");
+                Configuration.PushCommand.Key = "bob";
+                Configuration.Sources = "https://localhost/somewhere/out/there";
+                _because();
 
-                configuration.PushCommand.Key.ShouldEqual("bob");
-                configSettingsService.Verify(c => c.GetApiKey(It.IsAny<ChocolateyConfiguration>(), It.IsAny<Action<ConfigFileApiKeySetting>>()), Times.Never);
+                Configuration.PushCommand.Key.ShouldEqual("bob");
+                ConfigSettingsService.Verify(c => c.GetApiKey(It.IsAny<ChocolateyConfiguration>(), It.IsAny<Action<ConfigFileApiKeySetting>>()), Times.Never);
             }
 
             [Fact]
             public void Should_not_try_to_determine_the_key_if_source_is_set_for_a_local_source()
             {
                 Reset();
-                configuration.Sources = "c:\\packages";
-                configuration.PushCommand.Key = "";
-                because();
+                Configuration.Sources = "c:\\packages";
+                Configuration.PushCommand.Key = "";
+                _because();
 
-                configSettingsService.Verify(c => c.GetApiKey(It.IsAny<ChocolateyConfiguration>(), It.IsAny<Action<ConfigFileApiKeySetting>>()), Times.Never);
+                ConfigSettingsService.Verify(c => c.GetApiKey(It.IsAny<ChocolateyConfiguration>(), It.IsAny<Action<ConfigFileApiKeySetting>>()), Times.Never);
             }
 
             [Fact]
             public void Should_not_try_to_determine_the_key_if_source_is_set_for_an_unc_source()
             {
                 Reset();
-                configuration.Sources = "\\\\someserver\\packages";
-                configuration.PushCommand.Key = "";
-                because();
+                Configuration.Sources = "\\\\someserver\\packages";
+                Configuration.PushCommand.Key = "";
+                _because();
 
-                configSettingsService.Verify(c => c.GetApiKey(It.IsAny<ChocolateyConfiguration>(), It.IsAny<Action<ConfigFileApiKeySetting>>()), Times.Never);
+                ConfigSettingsService.Verify(c => c.GetApiKey(It.IsAny<ChocolateyConfiguration>(), It.IsAny<Action<ConfigFileApiKeySetting>>()), Times.Never);
             }
 
             [Fact]
             public void Should_throw_if_multiple_sources_are_passed()
             {
                 Reset();
-                configuration.Sources = "https://localhost/somewhere/out/there;https://localhost/somewhere/out/there";
+                Configuration.Sources = "https://localhost/somewhere/out/there;https://localhost/somewhere/out/there";
 
-                Assert.Throws<ApplicationException>(() => because(), "Multiple sources are not support by push command.");
+                Assert.Throws<ApplicationException>(() => _because(), "Multiple sources are not support by push command.");
             }
 
             [Fact]
             public void Should_update_source_if_alias_is_passed()
             {
                 Reset();
-                configuration.Sources = "chocolatey";
-                configuration.MachineSources = new List<MachineSourceConfiguration>
+                Configuration.Sources = "chocolatey";
+                Configuration.MachineSources = new List<MachineSourceConfiguration>
                 {
                     new MachineSourceConfiguration
                     {
@@ -269,18 +269,18 @@ namespace chocolatey.tests.infrastructure.app.commands
                         Key = "https://localhost/somewhere/out/there"
                     }
                  };
-                because();
+                _because();
 
-                configuration.Sources.ShouldEqual("https://localhost/somewhere/out/there");
+                Configuration.Sources.ShouldEqual("https://localhost/somewhere/out/there");
             }
 
             [Fact]
             public void Should_update_source_if_alias_is_passed_via_defaultpushsource()
             {
                 Reset();
-                configuration.Sources = "";
-                configuration.PushCommand.DefaultSource = "myrepo";
-                configuration.MachineSources = new List<MachineSourceConfiguration>
+                Configuration.Sources = "";
+                Configuration.PushCommand.DefaultSource = "myrepo";
+                Configuration.MachineSources = new List<MachineSourceConfiguration>
                 {
                     new MachineSourceConfiguration
                     {
@@ -288,31 +288,31 @@ namespace chocolatey.tests.infrastructure.app.commands
                         Key = "https://localhost/somewhere/out/there"
                     }
                 };
-                because();
+                _because();
 
-                configuration.Sources.ShouldEqual("https://localhost/somewhere/out/there");
+                Configuration.Sources.ShouldEqual("https://localhost/somewhere/out/there");
             }
         }
 
         public class When_validating : ChocolateyPushCommandSpecsBase
         {
-            private Action because;
+            private Action _because;
 
             public override void Because()
             {
-                because = () => command.Validate(configuration);
+                _because = () => Command.Validate(Configuration);
             }
 
             [Fact]
             public void Should_throw_when_source_is_not_set()
             {
-                configuration.Sources = "";
+                Configuration.Sources = "";
                 var errored = false;
                 Exception error = null;
 
                 try
                 {
-                    because();
+                    _because();
                 }
                 catch (Exception ex)
                 {
@@ -329,14 +329,14 @@ namespace chocolatey.tests.infrastructure.app.commands
             [Fact]
             public void Should_throw_when_apiKey_has_not_been_set_or_determined_for_a_https_source()
             {
-                configuration.Sources = "https://somewhere/out/there";
-                configuration.PushCommand.Key = "";
+                Configuration.Sources = "https://somewhere/out/there";
+                Configuration.PushCommand.Key = "";
                 var errored = false;
                 Exception error = null;
 
                 try
                 {
-                    because();
+                    _because();
                 }
                 catch (Exception ex)
                 {
@@ -353,39 +353,39 @@ namespace chocolatey.tests.infrastructure.app.commands
             [Fact]
             public void Should_continue_when_source_and_apikey_is_set_for_a_https_source()
             {
-                configuration.Sources = "https://somewhere/out/there";
-                configuration.PushCommand.Key = "bob";
-                because();
+                Configuration.Sources = "https://somewhere/out/there";
+                Configuration.PushCommand.Key = "bob";
+                _because();
             }
 
             [Fact]
             public void Should_continue_when_source_is_set_for_a_local_source()
             {
-                configuration.Sources = "c:\\packages";
-                configuration.PushCommand.Key = "";
-                because();
+                Configuration.Sources = "c:\\packages";
+                Configuration.PushCommand.Key = "";
+                _because();
             }
 
             [Fact]
             public void Should_continue_when_source_is_set_for_an_unc_source()
             {
-                configuration.Sources = "\\\\someserver\\packages";
-                configuration.PushCommand.Key = "";
-                because();
+                Configuration.Sources = "\\\\someserver\\packages";
+                Configuration.PushCommand.Key = "";
+                _because();
             }
 
             [Fact]
             public void Should_throw_when_source_is_http_and_not_secure()
             {
-                configuration.Sources = "http://somewhere/out/there";
-                configuration.PushCommand.Key = "bob";
-                configuration.Force = false;
+                Configuration.Sources = "http://somewhere/out/there";
+                Configuration.PushCommand.Key = "bob";
+                Configuration.Force = false;
                 var errored = false;
                 Exception error = null;
 
                 try
                 {
-                    because();
+                    _because();
                 }
                 catch (Exception ex)
                 {
@@ -396,17 +396,17 @@ namespace chocolatey.tests.infrastructure.app.commands
                 errored.ShouldBeTrue();
                 error.ShouldNotBeNull();
                 error.ShouldBeType<ApplicationException>();
-                error.Message.ShouldContain("WARNING! The specified source '{0}' is not secure".FormatWith(configuration.Sources));
+                error.Message.ShouldContain("WARNING! The specified source '{0}' is not secure".FormatWith(Configuration.Sources));
             }
 
             [Fact]
             public void Should_continue_when_source_is_http_and_not_secure_if_force_is_passed()
             {
-                configuration.Sources = "http://somewhere/out/there";
-                configuration.PushCommand.Key = "bob";
-                configuration.Force = true;
+                Configuration.Sources = "http://somewhere/out/there";
+                Configuration.PushCommand.Key = "bob";
+                Configuration.Force = true;
 
-                because();
+                _because();
             }
         }
 
@@ -414,13 +414,13 @@ namespace chocolatey.tests.infrastructure.app.commands
         {
             public override void Because()
             {
-                command.DryRun(configuration);
+                Command.DryRun(Configuration);
             }
 
             [Fact]
             public void Should_call_service_push_noop()
             {
-                packageService.Verify(c => c.PushDryRun(configuration), Times.Once);
+                PackageService.Verify(c => c.PushDryRun(Configuration), Times.Once);
             }
         }
 
@@ -428,13 +428,13 @@ namespace chocolatey.tests.infrastructure.app.commands
         {
             public override void Because()
             {
-                command.Run(configuration);
+                Command.Run(Configuration);
             }
 
             [Fact]
             public void Should_call_service_push_run()
             {
-                packageService.Verify(c => c.Push(configuration), Times.Once);
+                PackageService.Verify(c => c.Push(Configuration), Times.Once);
             }
         }
     }

--- a/tests/chocolatey-tests/commands/choco-help.Tests.ps1
+++ b/tests/chocolatey-tests/commands/choco-help.Tests.ps1
@@ -1,6 +1,6 @@
 ﻿param(
     # Which help command to test
-    [string[]]$Command = @(
+    [string[]]$HelpOptions = @(
         "--help"
         "-?"
         "-help"
@@ -9,19 +9,17 @@
     # Commands that don't have full help
     [string[]]$SkipCommand = @(
         "unpackself"  # Out of spec
-        "version"     # Deprecated
-        "update"      # Deprecated
         "support"     # This should be tested separately
     )
 )
 Import-Module helpers/common-helpers
 
 BeforeDiscovery {
-    $AllTopLevelCommands = (Invoke-Choco $Command[0]).Lines -match " \* (?<Command>\w+) -" -replace " \* (?<Command>\w+) -.+", '$1'
+    $AllTopLevelCommands = (Invoke-Choco $HelpOptions[0]).Lines -match "\* (?<Command>\w+) -" -replace "\* (?<Command>\w+) -.+", '${Command}'
     $TopLevelCommands = $AllTopLevelCommands.Where{ $_ -notin $SkipCommand }
 }
 
-Describe "choco help sections with command <_>" -ForEach $Command -Tag Chocolatey, HelpCommand {
+Describe "choco help sections with option <_>" -ForEach $HelpOptions -Tag Chocolatey, HelpCommand {
     BeforeDiscovery {
         $helpArgument = $_
     }
@@ -30,7 +28,9 @@ Describe "choco help sections with command <_>" -ForEach $Command -Tag Chocolate
         Remove-NuGetPaths
         $helpArgument = $_
         Initialize-ChocolateyTestInstall
-        New-ChocolateyInstallSnapshot
+
+        # We're just testing help output here, we don't need to copy config/package files
+        New-ChocolateyInstallSnapshot -NoSnapshotCopy
     }
 
     AfterAll {
@@ -39,7 +39,7 @@ Describe "choco help sections with command <_>" -ForEach $Command -Tag Chocolate
 
     Context "Top Level Help" {
         BeforeAll {
-            $Output = Invoke-Choco $_ $helpArgument
+            $Output = Invoke-Choco $_
         }
 
         It "Exits with Success (0)" {


### PR DESCRIPTION
## Description Of Changes

- Move the errors / logic from the AdditionalArgumentParsing into the Validate method instead
- Update the tests to match the behaviour

## Motivation and Context

We should avoid throwing from `ParseAdditionalArguments` entirely, as throwing from here means that not even `--help` works for the command at all, unless the user figures out what other params to provide to avoid the errors, which is just not how help should work.

This error was introduced as part of #2430, this PR is a follow up to fix the behaviour and the related tests.

## Testing

1. Run the unit tests
2. Tests should pass
3. Run `choco push --help` with no `defaultPushSource` config and no `--source` set.
4. You should be able to see the help message

### Operating Systems Testing

Win11

## Change Types Made
<!-- Tick the boxes for the type of changes that have been made -->

* [x] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [x] Tests to cover my changes, have been added.
* [x] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue
<!-- Make sure you have raised an issue for this pull request before
continuing. -->

#2219

<!-- PLEASE REMOVE ALL COMMENTS BEFORE SUBMITTING -->
