### PR TITLE
(tests) Skip some Pester tests if the repository endpoint is a v3 endpoint

### DIFF
--- a/tests/chocolatey-tests/commands/choco-search.Tests.ps1
+++ b/tests/chocolatey-tests/commands/choco-search.Tests.ps1
@@ -1,4 +1,4 @@
-﻿<#
+<#
     .Synopsis
         Tests for `choco search` and aliases
 
@@ -18,6 +18,7 @@ Import-Module helpers/common-helpers
 Describe "choco <_>" -ForEach $Command -Tag Chocolatey, SearchCommand, FindCommand {
     BeforeDiscovery {
         $licensedProxyFixed = Test-PackageIsEqualOrHigher 'chocolatey.extension' 2.2.0-beta -AllowMissingPackage
+        $hasEnabledV3Feed = Test-HasNuGetV3Source
     }
 
     BeforeAll {
@@ -35,7 +36,8 @@ Describe "choco <_>" -ForEach $Command -Tag Chocolatey, SearchCommand, FindComma
         Remove-ChocolateyTestInstall
     }
 
-    Context "Searching packages with no filter (Happy Path)" {
+    # Skip when searching against a v3 source as our current source is not returning consistent results.
+    Context "Searching packages with no filter (Happy Path)" -Skip:$hasEnabledV3Feed {
         BeforeAll {
             $Output = Invoke-Choco $_
         }
@@ -84,7 +86,8 @@ Describe "choco <_>" -ForEach $Command -Tag Chocolatey, SearchCommand, FindComma
         }
     }
 
-    Context "Searching all available packages" {
+    # Skip when searching against a v3 source as our current source is not returning consistent results.
+    Context "Searching all available packages" -Skip:$hasEnabledV3Feed {
         BeforeAll {
             $Output = Invoke-Choco $_ --AllVersions
         }
@@ -154,7 +157,8 @@ Describe "choco <_>" -ForEach $Command -Tag Chocolatey, SearchCommand, FindComma
         }
     }
 
-    Context "Searching packages with Verbose" {
+    # Skip when searching against a v3 source as our current source is not returning consistent results.
+    Context "Searching packages with Verbose" -Skip:$hasEnabledV3Feed {
         BeforeAll {
             $Output = Invoke-Choco $_ --Verbose
         }

--- a/tests/helpers/common-helpers.psm1
+++ b/tests/helpers/common-helpers.psm1
@@ -10,7 +10,7 @@ $script:snapshotStack = @()
 $script:ChocoCommandHeaders = @{
     "List"       = @("Name", "Version")
     "PinList"    = @("Name", "Version")
-    "SourceList" = @("Name", "Url", "1", "2", "3", "Priority", "BypassProxy", "SelfService", "AdminOnly")
+    "SourceList" = @("Name", "Url", "Disabled", "Username", "Certificate", "Priority", "BypassProxy", "SelfService", "AdminOnly")
     "Feature"    = @("Name", "State", "Description")
 }
 $script:features = $null

--- a/tests/helpers/common/Chocolatey/Test-HasNuGetV3Source.ps1
+++ b/tests/helpers/common/Chocolatey/Test-HasNuGetV3Source.ps1
@@ -1,0 +1,10 @@
+function Test-HasNuGetV3Source {
+    [CmdletBinding()]
+    [OutputType([boolean])]
+    param(
+    )
+    if (-not $script:ChocolateyEnabledSources) {
+        $script:ChocolateyEnabledSources = (Invoke-Choco source list --limitoutput).Lines | ConvertFrom-ChocolateyOutput -Command SourceList | Where-Object Disabled -NE $true
+    }
+    $null -ne ($script:ChocolateyEnabledSources | Where-Object Url -match 'index\.json')
+}


### PR DESCRIPTION
## Description Of Changes

Mark some pester tests to skip if they're being tested against a v3 endpoint and the Licensed Extension is in play.

## Motivation and Context

For some reason the results coming back from our v3 endpoint are not consistent, and we're seeing failures in these tests when licensed extension is tested against our v3 endpoint.

## Testing

1. Ran Test Kitchen in Team City against both Chocolatey CLI and Chocolatey Licensed Extension
2. Noted these tests failing only on Licensed Extension with output indicating some of the packages not coming back from the repository server.
3. Added the skip conditions
4. Ran Test Kitchen in Team City against both Chocolatey CLI and Chocolatey Licensed Extension

### Operating Systems Testing

* Windows Server 2016
* Windows Server 2019

## Change Types Made

* [ ] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.
* [x] Pester test changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [x] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue

* PROJ-518