### PR TITLE
(#2902) Make HttpsSecurity class public

### DIFF
--- a/src/chocolatey/infrastructure/registration/HttpsSecurity.cs
+++ b/src/chocolatey/infrastructure/registration/HttpsSecurity.cs
@@ -7,13 +7,13 @@
     using System.Text;
     using System.Threading.Tasks;
 
-    internal static class HttpsSecurity
+    public static class HttpsSecurity
     {
         /// <summary>
         /// Resets the <see cref="ServicePointManager.SecurityProtocol"/> and <see cref="ServicePointManager.ServerCertificateValidationCallback"/> for HTTPS connections
         /// in order to ensure that PowerShell scripts we run can't have a persistent effect on these settings across the whole process after they're done running.
         /// </summary>
-        internal static void Reset()
+        public static void Reset()
         {
             // SystemDefault is used because:
             // 1. Most supported operating systems default to / require TLS 1.2 anyway.


### PR DESCRIPTION
## Description Of Changes

- Make HttpsSecurity class and the Reset method public

## Motivation and Context

The old method is needed in CLE, so we should make the new one public as well.

## Testing

N/A, API visibility change only.

### Operating Systems Testing

N/A

## Change Types Made

* [ ] Bug fix (non-breaking change).
* [x] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [ ] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue

Related to #2902 