### PR TITLE
(#1720) Parse multi-protocol proxy configurations

### DIFF
--- a/src/chocolatey/infrastructure.app/builders/ConfigurationBuilder.cs
+++ b/src/chocolatey/infrastructure.app/builders/ConfigurationBuilder.cs
@@ -463,15 +463,40 @@ namespace chocolatey.infrastructure.app.builders
         private static void SetProxyOptions(ChocolateyConfiguration config, Container container)
         {
             // Evaluation order of Proxy settings: System Set -> Environment Variable Set -> Chocolatey Configuration File Set -> CLI Passed in Argument
-            // If we don't yet have a Proxy Location, check if the system has one configured in the registry
-            if (string.IsNullOrWhiteSpace(config.Proxy.Location) && Platform.GetPlatform() == PlatformType.Windows)
+            var proxyAlreadySet = !string.IsNullOrWhiteSpace(config.Proxy.Location);
+            var onWindows = Platform.GetPlatform() == PlatformType.Windows;
+
+            // Only Windows has a registry provider, if it's already set, or we're not on Windows we don't need to continue.
+            if (proxyAlreadySet || !onWindows)
             {
-                var registryService = container.GetInstance<IRegistryService>();
-                var internetSettingsRegKey = registryService.GetKey(RegistryHive.CurrentUser, "SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Internet Settings");
-                if (internetSettingsRegKey.GetValue("ProxyEnable").ToStringSafe().IsEqualTo("1"))
+                return;
+            }
+
+            // We don't yet have a Proxy Location, check if the system has one configured in the registry
+            var registryService = container.GetInstance<IRegistryService>();
+            var internetSettingsRegKey = registryService.GetKey(RegistryHive.CurrentUser, "SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Internet Settings");
+
+            if (internetSettingsRegKey.GetValue("ProxyEnable").ToStringSafe().IsEqualTo("1"))
+            {
+                var proxySetting = internetSettingsRegKey.GetValue("ProxyServer").ToStringSafe();
+
+                if (string.IsNullOrWhiteSpace(proxySetting))
                 {
-                    config.Proxy.Location = internetSettingsRegKey.GetValue("ProxyServer").ToStringSafe();
+                    return;
                 }
+
+                if (proxySetting.IndexOf(';') != -1)
+                {
+                    var allProxies = proxySetting.Split(';');
+                    proxySetting = allProxies.FirstOrDefault(s => s.TrimSafe().StartsWith("https="))?.Replace("https=", string.Empty);
+
+                    if (string.IsNullOrWhiteSpace(proxySetting))
+                    {
+                        proxySetting = allProxies.FirstOrDefault(s => s.TrimSafe().StartsWith("http="))?.Replace("http=", string.Empty);
+                    }
+                }
+
+                config.Proxy.Location = proxySetting;
             }
         }
 

--- a/tests/chocolatey-tests/features/Proxy.Tests.ps1
+++ b/tests/chocolatey-tests/features/Proxy.Tests.ps1
@@ -2,147 +2,147 @@ Import-Module helpers/common-helpers
 
 $TestCases = @(
     @{
-        Name = 'None'
+        Name                 = 'None'
         ConfigurationsToTest = @{
-            System = $false
+            System              = $false
             EnvironmentVariable = $false
-            ConfigFile = $false
-            CliArgument = $false
+            ConfigFile          = $false
+            CliArgument         = $false
         }
     }
     @{
-        Name = 'System'
+        Name                 = 'System'
         ConfigurationsToTest = @{
-            System = $true
+            System              = $true
             EnvironmentVariable = $false
-            ConfigFile = $false
-            CliArgument = $false
+            ConfigFile          = $false
+            CliArgument         = $false
         }
     }
     @{
-        Name = 'SystemConfig'
+        Name                 = 'SystemConfig'
         ConfigurationsToTest = @{
-            System = $true
+            System              = $true
             EnvironmentVariable = $false
-            ConfigFile = $true
-            CliArgument = $false
+            ConfigFile          = $true
+            CliArgument         = $false
         }
     }
     @{
-        Name = 'SystemEnvironmentVariable'
+        Name                 = 'SystemEnvironmentVariable'
         ConfigurationsToTest = @{
-            System = $true
+            System              = $true
             EnvironmentVariable = $true
-            ConfigFile = $false
-            CliArgument = $false
+            ConfigFile          = $false
+            CliArgument         = $false
         }
     }
     @{
-        Name = 'SystemCliArgument'
+        Name                 = 'SystemCliArgument'
         ConfigurationsToTest = @{
-            System = $true
+            System              = $true
             EnvironmentVariable = $true
-            ConfigFile = $false
-            CliArgument = $false
+            ConfigFile          = $false
+            CliArgument         = $false
         }
     }
     @{
-        Name = 'SystemConfigFileEnvironmentVariable'
+        Name                 = 'SystemConfigFileEnvironmentVariable'
         ConfigurationsToTest = @{
-            System = $true
+            System              = $true
             EnvironmentVariable = $true
-            ConfigFile = $true
-            CliArgument = $false
+            ConfigFile          = $true
+            CliArgument         = $false
         }
     }
     @{
-        Name = 'SystemConfigFileCliArgument'
+        Name                 = 'SystemConfigFileCliArgument'
         ConfigurationsToTest = @{
-            System = $true
+            System              = $true
             EnvironmentVariable = $false
-            ConfigFile = $true
-            CliArgument = $true
+            ConfigFile          = $true
+            CliArgument         = $true
         }
     }
     @{
-        Name = 'SystemEnvironmentVariableCliAgrument'
+        Name                 = 'SystemEnvironmentVariableCliAgrument'
         ConfigurationsToTest = @{
-            System = $true
+            System              = $true
             EnvironmentVariable = $true
-            ConfigFile = $false
-            CliArgument = $true
+            ConfigFile          = $false
+            CliArgument         = $true
         }
     }
     @{
-        Name = 'SystemConfigFileEnvironmentVariableCliArgument'
+        Name                 = 'SystemConfigFileEnvironmentVariableCliArgument'
         ConfigurationsToTest = @{
-            System = $true
+            System              = $true
             EnvironmentVariable = $true
-            ConfigFile = $true
-            CliArgument = $true
+            ConfigFile          = $true
+            CliArgument         = $true
         }
     }
     @{
-        Name = 'ConfigFile'
+        Name                 = 'ConfigFile'
         ConfigurationsToTest = @{
-            System = $false
+            System              = $false
             EnvironmentVariable = $false
-            ConfigFile = $true
-            CliArgument = $false
+            ConfigFile          = $true
+            CliArgument         = $false
         }
     }
     @{
-        Name = 'ConfigFileEnvironmentVariable'
+        Name                 = 'ConfigFileEnvironmentVariable'
         ConfigurationsToTest = @{
-            System = $false
+            System              = $false
             EnvironmentVariable = $true
-            ConfigFile = $true
-            CliArgument = $false
+            ConfigFile          = $true
+            CliArgument         = $false
         }
     }
     @{
-        Name = 'ConfigFileCliArgument'
+        Name                 = 'ConfigFileCliArgument'
         ConfigurationsToTest = @{
-            System = $false
+            System              = $false
             EnvironmentVariable = $false
-            ConfigFile = $true
-            CliArgument = $true
+            ConfigFile          = $true
+            CliArgument         = $true
         }
     }
     @{
-        Name = 'ConfigFileEnvironmentVariableCliArgument'
+        Name                 = 'ConfigFileEnvironmentVariableCliArgument'
         ConfigurationsToTest = @{
-            System = $false
+            System              = $false
             EnvironmentVariable = $true
-            ConfigFile = $true
-            CliArgument = $true
+            ConfigFile          = $true
+            CliArgument         = $true
         }
     }
     @{
-        Name = 'EnvironmentVariable'
+        Name                 = 'EnvironmentVariable'
         ConfigurationsToTest = @{
-            System = $false
+            System              = $false
             EnvironmentVariable = $true
-            ConfigFile = $false
-            CliArgument = $false
+            ConfigFile          = $false
+            CliArgument         = $false
         }
     }
     @{
-        Name = 'EnvironmentVariableCliArgument'
+        Name                 = 'EnvironmentVariableCliArgument'
         ConfigurationsToTest = @{
-            System = $false
+            System              = $false
             EnvironmentVariable = $true
-            ConfigFile = $false
-            CliArgument = $true
+            ConfigFile          = $false
+            CliArgument         = $true
         }
     }
     @{
-        Name = 'CliArgument'
+        Name                 = 'CliArgument'
         ConfigurationsToTest = @{
-            System = $false
+            System              = $false
             EnvironmentVariable = $false
-            ConfigFile = $false
-            CliArgument = $true
+            ConfigFile          = $false
+            CliArgument         = $true
         }
     }
 )
@@ -170,8 +170,8 @@ Describe "Proxy configuration (<Name>)" -Tag Proxy, ProxySkip -ForEach $TestCase
         $CliArgumentSet = "CliArgumentSetProxy"
 
         if ($ConfigurationsToTest.System) {
-            Set-ItemProperty -Path 'HKCU:/Software/Microsoft/Windows/CurrentVersion/Internet Settings' -name ProxyServer -Value "http=none;https=$SystemSet;"
-            Set-ItemProperty -Path 'HKCU:/Software/Microsoft/Windows/CurrentVersion/Internet Settings' -name ProxyEnable -Value 1
+            Set-ItemProperty -Path 'HKCU:/Software/Microsoft/Windows/CurrentVersion/Internet Settings' -Name ProxyServer -Value "https=$SystemSet;ftp=someFtp;socks=socksProxy"
+            Set-ItemProperty -Path 'HKCU:/Software/Microsoft/Windows/CurrentVersion/Internet Settings' -Name ProxyEnable -Value 1
         }
 
         if ($ConfigurationsToTest.ConfigFile) {
@@ -191,8 +191,8 @@ Describe "Proxy configuration (<Name>)" -Tag Proxy, ProxySkip -ForEach $TestCase
 
     AfterAll {
         Remove-ChocolateyTestInstall
-        Remove-ItemProperty -Path 'HKCU:/Software/Microsoft/Windows/CurrentVersion/Internet Settings' -name ProxyServer -ErrorAction Ignore
-        Remove-ItemProperty -Path 'HKCU:/Software/Microsoft/Windows/CurrentVersion/Internet Settings' -name ProxyEnable -ErrorAction Ignore
+        Remove-ItemProperty -Path 'HKCU:/Software/Microsoft/Windows/CurrentVersion/Internet Settings' -Name ProxyServer -ErrorAction Ignore
+        Remove-ItemProperty -Path 'HKCU:/Software/Microsoft/Windows/CurrentVersion/Internet Settings' -Name ProxyEnable -ErrorAction Ignore
         $env:https_proxy = $null
     }
 

--- a/tests/chocolatey-tests/features/Proxy.Tests.ps1
+++ b/tests/chocolatey-tests/features/Proxy.Tests.ps1
@@ -170,7 +170,7 @@ Describe "Proxy configuration (<Name>)" -Tag Proxy, ProxySkip -ForEach $TestCase
         $CliArgumentSet = "CliArgumentSetProxy"
 
         if ($ConfigurationsToTest.System) {
-            Set-ItemProperty -Path 'HKCU:/Software/Microsoft/Windows/CurrentVersion/Internet Settings' -name ProxyServer -Value $SystemSet
+            Set-ItemProperty -Path 'HKCU:/Software/Microsoft/Windows/CurrentVersion/Internet Settings' -name ProxyServer -Value "http=none;https=$SystemSet;"
             Set-ItemProperty -Path 'HKCU:/Software/Microsoft/Windows/CurrentVersion/Internet Settings' -name ProxyEnable -Value 1
         }
 

--- a/tests/chocolatey-tests/features/Proxy.Tests.ps1
+++ b/tests/chocolatey-tests/features/Proxy.Tests.ps1
@@ -234,3 +234,33 @@ Describe "Proxy configuration (<Name>)" -Tag Proxy, ProxySkip -ForEach $TestCase
         }
     }
 }
+
+Describe "Multi-Protocol Proxy configuration" -Tag Proxy, ProxySkip -Skip:(-not $env:TEST_KITCHEN) {
+    BeforeAll {
+        Initialize-ChocolateyTestInstall
+        New-ChocolateyInstallSnapshot
+        $arguments = $null
+
+        $SystemSet = "SystemSetProxy"
+        Set-ItemProperty -Path 'HKCU:/Software/Microsoft/Windows/CurrentVersion/Internet Settings' -Name ProxyServer -Value "ftp=something;socks=another"
+        Set-ItemProperty -Path 'HKCU:/Software/Microsoft/Windows/CurrentVersion/Internet Settings' -Name ProxyEnable -Value 1
+    }
+
+    AfterAll {
+        Remove-ChocolateyTestInstall
+        Remove-ItemProperty -Path 'HKCU:/Software/Microsoft/Windows/CurrentVersion/Internet Settings' -Name ProxyServer -ErrorAction Ignore
+        Remove-ItemProperty -Path 'HKCU:/Software/Microsoft/Windows/CurrentVersion/Internet Settings' -Name ProxyEnable -ErrorAction Ignore
+        $env:https_proxy = $null
+    }
+
+    Context "Configured for command (<Command>)" -ForEach $CommandsToTest {
+        BeforeAll {
+            $Output = Invoke-Choco $Command @arguments @ExtraArguments --debug --verbose --noop
+        }
+
+        It "Should output the correct Proxy setting" {
+            $Output.String | Should -Not -MatchExactly "Proxy\.Location='$SystemSet'"
+            $Output.String | Should -Not -MatchExactly "Proxy\.Location"
+        }
+    }
+}


### PR DESCRIPTION
## Description Of Changes

Update Proxy configuration to parse the setting if it's specifying multiple protocols.

## Motivation and Context

Windows has the concept of protocol specific proxies, as such it can store the proxy information in the registry as `http=server:port;https=server:port;ftp=server:port;socks=server:port`. We need to parse this instead of just blindly taking it.

## Testing

1. Ran build locally
2. Ran build in Team City.
3. Ran Test Kitchen on Team City.

### Operating Systems Testing

- Windows Server 2016
- Windows Server 2019

## Change Types Made

* [x] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [x] Tests to cover my changes, have been added.
* [x] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue

* Fixes #1720 
* PROJ-583
