### PR TITLE
(maint) Add ability to get rules from the registered rules.

### DIFF
--- a/src/chocolatey.tests/chocolatey.tests.csproj
+++ b/src/chocolatey.tests/chocolatey.tests.csproj
@@ -186,6 +186,7 @@
     <Compile Include="infrastructure.app\services\FilesServiceSpecs.cs" />
     <Compile Include="infrastructure.app\services\NugetServiceSpecs.cs" />
     <Compile Include="infrastructure.app\services\RegistryServiceSpecs.cs" />
+    <Compile Include="infrastructure.app\services\RulesServiceSpecs.cs" />
     <Compile Include="infrastructure.app\services\TemplateServiceSpecs.cs" />
     <Compile Include="infrastructure.app\utility\ArgumentsUtilitySpecs.cs" />
     <Compile Include="infrastructure\commands\ExternalCommandArgsBuilderSpecs.cs" />

--- a/src/chocolatey.tests/infrastructure.app/services/RulesServiceSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/services/RulesServiceSpecs.cs
@@ -1,0 +1,73 @@
+﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+// Copyright © 2011 - 2017 RealDimensions Software, LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace chocolatey.tests.infrastructure.app.services
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Reflection;
+    using chocolatey.infrastructure.app.rules;
+    using chocolatey.infrastructure.app.services;
+    using chocolatey.infrastructure.rules;
+    using chocolatey.infrastructure.services;
+    using Should;
+
+    public class RulesServiceSpecs : TinySpec
+    {
+        private RuleService _service;
+        private IReadOnlyList<ImmutableRule> _detectedRules;
+        // We can't reference RuleIdentifiers directly as it's Internal. We should either get these from there, or do something different...
+        private const string EmptyRequiredElement = "CHCR0001";
+        private const string InvalidTypeElement = "CHCU0001";
+        private const string MissingElementOnRequiringLicenseAcceptance = "CHCR0002";
+        private const string UnsupportedElementUsed = "CHCU0002";
+
+        public override void Context()
+        {
+            Type[] availableRules = typeof(IRuleService).Assembly
+                .GetTypes()
+                .Where(t => !t.IsInterface && !t.IsAbstract && typeof(IMetadataRule).IsAssignableFrom(t))
+                .ToArray();
+            var rules = new List<IMetadataRule>();
+
+            foreach (Type availableRule in availableRules)
+            {
+                // We do first here as we want it to fail if the constructor can't be found.
+                var rule = availableRule.GetConstructors().First().Invoke(new object[] { });
+                rules.Add((MetadataRuleBase)rule);
+            }
+
+            _service = new RuleService(rules.ToArray());
+        }
+
+        public override void Because()
+        {
+            _detectedRules = _service.GetAllAvailableRules();
+        }
+
+        [Fact]
+        public void GetsRulesFromService()
+        {
+            _detectedRules.Count().ShouldEqual(4);
+            IEnumerable<string> ruleIds = _detectedRules.Select(t => t.Id);
+            ruleIds.ShouldContain(UnsupportedElementUsed);
+            ruleIds.ShouldContain(EmptyRequiredElement);
+            ruleIds.ShouldContain(InvalidTypeElement);
+            ruleIds.ShouldContain(MissingElementOnRequiringLicenseAcceptance);
+        }
+    }
+}

--- a/src/chocolatey/chocolatey.csproj
+++ b/src/chocolatey/chocolatey.csproj
@@ -274,6 +274,7 @@
     <Compile Include="infrastructure\registration\AssemblyResolution.cs" />
     <Compile Include="infrastructure\registration\HttpsSecurity.cs" />
     <Compile Include="infrastructure\rules\IMetadataRule.cs" />
+    <Compile Include="infrastructure\rules\ImmutableRule.cs" />
     <Compile Include="infrastructure\rules\RuleResult.cs" />
     <Compile Include="infrastructure\rules\RuleType.cs" />
     <Compile Include="infrastructure\services\IRuleService.cs" />

--- a/src/chocolatey/infrastructure.app/rules/EmptyOrInvalidUrlMetadataRule.cs
+++ b/src/chocolatey/infrastructure.app/rules/EmptyOrInvalidUrlMetadataRule.cs
@@ -43,15 +43,20 @@ namespace chocolatey.infrastructure.app.rules
 
                     if (string.IsNullOrWhiteSpace(value))
                     {
-                        yield return new RuleResult(RuleType.Error, RuleIdentifiers.EmptyRequiredElement, "The {0} element in the package nuspec file cannot be empty.".FormatWith(item));
+                        yield return GetRule(RuleIdentifiers.EmptyRequiredElement, "The {0} element in the package nuspec file cannot be empty.".FormatWith(item));
                     }
                     else if (!Uri.TryCreate(value, UriKind.Absolute, out _))
                     {
-                        yield return new RuleResult(RuleType.Error, RuleIdentifiers.InvalidTypeElement, "'{0}' is not a valid URL for the {1} element in the package nuspec file.".FormatWith(value, item));
+                        yield return GetRule(RuleIdentifiers.InvalidTypeElement, "'{0}' is not a valid URL for the {1} element in the package nuspec file.".FormatWith(value, item));
                     }
                 }
             }
         }
 
+        protected override IEnumerable<ImmutableRule> GetRules()
+        {
+            yield return new ImmutableRule(RuleType.Error, RuleIdentifiers.EmptyRequiredElement, "A required element does not contain any content.");
+            yield return new ImmutableRule(RuleType.Error, RuleIdentifiers.InvalidTypeElement, "The specified content of the element is not of the expected type and can not be accepted.");
+        }
     }
 }

--- a/src/chocolatey/infrastructure.app/rules/FrameWorkReferencesMetadataRule.cs
+++ b/src/chocolatey/infrastructure.app/rules/FrameWorkReferencesMetadataRule.cs
@@ -19,14 +19,19 @@ namespace chocolatey.infrastructure.app.rules
     using chocolatey.infrastructure.rules;
     using NuGet.Packaging;
 
-    internal sealed class FrameWorkReferencesMetadataRule : MetadataRuleBase
+    internal class FrameWorkReferencesMetadataRule : MetadataRuleBase
     {
         public override IEnumerable<RuleResult> Validate(NuspecReader reader)
         {
             if (HasElement(reader, "frameworkReferences"))
             {
-                yield return new RuleResult(RuleType.Error, RuleIdentifiers.UnsupportedElementUsed, "<frameworkReferences> elements are not supported in Chocolatey CLI.");
+                yield return GetRule(RuleIdentifiers.UnsupportedElementUsed, "<frameworkReferences> elements are not supported in Chocolatey CLI.");
             }
+        }
+
+        protected override IEnumerable<ImmutableRule> GetRules()
+        {
+            yield return new ImmutableRule(RuleType.Error, RuleIdentifiers.UnsupportedElementUsed, "Unsupported element is used.");
         }
     }
 }

--- a/src/chocolatey/infrastructure.app/rules/LicenseMetadataRule.cs
+++ b/src/chocolatey/infrastructure.app/rules/LicenseMetadataRule.cs
@@ -16,17 +16,16 @@
 namespace chocolatey.infrastructure.app.rules
 {
     using System.Collections.Generic;
-    using System.Runtime.CompilerServices;
     using chocolatey.infrastructure.rules;
     using NuGet.Packaging;
 
-    internal sealed class LicenseMetadataRule : MetadataRuleBase
+    internal sealed class LicenseMetadataRule : FrameWorkReferencesMetadataRule
     {
         public override IEnumerable<RuleResult> Validate(NuspecReader reader)
         {
             if (!(reader.GetLicenseMetadata() is null))
             {
-                yield return new RuleResult(RuleType.Error, RuleIdentifiers.UnsupportedElementUsed, "<license> elements are not supported in Chocolatey CLI, use <licenseUrl> instead.");
+                yield return GetRule(RuleIdentifiers.UnsupportedElementUsed, "<license> elements are not supported in Chocolatey CLI, use <licenseUrl> instead.");
             }
         }
     }

--- a/src/chocolatey/infrastructure.app/rules/PackageTypesMetadataRule.cs
+++ b/src/chocolatey/infrastructure.app/rules/PackageTypesMetadataRule.cs
@@ -19,13 +19,13 @@ namespace chocolatey.infrastructure.app.rules
     using chocolatey.infrastructure.rules;
     using NuGet.Packaging;
 
-    internal sealed class PackageTypesMetadataRule : MetadataRuleBase
+    internal sealed class PackageTypesMetadataRule : FrameWorkReferencesMetadataRule
     {
         public override IEnumerable<RuleResult> Validate(NuspecReader reader)
         {
             if (HasElement(reader, "packageTypes"))
             {
-                yield return new RuleResult(RuleType.Error, RuleIdentifiers.UnsupportedElementUsed, "<packageTypes> elements are not supported in Chocolatey CLI.");
+                yield return GetRule(RuleIdentifiers.UnsupportedElementUsed, "<packageTypes> elements are not supported in Chocolatey CLI.");
             }
         }
     }

--- a/src/chocolatey/infrastructure.app/rules/ReadmeMetadataRule.cs
+++ b/src/chocolatey/infrastructure.app/rules/ReadmeMetadataRule.cs
@@ -19,13 +19,13 @@ namespace chocolatey.infrastructure.app.rules
     using chocolatey.infrastructure.rules;
     using NuGet.Packaging;
 
-    internal sealed class ReadmeMetadataRule : MetadataRuleBase
+    internal sealed class ReadmeMetadataRule : FrameWorkReferencesMetadataRule
     {
         public override IEnumerable<RuleResult> Validate(NuspecReader reader)
         {
             if (!(reader.GetReadme() is null))
             {
-                yield return new RuleResult(RuleType.Error, RuleIdentifiers.UnsupportedElementUsed, "<readme> elements are not supported in Chocolatey CLI.");
+                yield return GetRule(RuleIdentifiers.UnsupportedElementUsed, "<readme> elements are not supported in Chocolatey CLI.");
             }
         }
     }

--- a/src/chocolatey/infrastructure.app/rules/RepositoryMetadataRule.cs
+++ b/src/chocolatey/infrastructure.app/rules/RepositoryMetadataRule.cs
@@ -21,7 +21,7 @@ namespace chocolatey.infrastructure.app.rules
     using chocolatey.infrastructure.rules;
     using NuGet.Packaging;
 
-    internal sealed class RepositoryMetadataRule : MetadataRuleBase
+    internal sealed class RepositoryMetadataRule : FrameWorkReferencesMetadataRule
     {
         public override IEnumerable<RuleResult> Validate(NuspecReader reader)
         {
@@ -29,7 +29,7 @@ namespace chocolatey.infrastructure.app.rules
 
             if (HasElement(reader, "repository"))
             {
-                yield return new RuleResult(RuleType.Error, RuleIdentifiers.UnsupportedElementUsed, "<repository> elements are not supported in Chocolatey CLI, use <packageSourceUrl> instead.");
+                yield return GetRule(RuleIdentifiers.UnsupportedElementUsed, "<repository> elements are not supported in Chocolatey CLI, use <packageSourceUrl> instead.");
             }
         }
     }

--- a/src/chocolatey/infrastructure.app/rules/RequireLicenseAcceptanceMetadataRule.cs
+++ b/src/chocolatey/infrastructure.app/rules/RequireLicenseAcceptanceMetadataRule.cs
@@ -25,8 +25,13 @@ namespace chocolatey.infrastructure.app.rules
         {
             if (string.IsNullOrWhiteSpace(reader.GetLicenseUrl()) && reader.GetRequireLicenseAcceptance())
             {
-                yield return new RuleResult(RuleType.Error, RuleIdentifiers.MissingElementOnRequiringLicenseAcceptance, "Enabling license acceptance requires a license url.");
+                yield return GetRule(RuleIdentifiers.MissingElementOnRequiringLicenseAcceptance);
             }
+        }
+
+        protected override IEnumerable<ImmutableRule> GetRules()
+        {
+            yield return new ImmutableRule(RuleType.Error, RuleIdentifiers.MissingElementOnRequiringLicenseAcceptance, "Enabling license acceptance requires a license url.");
         }
     }
 }

--- a/src/chocolatey/infrastructure.app/rules/RequiredMetadataRule.cs
+++ b/src/chocolatey/infrastructure.app/rules/RequiredMetadataRule.cs
@@ -35,9 +35,14 @@ namespace chocolatey.infrastructure.app.rules
             {
                 if (string.IsNullOrWhiteSpace(GetElementValue(reader, item)))
                 {
-                    yield return new RuleResult(RuleType.Error, RuleIdentifiers.EmptyRequiredElement, "{0} is a required element in the package nuspec file.".FormatWith(item));
+                    yield return GetRule(RuleIdentifiers.EmptyRequiredElement, "{0} is a required element in the package nuspec file.".FormatWith(item));
                 }
             }
+        }
+
+        protected override IEnumerable<ImmutableRule> GetRules()
+        {
+            yield return new ImmutableRule(RuleType.Error, RuleIdentifiers.EmptyRequiredElement, "A required element is missing or has no content in the package nuspec file.");
         }
     }
 }

--- a/src/chocolatey/infrastructure.app/rules/ServicableMetadataRule.cs
+++ b/src/chocolatey/infrastructure.app/rules/ServicableMetadataRule.cs
@@ -19,13 +19,13 @@ namespace chocolatey.infrastructure.app.rules
     using chocolatey.infrastructure.rules;
     using NuGet.Packaging;
 
-    internal sealed class ServicableMetadataRule : MetadataRuleBase
+    internal sealed class ServicableMetadataRule : FrameWorkReferencesMetadataRule
     {
         public override IEnumerable<RuleResult> Validate(NuspecReader reader)
         {
             if (HasElement(reader, "serviceable"))
             {
-                yield return new RuleResult(RuleType.Error, RuleIdentifiers.UnsupportedElementUsed, "<serviceable> elements are not supported in Chocolatey CLI.");
+                yield return GetRule(RuleIdentifiers.UnsupportedElementUsed, "<serviceable> elements are not supported in Chocolatey CLI.");
             }
         }
     }

--- a/src/chocolatey/infrastructure.app/rules/VersionMetadataRule.cs
+++ b/src/chocolatey/infrastructure.app/rules/VersionMetadataRule.cs
@@ -30,8 +30,13 @@ namespace chocolatey.infrastructure.app.rules
             // before the package gets created
             if (!string.IsNullOrEmpty(version) && !version.IsEqualTo("$version$") && !NuGetVersion.TryParse(version, out _))
             {
-                yield return new RuleResult(RuleType.Error, RuleIdentifiers.InvalidTypeElement, "'{0}' is not a valid version string in the package nuspec file.".FormatWith(version));
+                yield return GetRule(RuleIdentifiers.InvalidTypeElement, "'{0}' is not a valid version string in the package nuspec file.".FormatWith(version));
             }
+        }
+
+        protected override IEnumerable<ImmutableRule> GetRules()
+        {
+            yield return new ImmutableRule(RuleType.Error, RuleIdentifiers.InvalidTypeElement, "The specified version is not a valid version string.");
         }
     }
 }

--- a/src/chocolatey/infrastructure/rules/IMetadataRule.cs
+++ b/src/chocolatey/infrastructure/rules/IMetadataRule.cs
@@ -25,6 +25,8 @@ namespace chocolatey.infrastructure.rules
     {
         IEnumerable<RuleResult> Validate(NuspecReader reader);
 
+        IReadOnlyList<ImmutableRule> GetAvailableRules();
+
 #pragma warning disable IDE1006
         [Obsolete("This overload is deprecated and will be removed in v3.")]
         IEnumerable<RuleResult> validate(NuspecReader reader);

--- a/src/chocolatey/infrastructure/rules/ImmutableRule.cs
+++ b/src/chocolatey/infrastructure/rules/ImmutableRule.cs
@@ -13,20 +13,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-namespace chocolatey.infrastructure.app.rules
+namespace chocolatey.infrastructure.rules
 {
-    using System.Collections.Generic;
-    using chocolatey.infrastructure.rules;
-    using NuGet.Packaging;
-
-    internal sealed class IconMetadataRule : FrameWorkReferencesMetadataRule
+    public readonly struct ImmutableRule
     {
-        public override IEnumerable<RuleResult> Validate(NuspecReader reader)
+        public ImmutableRule(RuleType severity, string id, string summary, string helpUrl = null)
         {
-            if (!(reader.GetIcon() is null))
-            {
-                yield return GetRule(RuleIdentifiers.UnsupportedElementUsed, "<icon> elements are not supported in Chocolatey CLI, use <iconUrl> instead.");
-            }
+            Severity = severity;
+            Id = id;
+            Summary = summary;
+            HelpUrl = helpUrl;
         }
+
+        public readonly RuleType Severity;
+        public readonly string Id;
+        public readonly string Summary;
+        public readonly string HelpUrl;
     }
 }

--- a/src/chocolatey/infrastructure/rules/RuleResult.cs
+++ b/src/chocolatey/infrastructure/rules/RuleResult.cs
@@ -28,5 +28,17 @@ namespace chocolatey.infrastructure.rules
         public string Id { get; private set; }
         public string Message { get; private set; }
         public RuleType Severity { get; set; }
+
+        internal static RuleResult FromImmutableRule(ImmutableRule result, string summary = null)
+        {
+            if (string.IsNullOrEmpty(summary))
+            {
+                return new RuleResult(result.Severity, result.Id, result.Summary) { HelpUrl = result.HelpUrl };
+            }
+            else
+            {
+                return new RuleResult(result.Severity, result.Id, summary) { HelpUrl = result.HelpUrl };
+            }
+        }
     }
 }


### PR DESCRIPTION
## Description Of Changes

This commit updates all available rules to return a read only
list of the rules each rule class implements, as well as updating
the rule engine to gather these rules so they can be used further
in the future when we have a need for this information.

Huge thanks to @corbob to get this started.

## Motivation and Context

There are future plans to improve the handling of rules, and to be able to do these in the future it is required to make changes to the rule engine and its rules to give this information.

## Testing

1. Run unit tests

### Operating Systems Testing

- N/A

## Change Types Made
<!-- Tick the boxes for the type of changes that have been made -->

* [ ] Bug fix (non-breaking change).
* [x] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [x] Tests to cover my changes, have been added.
* [x] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue

- https://app.clickup.com/t/20540031/PROJ-595

