### PR TITLE
(maint) Fix failing Pester tests

### DIFF
--- a/src/chocolatey.resources/helpers/ChocolateyTabExpansion.ps1
+++ b/src/chocolatey.resources/helpers/ChocolateyTabExpansion.ps1
@@ -63,7 +63,7 @@ $commandOptions = @{
 $commandOptions['find'] = $commandOptions['search']
 
 try {
-    $licenseFile = Get-Item -Path "$env:ChocolateyInstall\license\chocolatey.license.xml" -ErrorAction SilentlyContinue
+    $licenseFile = Get-Item -Path "$env:ChocolateyInstall\license\chocolatey.license.xml" -ErrorAction Stop
 
     if ($licenseFile) {
         # Add pro-only commands
@@ -86,7 +86,7 @@ try {
         $commandOptions.pin += " --note=''"
 
         # Add Business-only commands and options if the license is a Business or Trial license
-        [xml]$xml = Get-Content -Path $licenseFile.FullName
+        [xml]$xml = Get-Content -Path $licenseFile.FullName -ErrorAction Stop
         $licenseType = $xml.license.type
 
         if ('Business', 'BusinessTrial' -contains $licenseType) {
@@ -111,6 +111,9 @@ try {
     }
 }
 catch {
+    # Remove the error that last occurred from $error so it doesn't cause any
+    # issues for users, as we're deliberately ignoring it.
+    $error.RemoveAt(0)
 }
 
 foreach ($key in @($commandOptions.Keys)) {

--- a/tests/chocolatey-tests/chocolatey.Tests.ps1
+++ b/tests/chocolatey-tests/chocolatey.Tests.ps1
@@ -146,9 +146,9 @@ Describe "Ensuring Chocolatey is correctly installed" -Tag Environment, Chocolat
         # This is FossOnly for now as there are some undetermined errors here that do not seem to present inside of Chocolatey. https://gitlab.com/chocolatey/build-automation/chocolatey-test-kitchen/-/issues/39
         It "Should be able to run the script in AllSigned mode" -Skip:($_ -notin $PowerShellFiles) -Tag FossOnly {
             $expectedErrors = 0
-            $command = "Import-Module $FileUnderTest -ErrorAction SilentlyContinue; exit `$error.count"
-            & powershell.exe -noprofile -ExecutionPolicy AllSigned -command $command 2>$null
-            $LastExitCode | Should -BeExactly $expectedErrors
+            $command = "Import-Module $FileUnderTest -ErrorAction SilentlyContinue; `$error;exit `$error.count"
+            $result = & powershell.exe -noprofile -ExecutionPolicy AllSigned -command $command *>&1
+            $LastExitCode | Should -BeExactly $expectedErrors -Because $result
         }
     }
 
@@ -182,15 +182,15 @@ Describe "Ensuring Chocolatey is correctly installed" -Tag Environment, Chocolat
         # This is Foss only as PowerShell running under version 2 doesn't have .net available and can't import the Licensed DLL.
         # Tests on Windows 7 show no issues with running Chocolatey under Windows 7 with PowerShell v2 aside from issues surrounding TLS versions that we cannot resolve without an upgrade to Windows 7.
         It "Imports ChocolateyInstaller module successfully in PowerShell v2" -Tag FossOnly {
-            $command = 'Import-Module $env:ChocolateyInstall\helpers\chocolateyInstaller.psm1;exit $error.count'
-            & powershell.exe -Version 2 -noprofile -command $command
-            $LastExitCode | Should -BeExactly 0
+            $command = 'Import-Module $env:ChocolateyInstall\helpers\chocolateyInstaller.psm1; $error; exit $error.count'
+            $result = & powershell.exe -Version 2 -noprofile -command $command
+            $LastExitCode | Should -BeExactly 0 -Because $result
         }
 
         It "Imports ChocolateyProfile module successfully in PowerShell v2" {
-            $command = 'Import-Module $env:ChocolateyInstall\helpers\chocolateyProfile.psm1;exit $error.count'
-            & powershell.exe -Version 2 -noprofile -command $command
-            $LastExitCode | Should -BeExactly 0
+            $command = 'Import-Module $env:ChocolateyInstall\helpers\chocolateyProfile.psm1; $error; exit $error.count'
+            $result = & powershell.exe -Version 2 -noprofile -command $command
+            $LastExitCode | Should -BeExactly 0 -Because $result
         }
 
         Context "chocolateyScriptRunner.ps1" {


### PR DESCRIPTION
## Description Of Changes

- Fix failing CI tests
- Improve error reporting when they fail
- Small fix into tab completion for ensuring expected & handled errors don't pollute $error for users. 
  - This was actually the cause of some of the failing tests, as they were checking $error to determine if something failed or not. :(

## Motivation and Context

Wanting to sort out our test failures before release.

## Testing

Tested locally where I can, but I will also be testing in CI.

### Operating Systems Testing
Win11

## Change Types Made
<!-- Tick the boxes for the type of changes that have been made -->

* [ ] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.
* [x] Pester tests updated

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [x] All new and existing tests passed?
* [x] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue

N/A, tests only.