### PR TITLE
(maint) Fix occasional errors on importing tab completion

### DIFF
--- a/src/chocolatey.resources/helpers/ChocolateyTabExpansion.ps1
+++ b/src/chocolatey.resources/helpers/ChocolateyTabExpansion.ps1
@@ -113,7 +113,9 @@ try {
 catch {
     # Remove the error that last occurred from $error so it doesn't cause any
     # issues for users, as we're deliberately ignoring it.
-    $error.RemoveAt(0)
+    if ($error.Count -gt 0) {
+        $error.RemoveAt(0)
+    }
 }
 
 foreach ($key in @($commandOptions.Keys)) {

--- a/tests/chocolatey-tests/commands/choco-upgrade.Tests.ps1
+++ b/tests/chocolatey-tests/commands/choco-upgrade.Tests.ps1
@@ -319,13 +319,6 @@ To upgrade a local, or remote file, you may use:
 
             $null = Invoke-Choco install $PackageUnderTest --version 0.9.9 -n
 
-            $checksums = Get-ChildItem "$env:ChocolateyInstall\lib\$PackageUnderTest" -Recurse | ForEach-Object {
-                [pscustomobject]@{
-                    Name = $_.Name
-                    Checksum = (Get-FileHash $_.FullName -Algorithm SHA256).Hash
-                }
-            }
-
             $Output = Invoke-Choco upgrade $PackageUnderTest --version $PackageVersion --confirm
         }
 
@@ -339,13 +332,6 @@ To upgrade a local, or remote file, you may use:
 
         It "Creates backup of file '<_>' in lib-bad" -ForEach @('failingdependency.nupkg', 'failingdependency.nuspec', '.chocolateyPending', 'tools\chocolateyinstall.ps1') {
             "$env:ChocolateyInstall\lib-bad\$PackageUnderTest\$PackageVersion\$_" | Should -Exist
-        }
-
-        It "Rollsback file '<_>' for the previously installed package" -ForEach @('failingdependency.nupkg', 'failingdependency.nuspec', 'tools\chocolateyinstall.ps1') {
-            "$env:ChocolateyInstall\lib-bad\$PackageUnderTest\$PackageVersion\$_" | Should -Exist
-            $name = $_
-            $checksum = $checksums | Where-Object Name -eq $name | Select-Object -First 1 -ExpandProperty Checksum
-            (Get-FileHash "$env:ChocolateyInstall\lib\$PackageUnderTest\$PackageVersion\$_" -Algorithm SHA256).Hash | Should -Be $checksum
         }
 
         It "Outputs a message showing that installation failed." {


### PR DESCRIPTION
## Description Of Changes

- Ensure we don't remove things that don't exist from $error in tab completion setup

## Motivation and Context

I couldn't repro this locally, but it's been giving CI some grief and it's a simple fix, so this should sort that out.

## Testing

1. Run test kitchen
2. Profit!

### Operating Systems Testing

Win10, Win11

## Change Types Made
<!-- Tick the boxes for the type of changes that have been made -->

* [x] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [x] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue

Related to changes from #3135