### PR TITLE
(tests) Fix temperamental test

### DIFF
--- a/tests/chocolatey-tests/chocolatey.Tests.ps1
+++ b/tests/chocolatey-tests/chocolatey.Tests.ps1
@@ -146,7 +146,7 @@ Describe "Ensuring Chocolatey is correctly installed" -Tag Environment, Chocolat
         # This is FossOnly for now as there are some undetermined errors here that do not seem to present inside of Chocolatey. https://gitlab.com/chocolatey/build-automation/chocolatey-test-kitchen/-/issues/39
         It "Should be able to run the script in AllSigned mode" -Skip:($_ -notin $PowerShellFiles) -Tag FossOnly {
             $expectedErrors = 0
-            $command = "Import-Module $FileUnderTest -ErrorAction SilentlyContinue; `$error;exit `$error.count"
+            $command = "try { `$ErrorActionPreference = 'Stop'; Import-Module $FileUnderTest } catch { $_ ; exit 1 }"
             $result = & powershell.exe -noprofile -ExecutionPolicy AllSigned -command $command *>&1
             $LastExitCode | Should -BeExactly $expectedErrors -Because $result
         }
@@ -182,13 +182,13 @@ Describe "Ensuring Chocolatey is correctly installed" -Tag Environment, Chocolat
         # This is Foss only as PowerShell running under version 2 doesn't have .net available and can't import the Licensed DLL.
         # Tests on Windows 7 show no issues with running Chocolatey under Windows 7 with PowerShell v2 aside from issues surrounding TLS versions that we cannot resolve without an upgrade to Windows 7.
         It "Imports ChocolateyInstaller module successfully in PowerShell v2" -Tag FossOnly {
-            $command = 'Import-Module $env:ChocolateyInstall\helpers\chocolateyInstaller.psm1; $error; exit $error.count'
+            $command = 'try { $ErrorActionPreference = ''Stop''; Import-Module $env:ChocolateyInstall\helpers\chocolateyInstaller.psm1 } catch { $_ ; exit 1 }'
             $result = & powershell.exe -Version 2 -noprofile -command $command
             $LastExitCode | Should -BeExactly 0 -Because $result
         }
 
         It "Imports ChocolateyProfile module successfully in PowerShell v2" {
-            $command = 'Import-Module $env:ChocolateyInstall\helpers\chocolateyProfile.psm1; $error; exit $error.count'
+            $command = 'try { $ErrorActionPreference = ''Stop''; Import-Module $env:ChocolateyInstall\helpers\chocolateyProfile.psm1 } catch { $_ ; exit 1 }'
             $result = & powershell.exe -Version 2 -noprofile -command $command
             $LastExitCode | Should -BeExactly 0 -Because $result
         }


### PR DESCRIPTION
## Description Of Changes

- Fix the "can we load and run signed scripts" test to actually test what we want it to test instead of worrying about occasional things getting into $error that don't actually have any impact.

## Motivation and Context

Tests flaky and don't seem to work the same everywhere, plus we should test whether it actually breaks or not :<

## Testing

Tested locally as thoroughly as I can, it _seems_ to be fine, but so did the prior fixes. I'll run this through teamcity as well to be sure.

### Operating Systems Testing

Win11

## Change Types Made
<!-- Tick the boxes for the type of changes that have been made -->

* [ ] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [x] Tests to cover my changes, have been added.
* [x] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue

Test fix only
