### PR TITLE
(#508) Add warning about filtering of packages

### DIFF
--- a/src/chocolatey/infrastructure.app/services/NugetService.cs
+++ b/src/chocolatey/infrastructure.app/services/NugetService.cs
@@ -161,6 +161,22 @@ install them.
                 }
             }
 
+            if ((config.ListCommand.ApprovedOnly || config.ListCommand.DownloadCacheAvailable || config.ListCommand.NotBroken) && config.RegularOutput)
+            {
+                // This warning has been added here, to provide context to the user, and a follow up issue
+
+                // has been added here: https://github.com/chocolatey/choco/issues/3139 to address the actual
+                // issue that causes this warning to be required.
+                this.Log().Warn(@"
+Starting vith Chocolatey CLI v2.0.0, changes have been made to the
+`choco search` command which means that filtering of packages using the
+`--approved-only`, `--download-cache`, and `--not-broken` options are
+now performed within Chocolatey CLI. Previously, this filtering would
+have been performed on the Chocolatey Community Repository. As a result,
+it is possible that incomplete package lists are returned from a command
+that uses these options.");
+            }
+
             if (config.RegularOutput) this.Log().Debug(() => "Running list with the following filter = '{0}'".FormatWith(config.Input));
             if (config.RegularOutput) this.Log().Debug(ChocolateyLoggers.Verbose, () => "--- Start of List ---");
             foreach (var pkg in NugetList.GetPackages(config, _nugetLogger, _fileSystem))


### PR DESCRIPTION
## Description Of Changes

This commit adds a warning, to inform the user that this may be happening.

## Motivation and Context

When running choco search, there are several options that would have previously caused packages to be filtered on the server side, before being returned to the client. The options were --approved-only, --download-cache, and --not-broken.  The decision was taken to no longer have these options passed to the server, since they can't (currently) be respected on a V3 feed.  Instead, the filtering is applied on the client side, within Chocolatey CLI.  The end result is that it is possible to get incomplete pages of data returned, as some packages may be filtered out on the client, and no additional packages will be requested.

## Testing

1. Run `choco search randompackage` and see that no warning is output
2. Run `choco search randompackage --approved-only` and see that the warning is output
3. Run `choco search randompackage --download-cache` and see that the warning is output
4. Run `choco search randompackage --not-broken` and see that the warning is output
5. Run `choco search randompackage --approved-only --limit-output` and see that no warning is output

### Operating Systems Testing

- Windows 10

## Change Types Made

* [ ] Bug fix (non-breaking change).
* [x] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [ ] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue

- https://app.clickup.com/t/20540031/PROJ-599