### PR TITLE
(tests) Mark some upgrade tests for locked files FossOnly

### DIFF
--- a/tests/chocolatey-tests/commands/choco-upgrade.Tests.ps1
+++ b/tests/chocolatey-tests/commands/choco-upgrade.Tests.ps1
@@ -339,7 +339,11 @@ To upgrade a local, or remote file, you may use:
         }
     }
 
-    Context "Upgrading a package when installer is locked" {
+    # This does not work as expected when runnning in test kitchen and with Chocolatey Licensed Extension installed.
+    # It is believed to be a problem with test kitchen, or the VM that we are using that is causing the issue.
+    # The result is that versioned backup files of each file in the package is created, instead of the package being
+    # removed. Consider the test partially broken.
+    Context "Upgrading a package when installer is locked" -Tag FossOnly {
         BeforeAll {
             Restore-ChocolateyInstallSnapshot
 
@@ -402,11 +406,19 @@ To upgrade a local, or remote file, you may use:
             $null = Invoke-Choco uninstall $PackageUnderTest --confirm
         }
 
-        It "Exits with Failure (1)" {
+        # This does not work as expected when runnning in test kitchen and with Chocolatey Licensed Extension installed.
+        # It is believed to be a problem with test kitchen, or the VM that we are using that is causing the issue.
+        # The result is that versioned backup files of each file in the package is created, instead of the package being
+        # removed. Consider the test partially broken.
+        It "Exits with Failure (1)" -Tag FossOnly {
             $Output.ExitCode | Should -Be 1 -Because $Output.String
         }
 
-        It "Keeps file '<_>' in the lib directory" -ForEach @('hasinnoinstaller.nuspec', 'hasinnoinstaller.nupkg', 'tools\chocolateyinstall.ps1', 'tools\chocolateyuninstall.ps1', 'tools\helloworld-1.0.0.exe', 'tools\helloworld-1.0.0.exe.ignore') {
+        # This does not work as expected when runnning in test kitchen and with Chocolatey Licensed Extension installed.
+        # It is believed to be a problem with test kitchen, or the VM that we are using that is causing the issue.
+        # The result is that versioned backup files of each file in the package is created, instead of the package being
+        # removed. Consider the test partially broken.
+        It "Keeps file '<_>' in the lib directory" -ForEach @('hasinnoinstaller.nuspec', 'hasinnoinstaller.nupkg', 'tools\chocolateyinstall.ps1', 'tools\chocolateyuninstall.ps1', 'tools\helloworld-1.0.0.exe', 'tools\helloworld-1.0.0.exe.ignore') -Tag FossOnly {
             "$env:ChocolateyInstall\lib\$PackageUnderTest\$_" | Should -Exist
         }
 
@@ -415,7 +427,11 @@ To upgrade a local, or remote file, you may use:
         }
 
         # Only two files are backed up as we was not able to download and extract the new package
-        It "Creates backup of file '<_>' in lib-bad" -ForEach @('.chocolateyPending', 'tools\a-locked-file.txt') {
+        # This does not work as expected when runnning in test kitchen and with Chocolatey Licensed Extension installed.
+        # It is believed to be a problem with test kitchen, or the VM that we are using that is causing the issue.
+        # The result is that versioned backup files of each file in the package is created, instead of the package being
+        # removed. Consider the test partially broken.
+        It "Creates backup of file '<_>' in lib-bad" -ForEach @('.chocolateyPending', 'tools\a-locked-file.txt') -Tag FossOnly {
             "$env:ChocolateyInstall\lib-bad\$PackageUnderTest\$PackageVersion\$_" | Should -Exist
         }
 
@@ -423,8 +439,12 @@ To upgrade a local, or remote file, you may use:
             "$env:ChocolateyInstall\lib-bad\$PackageUnderTest\$PackageVersion\$_" | Should -Not -Exist
         }
 
-        It "Outputs a message showing that installation failed." {
-            $Output.Lines | Should -Contain "Chocolatey upgraded 0/1 packages. 1 packages failed."
+        # This does not work as expected when runnning in test kitchen and with Chocolatey Licensed Extension installed.
+        # It is believed to be a problem with test kitchen, or the VM that we are using that is causing the issue.
+        # The result is that versioned backup files of each file in the package is created, instead of the package being
+        # removed. Consider the test partially broken.
+        It "Outputs a message showing that installation failed." -TagFossOnly {
+            $Output.Lines | Should -Contain "Chocolatey upgraded 0/1 packages. 1 packages failed." -Because $Output.String
         }
     }
 

--- a/tests/chocolatey-tests/commands/choco-upgrade.Tests.ps1
+++ b/tests/chocolatey-tests/commands/choco-upgrade.Tests.ps1
@@ -443,7 +443,8 @@ To upgrade a local, or remote file, you may use:
         # It is believed to be a problem with test kitchen, or the VM that we are using that is causing the issue.
         # The result is that versioned backup files of each file in the package is created, instead of the package being
         # removed. Consider the test partially broken.
-        It "Outputs a message showing that installation failed." -TagFossOnly {
+        It "Outputs a message showing that installation failed." -Tag FossOnly {
+
             $Output.Lines | Should -Contain "Chocolatey upgraded 0/1 packages. 1 packages failed." -Because $Output.String
         }
     }


### PR DESCRIPTION
## Description Of Changes

Mark a few upgrade tests concerning locked files FossOnly for now.

## Motivation and Context

These tests fail inexplicably on teamcity only if CLE is installed, but these failures can't be reproduced locally.

Marking them as FossOnly for now, we'll file follow up issues in CLE to investigate.

## Testing

N/A, just flagging partially broken CLE tests so we can follow up on them later.

### Operating Systems Testing

N/A

## Change Types Made
<!-- Tick the boxes for the type of changes that have been made -->

* [ ] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [x] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue

N/A