### PR TITLE
(#508) Add warning result if before modify script fails

### DIFF
--- a/src/chocolatey.tests.integration/scenarios/UpgradeScenarios.cs
+++ b/src/chocolatey.tests.integration/scenarios/UpgradeScenarios.cs
@@ -289,9 +289,12 @@ namespace chocolatey.tests.integration.scenarios
             }
 
             [Fact]
-            public void Should_not_have_warning_package_result()
+            public void Should_not_have_warning_package_result_other_than_before_modify_failures()
             {
-                _packageResult.Warning.ShouldBeFalse();
+                // For before modify scripts that fail, we add a warning message.
+                // So we will ignore any such warnings.
+                var messages = _packageResult.Messages.Where(m => m.MessageType == ResultType.Warn && !m.Message.ContainsSafe("chocolateyBeforeModify"));
+                messages.ShouldBeEmpty();
             }
 
             [Fact]
@@ -629,9 +632,12 @@ namespace chocolatey.tests.integration.scenarios
             }
 
             [Fact]
-            public void Should_not_have_warning_package_result()
+            public void Should_not_have_warning_package_result_other_than_before_modify_failures()
             {
-                _packageResult.Warning.ShouldBeFalse();
+                // For before modify scripts that fail, we add a warning message.
+                // So we will ignore any such warnings.
+                var messages = _packageResult.Messages.Where(m => m.MessageType == ResultType.Warn && !m.Message.ContainsSafe("chocolateyBeforeModify"));
+                messages.ShouldBeEmpty();
             }
 
             [Fact]
@@ -784,9 +790,12 @@ namespace chocolatey.tests.integration.scenarios
             }
 
             [Fact]
-            public void Should_not_have_warning_package_result()
+            public void Should_not_have_warning_package_result_other_than_before_modify_failures()
             {
-                _packageResult.Warning.ShouldBeFalse();
+                // For before modify scripts that fail, we add a warning message.
+                // So we will ignore any such warnings.
+                var messages = _packageResult.Messages.Where(m => m.MessageType == ResultType.Warn && !m.Message.ContainsSafe("chocolateyBeforeModify"));
+                messages.ShouldBeEmpty();
             }
 
             [Fact]
@@ -1600,9 +1609,12 @@ namespace chocolatey.tests.integration.scenarios
             }
 
             [Fact]
-            public void Should_not_have_warning_package_result()
+            public void Should_not_have_warning_package_result_other_than_before_modify_failures()
             {
-                _packageResult.Warning.ShouldBeFalse();
+                // For before modify scripts that fail, we add a warning message.
+                // So we will ignore any such warnings.
+                var messages = _packageResult.Messages.Where(m => m.MessageType == ResultType.Warn && !m.Message.ContainsSafe("chocolateyBeforeModify"));
+                messages.ShouldBeEmpty();
             }
 
             [Fact]
@@ -1920,9 +1932,12 @@ namespace chocolatey.tests.integration.scenarios
             }
 
             [Fact]
-            public void Should_not_have_warning_package_result()
+            public void Should_not_have_warning_package_result_other_than_before_modify_failures()
             {
-                _packageResult.Warning.ShouldBeFalse();
+                // For before modify scripts that fail, we add a warning message.
+                // So we will ignore any such warnings.
+                var messages = _packageResult.Messages.Where(m => m.MessageType == ResultType.Warn && !m.Message.ContainsSafe("chocolateyBeforeModify"));
+                messages.ShouldBeEmpty();
             }
         }
 
@@ -2043,9 +2058,12 @@ namespace chocolatey.tests.integration.scenarios
             }
 
             [Fact]
-            public void Should_not_have_warning_package_result()
+            public void Should_not_have_warning_package_result_other_than_before_modify_failures()
             {
-                _packageResult.Warning.ShouldBeFalse();
+                // For before modify scripts that fail, we add a warning message.
+                // So we will ignore any such warnings.
+                var messages = _packageResult.Messages.Where(m => m.MessageType == ResultType.Warn && !m.Message.ContainsSafe("chocolateyBeforeModify"));
+                messages.ShouldBeEmpty();
             }
         }
 
@@ -2222,9 +2240,12 @@ namespace chocolatey.tests.integration.scenarios
             }
 
             [Fact]
-            public void Should_not_have_warning_package_result()
+            public void Should_not_have_warning_package_result_other_than_before_modify_failures()
             {
-                _packageResult.Warning.ShouldBeFalse();
+                // For before modify scripts that fail, we add a warning message.
+                // So we will ignore any such warnings.
+                var messages = _packageResult.Messages.Where(m => m.MessageType == ResultType.Warn && !m.Message.ContainsSafe("chocolateyBeforeModify"));
+                messages.ShouldBeEmpty();
             }
 
             [Fact]
@@ -2302,9 +2323,12 @@ namespace chocolatey.tests.integration.scenarios
             }
 
             [Fact]
-            public void Should_not_have_warning_package_result()
+            public void Should_not_have_warning_package_result_other_than_before_modify_failures()
             {
-                _packageResult.Warning.ShouldBeFalse();
+                // For before modify scripts that fail, we add a warning message.
+                // So we will ignore any such warnings.
+                var messages = _packageResult.Messages.Where(m => m.MessageType == ResultType.Warn && !m.Message.ContainsSafe("chocolateyBeforeModify"));
+                messages.ShouldBeEmpty();
             }
 
             [Fact]
@@ -3745,9 +3769,12 @@ namespace chocolatey.tests.integration.scenarios
             }
 
             [Fact]
-            public void Should_not_have_warning_package_result()
+            public void Should_not_have_warning_package_result_other_than_before_modify_failures()
             {
-                _packageResult.Warning.ShouldBeFalse();
+                // For before modify scripts that fail, we add a warning message.
+                // So we will ignore any such warnings.
+                var messages = _packageResult.Messages.Where(m => m.MessageType == ResultType.Warn && !m.Message.ContainsSafe("chocolateyBeforeModify"));
+                messages.ShouldBeEmpty();
             }
 
             [Fact]
@@ -3845,9 +3872,12 @@ namespace chocolatey.tests.integration.scenarios
             }
 
             [Fact]
-            public void Should_not_have_warning_package_result()
+            public void Should_not_have_warning_package_result_other_than_before_modify_failures()
             {
-                _packageResult.Warning.ShouldBeFalse();
+                // For before modify scripts that fail, we add a warning message.
+                // So we will ignore any such warnings.
+                var messages = _packageResult.Messages.Where(m => m.MessageType == ResultType.Warn && !m.Message.ContainsSafe("chocolateyBeforeModify"));
+                messages.ShouldBeEmpty();
             }
 
             [Fact]
@@ -4164,9 +4194,12 @@ namespace chocolatey.tests.integration.scenarios
             }
 
             [Fact]
-            public void Should_not_have_warning_package_result()
+            public void Should_not_have_warning_package_result_other_than_before_modify_failures()
             {
-                _packageResult.Warning.ShouldBeFalse();
+                // For before modify scripts that fail, we add a warning message.
+                // So we will ignore any such warnings.
+                var messages = _packageResult.Messages.Where(m => m.MessageType == ResultType.Warn && !m.Message.ContainsSafe("chocolateyBeforeModify"));
+                messages.ShouldBeEmpty();
             }
 
             [Fact]
@@ -4486,9 +4519,12 @@ namespace chocolatey.tests.integration.scenarios
             }
 
             [Fact]
-            public void Should_not_have_warning_package_result()
+            public void Should_not_have_warning_package_result_other_than_before_modify_failures()
             {
-                _packageResult.Warning.ShouldBeFalse();
+                // For before modify scripts that fail, we add a warning message.
+                // So we will ignore any such warnings.
+                var messages = _packageResult.Messages.Where(m => m.MessageType == ResultType.Warn && !m.Message.ContainsSafe("chocolateyBeforeModify"));
+                messages.ShouldBeEmpty();
             }
 
             [Fact]
@@ -4986,9 +5022,12 @@ namespace chocolatey.tests.integration.scenarios
             }
 
             [Fact]
-            public void Should_not_have_warning_package_result()
+            public void Should_not_have_warning_package_result_other_than_before_modify_failures()
             {
-                _packageResult.Warning.ShouldBeFalse();
+                // For before modify scripts that fail, we add a warning message.
+                // So we will ignore any such warnings.
+                var messages = _packageResult.Messages.Where(m => m.MessageType == ResultType.Warn && !m.Message.ContainsSafe("chocolateyBeforeModify"));
+                messages.ShouldBeEmpty();
             }
 
             [Fact]

--- a/tests/chocolatey-tests/commands/choco-uninstall.Tests.ps1
+++ b/tests/chocolatey-tests/commands/choco-uninstall.Tests.ps1
@@ -70,6 +70,10 @@ Describe "choco uninstall" -Tag Chocolatey, UninstallCommand {
         It "Outputs Successful uninstall" {
             $Output.Lines | Should -Contain "Chocolatey uninstalled 1/1 packages."
         }
+
+        It "Outputs additiontal warning about before modify script" {
+            $Output.Lines | Should -Contain "- upgradepackage - Error while running the 'chocolateyBeforeModify.ps1'." -Because $Output.String
+        }
     }
 
     Context "Uninstalling a package with a failing uninstall script" {

--- a/tests/chocolatey-tests/commands/choco-upgrade.Tests.ps1
+++ b/tests/chocolatey-tests/commands/choco-upgrade.Tests.ps1
@@ -509,6 +509,10 @@ To upgrade a local, or remote file, you may use:
         It "Outputs a message showing that installation was successful" {
             $Output.Lines | Should -Contain "Chocolatey upgraded 1/1 packages."
         }
+
+        It "Outputs additiontal warning about before modify script" {
+            $Output.Lines | Should -Contain "- upgradepackage - v1.0.0 - Error while running the 'chocolateyBeforeModify.ps1'." -Because $Output.String
+        }
     }
 
     # This needs to be (almost) the last test in this block, to ensure NuGet configurations aren't being created.


### PR DESCRIPTION
## Description Of Changes

THe change in this PR ensures that any warnings that are outputted as part of a failure in a before modify script is propagated to the end of any uninstall, or upgrade so it can more easily be identified by the user/maintainer.

## Motivation and Context

To make errors and warnings more visible to the user.

## Testing

1. Install smoke package `upgradepackage` version `1.0.0`.
2. Upgrade smoke package to latest version (`1.1.0`)
3. Ensure there is an additional warning list after upgrade that mentions an error in the before modify script.
4. Uninstall `upgradepackage` v1.1.0
5. Ensure no warning is outputted regarding the before modify script.
6. Install again the smoke package `upgradepackage` version `1.0.0`
7. Uninstall the same smoke package.
8. Verify there is an additional warning list after uninstall that mentions an error in the before modify script.
9. Run changed E2E tests.

### Operating Systems Testing

- Windows 10
- Windows Server 2019

## Change Types Made

* [ ] Bug fix (non-breaking change).
* [x] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [x] Tests to cover my changes, have been added.
* [x] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue

- ref #508
- https://app.clickup.com/t/20540031/PROJ-615
