### PR TITLE
(#508) Fix forcing dependency uninstall fails if dependency is referenced by other packages

### DIFF
--- a/src/chocolatey.tests.integration/chocolatey.tests.integration.csproj
+++ b/src/chocolatey.tests.integration/chocolatey.tests.integration.csproj
@@ -78,22 +78,22 @@
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Chocolatey.NuGet.Common, Version=3.0.0.258, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
+    <Reference Include="Chocolatey.NuGet.Common">
       <HintPath>..\packages\Chocolatey.NuGet.Common.3.0.0\lib\net472\Chocolatey.NuGet.Common.dll</HintPath>
     </Reference>
-    <Reference Include="Chocolatey.NuGet.Configuration, Version=3.0.0.258, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
+    <Reference Include="Chocolatey.NuGet.Configuration">
       <HintPath>..\packages\Chocolatey.NuGet.Configuration.3.0.0\lib\net472\Chocolatey.NuGet.Configuration.dll</HintPath>
     </Reference>
-    <Reference Include="Chocolatey.NuGet.Frameworks, Version=3.0.0.258, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
+    <Reference Include="Chocolatey.NuGet.Frameworks">
       <HintPath>..\packages\Chocolatey.NuGet.Frameworks.3.0.0\lib\net472\Chocolatey.NuGet.Frameworks.dll</HintPath>
     </Reference>
-    <Reference Include="Chocolatey.NuGet.Packaging, Version=3.0.0.258, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
+    <Reference Include="Chocolatey.NuGet.Packaging">
       <HintPath>..\packages\Chocolatey.NuGet.Packaging.3.0.0\lib\net472\Chocolatey.NuGet.Packaging.dll</HintPath>
     </Reference>
-    <Reference Include="Chocolatey.NuGet.Protocol, Version=3.0.0.258, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
+    <Reference Include="Chocolatey.NuGet.Protocol">
       <HintPath>..\packages\Chocolatey.NuGet.Protocol.3.0.0\lib\net472\Chocolatey.NuGet.Protocol.dll</HintPath>
     </Reference>
-    <Reference Include="Chocolatey.NuGet.Versioning, Version=3.0.0.258, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
+    <Reference Include="Chocolatey.NuGet.Versioning">
       <HintPath>..\packages\Chocolatey.NuGet.Versioning.3.0.0\lib\net472\Chocolatey.NuGet.Versioning.dll</HintPath>
     </Reference>
     <Reference Include="log4net, Version=2.0.12.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">

--- a/src/chocolatey.tests.integration/chocolatey.tests.integration.csproj
+++ b/src/chocolatey.tests.integration/chocolatey.tests.integration.csproj
@@ -79,22 +79,22 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Chocolatey.NuGet.Common">
-      <HintPath>..\packages\Chocolatey.NuGet.Common.3.0.0\lib\net472\Chocolatey.NuGet.Common.dll</HintPath>
+      <HintPath>..\packages\Chocolatey.NuGet.Common.3.1.0\lib\net472\Chocolatey.NuGet.Common.dll</HintPath>
     </Reference>
     <Reference Include="Chocolatey.NuGet.Configuration">
-      <HintPath>..\packages\Chocolatey.NuGet.Configuration.3.0.0\lib\net472\Chocolatey.NuGet.Configuration.dll</HintPath>
+      <HintPath>..\packages\Chocolatey.NuGet.Configuration.3.1.0\lib\net472\Chocolatey.NuGet.Configuration.dll</HintPath>
     </Reference>
     <Reference Include="Chocolatey.NuGet.Frameworks">
-      <HintPath>..\packages\Chocolatey.NuGet.Frameworks.3.0.0\lib\net472\Chocolatey.NuGet.Frameworks.dll</HintPath>
+      <HintPath>..\packages\Chocolatey.NuGet.Frameworks.3.1.0\lib\net472\Chocolatey.NuGet.Frameworks.dll</HintPath>
     </Reference>
     <Reference Include="Chocolatey.NuGet.Packaging">
-      <HintPath>..\packages\Chocolatey.NuGet.Packaging.3.0.0\lib\net472\Chocolatey.NuGet.Packaging.dll</HintPath>
+      <HintPath>..\packages\Chocolatey.NuGet.Packaging.3.1.0\lib\net472\Chocolatey.NuGet.Packaging.dll</HintPath>
     </Reference>
     <Reference Include="Chocolatey.NuGet.Protocol">
-      <HintPath>..\packages\Chocolatey.NuGet.Protocol.3.0.0\lib\net472\Chocolatey.NuGet.Protocol.dll</HintPath>
+      <HintPath>..\packages\Chocolatey.NuGet.Protocol.3.1.0\lib\net472\Chocolatey.NuGet.Protocol.dll</HintPath>
     </Reference>
     <Reference Include="Chocolatey.NuGet.Versioning">
-      <HintPath>..\packages\Chocolatey.NuGet.Versioning.3.0.0\lib\net472\Chocolatey.NuGet.Versioning.dll</HintPath>
+      <HintPath>..\packages\Chocolatey.NuGet.Versioning.3.1.0\lib\net472\Chocolatey.NuGet.Versioning.dll</HintPath>
     </Reference>
     <Reference Include="log4net, Version=2.0.12.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
       <HintPath>..\packages\log4net.2.0.12\lib\net45\log4net.dll</HintPath>

--- a/src/chocolatey.tests.integration/packages.config
+++ b/src/chocolatey.tests.integration/packages.config
@@ -1,11 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Chocolatey.NuGet.Common" version="3.0.0" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.Configuration" version="3.0.0" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.Frameworks" version="3.0.0" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.Packaging" version="3.0.0" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.Protocol" version="3.0.0" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.Versioning" version="3.0.0" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.Common" version="3.1.0" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.Configuration" version="3.1.0" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.Frameworks" version="3.1.0" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.Packaging" version="3.1.0" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.Protocol" version="3.1.0" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.Versioning" version="3.1.0" targetFramework="net48" />
   <package id="log4net" version="2.0.12" targetFramework="net48" />
   <package id="Microsoft.Web.Xdt" version="3.1.0" targetFramework="net48" />
   <package id="Moq" version="4.2.1402.2112" targetFramework="net40" />

--- a/src/chocolatey.tests/chocolatey.tests.csproj
+++ b/src/chocolatey.tests/chocolatey.tests.csproj
@@ -77,43 +77,43 @@
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Chocolatey.NuGet.Commands, Version=3.0.0.258, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
+    <Reference Include="Chocolatey.NuGet.Commands">
       <HintPath>..\packages\Chocolatey.NuGet.Commands.3.0.0\lib\net472\Chocolatey.NuGet.Commands.dll</HintPath>
     </Reference>
-    <Reference Include="Chocolatey.NuGet.Common, Version=3.0.0.258, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
+    <Reference Include="Chocolatey.NuGet.Common">
       <HintPath>..\packages\Chocolatey.NuGet.Common.3.0.0\lib\net472\Chocolatey.NuGet.Common.dll</HintPath>
     </Reference>
-    <Reference Include="Chocolatey.NuGet.Configuration, Version=3.0.0.258, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
+    <Reference Include="Chocolatey.NuGet.Configuration">
       <HintPath>..\packages\Chocolatey.NuGet.Configuration.3.0.0\lib\net472\Chocolatey.NuGet.Configuration.dll</HintPath>
     </Reference>
-    <Reference Include="Chocolatey.NuGet.Credentials, Version=3.0.0.258, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
+    <Reference Include="Chocolatey.NuGet.Credentials">
       <HintPath>..\packages\Chocolatey.NuGet.Credentials.3.0.0\lib\net472\Chocolatey.NuGet.Credentials.dll</HintPath>
     </Reference>
-    <Reference Include="Chocolatey.NuGet.DependencyResolver.Core, Version=3.0.0.258, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
+    <Reference Include="Chocolatey.NuGet.DependencyResolver.Core">
       <HintPath>..\packages\Chocolatey.NuGet.DependencyResolver.Core.3.0.0\lib\net472\Chocolatey.NuGet.DependencyResolver.Core.dll</HintPath>
     </Reference>
-    <Reference Include="Chocolatey.NuGet.Frameworks, Version=3.0.0.258, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
+    <Reference Include="Chocolatey.NuGet.Frameworks">
       <HintPath>..\packages\Chocolatey.NuGet.Frameworks.3.0.0\lib\net472\Chocolatey.NuGet.Frameworks.dll</HintPath>
     </Reference>
-    <Reference Include="Chocolatey.NuGet.LibraryModel, Version=3.0.0.258, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
+    <Reference Include="Chocolatey.NuGet.LibraryModel">
       <HintPath>..\packages\Chocolatey.NuGet.LibraryModel.3.0.0\lib\net472\Chocolatey.NuGet.LibraryModel.dll</HintPath>
     </Reference>
-    <Reference Include="Chocolatey.NuGet.PackageManagement, Version=3.0.0.258, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
+    <Reference Include="Chocolatey.NuGet.PackageManagement">
       <HintPath>..\packages\Chocolatey.NuGet.PackageManagement.3.0.0\lib\net472\Chocolatey.NuGet.PackageManagement.dll</HintPath>
     </Reference>
-    <Reference Include="Chocolatey.NuGet.Packaging, Version=3.0.0.258, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
+    <Reference Include="Chocolatey.NuGet.Packaging">
       <HintPath>..\packages\Chocolatey.NuGet.Packaging.3.0.0\lib\net472\Chocolatey.NuGet.Packaging.dll</HintPath>
     </Reference>
-    <Reference Include="Chocolatey.NuGet.ProjectModel, Version=3.0.0.258, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
+    <Reference Include="Chocolatey.NuGet.ProjectModel">
       <HintPath>..\packages\Chocolatey.NuGet.ProjectModel.3.0.0\lib\net472\Chocolatey.NuGet.ProjectModel.dll</HintPath>
     </Reference>
-    <Reference Include="Chocolatey.NuGet.Protocol, Version=3.0.0.258, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
+    <Reference Include="Chocolatey.NuGet.Protocol">
       <HintPath>..\packages\Chocolatey.NuGet.Protocol.3.0.0\lib\net472\Chocolatey.NuGet.Protocol.dll</HintPath>
     </Reference>
-    <Reference Include="Chocolatey.NuGet.Resolver, Version=3.0.0.258, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
+    <Reference Include="Chocolatey.NuGet.Resolver">
       <HintPath>..\packages\Chocolatey.NuGet.Resolver.3.0.0\lib\net472\Chocolatey.NuGet.Resolver.dll</HintPath>
     </Reference>
-    <Reference Include="Chocolatey.NuGet.Versioning, Version=3.0.0.258, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
+    <Reference Include="Chocolatey.NuGet.Versioning">
       <HintPath>..\packages\Chocolatey.NuGet.Versioning.3.0.0\lib\net472\Chocolatey.NuGet.Versioning.dll</HintPath>
     </Reference>
     <Reference Include="log4net, Version=2.0.12.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">

--- a/src/chocolatey.tests/chocolatey.tests.csproj
+++ b/src/chocolatey.tests/chocolatey.tests.csproj
@@ -78,43 +78,43 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Chocolatey.NuGet.Commands">
-      <HintPath>..\packages\Chocolatey.NuGet.Commands.3.0.0\lib\net472\Chocolatey.NuGet.Commands.dll</HintPath>
+      <HintPath>..\packages\Chocolatey.NuGet.Commands.3.1.0\lib\net472\Chocolatey.NuGet.Commands.dll</HintPath>
     </Reference>
     <Reference Include="Chocolatey.NuGet.Common">
-      <HintPath>..\packages\Chocolatey.NuGet.Common.3.0.0\lib\net472\Chocolatey.NuGet.Common.dll</HintPath>
+      <HintPath>..\packages\Chocolatey.NuGet.Common.3.1.0\lib\net472\Chocolatey.NuGet.Common.dll</HintPath>
     </Reference>
     <Reference Include="Chocolatey.NuGet.Configuration">
-      <HintPath>..\packages\Chocolatey.NuGet.Configuration.3.0.0\lib\net472\Chocolatey.NuGet.Configuration.dll</HintPath>
+      <HintPath>..\packages\Chocolatey.NuGet.Configuration.3.1.0\lib\net472\Chocolatey.NuGet.Configuration.dll</HintPath>
     </Reference>
     <Reference Include="Chocolatey.NuGet.Credentials">
-      <HintPath>..\packages\Chocolatey.NuGet.Credentials.3.0.0\lib\net472\Chocolatey.NuGet.Credentials.dll</HintPath>
+      <HintPath>..\packages\Chocolatey.NuGet.Credentials.3.1.0\lib\net472\Chocolatey.NuGet.Credentials.dll</HintPath>
     </Reference>
     <Reference Include="Chocolatey.NuGet.DependencyResolver.Core">
-      <HintPath>..\packages\Chocolatey.NuGet.DependencyResolver.Core.3.0.0\lib\net472\Chocolatey.NuGet.DependencyResolver.Core.dll</HintPath>
+      <HintPath>..\packages\Chocolatey.NuGet.DependencyResolver.Core.3.1.0\lib\net472\Chocolatey.NuGet.DependencyResolver.Core.dll</HintPath>
     </Reference>
     <Reference Include="Chocolatey.NuGet.Frameworks">
-      <HintPath>..\packages\Chocolatey.NuGet.Frameworks.3.0.0\lib\net472\Chocolatey.NuGet.Frameworks.dll</HintPath>
+      <HintPath>..\packages\Chocolatey.NuGet.Frameworks.3.1.0\lib\net472\Chocolatey.NuGet.Frameworks.dll</HintPath>
     </Reference>
     <Reference Include="Chocolatey.NuGet.LibraryModel">
-      <HintPath>..\packages\Chocolatey.NuGet.LibraryModel.3.0.0\lib\net472\Chocolatey.NuGet.LibraryModel.dll</HintPath>
+      <HintPath>..\packages\Chocolatey.NuGet.LibraryModel.3.1.0\lib\net472\Chocolatey.NuGet.LibraryModel.dll</HintPath>
     </Reference>
     <Reference Include="Chocolatey.NuGet.PackageManagement">
-      <HintPath>..\packages\Chocolatey.NuGet.PackageManagement.3.0.0\lib\net472\Chocolatey.NuGet.PackageManagement.dll</HintPath>
+      <HintPath>..\packages\Chocolatey.NuGet.PackageManagement.3.1.0\lib\net472\Chocolatey.NuGet.PackageManagement.dll</HintPath>
     </Reference>
     <Reference Include="Chocolatey.NuGet.Packaging">
-      <HintPath>..\packages\Chocolatey.NuGet.Packaging.3.0.0\lib\net472\Chocolatey.NuGet.Packaging.dll</HintPath>
+      <HintPath>..\packages\Chocolatey.NuGet.Packaging.3.1.0\lib\net472\Chocolatey.NuGet.Packaging.dll</HintPath>
     </Reference>
     <Reference Include="Chocolatey.NuGet.ProjectModel">
-      <HintPath>..\packages\Chocolatey.NuGet.ProjectModel.3.0.0\lib\net472\Chocolatey.NuGet.ProjectModel.dll</HintPath>
+      <HintPath>..\packages\Chocolatey.NuGet.ProjectModel.3.1.0\lib\net472\Chocolatey.NuGet.ProjectModel.dll</HintPath>
     </Reference>
     <Reference Include="Chocolatey.NuGet.Protocol">
-      <HintPath>..\packages\Chocolatey.NuGet.Protocol.3.0.0\lib\net472\Chocolatey.NuGet.Protocol.dll</HintPath>
+      <HintPath>..\packages\Chocolatey.NuGet.Protocol.3.1.0\lib\net472\Chocolatey.NuGet.Protocol.dll</HintPath>
     </Reference>
     <Reference Include="Chocolatey.NuGet.Resolver">
-      <HintPath>..\packages\Chocolatey.NuGet.Resolver.3.0.0\lib\net472\Chocolatey.NuGet.Resolver.dll</HintPath>
+      <HintPath>..\packages\Chocolatey.NuGet.Resolver.3.1.0\lib\net472\Chocolatey.NuGet.Resolver.dll</HintPath>
     </Reference>
     <Reference Include="Chocolatey.NuGet.Versioning">
-      <HintPath>..\packages\Chocolatey.NuGet.Versioning.3.0.0\lib\net472\Chocolatey.NuGet.Versioning.dll</HintPath>
+      <HintPath>..\packages\Chocolatey.NuGet.Versioning.3.1.0\lib\net472\Chocolatey.NuGet.Versioning.dll</HintPath>
     </Reference>
     <Reference Include="log4net, Version=2.0.12.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
       <HintPath>..\packages\log4net.2.0.12\lib\net45\log4net.dll</HintPath>

--- a/src/chocolatey.tests/packages.config
+++ b/src/chocolatey.tests/packages.config
@@ -1,18 +1,18 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Chocolatey.NuGet.Commands" version="3.0.0" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.Common" version="3.0.0" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.Configuration" version="3.0.0" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.Credentials" version="3.0.0" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.DependencyResolver.Core" version="3.0.0" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.Frameworks" version="3.0.0" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.LibraryModel" version="3.0.0" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.PackageManagement" version="3.0.0" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.Packaging" version="3.0.0" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.ProjectModel" version="3.0.0" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.Protocol" version="3.0.0" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.Resolver" version="3.0.0" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.Versioning" version="3.0.0" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.Commands" version="3.1.0" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.Common" version="3.1.0" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.Configuration" version="3.1.0" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.Credentials" version="3.1.0" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.DependencyResolver.Core" version="3.1.0" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.Frameworks" version="3.1.0" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.LibraryModel" version="3.1.0" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.PackageManagement" version="3.1.0" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.Packaging" version="3.1.0" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.ProjectModel" version="3.1.0" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.Protocol" version="3.1.0" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.Resolver" version="3.1.0" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.Versioning" version="3.1.0" targetFramework="net48" />
   <package id="log4net" version="2.0.12" targetFramework="net48" />
   <package id="Microsoft.CSharp" version="4.3.0" targetFramework="net48" />
   <package id="Microsoft.Web.Xdt" version="3.1.0" targetFramework="net48" />

--- a/src/chocolatey/chocolatey.csproj
+++ b/src/chocolatey/chocolatey.csproj
@@ -101,43 +101,43 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\AlphaFS.2.1.3\lib\net40\AlphaFS.dll</HintPath>
     </Reference>
-    <Reference Include="Chocolatey.NuGet.Commands, Version=3.0.0.258, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
+    <Reference Include="Chocolatey.NuGet.Commands">
       <HintPath>..\packages\Chocolatey.NuGet.Commands.3.0.0\lib\net472\Chocolatey.NuGet.Commands.dll</HintPath>
     </Reference>
-    <Reference Include="Chocolatey.NuGet.Common, Version=3.0.0.258, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
+    <Reference Include="Chocolatey.NuGet.Common">
       <HintPath>..\packages\Chocolatey.NuGet.Common.3.0.0\lib\net472\Chocolatey.NuGet.Common.dll</HintPath>
     </Reference>
-    <Reference Include="Chocolatey.NuGet.Configuration, Version=3.0.0.258, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
+    <Reference Include="Chocolatey.NuGet.Configuration">
       <HintPath>..\packages\Chocolatey.NuGet.Configuration.3.0.0\lib\net472\Chocolatey.NuGet.Configuration.dll</HintPath>
     </Reference>
-    <Reference Include="Chocolatey.NuGet.Credentials, Version=3.0.0.258, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
+    <Reference Include="Chocolatey.NuGet.Credentials">
       <HintPath>..\packages\Chocolatey.NuGet.Credentials.3.0.0\lib\net472\Chocolatey.NuGet.Credentials.dll</HintPath>
     </Reference>
-    <Reference Include="Chocolatey.NuGet.DependencyResolver.Core, Version=3.0.0.258, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
+    <Reference Include="Chocolatey.NuGet.DependencyResolver.Core">
       <HintPath>..\packages\Chocolatey.NuGet.DependencyResolver.Core.3.0.0\lib\net472\Chocolatey.NuGet.DependencyResolver.Core.dll</HintPath>
     </Reference>
-    <Reference Include="Chocolatey.NuGet.Frameworks, Version=3.0.0.258, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
+    <Reference Include="Chocolatey.NuGet.Frameworks">
       <HintPath>..\packages\Chocolatey.NuGet.Frameworks.3.0.0\lib\net472\Chocolatey.NuGet.Frameworks.dll</HintPath>
     </Reference>
-    <Reference Include="Chocolatey.NuGet.LibraryModel, Version=3.0.0.258, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
+    <Reference Include="Chocolatey.NuGet.LibraryModel">
       <HintPath>..\packages\Chocolatey.NuGet.LibraryModel.3.0.0\lib\net472\Chocolatey.NuGet.LibraryModel.dll</HintPath>
     </Reference>
-    <Reference Include="Chocolatey.NuGet.PackageManagement, Version=3.0.0.258, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
+    <Reference Include="Chocolatey.NuGet.PackageManagement">
       <HintPath>..\packages\Chocolatey.NuGet.PackageManagement.3.0.0\lib\net472\Chocolatey.NuGet.PackageManagement.dll</HintPath>
     </Reference>
-    <Reference Include="Chocolatey.NuGet.Packaging, Version=3.0.0.258, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
+    <Reference Include="Chocolatey.NuGet.Packaging">
       <HintPath>..\packages\Chocolatey.NuGet.Packaging.3.0.0\lib\net472\Chocolatey.NuGet.Packaging.dll</HintPath>
     </Reference>
-    <Reference Include="Chocolatey.NuGet.ProjectModel, Version=3.0.0.258, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
+    <Reference Include="Chocolatey.NuGet.ProjectModel">
       <HintPath>..\packages\Chocolatey.NuGet.ProjectModel.3.0.0\lib\net472\Chocolatey.NuGet.ProjectModel.dll</HintPath>
     </Reference>
-    <Reference Include="Chocolatey.NuGet.Protocol, Version=3.0.0.258, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
+    <Reference Include="Chocolatey.NuGet.Protocol">
       <HintPath>..\packages\Chocolatey.NuGet.Protocol.3.0.0\lib\net472\Chocolatey.NuGet.Protocol.dll</HintPath>
     </Reference>
-    <Reference Include="Chocolatey.NuGet.Resolver, Version=3.0.0.258, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
+    <Reference Include="Chocolatey.NuGet.Resolver">
       <HintPath>..\packages\Chocolatey.NuGet.Resolver.3.0.0\lib\net472\Chocolatey.NuGet.Resolver.dll</HintPath>
     </Reference>
-    <Reference Include="Chocolatey.NuGet.Versioning, Version=3.0.0.258, Culture=neutral, PublicKeyToken=fd112f53c3ab578c, processorArchitecture=MSIL">
+    <Reference Include="Chocolatey.NuGet.Versioning">
       <HintPath>..\packages\Chocolatey.NuGet.Versioning.3.0.0\lib\net472\Chocolatey.NuGet.Versioning.dll</HintPath>
     </Reference>
     <Reference Include="log4net, Version=2.0.12.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">

--- a/src/chocolatey/chocolatey.csproj
+++ b/src/chocolatey/chocolatey.csproj
@@ -102,43 +102,43 @@
       <HintPath>..\packages\AlphaFS.2.1.3\lib\net40\AlphaFS.dll</HintPath>
     </Reference>
     <Reference Include="Chocolatey.NuGet.Commands">
-      <HintPath>..\packages\Chocolatey.NuGet.Commands.3.0.0\lib\net472\Chocolatey.NuGet.Commands.dll</HintPath>
+      <HintPath>..\packages\Chocolatey.NuGet.Commands.3.1.0\lib\net472\Chocolatey.NuGet.Commands.dll</HintPath>
     </Reference>
     <Reference Include="Chocolatey.NuGet.Common">
-      <HintPath>..\packages\Chocolatey.NuGet.Common.3.0.0\lib\net472\Chocolatey.NuGet.Common.dll</HintPath>
+      <HintPath>..\packages\Chocolatey.NuGet.Common.3.1.0\lib\net472\Chocolatey.NuGet.Common.dll</HintPath>
     </Reference>
     <Reference Include="Chocolatey.NuGet.Configuration">
-      <HintPath>..\packages\Chocolatey.NuGet.Configuration.3.0.0\lib\net472\Chocolatey.NuGet.Configuration.dll</HintPath>
+      <HintPath>..\packages\Chocolatey.NuGet.Configuration.3.1.0\lib\net472\Chocolatey.NuGet.Configuration.dll</HintPath>
     </Reference>
     <Reference Include="Chocolatey.NuGet.Credentials">
-      <HintPath>..\packages\Chocolatey.NuGet.Credentials.3.0.0\lib\net472\Chocolatey.NuGet.Credentials.dll</HintPath>
+      <HintPath>..\packages\Chocolatey.NuGet.Credentials.3.1.0\lib\net472\Chocolatey.NuGet.Credentials.dll</HintPath>
     </Reference>
     <Reference Include="Chocolatey.NuGet.DependencyResolver.Core">
-      <HintPath>..\packages\Chocolatey.NuGet.DependencyResolver.Core.3.0.0\lib\net472\Chocolatey.NuGet.DependencyResolver.Core.dll</HintPath>
+      <HintPath>..\packages\Chocolatey.NuGet.DependencyResolver.Core.3.1.0\lib\net472\Chocolatey.NuGet.DependencyResolver.Core.dll</HintPath>
     </Reference>
     <Reference Include="Chocolatey.NuGet.Frameworks">
-      <HintPath>..\packages\Chocolatey.NuGet.Frameworks.3.0.0\lib\net472\Chocolatey.NuGet.Frameworks.dll</HintPath>
+      <HintPath>..\packages\Chocolatey.NuGet.Frameworks.3.1.0\lib\net472\Chocolatey.NuGet.Frameworks.dll</HintPath>
     </Reference>
     <Reference Include="Chocolatey.NuGet.LibraryModel">
-      <HintPath>..\packages\Chocolatey.NuGet.LibraryModel.3.0.0\lib\net472\Chocolatey.NuGet.LibraryModel.dll</HintPath>
+      <HintPath>..\packages\Chocolatey.NuGet.LibraryModel.3.1.0\lib\net472\Chocolatey.NuGet.LibraryModel.dll</HintPath>
     </Reference>
     <Reference Include="Chocolatey.NuGet.PackageManagement">
-      <HintPath>..\packages\Chocolatey.NuGet.PackageManagement.3.0.0\lib\net472\Chocolatey.NuGet.PackageManagement.dll</HintPath>
+      <HintPath>..\packages\Chocolatey.NuGet.PackageManagement.3.1.0\lib\net472\Chocolatey.NuGet.PackageManagement.dll</HintPath>
     </Reference>
     <Reference Include="Chocolatey.NuGet.Packaging">
-      <HintPath>..\packages\Chocolatey.NuGet.Packaging.3.0.0\lib\net472\Chocolatey.NuGet.Packaging.dll</HintPath>
+      <HintPath>..\packages\Chocolatey.NuGet.Packaging.3.1.0\lib\net472\Chocolatey.NuGet.Packaging.dll</HintPath>
     </Reference>
     <Reference Include="Chocolatey.NuGet.ProjectModel">
-      <HintPath>..\packages\Chocolatey.NuGet.ProjectModel.3.0.0\lib\net472\Chocolatey.NuGet.ProjectModel.dll</HintPath>
+      <HintPath>..\packages\Chocolatey.NuGet.ProjectModel.3.1.0\lib\net472\Chocolatey.NuGet.ProjectModel.dll</HintPath>
     </Reference>
     <Reference Include="Chocolatey.NuGet.Protocol">
-      <HintPath>..\packages\Chocolatey.NuGet.Protocol.3.0.0\lib\net472\Chocolatey.NuGet.Protocol.dll</HintPath>
+      <HintPath>..\packages\Chocolatey.NuGet.Protocol.3.1.0\lib\net472\Chocolatey.NuGet.Protocol.dll</HintPath>
     </Reference>
     <Reference Include="Chocolatey.NuGet.Resolver">
-      <HintPath>..\packages\Chocolatey.NuGet.Resolver.3.0.0\lib\net472\Chocolatey.NuGet.Resolver.dll</HintPath>
+      <HintPath>..\packages\Chocolatey.NuGet.Resolver.3.1.0\lib\net472\Chocolatey.NuGet.Resolver.dll</HintPath>
     </Reference>
     <Reference Include="Chocolatey.NuGet.Versioning">
-      <HintPath>..\packages\Chocolatey.NuGet.Versioning.3.0.0\lib\net472\Chocolatey.NuGet.Versioning.dll</HintPath>
+      <HintPath>..\packages\Chocolatey.NuGet.Versioning.3.1.0\lib\net472\Chocolatey.NuGet.Versioning.dll</HintPath>
     </Reference>
     <Reference Include="log4net, Version=2.0.12.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
       <HintPath>..\packages\log4net.2.0.12\lib\net45\log4net.dll</HintPath>

--- a/src/chocolatey/infrastructure.app/services/NugetService.cs
+++ b/src/chocolatey/infrastructure.app/services/NugetService.cs
@@ -2168,12 +2168,12 @@ Please see https://docs.chocolatey.org/en-us/troubleshooting for more
                                 localRepositorySource,
                                 null,
                                 null)));
-                    var uninstallationContext = new UninstallationContext(removeDependencies: config.ForceDependencies, forceRemove: config.Force);
+                    var uninstallationContext = new UninstallationContext(removeDependencies: config.ForceDependencies, forceRemove: config.Force, warnDependencyResolvingFailure: true);
 
                     ICollection<PackageIdentity> resolvedPackages = null;
                     try
                     {
-                        resolvedPackages = UninstallResolver.GetPackagesToBeUninstalled(installedPackage.Identity, localPackagesDependencyInfos, allPackagesIdentities, uninstallationContext);
+                        resolvedPackages = UninstallResolver.GetPackagesToBeUninstalled(installedPackage.Identity, localPackagesDependencyInfos, allPackagesIdentities, uninstallationContext, _nugetLogger);
                     }
                     catch (Exception ex)
                     {

--- a/src/chocolatey/packages.config
+++ b/src/chocolatey/packages.config
@@ -1,19 +1,19 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="AlphaFS" version="2.1.3" targetFramework="net40-Client" />
-  <package id="Chocolatey.NuGet.Commands" version="3.0.0" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.Common" version="3.0.0" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.Configuration" version="3.0.0" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.Credentials" version="3.0.0" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.DependencyResolver.Core" version="3.0.0" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.Frameworks" version="3.0.0" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.LibraryModel" version="3.0.0" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.PackageManagement" version="3.0.0" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.Packaging" version="3.0.0" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.ProjectModel" version="3.0.0" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.Protocol" version="3.0.0" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.Resolver" version="3.0.0" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.Versioning" version="3.0.0" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.Commands" version="3.1.0" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.Common" version="3.1.0" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.Configuration" version="3.1.0" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.Credentials" version="3.1.0" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.DependencyResolver.Core" version="3.1.0" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.Frameworks" version="3.1.0" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.LibraryModel" version="3.1.0" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.PackageManagement" version="3.1.0" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.Packaging" version="3.1.0" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.ProjectModel" version="3.1.0" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.Protocol" version="3.1.0" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.Resolver" version="3.1.0" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.Versioning" version="3.1.0" targetFramework="net48" />
   <package id="log4net" version="2.0.12" targetFramework="net48" />
   <package id="Microsoft.Bcl.HashCode" version="1.1.1" targetFramework="net48" />
   <package id="Microsoft.CodeAnalysis.BannedApiAnalyzers" version="3.3.3" targetFramework="net48" developmentDependency="true" />


### PR DESCRIPTION
## Description Of Changes

The changes in this pull request make use of the changes that have been added in Chocolatey's NuGet.Client to allow uninstalls of a package to continue even if one or more of its dependencies are referenced by a different package.
Additionally, there is also a change to the order of package uninstalls to try ensuring they are uninstalled in the correct order when multiple package names has been specified.

## Motivation and Context

This change was required so packages can uninstall themself with any dependencies that aren't referenced by other packages.
The change in the ordering was done to prevent warnings being outputted when they aren't needed by making sure that dependencies specified on the commandline are attempted after the parent package that was also specified (only possible if the dependency is a direct dependency of the package).

## Testing

#### Scenario 1

1. Run `choco install 7zip vlc -n`
2. Uninstall 7zip using `choco uninstall 7zip --force-dependencies -n`
3. Ensure warnings about `chocolatey-core.extension` and `chocolatey-compatibility.extension` is outputted.

#### Scenario 2

1. Run `choco install 7zip -n`
2. Uninstall a dependency using `choco uninstall chocolatey-core.extension`
3. Verify an error about not being able to uninstall package is shown.

### Scenario 3

1. Run `choco install 7zip -n`
2. Uninstall the packages using `choco uninstall 7zip.install 7zip -n`
3. Verify 7zip is attempted to uninstall first, and 7zip.install afterwards. This should be successful.

### Scenario 4

1. Run `choco install vlc -n`, and make sure no other packages that depend on `chocolatey-core.extension` or `chocolatey-compatibility.extension` is installed.
2. Uninstall a dependent package and main package using `choco uninstall chocolatey-core.extension vlc -n` (select no when prompted about metapackage uninstallation)
3. Verify vlc was uninstalled and `chocolatey-core.extension` failed to uninstall.

### Scenario 5

1. Run `choco install vlc -n`, and make sure no other packages that depend on `chocolatey-core.extension` or `chocolatey-compatibility.extension` is installed.
2. Uninstall the package using `choco uninstall chocolatey-core.extension vlc -n --force-dependencies`
3. Verify warning about `chocolatey-core.extension` is shown, and `vlc`, `vlc.install`, `choocolatey-core.extension` and `chocolatey-compatibilty.extension` was uninstalled

### Operating Systems Testing

1. Windows 10

## Change Types Made
<!-- Tick the boxes for the type of changes that have been made -->

* [x] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [x] Tests to cover my changes, have been added.
* [x] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue

- https://app.clickup.com/t/20540031/PROJ-623
- #508
