### PR TITLE
(#2902) Ensure Chocolatey's default TLS settings are used in PowerShell tasks

### DIFF
--- a/src/chocolatey/infrastructure.app/services/PowershellService.cs
+++ b/src/chocolatey/infrastructure.app/services/PowershellService.cs
@@ -185,7 +185,7 @@ namespace chocolatey.infrastructure.app.services
             // many issues in existing packages, including upgrading
             // Chocolatey from older POSH client due to log errors
             //$ErrorActionPreference = 'Stop';
-            return "[System.Threading.Thread]::CurrentThread.CurrentCulture = '';[System.Threading.Thread]::CurrentThread.CurrentUICulture = ''; & import-module -name '{0}';{2} & '{1}' {3}"
+            return "[System.Threading.Thread]::CurrentThread.CurrentCulture = '';[System.Threading.Thread]::CurrentThread.CurrentUICulture = '';[System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]::SystemDefault; & import-module -name '{0}';{2} & '{1}' {3}"
                 .FormatWith(
                     installerModule,
                     scriptRunner,


### PR DESCRIPTION
## Description Of Changes

- Added an explicit override to our PowerShell runner preamble to ensure TLS settings are correctly set to the SystemDefault.

## Motivation and Context

See #3123 for some context in terms of the rationale.

During testing we determined that some Windows PowerShell versions, for example the builds provided on Server 2019 and below, are configured to _override_ the system's TLS settings and force the settings to `Tls, Tls11, Tls12` (though the exact setting seems like it may depend on the Windows and/or Windows PowerShell version). As covered in the related issue and previous PR, this is explicitly enabled TLS downgrade attacks if the system has been hardened, and additionally prevents users from communicating with any servers that use TLS 1.3 for the duration of the PowerShell task during package operations.

## Testing

1. Build the Chocolatey CLI package
2. Install it on a Windows Server 2019 or older VM (PowerShell's default settings appear to be correct in Windows 11 / Server 2022 from what I could tell)
3. Attempt to install any package (I tested with `vlc` and `notepadplusplus`)
4. You should **not** see any warnings about Chocolatey having to reset the TLS back to SystemDefault.

### Operating Systems Testing

Windows Server 2019, 2022, and Windows 11.

## Change Types Made
<!-- Tick the boxes for the type of changes that have been made -->

* [x] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [x] All new and existing tests passed?
* [x] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue
<!-- Make sure you have raised an issue for this pull request before
continuing. -->

Follow up addition to fixes made for #2902

<!-- PLEASE REMOVE ALL COMMENTS BEFORE SUBMITTING -->
