### PR TITLE
(maint) Migrate 2.0.0 tests to 1.x

### DIFF
--- a/tests/chocolatey-tests/chocolatey.Tests.ps1
+++ b/tests/chocolatey-tests/chocolatey.Tests.ps1
@@ -231,6 +231,8 @@ exit $error.count
     # This is skipped when not run in CI because it modifies the local system.
     Context 'License warning is worded properly' -Tag FossOnly -Skip:((-not $env:TEST_KITCHEN) -or (-not (Test-ChocolateyVersionEqualOrHigherThan '1.0.0'))) {
         BeforeAll {
+            Restore-ChocolateyInstallSnapshot
+            Enable-ChocolateySource -Name hermes-setup
             $null = Invoke-Choco install chocolatey-license-business -y
             $Output = Invoke-Choco list -lo
         }
@@ -240,16 +242,17 @@ exit $error.count
         }
 
         It 'Should display warning' {
-            $Output.Lines | Should -Contain 'A valid chocolatey license was found, but the chocolatey.licensed.dll assembly could not be loaded:'
-            $Output.Lines | Should -Contain 'Ensure that the chocolatey.licensed.dll exists at the following path:'
-            $Output.Lines | Should -Contain 'To resolve this, install the Chocolatey Licensed Extension package with'
-            $Output.Lines | Should -Contain '`choco install chocolatey.extension`'
+            $Output.Lines | Should -Contain 'A valid chocolatey license was found, but the chocolatey.licensed.dll assembly could not be loaded:' -Because $Output.String
+            $Output.Lines | Should -Contain 'Ensure that the chocolatey.licensed.dll exists at the following path:' -Because $Output.String
+            $Output.Lines | Should -Contain 'To resolve this, install the Chocolatey Licensed Extension package with' -Because $Output.String
+            $Output.Lines | Should -Contain '`choco install chocolatey.extension`' -Because $Output.String
         }
     }
 
     # This is skipped when not run in CI because it modifies the local system.
     Context 'PowerShell Profile comments updated correctly' -Skip:((-not $env:TEST_KITCHEN) -or (-not (Test-ChocolateyVersionEqualOrHigherThan '1.0.0'))) {
         BeforeAll {
+            Restore-ChocolateyInstallSnapshot
             Remove-Item $Profile.CurrentUserCurrentHost -ErrorAction Ignore
             New-Item $Profile.CurrentUserCurrentHost -Force
             $chocolatey = (Invoke-Choco list chocolatey -lo -r --exact).Lines | ConvertFrom-ChocolateyOutput -Command List
@@ -325,7 +328,7 @@ exit $error.count
                 }
             }
 
-            Enable-ChocolateySource -Name local
+            Enable-ChocolateySource -Name hermes-setup
             $Output = Invoke-Choco install chocolatey -f --version $chocolatey.Version --no-progress
         }
 
@@ -368,6 +371,7 @@ exit $error.count
     ) -Skip:((-not $env:TEST_KITCHEN) -or (-not (Test-ChocolateyVersionEqualOrHigherThan '1.1.0'))) {
         BeforeAll {
             New-ChocolateyInstallSnapshot
+            Enable-ChocolateySource -Name hermes-setup
             $pwshInstall = Invoke-Choco install $_ -y
             $ChocoUnzipped = "$(Get-TempDirectory)$(New-Guid)"
             $modulePath = "$ChocoUnzipped/tools/chocolateySetup.psm1"

--- a/tests/chocolatey-tests/commands/choco-apikey.Tests.ps1
+++ b/tests/chocolatey-tests/commands/choco-apikey.Tests.ps1
@@ -1,4 +1,4 @@
-﻿param(
+param(
     # The command to test.
     [string[]]$Command = @(
         "apikey"
@@ -36,9 +36,42 @@ Describe "choco <_>" -ForEach $Command -Tag Chocolatey, ApiKeyCommand {
         }
     }
 
+    # Even though v1.x does not support explicit list command, it still functions as expected.
+    # As such we keep this test here to be comparable with v2.x
+    Context "Running $CurrentCommand list with no sources configured" {
+        BeforeAll {
+            $Output = Invoke-Choco $CurrentCommand list
+        }
+
+        It "Exits with Success (0)" {
+            $Output.ExitCode | Should -Be 0
+        }
+
+        It "Only displays chocolatey name with version" {
+
+            $Output.String | Should -Match "(?m)^$expectedLicenseHeader(\s*|\s*Chocolatey is not an official build.*)$"
+        }
+    }
+
     Context "Running $CurrentCommand with no sources configured with source parameter" {
         BeforeAll {
             $Output = Invoke-Choco $CurrentCommand --source "https://not-existing.test.com/api"
+        }
+
+        It "Exits with Success (0)" {
+            $Output.ExitCode | Should -Be 0
+        }
+
+        It "Only displays chocolatey name with version" {
+            $Output.String | Should -Match "(?m)^$expectedLicenseHeader(\s*|\s*Chocolatey is not an official build.*)$"
+        }
+    }
+
+    # Even though v1.x does not support explicit list command, it still functions as expected.
+    # As such we keep this test here to be comparable with v2.x
+    Context "Running $CurrentCommand list with no sources configured with source parameter" {
+        BeforeAll {
+            $Output = Invoke-Choco $CurrentCommand list --source "https://not-existing.test.com/api"
         }
 
         It "Exits with Success (0)" {
@@ -233,6 +266,30 @@ Describe "choco <_>" -ForEach $Command -Tag Chocolatey, ApiKeyCommand {
 
         It "Displays a message with the configured apikey" {
             $Output.Lines | Should -Contain "https://test.com/api - (Authenticated)"
+        }
+    }
+
+    # Even though v1.x does not support explicit list command, it still functions as expected.
+    # As such we keep this test here to be comparable with v2.x
+    Context "Returns configured apikey source by source name with list subcommand" {
+        BeforeAll {
+            $null = Invoke-Choco $CurrentCommand --key "test-api-key" --source "https://test.com/api"
+            $null = Invoke-Choco $CurrentCommand --key "test-api-key" --source "https://test.com/api/2"
+
+            $Output = Invoke-Choco $CurrentCommand list --source "https://test.com/api"
+        }
+
+        It "Exits with Success (0)" {
+            $Output.ExitCode | Should -Be 0
+        }
+
+        It "Displays chocolatey name with version" {
+            $Output.Lines | Should -Contain $expectedLicenseHeader
+        }
+
+        It "Displays a message with the configured apikey" {
+            $Output.Lines | Should -Contain "https://test.com/api - (Authenticated)"
+            $Output.Lines | Should -Not -Contain "https://test.com/api/2 - (Authenticated)"
         }
     }
 

--- a/tests/chocolatey-tests/commands/choco-apikey.Tests.ps1
+++ b/tests/chocolatey-tests/commands/choco-apikey.Tests.ps1
@@ -10,6 +10,7 @@ Import-Module helpers/common-helpers
 
 Describe "choco <_>" -ForEach $Command -Tag Chocolatey, ApiKeyCommand {
     BeforeAll {
+        Remove-NuGetPaths
         Initialize-ChocolateyTestInstall
         $CurrentCommand = $_
 
@@ -234,4 +235,7 @@ Describe "choco <_>" -ForEach $Command -Tag Chocolatey, ApiKeyCommand {
             $Output.Lines | Should -Contain "https://test.com/api - (Authenticated)"
         }
     }
+
+    # This needs to be the last test in this block, to ensure NuGet configurations aren't being created.
+    Test-NuGetPaths
 }

--- a/tests/chocolatey-tests/commands/choco-config.Tests.ps1
+++ b/tests/chocolatey-tests/commands/choco-config.Tests.ps1
@@ -2,6 +2,7 @@
 
 Describe "choco config" -Tag Chocolatey, ConfigCommand {
     BeforeAll {
+        Remove-NuGetPaths
         Initialize-ChocolateyTestInstall
         New-ChocolateyInstallSnapshot
 
@@ -352,4 +353,7 @@ Describe "choco config" -Tag Chocolatey, ConfigCommand {
             $value | Should -HaveCount 0
         }
     }
+
+    # This needs to be the last test in this block, to ensure NuGet configurations aren't being created.
+    Test-NuGetPaths
 }

--- a/tests/chocolatey-tests/commands/choco-export.Tests.ps1
+++ b/tests/chocolatey-tests/commands/choco-export.Tests.ps1
@@ -12,6 +12,7 @@ Describe "choco export" -Tag Chocolatey, ExportCommand {
     }
 
     BeforeAll {
+        Remove-NuGetPaths
         $expectedHeader = Get-ExpectedChocolateyHeader
         Initialize-ChocolateyTestInstall
 
@@ -466,4 +467,7 @@ Describe "choco export" -Tag Chocolatey, ExportCommand {
             $Output.Lines | Should -Contain "Export all currently installed packages to a file."
         }
     }
+
+    # This needs to be the last test in this block, to ensure NuGet configurations aren't being created.
+    Test-NuGetPaths
 }

--- a/tests/chocolatey-tests/commands/choco-feature.Tests.ps1
+++ b/tests/chocolatey-tests/commands/choco-feature.Tests.ps1
@@ -14,6 +14,7 @@ Describe "choco <_>" -ForEach $Command -Tag Chocolatey, FeatureCommand {
     }
 
     BeforeAll {
+        Remove-NuGetPaths
         $CommandUnderTest = $_
         Initialize-ChocolateyTestInstall
 
@@ -212,4 +213,7 @@ Describe "choco <_>" -ForEach $Command -Tag Chocolatey, FeatureCommand {
             $Output.String | Should -Match "Feature 'nonExistingFeature' not found"
         }
     }
+
+    # This needs to be the last test in this block, to ensure NuGet configurations aren't being created.
+    Test-NuGetPaths
 }

--- a/tests/chocolatey-tests/commands/choco-help.Tests.ps1
+++ b/tests/chocolatey-tests/commands/choco-help.Tests.ps1
@@ -27,6 +27,7 @@ Describe "choco help sections with command <_>" -ForEach $Command -Tag Chocolate
     }
 
     BeforeAll {
+        Remove-NuGetPaths
         $helpArgument = $_
         Initialize-ChocolateyTestInstall
         New-ChocolateyInstallSnapshot
@@ -90,4 +91,7 @@ Describe "choco help sections with command <_>" -ForEach $Command -Tag Chocolate
             $Output.Lines | Should -Contain "Options and Switches"
         }
     }
+
+    # This needs to be the last test in this block, to ensure NuGet configurations aren't being created.
+    Test-NuGetPaths
 }

--- a/tests/chocolatey-tests/commands/choco-help.Tests.ps1
+++ b/tests/chocolatey-tests/commands/choco-help.Tests.ps1
@@ -1,6 +1,6 @@
 ﻿param(
     # Which help command to test
-    [string[]]$Command = @(
+    [string[]]$HelpOptions = @(
         "--help"
         "-?"
         "-help"
@@ -17,11 +17,11 @@
 Import-Module helpers/common-helpers
 
 BeforeDiscovery {
-    $AllTopLevelCommands = (Invoke-Choco $Command[0]).Lines -match " \* (?<Command>\w+) -" -replace " \* (?<Command>\w+) -.+", '$1'
-    $TopLevelCommands = $AllTopLevelCommands.Where{$_ -notin $SkipCommand}
+    $AllTopLevelCommands = (Invoke-Choco $HelpOptions[0]).Lines -match "\* (?<Command>\w+) -" -replace "\* (?<Command>\w+) -.+", '${Command}'
+    $TopLevelCommands = $AllTopLevelCommands.Where{ $_ -notin $SkipCommand }
 }
 
-Describe "choco help sections with command <_>" -ForEach $Command -Tag Chocolatey, HelpCommand {
+Describe "choco help sections with option <_>" -ForEach $HelpOptions -Tag Chocolatey, HelpCommand {
     BeforeDiscovery {
         $helpArgument = $_
     }
@@ -30,7 +30,9 @@ Describe "choco help sections with command <_>" -ForEach $Command -Tag Chocolate
         Remove-NuGetPaths
         $helpArgument = $_
         Initialize-ChocolateyTestInstall
-        New-ChocolateyInstallSnapshot
+
+        # We're just testing help output here, we don't need to copy config/package files
+        New-ChocolateyInstallSnapshot -NoSnapshotCopy
     }
 
     AfterAll {
@@ -39,7 +41,7 @@ Describe "choco help sections with command <_>" -ForEach $Command -Tag Chocolate
 
     Context "Top Level Help" {
         BeforeAll {
-            $Output = Invoke-Choco $_ $helpArgument
+            $Output = Invoke-Choco $_
         }
 
         It "Exits with Success (0)" {

--- a/tests/chocolatey-tests/commands/choco-info.Tests.ps1
+++ b/tests/chocolatey-tests/commands/choco-info.Tests.ps1
@@ -23,6 +23,7 @@ Describe "choco info" -Tag Chocolatey, InfoCommand {
         }
 
         BeforeAll {
+            Remove-NuGetPaths
             $Output = Invoke-Choco info mvcmusicstore-web
             $Output.Lines = $Output.Lines
         }
@@ -162,4 +163,7 @@ Describe "choco info" -Tag Chocolatey, InfoCommand {
             $Output.Lines | Should -Contain "Side by side installations are deprecated and is pending removal in v2.0.0." -Because $Output.String
         }
     }
+
+    # This needs to be the last test in this block, to ensure NuGet configurations aren't being created.
+    Test-NuGetPaths
 }

--- a/tests/chocolatey-tests/commands/choco-info.Tests.ps1
+++ b/tests/chocolatey-tests/commands/choco-info.Tests.ps1
@@ -177,8 +177,8 @@ Describe "choco info" -Tag Chocolatey, InfoCommand {
             $Output.ExitCode | Should -Be 0
         }
 
-        It 'Outputs warning about unable to load service index' {
-            $Output.Lines | Should -Contain 'Error retrieving packages from source 'https://invalid.chocolatey.org/api/v2/':'
+        It 'Outputs warning about unable to retrieve packages from source' {
+            $Output.String | Should -Match 'Error retrieving packages from source 'https://invalid.chocolatey.org/api/v2/':'
         }
 
         It 'Output information about the package' {

--- a/tests/chocolatey-tests/commands/choco-info.Tests.ps1
+++ b/tests/chocolatey-tests/commands/choco-info.Tests.ps1
@@ -164,6 +164,28 @@ Describe "choco info" -Tag Chocolatey, InfoCommand {
         }
     }
 
+    Context "Listing package information when invalid package source is being used" {
+        BeforeAll {
+            Restore-ChocolateyInstallSnapshot
+
+            $null = Invoke-Choco source add -n "invalid" -s "https://invalid.chocolatey.org/api/v2/"
+
+            $Output = Invoke-Choco info chocolatey
+        }
+
+        It 'Exits with Success (0)' {
+            $Output.ExitCode | Should -Be 0
+        }
+
+        It 'Outputs warning about unable to load service index' {
+            $Output.Lines | Should -Contain 'Error retrieving packages from source 'https://invalid.chocolatey.org/api/v2/':'
+        }
+
+        It 'Output information about the package' {
+            $Output.String | Should -Match "Title: Chocolatey "
+        }
+    }
+
     # This needs to be the last test in this block, to ensure NuGet configurations aren't being created.
     Test-NuGetPaths
 }

--- a/tests/chocolatey-tests/commands/choco-info.Tests.ps1
+++ b/tests/chocolatey-tests/commands/choco-info.Tests.ps1
@@ -6,6 +6,7 @@ Describe "choco info" -Tag Chocolatey, InfoCommand {
     }
 
     BeforeAll {
+        Remove-NuGetPaths
         Initialize-ChocolateyTestInstall
     }
 
@@ -23,7 +24,6 @@ Describe "choco info" -Tag Chocolatey, InfoCommand {
         }
 
         BeforeAll {
-            Remove-NuGetPaths
             $Output = Invoke-Choco info mvcmusicstore-web
             $Output.Lines = $Output.Lines
         }

--- a/tests/chocolatey-tests/commands/choco-install.Tests.ps1
+++ b/tests/chocolatey-tests/commands/choco-install.Tests.ps1
@@ -14,6 +14,7 @@ Describe "choco install" -Tag Chocolatey, InstallCommand {
     }
 
     BeforeAll {
+        Remove-NuGetPaths
         Initialize-ChocolateyTestInstall
 
         New-ChocolateyInstallSnapshot
@@ -1636,4 +1637,7 @@ Describe "choco install" -Tag Chocolatey, InstallCommand {
             $prompts.Count | Should -Be 1
         }
     }
+
+    # This needs to be the last test in this block, to ensure NuGet configurations aren't being created.
+    Test-NuGetPaths
 }

--- a/tests/chocolatey-tests/commands/choco-install.Tests.ps1
+++ b/tests/chocolatey-tests/commands/choco-install.Tests.ps1
@@ -1467,6 +1467,7 @@ Describe "choco install" -Tag Chocolatey, InstallCommand {
     Context "Installing license only package on open source" -Tag FossOnly {
         BeforeAll {
             New-ChocolateyInstallSnapshot
+            Enable-ChocolateySource -Name hermes-setup
 
             $Output = Invoke-Choco install business-only-license --confirm
         }
@@ -1645,7 +1646,7 @@ Describe "choco install" -Tag Chocolatey, InstallCommand {
         BeforeAll {
             $paths = Restore-ChocolateyInstallSnapshot
 
-            $Output = Invoke-Choco install install-chocolateyzip --version 3.21.2 --confirm "$_" "$($paths.CachePathLong)" --no-progress
+            $Output = Invoke-Choco install install-chocolateyzip --version 3.21.2 --confirm "$_" "$($paths.CachePath)" --no-progress
         }
 
         AfterAll {
@@ -1677,7 +1678,7 @@ Describe "choco install" -Tag Chocolatey, InstallCommand {
             $testMessage = if ($features.License) {
                 "Extracting cmake-3.21.2-windows-x86_64.zip to $env:ChocolateyInstall\lib\install-chocolateyzip\tools..."
             } else {
-                "Extracting $($paths.CachePathLong)\install-chocolateyzip\3.21.2\cmake-3.21.2-windows-x86_64.zip to $env:ChocolateyInstall\lib\install-chocolateyzip\tools..."
+                "Extracting $($paths.CachePath)\install-chocolateyzip\3.21.2\cmake-3.21.2-windows-x86_64.zip to $env:ChocolateyInstall\lib\install-chocolateyzip\tools..."
             }
             $Output.Lines | Should -Contain $testMessage -Because $Output.String
         }
@@ -1697,7 +1698,7 @@ Describe "choco install" -Tag Chocolatey, InstallCommand {
 
         It 'Should have cached installed directory in custom cache' {
             # Need to be verified, but the file may not exist on licensed edition
-            "$($paths.CachePathLong)\install-chocolateyzip\3.21.2\cmake-3.21.2-windows-x86_64.zip" | Should -Exist
+            "$($paths.CachePath)\install-chocolateyzip\3.21.2\cmake-3.21.2-windows-x86_64.zip" | Should -Exist
         }
 
         It 'Installed software to expected directory' {
@@ -1823,7 +1824,7 @@ Describe "choco install" -Tag Chocolatey, InstallCommand {
         }
 
         It 'Outputs warning about unable to load service index' {
-            $Output.Lines | Should -Contain 'Unable to load the service index for source https://invalid.com/api/v2/.'
+            $Output.String | Should -Match "Error retrieving packages from source 'https://invalid.chocolatey.org/api/v2/':"
         }
 
         It 'Outputs successful installation of single package' {

--- a/tests/chocolatey-tests/commands/choco-install.Tests.ps1
+++ b/tests/chocolatey-tests/commands/choco-install.Tests.ps1
@@ -1638,6 +1638,199 @@ Describe "choco install" -Tag Chocolatey, InstallCommand {
         }
     }
 
+    # We are marking this test as internal, as the package we need to make use
+    # of downloads a zip archive from a internal server, and the package is also
+    # only located on an internal feed.
+    Context "Installing package while specifying a cache location (Arg: <_>)" -ForEach '-c', '--cache', '--cachelocation', '--cache-location' -Tag Internal, LongPaths, CacheLocation {
+        BeforeAll {
+            $paths = Restore-ChocolateyInstallSnapshot
+
+            $Output = Invoke-Choco install install-chocolateyzip --version 3.21.2 --confirm "$_" "$($paths.CachePathLong)" --no-progress
+        }
+
+        AfterAll {
+            $null = Invoke-Choco uninstall install-chocolateyzip --confirm
+        }
+
+        It 'Exits with Success (0)' {
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
+        }
+
+        It 'Runs under background Service' -Tag Background {
+            $Output.Lines | Should -Contain 'Running in background mode' -Because $Output.String
+        }
+
+        It 'Outputs downloading 64bit package' {
+            $Output.Lines | Should -Contain 'Downloading install-chocolateyzip 64 bit' -Because $Output.String
+        }
+
+        It 'Outputs download completed' {
+            $testMessage = if ($features.License) {
+                "Download of 'cmake-3.21.2-windows-x86_64.zip' (36.01 MB) completed."
+            } else {
+                "Download of cmake-3.21.2-windows-x86_64.zip (36.01 MB) completed."
+            }
+            $Output.Lines | Should -Contain $testMessage -Because $Output.String
+        }
+
+        It 'Outputs extracting correct archive' {
+            $testMessage = if ($features.License) {
+                "Extracting cmake-3.21.2-windows-x86_64.zip to $env:ChocolateyInstall\lib\install-chocolateyzip\tools..."
+            } else {
+                "Extracting $($paths.CachePathLong)\install-chocolateyzip\3.21.2\cmake-3.21.2-windows-x86_64.zip to $env:ChocolateyInstall\lib\install-chocolateyzip\tools..."
+            }
+            $Output.Lines | Should -Contain $testMessage -Because $Output.String
+        }
+
+        It 'Created shim for <_>' -ForEach 'cmake-gui.exe', 'cmake.exe', 'cmcldeps.exe', 'cpack.exe', 'ctest.exe' {
+            $Output.Lines | Should -Contain "ShimGen has successfully created a shim for $_"
+            "$env:ChocolateyInstall\bin\$_" | Should -Exist
+        }
+
+        It 'Outputs installation was successful' {
+            $Output.Lines | Should -Contain 'The install of install-chocolateyzip was successful.' -Because $Output.String
+        }
+
+        It 'Outputs software installation directory' {
+            $Output.Lines | Should -Contain "Software installed to '$env:ChocolateyInstall\lib\install-chocolateyzip\tools'" -Because $Output.String
+        }
+
+        It 'Should have cached installed directory in custom cache' {
+            # Need to be verified, but the file may not exist on licensed edition
+            "$($paths.CachePathLong)\install-chocolateyzip\3.21.2\cmake-3.21.2-windows-x86_64.zip" | Should -Exist
+        }
+
+        It 'Installed software to expected directory' {
+            "$env:ChocolateyInstall\lib\install-chocolateyzip\tools\cmake-3.21.2-windows-x86_64\bin\cmake.exe" | Should -Exist
+        }
+    }
+
+    Context 'Installing a package while passing in an uppercase letter as the identifier' {
+        BeforeAll {
+            Restore-ChocolateyInstallSnapshot
+
+            $Output = Invoke-Choco install IsDependency --confirm
+        }
+
+        It 'Exits with Success (0)' {
+            $Output.ExitCode | Should -Be 0
+        }
+
+        It 'Installs package to expected directory' {
+            "$env:ChocolateyInstall\lib\isdependency\isdependency.nuspec" | Should -Exist
+        }
+
+        It 'Outputs installation was successful' {
+            $Output.Lines | Should -Contain 'The install of isdependency was successful.' -Because $Output.String
+        }
+
+        It "Installs the expected version of the package" {
+            "$env:ChocolateyInstall\lib\isdependency\isdependency.nuspec" | Should -Exist
+            [xml]$XML = Get-Content "$env:ChocolateyInstall\lib\isdependency\isdependency.nuspec"
+            $XML.package.metadata.version | Should -Be "2.1.0"
+        }
+    }
+
+    Context 'Installing a package while passing in an uppercase letter as the identifier (Repository optimization disabled)' {
+        BeforeAll {
+            Restore-ChocolateyInstallSnapshot
+
+            $Output = Invoke-Choco install IsDependency --confirm --disable-repository-optimizations
+        }
+
+        It 'Exits with Success (0)' {
+            $Output.ExitCode | Should -Be 0
+        }
+
+        It 'Installs package to expected directory' {
+            "$env:ChocolateyInstall\lib\isdependency\isdependency.nuspec" | Should -Exist
+        }
+
+        It 'Outputs installation was successful' {
+            $Output.Lines | Should -Contain 'The install of isdependency was successful.' -Because $Output.String
+        }
+
+        It "Installs the expected version of the package" {
+            "$env:ChocolateyInstall\lib\isdependency\isdependency.nuspec" | Should -Exist
+            [xml]$XML = Get-Content "$env:ChocolateyInstall\lib\isdependency\isdependency.nuspec"
+            $XML.package.metadata.version | Should -Be "2.1.0"
+        }
+    }
+
+    Context 'Installing a package while passing in an uppercase letter as the identifier and specific version' {
+        BeforeAll {
+            Restore-ChocolateyInstallSnapshot
+
+            $Output = Invoke-Choco install IsDependency --confirm --disable-repository-optimizations --version 1.0.0
+        }
+
+        It 'Exits with Success (0)' {
+            $Output.ExitCode | Should -Be 0
+        }
+
+        It 'Installs package to expected directory' {
+            "$env:ChocolateyInstall\lib\isdependency\isdependency.nuspec" | Should -Exist
+        }
+
+        It 'Outputs installation was successful' {
+            $Output.Lines | Should -Contain 'The install of isdependency was successful.' -Because $Output.String
+        }
+
+        It "Installs the expected version of the package" {
+            "$env:ChocolateyInstall\lib\isdependency\isdependency.nuspec" | Should -Exist
+            [xml]$XML = Get-Content "$env:ChocolateyInstall\lib\isdependency\isdependency.nuspec"
+            $XML.package.metadata.version | Should -Be "1.0.0"
+        }
+    }
+
+    Context 'Installing a package while passing in an uppercase letter as the identifier and specific version (Repository optimization disabled)' {
+        BeforeAll {
+            Restore-ChocolateyInstallSnapshot
+
+            $Output = Invoke-Choco install IsDependency --confirm --disable-repository-optimizations --version 1.0.0
+        }
+
+        It 'Exits with Success (0)' {
+            $Output.ExitCode | Should -Be 0
+        }
+
+        It 'Installs package to expected directory' {
+            "$env:ChocolateyInstall\lib\isdependency\isdependency.nuspec" | Should -Exist
+        }
+
+        It 'Outputs installation was successful' {
+            $Output.Lines | Should -Contain 'The install of isdependency was successful.' -Because $Output.String
+        }
+
+        It "Installs the expected version of the package" {
+            "$env:ChocolateyInstall\lib\isdependency\isdependency.nuspec" | Should -Exist
+            [xml]$XML = Get-Content "$env:ChocolateyInstall\lib\isdependency\isdependency.nuspec"
+            $XML.package.metadata.version | Should -Be "1.0.0"
+        }
+    }
+
+    Context "Installing a package when invalid package source is being used" {
+        BeforeAll {
+            Restore-ChocolateyInstallSnapshot
+
+            $null = Invoke-Choco source add -n "invalid" -s "https://invalid.chocolatey.org/api/v2/"
+
+            $Output = Invoke-Choco install installpackage --confirm
+        }
+
+        It 'Exits with Success (0)' {
+            $Output.ExitCode | Should -Be 0
+        }
+
+        It 'Outputs warning about unable to load service index' {
+            $Output.Lines | Should -Contain 'Unable to load the service index for source https://invalid.com/api/v2/.'
+        }
+
+        It 'Outputs successful installation of single package' {
+            $Output.Lines | Should -Contain 'Chocolatey installed 1/1 packages.'
+        }
+    }
+
     # This needs to be the last test in this block, to ensure NuGet configurations aren't being created.
     Test-NuGetPaths
 }

--- a/tests/chocolatey-tests/commands/choco-list.Tests.ps1
+++ b/tests/chocolatey-tests/commands/choco-list.Tests.ps1
@@ -22,6 +22,7 @@ Describe "choco <_>" -ForEach $Command -Tag Chocolatey, ListCommand, SearchComma
     }
 
     BeforeAll {
+        Remove-NuGetPaths
         Initialize-ChocolateyTestInstall -Source $PSScriptRoot\testpackages
         Invoke-Choco install installpackage --version 1.0.0 --confirm
         Invoke-Choco install upgradepackage --version 1.0.0 --confirm
@@ -428,4 +429,8 @@ Describe "choco <_>" -ForEach $Command -Tag Chocolatey, ListCommand, SearchComma
             $Output.Lines | Should -Contain 'The `webpi` source is deprecated and will be removed in Chocolatey v2.0.0.' -Because $Output.String
         }
     }
+
+
+    # This needs to be the last test in this block, to ensure NuGet configurations aren't being created.
+    Test-NuGetPaths
 }

--- a/tests/chocolatey-tests/commands/choco-list.Tests.ps1
+++ b/tests/chocolatey-tests/commands/choco-list.Tests.ps1
@@ -430,6 +430,28 @@ Describe "choco <_>" -ForEach $Command -Tag Chocolatey, ListCommand, SearchComma
         }
     }
 
+    Context "Searching for package when invalid package source is being used" {
+        BeforeAll {
+            Restore-ChocolateyInstallSnapshot
+
+            $null = Invoke-Choco source add -n "invalid" -s "https://invalid.chocolatey.org/api/v2/"
+
+            $Output = Invoke-Choco search dependency
+        }
+
+        It 'Exits with Success (0)' {
+            $Output.ExitCode | Should -Be 0
+        }
+
+        It 'Outputs warning about unable to load service index' {
+            $Output.Lines | Should -Match "Not able to contact source 'https://invalid.chocolatey.org.com/api/v2/'."
+        }
+
+        It 'Outputs the results of the search' {
+            $Output.Lines | Should -Contain 'hasrebootdependency 1.0.0'
+        }
+    }
+
 
     # This needs to be the last test in this block, to ensure NuGet configurations aren't being created.
     Test-NuGetPaths

--- a/tests/chocolatey-tests/commands/choco-list.Tests.ps1
+++ b/tests/chocolatey-tests/commands/choco-list.Tests.ps1
@@ -443,8 +443,8 @@ Describe "choco <_>" -ForEach $Command -Tag Chocolatey, ListCommand, SearchComma
             $Output.ExitCode | Should -Be 0
         }
 
-        It 'Outputs warning about unable to load service index' {
-            $Output.Lines | Should -Match "Not able to contact source 'https://invalid.chocolatey.org.com/api/v2/'."
+        It 'Outputs warning about unable to contact source' {
+            $Output.String | Should -Match "Not able to contact source 'https://invalid.chocolatey.org/api/v2/'." -Because $Output.String
         }
 
         It 'Outputs the results of the search' {

--- a/tests/chocolatey-tests/commands/choco-new.Tests.ps1
+++ b/tests/chocolatey-tests/commands/choco-new.Tests.ps1
@@ -17,6 +17,7 @@ $EmptyFolders = @(
 )
 Describe "choco new" -Tag Chocolatey, NewCommand {
     BeforeAll {
+        Remove-NuGetPaths
         Initialize-ChocolateyTestInstall
 
         $expectedHeader = Get-ExpectedChocolateyHeader
@@ -157,4 +158,7 @@ Describe "choco new" -Tag Chocolatey, NewCommand {
             "$PWD\emptyfolder\$_" | Should -Exist
         }
     }
+
+    # This needs to be the last test in this block, to ensure NuGet configurations aren't being created.
+    Test-NuGetPaths
 }

--- a/tests/chocolatey-tests/commands/choco-outdated.Tests.ps1
+++ b/tests/chocolatey-tests/commands/choco-outdated.Tests.ps1
@@ -2,6 +2,7 @@
 
 Describe "choco outdated" -Tag Chocolatey, OutdatedCommand {
     BeforeAll {
+        Remove-NuGetPaths
         Initialize-ChocolateyTestInstall
         # Pin all of the Chocolatey packages
         @(
@@ -41,4 +42,7 @@ Describe "choco outdated" -Tag Chocolatey, OutdatedCommand {
             $Output.Lines | Should -Not:($ExitCode -eq 0) -Contain 'upgradepackage|1.0.0|1.1.0|true'
         }
     }
+
+    # This needs to be the last test in this block, to ensure NuGet configurations aren't being created.
+    Test-NuGetPaths
 }

--- a/tests/chocolatey-tests/commands/choco-pack.Tests.ps1
+++ b/tests/chocolatey-tests/commands/choco-pack.Tests.ps1
@@ -26,6 +26,7 @@ $invalidFailures = @(
 
 Describe "choco pack" -Tag Chocolatey, PackCommand {
     BeforeAll {
+        Remove-NuGetPaths
         $testPackageLocation = "$(Get-TempDirectory)ChocolateyTests\packages"
         Initialize-ChocolateyTestInstall -Source $testPackageLocation
 
@@ -367,4 +368,7 @@ Describe "choco pack" -Tag Chocolatey, PackCommand {
             "$PWD\archiveContents\tools\purpose.txt" | Should -Exist
         }
     }
+
+    # This needs to be the last test in this block, to ensure NuGet configurations aren't being created.
+    Test-NuGetPaths
 }

--- a/tests/chocolatey-tests/commands/choco-pin.Tests.ps1
+++ b/tests/chocolatey-tests/commands/choco-pin.Tests.ps1
@@ -4,6 +4,7 @@
 
 Describe "choco pin" -Tag Chocolatey, PinCommand {
     BeforeAll {
+        Remove-NuGetPaths
         $testPackageLocation = "$(Get-TempDirectory)ChocolateyTests\packages"
         Initialize-ChocolateyTestInstall -Source $testPackageLocation
 
@@ -185,4 +186,7 @@ Describe "choco pin" -Tag Chocolatey, PinCommand {
             $Output.Lines | Should -Contain "Unable to find package named 'whatisthis' to pin. Please check to ensure it is installed."
         }
     }
+
+    # This needs to be the last test in this block, to ensure NuGet configurations aren't being created.
+    Test-NuGetPaths
 }

--- a/tests/chocolatey-tests/commands/choco-push.Tests.ps1
+++ b/tests/chocolatey-tests/commands/choco-push.Tests.ps1
@@ -128,3 +128,93 @@ Describe "choco push" -Tag Chocolatey, PushCommand, ProxySkip -Skip:($null -eq $
     # This needs to be the last test in this block, to ensure NuGet configurations aren't being created.
     Test-NuGetPaths
 }
+
+Describe 'choco push nuget <_> repository' -Tag Chocolatey, PushCommand -Skip:($null -eq $env:NUGET_SOURCE_USERNAME -or $null -eq $env:NUGET_SOURCE_PASSWORD -or $null -eq $env:NUGET_API_KEY -or $null -eq $env:NUGET_PUSH_REPO) -ForEach @('v2', 'v3') {
+    BeforeDiscovery {
+        $TestCases = @(
+            @{ Wording = 'using config' ; UseConfig = $true }
+            @{ Wording = 'using command line parameters' ; UseConfig = $false }
+        )
+    }
+
+    BeforeAll {
+        $RepositoryEndpoint = switch ($_) {
+            'v2' { '' }
+        }
+
+        $ApiKey = $env:NUGET_API_KEY
+        $RepositoryToUse = $env:NUGET_PUSH_REPO
+
+        Initialize-ChocolateyTestInstall
+
+        New-ChocolateyInstallSnapshot
+    }
+
+    AfterAll {
+        Remove-ChocolateyTestInstall
+    }
+
+    Context "Pushing package successfully <Wording>" -ForEach $TestCases {
+        BeforeAll {
+            $snapshotPath = New-ChocolateyInstallSnapshot
+            $PackageUnderTest = "chocolatey-dummy-package"
+            $TestPath = "$PSScriptRoot\testpackages"
+            $VersionUnderTest = '1.0.0'
+            $AddedVersion = "a$(((New-Guid) -split '-')[0])"
+            $NewChocolateyTestPackage = @{
+                TestPath     = $TestPath
+                Name         = $PackageUnderTest
+                Version      = $VersionUnderTest
+                AddedVersion = $AddedVersion
+            }
+            $PackagePath = New-ChocolateyTestPackage @NewChocolateyTestPackage
+
+            if ($UseConfig) {
+                $null = Invoke-Choco apikey add --source $RepositoryToUse$RepositoryEndpoint --api-key $ApiKey
+                # Ensure the key is null (should always be, but scoping can be wonky)
+                $KeyParameter = $null
+            } else {
+                # PowerShell requires this for reasons that only PowerShell knows
+                $KeyParameter = @("--api-key", $ApiKey)
+            }
+
+            $Output = Invoke-Choco push $PackagePath --source $RepositoryToUse$RepositoryEndpoint @KeyParameter
+
+            $VerifyPackagesSplat = @(
+                "--pre"
+                "--source"
+                "$RepositoryToUse$RepositoryEndpoint"
+                "--user"
+                $env:NUGET_SOURCE_USERNAME
+                "--password"
+                $env:NUGET_SOURCE_PASSWORD
+                "--version"
+                "$VersionUnderTest-$AddedVersion"
+            )
+
+            # Nexus can take a moment to index the package, but we want to validate that it was successfully pushed
+            $Timer =  [System.Diagnostics.Stopwatch]::StartNew()
+            while ($Timer.Elapsed.TotalSeconds -lt 300 -and -not (
+                $Packages = (Invoke-Choco find $PackageUnderTest @VerifyPackagesSplat --Limit-Output).Lines | ConvertFrom-ChocolateyOutput -Command List
+            )) {
+                Write-Verbose "$($PackageUnderTest) was not found on $($RepositoryToUse)$($RepositoryEndpoint). Waiting for 5 seconds before trying again."
+                Start-Sleep -Seconds 5
+            }
+        }
+
+        AfterAll {
+            if ($Packages) {
+                $null = Invoke-Choco install nuget.commandline -y
+                & "$env:ChocolateyInstall/bin/nuget.exe" delete $PackageUnderTest "$VersionUnderTest-$AddedVersion" -Source $RepositoryToUse -ApiKey $ApiKey -NonInteractive
+            }
+        }
+
+        It 'Exits with Success (0)' {
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
+        }
+
+        It 'Successfully pushed the package to the repository' {
+            $Packages | Should -Not -BeNullOrEmpty -Because "Package $PackageUnderTest with version '$VersionUnderTest-$AddedVersion' should be found on $RepositoryToUse$RepositoryEndpoint"
+        }
+    }
+}

--- a/tests/chocolatey-tests/commands/choco-push.Tests.ps1
+++ b/tests/chocolatey-tests/commands/choco-push.Tests.ps1
@@ -13,6 +13,7 @@ Describe "choco push" -Tag Chocolatey, PushCommand, ProxySkip -Skip:($null -eq $
     }
 
     BeforeAll {
+        Remove-NuGetPaths
         # Ideally this comes from an environment variable, but that's proving harder to put into the tests than is desired.
         $ApiKey = $env:API_KEY
         # Using Chocolatey Community Repository for pushing as choco-test could be blown away at any time, and we'd have to reset up the user and packages.
@@ -123,4 +124,7 @@ Describe "choco push" -Tag Chocolatey, PushCommand, ProxySkip -Skip:($null -eq $
             $Output.Lines | Should -Contain "The remote server returned an error: (409) Conflict.."
         }
     }
+
+    # This needs to be the last test in this block, to ensure NuGet configurations aren't being created.
+    Test-NuGetPaths
 }

--- a/tests/chocolatey-tests/commands/choco-source.Tests.ps1
+++ b/tests/chocolatey-tests/commands/choco-source.Tests.ps1
@@ -10,6 +10,7 @@ Import-Module helpers/common-helpers
 
 Describe "choco <_>" -ForEach $Command -Tag Chocolatey, SourceCommand {
     BeforeAll {
+        Remove-NuGetPaths
         Initialize-ChocolateyTestInstall
         New-ChocolateyInstallSnapshot
 
@@ -425,4 +426,7 @@ Describe "choco <_>" -ForEach $Command -Tag Chocolatey, SourceCommand {
             $Output.Lines | Should -Contain "Nothing to change. Config already set."
         }
     }
+
+    # This needs to be the last test in this block, to ensure NuGet configurations aren't being created.
+    Test-NuGetPaths
 }

--- a/tests/chocolatey-tests/commands/choco-template.Tests.ps1
+++ b/tests/chocolatey-tests/commands/choco-template.Tests.ps1
@@ -9,6 +9,7 @@ Describe "choco <_>" -ForEach @(
     }
 
     BeforeAll {
+        Remove-NuGetPaths
         Initialize-ChocolateyTestInstall
 
         New-ChocolateyInstallSnapshot
@@ -296,4 +297,7 @@ Describe "choco <_>" -ForEach @(
             "$env:ChocolateyInstall\templates\$_\.parameters" | Should -Exist
         }
     }
+
+    # This needs to be the last test in this block, to ensure NuGet configurations aren't being created.
+    Test-NuGetPaths
 }

--- a/tests/chocolatey-tests/commands/choco-uninstall.Tests.ps1
+++ b/tests/chocolatey-tests/commands/choco-uninstall.Tests.ps1
@@ -1,4 +1,4 @@
-Import-Module helpers/common-helpers
+﻿Import-Module helpers/common-helpers
 
 Describe "choco uninstall" -Tag Chocolatey, UninstallCommand {
     BeforeAll {
@@ -63,7 +63,172 @@ Describe "choco uninstall" -Tag Chocolatey, UninstallCommand {
             'Package Path in Uninstall Script: <installPath>\lib\test-chocolateypath'
             'Install Path in Uninstall Script: <installPath>'
         ) {
-            $Output.Lines | Should -Contain ($_ -replace '<installPath>',$env:ChocolateyInstall) -Because $Output.String
+            $Output.Lines | Should -Contain ($_ -replace '<installPath>', $env:ChocolateyInstall) -Because $Output.String
+        }
+    }
+
+    Context "Uninstalling a package when chocolateyBeforeModify fails" {
+        BeforeAll {
+            Restore-ChocolateyInstallSnapshot
+
+            $null = Invoke-Choco install upgradepackage --version 1.0.0 --confirm
+
+            $Output = Invoke-Choco uninstall upgradepackage --confirm
+        }
+
+        # Broken since v1.0.0
+        It "Exits with Success (0)" -Tag Broken {
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
+        }
+
+        It "Should have removed lib package directory" {
+            "$env:ChocolateyInstall\lib\upgradepackage" | Should -Not -Exist
+        }
+
+        It "Should not have created lib-bad directory" {
+            "$env:ChocolateyInstall\lib-bad\upgradepackage" | Should -Not -Exist
+        }
+
+        It "Should have removed lib-bkp directory" {
+            "$env:ChocolateyInstall\lib-bkp\upgradepackage" | Should -Not -Exist
+        }
+
+        It "Outputs Successful uninstall" {
+            $Output.Lines | Should -Contain "Chocolatey uninstalled 1/1 packages."
+        }
+    }
+
+    Context "Uninstalling a package with a failing uninstall script" {
+        BeforeAll {
+            Restore-ChocolateyInstallSnapshot
+
+            $null = Invoke-Choco install uninstallfailure --confirm --no-progress
+
+            "Test file" | Out-File "$env:ChocolateyInstall\lib\uninstallfailure\test-file.txt"
+
+            $Output = Invoke-Choco uninstall uninstallfailure --confirm
+        }
+
+        It "Exits with Failure (-1)" {
+            $Output.ExitCode | Should -Be -1 -Because $Output.String
+        }
+
+        It "Should have kept file '<_>' in lib directory" -ForEach @('uninstallfailure.nupkg', 'uninstallfailure.nuspec', 'tools\chocolateyuninstall.ps1', "test-file.txt") {
+            "$env:ChocolateyInstall\lib\uninstallfailure\$_" | Should -Exist
+        }
+
+        It "Should have kept backup files" {
+            "$env:ChocolateyInstall\lib-bkp\uninstallfailure" | Should -Exist
+        }
+
+        It "Outputs no package uninstalled" {
+            $Output.Lines | Should -Contain "Chocolatey uninstalled 0/1 packages. 1 packages failed."
+        }
+    }
+
+    Context "Uninstalling a package where non-package file is locked" {
+        BeforeAll {
+            Restore-ChocolateyInstallSnapshot
+
+            $null = Invoke-Choco install installpackage --confirm --no-progress
+
+            $LockedFile = [System.IO.File]::Open("$env:ChocolateyInstall\lib\installpackage\a-locked-file.txt", 'OpenOrCreate', 'Read', 'Read')
+
+            $Output = Invoke-Choco uninstall installpackage --confirm
+        }
+
+        AfterAll {
+            $LockedFile.Dispose()
+        }
+
+        It "Exits with Success (0)" {
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
+        }
+
+        It "Should have kept locked file in lib directory" {
+            "$env:ChocolateyInstall\lib\installpackage\a-locked-file.txt" | Should -Exist
+        }
+
+        It "Should have removed file '<_>' in lib directory" -ForEach @('installpackage.nupkg', 'installpackage.nuspec', 'tools\casemismatch.exe', 'tools\Casemismatch.exe.ignore', 'tools\chocolateyBeforeModify.ps1', 'tools\chocolateyinstall.ps1', 'tools\chocolateyuninstall.ps1', 'tools\console.exe', 'tools\graphical.exe', 'tools\graphical.exe.gui', 'tools\not.installed.exe', 'tools\not.installed.exe.ignore', 'tools\simplefile.txt') {
+            "$env:ChocolateyInstall\lib\installpackage\$_" | Should -Not -Exist
+        }
+
+        It "Should not have created lib-bad directory" {
+            "$env:ChocolateyInstall\lib-bad\upgradepackage" | Should -Not -Exist
+        }
+
+        It "Should have removed lib-bkp directory" {
+            "$env:ChocolateyInstall\lib-bkp\upgradepackage" | Should -Not -Exist
+        }
+
+        It "Outputs Successful uninstall" {
+            $Output.Lines | Should -Contain "Chocolatey uninstalled 1/1 packages."
+        }
+    }
+
+    Context "When specifying non-existing package before and after failing package does not abort execution" {
+        BeforeAll {
+            $null = Invoke-Choco install uninstallfailure installpackage --confirm
+
+            $Output = Invoke-Choco uninstall packageA uninstallfailure packageB installpackage --confirm
+        }
+
+        It "Exits with Failure (-1)" {
+            $Output.ExitCode | Should -Be -1 -Because $Output.String
+        }
+
+        It "Outputs package not existing (<_>)" -ForEach @('packageA', 'packageB') {
+            $Output.Lines | Should -Contain "$_ is not installed. Cannot uninstall a non-existent package." -Because $Output.String
+            $Output.Lines | Should -Contain "- $_ - $_ is not installed. Cannot uninstall a non-existent package." -Because $Output.String
+        }
+
+        It "Outputs failing to uninstall package uninstallfailure" {
+            $Output.Lines | Should -Contain "uninstallfailure not uninstalled. An error occurred during uninstall:" -Because $Output.String
+            $Output.Lines | Should -Contain "uninstallfailure uninstall not successful." -Because $Output.String
+            $Output.String | Should -Match "- uninstallfailure \(exited -1\) - Error while running"
+        }
+
+        It "Should have uninstall package installpackage" {
+            "$env:ChocolateyInstall\lib\installpackage" | Should -Not -Exist -Because $Output.String
+        }
+
+        It "Outputs successful uninstall of installpackage" {
+            $Output.Lines | Should -Contain "installpackage has been successfully uninstalled." -Because $Output.String
+        }
+
+        It "Outputs 1/3 successful uninstalls" {
+            $Output.Lines | Should -Contain "Chocolatey uninstalled 1/4 packages. 3 packages failed." -Because $Output.String
+        }
+    }
+
+    Context "When uninstalling a package, forcing dependencies to uninstall and dependency is referenced by other packages" {
+        BeforeAll {
+            Restore-ChocolateyInstallSnapshot
+
+            $null = Invoke-Choco install hasdependency --version 1.0.0 --confirm
+            $null = Invoke-Choco install toplevelhasexactversiondependency --confirm
+
+            $Output = Invoke-Choco uninstall hasdependency --force-dependencies --confirm
+        }
+
+        It "Exits with Success (0)" {
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
+        }
+
+        It "Should have removed <_>" -ForEach @('hasdependency', 'isdependency') {
+            "$env:ChocolateyInstall\lib\$_" | Should -Not -Exist -Because $Output.String
+        }
+
+        It "Should not have removed <_>" -ForEach @('isexactversiondependency', 'childdependencywithlooserversiondependency', 'toplevelhasexactversiondependency') {
+            "$env:ChocolateyInstall\lib\$_" | Should -Exist -Because $Output.String
+        }
+
+        It "Outputs <_> was successfully uninstalled" -ForEach @('hasdependency', 'isdependency') {
+            $Output.Lines | Should -Contain "$_ has been successfully uninstalled." -Because $Output.String
+        }
+
+        It "Outputs 2/2 packages uninstalled" {
+            $Output.Lines | Should -Contain "Chocolatey uninstalled 2/2 packages."
         }
     }
 

--- a/tests/chocolatey-tests/commands/choco-uninstall.Tests.ps1
+++ b/tests/chocolatey-tests/commands/choco-uninstall.Tests.ps1
@@ -2,6 +2,7 @@ Import-Module helpers/common-helpers
 
 Describe "choco uninstall" -Tag Chocolatey, UninstallCommand {
     BeforeAll {
+        Remove-NuGetPaths
         Initialize-ChocolateyTestInstall
 
         New-ChocolateyInstallSnapshot
@@ -65,4 +66,7 @@ Describe "choco uninstall" -Tag Chocolatey, UninstallCommand {
             $Output.Lines | Should -Contain ($_ -replace '<installPath>',$env:ChocolateyInstall) -Because $Output.String
         }
     }
+
+    # This needs to be the last test in this block, to ensure NuGet configurations aren't being created.
+    Test-NuGetPaths
 }

--- a/tests/chocolatey-tests/commands/choco-upgrade.Tests.ps1
+++ b/tests/chocolatey-tests/commands/choco-upgrade.Tests.ps1
@@ -2,6 +2,7 @@ Import-Module helpers/common-helpers
 
 Describe "choco upgrade" -Tag Chocolatey, UpgradeCommand {
     BeforeAll {
+        Remove-NuGetPaths
         Initialize-ChocolateyTestInstall
 
         New-ChocolateyInstallSnapshot
@@ -256,4 +257,8 @@ Describe "choco upgrade" -Tag Chocolatey, UpgradeCommand {
             }
         }
     }
+
+
+    # This needs to be the last test in this block, to ensure NuGet configurations aren't being created.
+    Test-NuGetPaths
 }

--- a/tests/chocolatey-tests/commands/choco-upgrade.Tests.ps1
+++ b/tests/chocolatey-tests/commands/choco-upgrade.Tests.ps1
@@ -1,4 +1,4 @@
-Import-Module helpers/common-helpers
+﻿Import-Module helpers/common-helpers
 
 Describe "choco upgrade" -Tag Chocolatey, UpgradeCommand {
     BeforeAll {
@@ -258,45 +258,6 @@ Describe "choco upgrade" -Tag Chocolatey, UpgradeCommand {
         }
     }
 
-
-            $PackageUnderTest = "installpackage"
-
-            New-ChocolateyTestPackage `
-                -TestPath "$PSScriptRoot\testpackages" `
-                -Name $PackageUnderTest `
-                -Version "1.0.0"
-
-            $PackagePath = "$($snapshotPath.PackagesPath)\$PackageUnderTest.1.0.0.nupkg"
-
-            $Output = Invoke-Choco upgrade $PackagePath --confirm --params '/ParameterOne:FirstOne /ParameterTwo:AnotherOne'
-        }
-
-        It "Exits with Failure (1)" {
-            $Output.ExitCode | Should -Be 1
-        }
-
-        It "Not Installed a package to the lib directory" {
-            "$env:ChocolateyInstall\lib\$PackageUnderTest" | Should -Not -Exist
-        }
-
-        It "Not Installed a package to the lib bad directory" {
-            "$env:ChocolateyInstall\lib-bad\$PackageUnderTest" | Should -Not -Exist
-        }
-
-        It "Not Installed a package to the lib backup directory" {
-            "$env:ChocolateyInstall\lib-backup\$PackageUnderTest" | Should -Not -Exist
-        }
-
-        It "Outputs expected error message" {
-            $Output.String | Should -Match @"
-Package name cannot be a path to a file on a remote, or local file system.
-
-To upgrade a local, or remote file, you may use:
-  choco upgrade $packageUnderTest --version="1.0.0" --source="$([regex]::Escape($snapshotPath.PackagesPath))
-"@
-        }
-    }
-
     # We are marking this test as internal, as the package we need to make use
     # of downloads a zip archive from a internal server, and the package is also
     # only located on an internal feed.
@@ -304,7 +265,7 @@ To upgrade a local, or remote file, you may use:
         BeforeAll {
             $paths = Restore-ChocolateyInstallSnapshot
 
-            $Output = Invoke-Choco upgrade install-chocolateyzip --version 3.21.2 --confirm "$_" "$($paths.CachePathLong)" --no-progress
+            $Output = Invoke-Choco upgrade install-chocolateyzip --version 3.21.2 --confirm "$_" "$($paths.CachePath)" --no-progress
         }
 
         AfterAll {
@@ -336,7 +297,7 @@ To upgrade a local, or remote file, you may use:
             $testMessage = if ($features.License) {
                 "Extracting cmake-3.21.2-windows-x86_64.zip to $env:ChocolateyInstall\lib\install-chocolateyzip\tools..."
             } else {
-                "Extracting $($paths.CachePathLong)\install-chocolateyzip\3.21.2\cmake-3.21.2-windows-x86_64.zip to $env:ChocolateyInstall\lib\install-chocolateyzip\tools..."
+                "Extracting $($paths.CachePath)\install-chocolateyzip\3.21.2\cmake-3.21.2-windows-x86_64.zip to $env:ChocolateyInstall\lib\install-chocolateyzip\tools..."
             }
             $Output.Lines | Should -Contain $testMessage -Because $Output.String
         }
@@ -356,7 +317,74 @@ To upgrade a local, or remote file, you may use:
 
         It 'Should have cached installed directory in custom cache' {
             # Need to be verified, but the file may not exist on licensed edition
-            "$($paths.CachePathLong)\install-chocolateyzip\3.21.2\cmake-3.21.2-windows-x86_64.zip" | Should -Exist
+            "$($paths.CachePath)\install-chocolateyzip\3.21.2\cmake-3.21.2-windows-x86_64.zip" | Should -Exist
+        }
+
+        It 'Installed software to expected directory' {
+            "$env:ChocolateyInstall\lib\install-chocolateyzip\tools\cmake-3.21.2-windows-x86_64\bin\cmake.exe" | Should -Exist
+        }
+    }
+
+    # We are marking this test as internal, as the package we need to make use
+    # of downloads a zip archive from a internal server, and the package is also
+    # only located on an internal feed.
+    Context "Upgrading non-existing package while specifying a cache location (Arg: <_>)" -ForEach '-c', '--cache', '--cachelocation', '--cache-location' -Tag Internal, LongPaths, CacheLocation {
+        BeforeAll {
+            $paths = Restore-ChocolateyInstallSnapshot
+
+            $Output = Invoke-Choco upgrade install-chocolateyzip --version 3.21.2 --confirm "$_" "$($paths.CachePath)" --no-progress
+        }
+
+        AfterAll {
+            $null = Invoke-Choco uninstall install-chocolateyzip --confirm
+        }
+
+        It 'Exits with Success (0)' {
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
+        }
+
+        It 'Runs under background Service' -Tag Background {
+            $Output.Lines | Should -Contain 'Running in background mode' -Because $Output.String
+        }
+
+        It 'Outputs downloading 64bit package' {
+            $Output.Lines | Should -Contain 'Downloading install-chocolateyzip 64 bit' -Because $Output.String
+        }
+
+        It 'Outputs download completed' {
+            $testMessage = if ($features.License) {
+                "Download of 'cmake-3.21.2-windows-x86_64.zip' (36.01 MB) completed."
+            } else {
+                "Download of cmake-3.21.2-windows-x86_64.zip (36.01 MB) completed."
+            }
+            $Output.Lines | Should -Contain $testMessage -Because $Output.String
+        }
+
+        It 'Outputs extracting correct archive' {
+            $testMessage = if ($features.License) {
+                "Extracting cmake-3.21.2-windows-x86_64.zip to $env:ChocolateyInstall\lib\install-chocolateyzip\tools..."
+            } else {
+                "Extracting $($paths.CachePath)\install-chocolateyzip\3.21.2\cmake-3.21.2-windows-x86_64.zip to $env:ChocolateyInstall\lib\install-chocolateyzip\tools..."
+            }
+            $Output.Lines | Should -Contain $testMessage -Because $Output.String
+        }
+
+        It 'Created shim for <_>' -ForEach 'cmake-gui.exe', 'cmake.exe', 'cmcldeps.exe', 'cpack.exe', 'ctest.exe' {
+            $Output.Lines | Should -Contain "ShimGen has successfully created a shim for $_"
+            "$env:ChocolateyInstall\bin\$_" | Should -Exist
+        }
+
+        It 'Outputs upgrading was successful' {
+            $Output.Lines | Should -Contain 'The upgrade of install-chocolateyzip was successful.' -Because $Output.String
+        }
+
+        It 'Outputs software installation directory' {
+            $Output.Lines | Should -Contain "Software installed to '$env:ChocolateyInstall\lib\install-chocolateyzip\tools'" -Because $Output.String
+        }
+
+        It 'Should have cached installed directory in custom cache' {
+            # Need to be verified, but the file may not exist on licensed edition
+            "$($paths.CachePath)\install-chocolateyzip\3.21.2\cmake-3.21.2-windows-x86_64.zip" | Should -Exist
         }
 
         It 'Installed software to expected directory' {
@@ -375,16 +403,221 @@ To upgrade a local, or remote file, you may use:
             $Output = Invoke-Choco upgrade upgradepackage --confirm
         }
 
-        It 'Exits with Success (0)' {
-            $Output.ExitCode | Should -Be 0
+        It 'Exits with Success (-1)' {
+            $Output.ExitCode | Should -Be -1
         }
 
         It 'Outputs warning about unable to load service index' {
-            $Output.Lines | Should -Contain 'Unable to load the service index for source https://invalid.com/api/v2/.'
+            $Output.String | Should -Match "Error retrieving packages from source 'https://invalid.chocolatey.org/api/v2/':"
         }
 
         It 'Outputs successful installation of single package' {
-            $Output.Lines | Should -Contain 'Chocolatey installed 1/1 packages.'
+            $Output.Lines | Should -Contain 'Chocolatey upgraded 1/1 packages.'
+        }
+    }
+
+    Context "Upgrading package should not downgrade existing package" {
+        BeforeAll {
+            Restore-ChocolateyInstallSnapshot
+            $DependentPackageName = 'isdependency'
+
+            $null = Invoke-Choco install $DependentPackageName --version 1.1.0 --confirm
+            $null = Invoke-Choco install hasdependency --version 1.0.0 --confirm
+
+            $Output = Invoke-Choco upgrade hasdependency
+            $Packages = (Invoke-Choco list -r).Lines | ConvertFrom-ChocolateyOutput -Command List
+            $DependentPackage = $Packages | Where-Object Name -EQ $DependentPackageName
+        }
+
+        It 'Exits with Success (0)' {
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
+        }
+
+        It 'should not have downgraded isdependency' {
+            Test-VersionEqualOrHigher -InstalledVersion $DependentPackage.Version -CompareVersion 1.1.0 | Should -BeTrue
+        }
+    }
+
+    Context "Upgrading a failing package creates creates bad backup and rolls back lib directory" {
+        BeforeAll {
+            Restore-ChocolateyInstallSnapshot
+
+            $PackageUnderTest = "failingdependency"
+            $PackageVersion = '1.0.0'
+
+            $null = Invoke-Choco install $PackageUnderTest --version 0.9.9 -n
+
+            $Output = Invoke-Choco upgrade $PackageUnderTest --version $PackageVersion --confirm
+        }
+
+        It "Exits with Failure (15608)" {
+            $Output.ExitCode | Should -Be 15608 -Because $Output.String
+        }
+
+        It "Doesn't keep a package backup in lib-bkp" {
+            "$env:ChocolateyInstall\lib-bkp\$PackageUnderTest" | Should -Not -Exist
+        }
+
+        It "Creates backup of file '<_>' in lib-bad" -ForEach @('failingdependency.nupkg', 'failingdependency.nuspec', '.chocolateyPending', 'tools\chocolateyinstall.ps1') {
+            "$env:ChocolateyInstall\lib-bad\$PackageUnderTest\$_" | Should -Exist
+        }
+
+        It "Outputs a message showing that installation failed." {
+            $Output.String | Should -Match "Chocolatey upgraded 0/1 packages\."
+        }
+    }
+
+    Context "Upgrading a package when installer is locked" {
+        BeforeAll {
+            Restore-ChocolateyInstallSnapshot
+
+            $PackageUnderTest = "hasinnoinstaller"
+            $PackageVersion   = '6.2.0.3'
+
+            # We are purposely using the --reduce-nupkg-only option (both here and in the next call to Invoke-Choco), to make the 
+            # test as close to default operation, when running both in the context of OSS and CLE. It was found during testing, that
+            # the Package Optimizer would remove the application installer, which is the file that is being locked during the test,
+            # which means then that the test doesn't actually test what we want it to. We are locking the exe here instead of say a
+            # PowerShell script, is to simulate the exe being used when the test is running.
+            $null = Invoke-Choco install $PackageUnderTest --version 6.2.0.0 --confirm --no-progress --reduce-nupkg-only
+
+            $LockedFile = [System.IO.File]::Open("$env:ChocolateyInstall\lib\$PackageUnderTest\tools\helloworld-1.0.0.exe", 'Open', 'Read',
+            'Read')
+
+            $Output = Invoke-Choco upgrade $PackageUnderTest --version $PackageVersion --confirm --no-progress --reduce-nupkg-only
+        }
+
+        AfterAll {
+            $LockedFile.Dispose()
+            $null = Invoke-Choco uninstall $PackageUnderTest --confirm
+        }
+
+        It "Exits with Failure (1)" {
+            $Output.ExitCode | Should -Be 1 -Because $Output.String
+        }
+
+        It "Keeps file '<_>' in the lib directory" -ForEach @('hasinnoinstaller.nuspec', 'hasinnoinstaller.nupkg', 'tools\chocolateyinstall.ps1', 'tools\chocolateyuninstall.ps1', 'tools\helloworld-1.0.0.exe') {
+            "$env:ChocolateyInstall\lib\$PackageUnderTest\$_" | Should -Exist
+        }
+
+        It "Doesn't keep a package backup in lib-bkp" {
+            "$env:ChocolateyInstall\lib-bkp\$PackageUnderTest" | Should -Not -Exist
+        }
+
+        # Only two files are backed up as we was not able to download and extract the new package
+        It "Creates backup of file '<_>' in lib-bad" -ForEach @('.chocolateyPending') {
+            "$env:ChocolateyInstall\lib-bad\$PackageUnderTest\$_" | Should -Exist
+        }
+
+        It "Outputs a message showing that installation failed." {
+            $Output.Lines | Should -Contain "Chocolatey upgraded 0/1 packages. 1 packages failed."
+        }
+    }
+
+    Context "Upgrading a package when non-package file is locked before initial installation" {
+        BeforeAll {
+            Restore-ChocolateyInstallSnapshot
+
+            $PackageUnderTest = "hasinnoinstaller"
+            $PackageVersion   = '6.2.0.3'
+
+            mkdir "$env:ChocolateyInstall\lib\$PackageUnderTest\tools"
+            $LockedFile = [System.IO.File]::Open("$env:ChocolateyInstall\lib\$PackageUnderTest\tools\a-locked-file.txt", 'OpenOrCreate', 'Read',
+            'Read')
+
+            # We are purposely using the --reduce-nupkg-only option here to make the test as close to default operation, when running
+            # both in the context of OSS and CLE. It was found during testing, that the Package Optimizer can remove files that are
+            # normally left in place, and this test is specifically for testing the back-up/restore process.
+            $null = Invoke-Choco install $PackageUnderTest --version 6.2.0.0 --confirm --no-progress --reduce-nupkg-only
+
+            $Output = Invoke-Choco upgrade $PackageUnderTest --version $PackageVersion --confirm --no-progress
+        }
+
+        AfterAll {
+            $LockedFile.Dispose()
+            $null = Invoke-Choco uninstall $PackageUnderTest --confirm
+        }
+
+        It "Exits with Success (0)" {
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
+        }
+
+        It "Keeps file '<_>' in the lib directory" -ForEach @('hasinnoinstaller.nuspec', 'hasinnoinstaller.nupkg', 'tools\chocolateyinstall.ps1', 'tools\chocolateyuninstall.ps1', 'tools\helloworld-1.0.0.exe', 'tools\helloworld-1.0.0.exe.ignore') {
+            "$env:ChocolateyInstall\lib\$PackageUnderTest\$_" | Should -Exist
+        }
+
+        It "Doesn't keep a package backup in lib-bkp" {
+            "$env:ChocolateyInstall\lib-bkp\$PackageUnderTest" | Should -Not -Exist
+        }
+
+        It "Did not create backup of file '<_>' in lib-bad" -ForEach @('hasinnoinstaller.nuspec', 'tools\chocolateyinstall.ps1', 'tools\chocolateyuninstall.ps1', 'tools\helloworld-1.0.0.exe', 'helloworld-1.0.0.exe.ignore') {
+            "$env:ChocolateyInstall\lib-bad\$PackageUnderTest\$PackageVersion\$_" | Should -Not -Exist
+        }
+
+        It "Did not create backup of file 'hasinnoinstaller.nupkg' in lib-bad" -Tag FossOnly {
+            "$env:ChocolateyInstall\lib-bad\$PackageUnderTest\$PackageVersion\hasinnoinstaller.nupkg" | Should -Not -Exist
+        }
+    }
+
+    Context "Upgrading a package when non-package file is locked after initial installation" {
+        BeforeAll {
+            Restore-ChocolateyInstallSnapshot
+
+            $PackageUnderTest = "hasinnoinstaller"
+            $PackageVersion   = '6.2.0.3'
+
+            $null = Invoke-Choco install $PackageUnderTest --version 6.2.0.0 --confirm --no-progress
+
+            $LockedFile = [System.IO.File]::Open("$env:ChocolateyInstall\lib\$PackageUnderTest\a-locked-file.txt", 'OpenOrCreate', 'Read',
+            'Read')
+
+            $Output = Invoke-Choco upgrade $PackageUnderTest --version $PackageVersion --confirm --no-progress
+        }
+
+        AfterAll {
+            $LockedFile.Dispose()
+            $null = Invoke-Choco uninstall $PackageUnderTest --confirm
+        }
+
+        It "Exits with Success (0)" {
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
+        }
+
+        It "Keeps have file '<_>' in the lib directory" -ForEach @('hasinnoinstaller.nuspec', 'hasinnoinstaller.nupkg', 'tools\chocolateyinstall.ps1', 'tools\chocolateyuninstall.ps1', 'tools\helloworld-1.0.0.exe', 'tools\helloworld-1.0.0.exe.ignore') {
+            "$env:ChocolateyInstall\lib\$PackageUnderTest\$_" | Should -Exist
+        }
+
+        It "Doesn't keep a package backup in lib-bkp" {
+            "$env:ChocolateyInstall\lib-bkp\$PackageUnderTest" | Should -Not -Exist
+        }
+
+        It "Doesn't keep a package backup in lib-bad" {
+            "$env:ChocolateyInstall\lib-bad\$PackageUnderTest" | Should -Not -Exist
+        }
+
+        It "Outputs a message showing that package was upgraded." {
+            $Output.Lines | Should -Contain "Chocolatey upgraded 1/1 packages." -Because $Output.String
+        }
+    }
+
+    Context "Upgrading a package where beforeModify fails still succeeds the installation" {
+        BeforeAll {
+            Restore-ChocolateyInstallSnapshot
+
+            $PackageUnderTest = 'upgradepackage'
+
+            $null = Invoke-Choco install upgradepackage --version 1.0.0 --confirm
+
+            $Output = Invoke-Choco upgrade upgradepackage --confirm
+        }
+
+        # This was broken in v1.0.0
+        It "Exits with Success (0)" -Tag Broken {
+            $Output.ExitCode | Should -Be 0
+        }
+
+        It "Outputs a message showing that installation was successful" {
+            $Output.Lines | Should -Contain "Chocolatey upgraded 1/1 packages."
         }
     }
 

--- a/tests/chocolatey-tests/commands/choco-version.Tests.ps1
+++ b/tests/chocolatey-tests/commands/choco-version.Tests.ps1
@@ -2,6 +2,7 @@
 
 Describe "choco version" -Tag Chocolatey, VersionCommand -Skip:(Test-ChocolateyVersionEqualOrHigherThan "1.0.0") {
     BeforeAll {
+        Remove-NuGetPaths
         Initialize-ChocolateyTestInstall
         New-ChocolateyInstallSnapshot
     }
@@ -50,4 +51,7 @@ Describe "choco version" -Tag Chocolatey, VersionCommand -Skip:(Test-ChocolateyV
             $Output.String | Should -Match "has been deprecated"
         }
     }
+
+    # This needs to be the last test in this block, to ensure NuGet configurations aren't being created.
+    Test-NuGetPaths
 }

--- a/tests/helpers/common/Chocolatey/New-ChocolateyInstallSnapshot.ps1
+++ b/tests/helpers/common/Chocolatey/New-ChocolateyInstallSnapshot.ps1
@@ -62,5 +62,8 @@
     [PSCustomObject]@{
         InstallPath  = $env:ChocolateyInstall
         PackagesPath = $env:CHOCOLATEY_TEST_PACKAGES_PATH
+        # we are not returning the long cache path, this does not work with Chocolatey CLI v1 as the full path needs to be less than 260 characters, and the directory length less than 248 characters.
+        # CachePathLong= "$SnapshotPath\ChocolateyCache\This\Cache\Is\Intended\to\Be\Very\Long\On\Purpose" # This path will most likely not be removed due to long path errors
+        CachePath    = "$SnapshotPath\Cache"
     }
 }

--- a/tests/helpers/common/Chocolatey/New-ChocolateyTestPackage.ps1
+++ b/tests/helpers/common/Chocolatey/New-ChocolateyTestPackage.ps1
@@ -20,10 +20,17 @@
 
         # Location to store the built package(s)
         [ValidateNotNullOrEmpty()]
-        [string]$Destination = $env:CHOCOLATEY_TEST_PACKAGES_PATH
+        [string]$Destination = $env:CHOCOLATEY_TEST_PACKAGES_PATH,
+
+        [Parameter()]
+        [string]$AddedVersion
     )
     process {
         $NuspecFile = Get-Item "$TestPath\$Name\$Version\$Name.nuspec"
+
+        if ($AddedVersion) {
+            $Version = "$Version-$AddedVersion"
+        }
 
         Write-Verbose "Building '$($NuspecFile.Count)' packages"
 
@@ -32,12 +39,14 @@
             $ExpectedPackage = Join-Path $Destination "$Name.$Version.nupkg"
 
             if (-not (Test-Path $ExpectedPackage)) {
-                $BuildOutput = Invoke-Choco pack $Package.FullName --outputdirectory $Destination
+                $BuildOutput = Invoke-Choco pack $Package.FullName --outputdirectory $Destination --version $Version
 
                 if ($BuildOutput.ExitCode -ne 0) {
                     throw $BuildOutput.String
                 }
             }
+
+            $ExpectedPackage
         }
     }
 }

--- a/tests/helpers/common/NuGet/Get-NuGetPaths.ps1
+++ b/tests/helpers/common/NuGet/Get-NuGetPaths.ps1
@@ -1,0 +1,8 @@
+function Get-NuGetPaths {
+    @(
+        "$env:localappdata\NuGet"
+        "$(Get-TempDirectory)\NuGetScratch"
+        "$env:userprofile\.nuget"
+        "${env:programfiles(x86)}\NuGet"
+    )
+}

--- a/tests/helpers/common/NuGet/Get-NuGetPaths.ps1
+++ b/tests/helpers/common/NuGet/Get-NuGetPaths.ps1
@@ -1,6 +1,6 @@
 function Get-NuGetPaths {
     @(
-        "$env:localappdata\NuGet"
+        # "$env:localappdata\NuGet" # The directory gets created during running v1 commands
         "$(Get-TempDirectory)\NuGetScratch"
         "$env:userprofile\.nuget"
         "${env:programfiles(x86)}\NuGet"

--- a/tests/helpers/common/NuGet/Remove-NuGetPaths.ps1
+++ b/tests/helpers/common/NuGet/Remove-NuGetPaths.ps1
@@ -1,0 +1,19 @@
+function Remove-NuGetPaths {
+    $NuGetPathsToRemove = Get-NuGetPaths
+    $ChocolateyNuGetPath = "$(Get-TempDirectory)\chocolatey-invalid"
+
+    if (Test-Path $ChocolateyNuGetPath) {
+        Remove-Item -Path $ChocolateyNuGetPath -Recurse -Force -ErrorAction Stop
+    }
+
+    $script:NuGetCleared = $true
+
+    # If we're in Test Kitchen, we're going to remove the NuGet config files because we don't need to worry about a user's config
+    if ($env:TEST_KITCHEN) {
+        foreach ($path in $NuGetPathsToRemove) {
+            if (Test-Path $path) {
+                Remove-Item -Path $path -Recurse -Force -ErrorAction Stop
+            }
+        }
+    }
+}

--- a/tests/helpers/common/NuGet/Test-NuGetPaths.ps1
+++ b/tests/helpers/common/NuGet/Test-NuGetPaths.ps1
@@ -1,0 +1,16 @@
+function Test-NuGetPaths {
+    $script:NuGetCleared = $false
+    $NuGetPathsToCheck = Get-NuGetPaths
+    $ChocolateyNuGetPath = "$(Get-TempDirectory)chocolatey-invalid"
+
+    It 'Did not create <_> directory' -ForEach $NuGetPathsToCheck -Skip:((-not $env:TEST_KITCHEN)) {
+        if (-not $script:NuGetCleared) {
+            Set-ItResult -Skipped -Because 'NuGet configurations were not removed before running tests'
+        }
+        $_ | Should -Not -Exist
+    }
+
+    It "Did not create <_>" -ForEach $ChocolateyNuGetPath {
+        $_ | Should -Not -Exist
+    }
+}


### PR DESCRIPTION
## Description Of Changes

This pull request updates the tests we run for 1.x of Chocolatey CLI to be equivalent to the tests we have added in Chocolatey CLI v2.0.0

## Motivation and Context

To have the same area covered for both v1 and v2 of Chocolatey CLI.

## Testing

A test kitchen run will be triggered.

### Operating Systems Testing

N/A

## Change Types Made
<!-- Tick the boxes for the type of changes that have been made -->

* [ ] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.
* [x] Tests

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [ ] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue

- https://app.clickup.com/t/20540031/PROJ-322

<!-- PLEASE REMOVE ALL COMMENTS BEFORE SUBMITTING -->
