### PR TITLE
(#158) Restore --source for choco list

### DIFF
--- a/src/chocolatey.tests/infrastructure.app/commands/ChocolateyListCommandSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/commands/ChocolateyListCommandSpecs.cs
@@ -83,6 +83,8 @@ namespace chocolatey.tests.infrastructure.app.commands
                     Command.ConfigureArgumentParser(_optionSet, Configuration);
                 }
 
+                [NUnit.Framework.TestCase("source")]
+                [NUnit.Framework.TestCase("s")]
                 [NUnit.Framework.TestCase("prerelease")]
                 [NUnit.Framework.TestCase("pre")]
                 [NUnit.Framework.TestCase("includeprograms")]
@@ -92,8 +94,6 @@ namespace chocolatey.tests.infrastructure.app.commands
                     _optionSet.Contains(option).ShouldBeTrue();
                 }
 
-                [NUnit.Framework.TestCase("source")]
-                [NUnit.Framework.TestCase("s")]
                 [NUnit.Framework.TestCase("localonly")]
                 [NUnit.Framework.TestCase("l")]
                 [NUnit.Framework.TestCase("user")]

--- a/src/chocolatey/infrastructure.app/commands/ChocolateyInstallCommand.cs
+++ b/src/chocolatey/infrastructure.app/commands/ChocolateyInstallCommand.cs
@@ -423,7 +423,6 @@ NOTE: Options and switches apply to all items passed, so if you are
 
         public virtual void Run(ChocolateyConfiguration configuration)
         {
-            _packageService.EnsureSourceAppInstalled(configuration);
             _packageService.Install(configuration);
         }
 

--- a/src/chocolatey/infrastructure.app/commands/ChocolateyListCommand.cs
+++ b/src/chocolatey/infrastructure.app/commands/ChocolateyListCommand.cs
@@ -80,6 +80,9 @@ namespace chocolatey.infrastructure.app.commands
         public virtual void ConfigureArgumentParser(OptionSet optionSet, ChocolateyConfiguration configuration)
         {
             optionSet
+                .Add("s=|source=",
+                     "Source - Source location for install. Can use special 'windowsfeatures', 'ruby', 'cygwin', or 'python' sources. Defaults to sources.",
+                     option => configuration.Sources = option.UnquoteSafe())
                 .Add("idonly|id-only",
                      "Id Only - Only return Package Ids in the list results.",
                      option => configuration.ListCommand.IdOnly = option != null)

--- a/src/chocolatey/infrastructure.app/commands/ChocolateyListCommand.cs
+++ b/src/chocolatey/infrastructure.app/commands/ChocolateyListCommand.cs
@@ -20,6 +20,7 @@ namespace chocolatey.infrastructure.app.commands
     using System.Linq;
     using chocolatey.infrastructure.app.attributes;
     using chocolatey.infrastructure.app.configuration;
+    using chocolatey.infrastructure.app.domain;
     using chocolatey.infrastructure.app.services;
     using chocolatey.infrastructure.commandline;
     using chocolatey.infrastructure.commands;
@@ -81,8 +82,12 @@ namespace chocolatey.infrastructure.app.commands
         {
             optionSet
                 .Add("s=|source=",
-                     "Source - Source location for install. Can use special 'windowsfeatures', 'ruby', 'cygwin', or 'python' sources. Defaults to sources.",
-                     option => configuration.Sources = option.UnquoteSafe())
+                     "Source - Name of alternative source to use, for example 'windowsfeatures', 'ruby', 'cygwin', or 'python'.",
+                     option =>
+                     {
+                         configuration.Sources = option.UnquoteSafe();
+                         configuration.ListCommand.ExplicitSource = true;
+                     })
                 .Add("idonly|id-only",
                      "Id Only - Only return Package Ids in the list results.",
                      option => configuration.ListCommand.IdOnly = option != null)
@@ -239,6 +244,13 @@ If you find other exit codes that we have not yet documented, please
 
         public virtual void Run(ChocolateyConfiguration config)
         {
+            // Would have liked to have done this in the Validate method, but can't, since the SourceType
+            // hasn't yet been set, since the sources have not yet been parsed.
+            if (config.ListCommand.ExplicitSource && config.SourceType ==  SourceTypes.Normal)
+            {
+                throw new ApplicationException("When using the '--source' option with the 'choco list' command, only a named alternative source can be provided.");
+            }
+
             config.ListCommand.LocalOnly = true;
 
             // note: you must leave the .ToList() here or else the method won't be evaluated!

--- a/src/chocolatey/infrastructure.app/commands/ChocolateySearchCommand.cs
+++ b/src/chocolatey/infrastructure.app/commands/ChocolateySearchCommand.cs
@@ -221,7 +221,6 @@ choco {0}: https://raw.githubusercontent.com/wiki/chocolatey/choco/images/gifs/c
 
         public virtual void Run(ChocolateyConfiguration configuration)
         {
-            _packageService.EnsureSourceAppInstalled(configuration);
             // note: you must leave the .ToList() here or else the method won't be evaluated!
             var packageResults = _packageService.List(configuration).ToList();
 

--- a/src/chocolatey/infrastructure.app/commands/ChocolateyUninstallCommand.cs
+++ b/src/chocolatey/infrastructure.app/commands/ChocolateyUninstallCommand.cs
@@ -283,7 +283,6 @@ NOTE: Options and switches apply to all items passed, so if you are
 
         public virtual void Run(ChocolateyConfiguration configuration)
         {
-            _packageService.EnsureSourceAppInstalled(configuration);
             _packageService.Uninstall(configuration);
         }
 

--- a/src/chocolatey/infrastructure.app/commands/ChocolateyUpgradeCommand.cs
+++ b/src/chocolatey/infrastructure.app/commands/ChocolateyUpgradeCommand.cs
@@ -378,7 +378,6 @@ NOTE: Options and switches apply to all items passed, so if you are
 
         public virtual void Run(ChocolateyConfiguration configuration)
         {
-            _packageService.EnsureSourceAppInstalled(configuration);
             _packageService.Upgrade(configuration);
         }
 

--- a/src/chocolatey/infrastructure.app/configuration/ChocolateyConfiguration.cs
+++ b/src/chocolatey/infrastructure.app/configuration/ChocolateyConfiguration.cs
@@ -572,6 +572,7 @@ NOTE: Hiding sensitive configuration data! Please double and triple
         public bool NotBroken { get; set; }
         public bool IncludeVersionOverrides { get; set; }
         public bool ExplicitPageSize { get; set; }
+        public bool ExplicitSource { get; set; }
     }
 
     [Serializable]

--- a/src/chocolatey/infrastructure.app/registration/ChocolateyRegistrationModule.cs
+++ b/src/chocolatey/infrastructure.app/registration/ChocolateyRegistrationModule.cs
@@ -36,6 +36,7 @@ namespace chocolatey.infrastructure.app.registration
     using chocolatey.infrastructure.app.rules;
     using System.Linq;
     using System;
+    using System.Security.AccessControl;
 
     internal class ChocolateyRegistrationModule : IExtensionModule
     {
@@ -66,12 +67,13 @@ namespace chocolatey.infrastructure.app.registration
             registrator.RegisterService<ICommandExecutor, CommandExecutor>();
             registrator.RegisterInstance(() => new adapters.CustomString(string.Empty));
 
+            registrator.RegisterSourceRunner<WindowsFeatureService>();
+            registrator.RegisterSourceRunner<CygwinService>();
+            registrator.RegisterSourceRunner<PythonService>();
+            registrator.RegisterSourceRunner<RubyGemsService>();
+
             registrator.RegisterService<ISourceRunner>(
-                typeof(INugetService),
-                typeof(WindowsFeatureService),
-                typeof(CygwinService),
-                typeof(PythonService),
-                typeof(RubyGemsService));
+                typeof(INugetService));
 
             registrator.RegisterService<IEventSubscriptionManagerService, EventSubscriptionManagerService>();
 

--- a/src/chocolatey/infrastructure.app/registration/IContainerRegistrator.cs
+++ b/src/chocolatey/infrastructure.app/registration/IContainerRegistrator.cs
@@ -28,6 +28,11 @@ namespace chocolatey.infrastructure.app.registration
 
         void RegisterService<TService>(params Type[] types);
 
+        void RegisterSourceRunner<TService>()
+            where TService : class;
+
+        void RegisterSourceRunner(Type serviceType);
+
         void RegisterInstance<TImplementation>(Func<TImplementation> instance)
             where TImplementation : class;
 

--- a/src/chocolatey/infrastructure.app/registration/SimpleInjectorContainerRegistrator.cs
+++ b/src/chocolatey/infrastructure.app/registration/SimpleInjectorContainerRegistrator.cs
@@ -23,6 +23,7 @@ namespace chocolatey.infrastructure.app.registration
     using System.Reflection;
     using chocolatey.infrastructure.adapters;
     using chocolatey.infrastructure.app.attributes;
+    using chocolatey.infrastructure.app.services;
     using infrastructure.commands;
     using infrastructure.events;
     using infrastructure.services;
@@ -221,6 +222,61 @@ namespace chocolatey.infrastructure.app.registration
         public void RegisterValidator(Func<Type, bool> validation_func)
         {
             _validationHandlers.Add(validation_func);
+        }
+
+        public void RegisterSourceRunner<TService>() where TService : class
+        {
+            RegisterSourceRunner(typeof(TService));
+        }
+
+        public void RegisterSourceRunner(Type serviceType)
+        {
+            EnsureNotBuilt();
+
+            if (!CanRegisterService(serviceType))
+            {
+                return;
+            }
+
+            if (!typeof(IAlternativeSourceRunner).IsAssignableFrom(serviceType))
+            {
+                return;
+            }
+
+            AddToMultiServices(typeof(IAlternativeSourceRunner), serviceType);
+
+            foreach (var interfaceType in serviceType.GetInterfaces())
+            {
+                if (interfaceType == typeof(ICountSourceRunner))
+                {
+                    AddToMultiServices(interfaceType, serviceType);
+                }
+
+                if (interfaceType == typeof(IListSourceRunner))
+                {
+                    AddToMultiServices(interfaceType, serviceType);
+                }
+
+                if (interfaceType == typeof(ISearchableSourceRunner))
+                {
+                    AddToMultiServices(interfaceType, serviceType);
+                }
+
+                if (interfaceType == typeof(IInstallSourceRunner))
+                {
+                    AddToMultiServices(interfaceType, serviceType);
+                }
+
+                if (interfaceType == typeof(IUpgradeSourceRunner))
+                {
+                    AddToMultiServices(interfaceType, serviceType);
+                }
+
+                if (interfaceType == typeof(IUninstallSourceRunner))
+                {
+                    AddToMultiServices(interfaceType, serviceType);
+                }
+            }
         }
 
         internal Container BuildContainer(Container container)

--- a/src/chocolatey/infrastructure.app/runners/GenericRunner.cs
+++ b/src/chocolatey/infrastructure.app/runners/GenericRunner.cs
@@ -113,7 +113,7 @@ Chocolatey is not an official build (bypassed with --allow-unofficial).
 
         private void SetSourceType(ChocolateyConfiguration config, Container container)
         {
-            var sourceRunner = container.GetAllInstances<ISourceRunner>()
+            var sourceRunner = container.GetAllInstances<IAlternativeSourceRunner>()
                 .FirstOrDefault(s => s.SourceType.IsEqualTo(config.Sources) || s.SourceType.IsEqualTo(config.Sources + "s"));
 
             var sourceType = SourceTypes.Normal;

--- a/src/chocolatey/infrastructure.app/services/ChocolateyPackageService.cs
+++ b/src/chocolatey/infrastructure.app/services/ChocolateyPackageService.cs
@@ -19,9 +19,11 @@ namespace chocolatey.infrastructure.app.services
     using System;
     using System.Collections.Concurrent;
     using System.Collections.Generic;
+    using System.ComponentModel.Design;
     using System.IO;
     using System.Linq;
     using System.Text;
+    using chocolatey.infrastructure.app.registration;
     using commandline;
     using configuration;
     using domain;
@@ -37,6 +39,7 @@ namespace chocolatey.infrastructure.app.services
     using NuGet.Versioning;
     using platforms;
     using results;
+    using SimpleInjector;
     using tolerance;
     using IFileSystem = filesystem.IFileSystem;
 
@@ -44,7 +47,6 @@ namespace chocolatey.infrastructure.app.services
     {
         private readonly INugetService _nugetService;
         private readonly IPowershellService _powershellService;
-        private readonly IEnumerable<ISourceRunner> _sourceRunners;
         private readonly IShimGenerationService _shimgenService;
         private readonly IFileSystem _fileSystem;
         private readonly IRegistryService _registryService;
@@ -53,6 +55,7 @@ namespace chocolatey.infrastructure.app.services
         private readonly IAutomaticUninstallerService _autoUninstallerService;
         private readonly IXmlService _xmlService;
         private readonly IConfigTransformService _configTransformService;
+        private readonly IContainerResolver _containerResolver;
         private readonly IDictionary<string, FileStream> _pendingLocks = new Dictionary<string, FileStream>();
 
         private readonly IList<string> _proBusinessMessages = new List<string> {
@@ -106,16 +109,21 @@ Did you know Pro / Business automatically syncs with Programs and
         // 3010 - restart required
         private readonly List<int> _rebootExitCodes = new List<int> { 1641, 3010 };
 
-        public ChocolateyPackageService(INugetService nugetService, IPowershellService powershellService,
-            IEnumerable<ISourceRunner> sourceRunners, IShimGenerationService shimgenService,
-            IFileSystem fileSystem, IRegistryService registryService,
-            IChocolateyPackageInformationService packageInfoService, IFilesService filesService,
-            IAutomaticUninstallerService autoUninstallerService, IXmlService xmlService,
-            IConfigTransformService configTransformService)
+        public ChocolateyPackageService(
+            INugetService nugetService,
+            IPowershellService powershellService,
+            IShimGenerationService shimgenService,
+            IFileSystem fileSystem,
+            IRegistryService registryService,
+            IChocolateyPackageInformationService packageInfoService,
+            IFilesService filesService,
+            IAutomaticUninstallerService autoUninstallerService,
+            IXmlService xmlService,
+            IConfigTransformService configTransformService,
+            IContainerResolver containerResolver)
         {
             _nugetService = nugetService;
             _powershellService = powershellService;
-            _sourceRunners = sourceRunners;
             _shimgenService = shimgenService;
             _fileSystem = fileSystem;
             _registryService = registryService;
@@ -124,72 +132,107 @@ Did you know Pro / Business automatically syncs with Programs and
             _autoUninstallerService = autoUninstallerService;
             _xmlService = xmlService;
             _configTransformService = configTransformService;
-        }
-
-        public virtual void EnsureSourceAppInstalled(ChocolateyConfiguration config)
-        {
-            PerformSourceRunnerAction(
-                config,
-                runner => 
-                {
-                    if (runner is IBootstrappableSourceRunner sr)
-                    {
-                        sr.EnsureSourceAppInstalled(config, (packageResult, configuration) => HandlePackageResult(packageResult, configuration, CommandNameType.Install));
-                    }
-                }
-            );
+            _containerResolver = containerResolver;
         }
 
         public virtual int Count(ChocolateyConfiguration config)
         {
-            return PerformSourceRunnerFunction(
+            return PerformSourceRunnerFunction<ICountSourceRunner, int>(
                 config,
-                runner => runner is ICountSourceRunner sr 
-                    ? sr.Count(config)
-                    : throw new NotSupportedException("The '{0}' source does not support counting packages.".FormatWith(runner.SourceType)));
+                runner => runner.Count(config),
+                throwOnException: true);
         }
 
-        private void PerformSourceRunnerAction(ChocolateyConfiguration config, Action<ISourceRunner> action)
+        private void PerformSourceRunnerAction<TSourceRunner>(ChocolateyConfiguration config, Action<TSourceRunner> action, bool throwOnException = false)
+            where TSourceRunner : class, IAlternativeSourceRunner
         {
-            var runner = GetSourceRunner(config.SourceType);
+            var alternativeSourceRunners = _containerResolver.ResolveAll<TSourceRunner>();
+            PerformSourceRunnerAction(config, action, alternativeSourceRunners, throwOnException);
+        }
+
+        private void PerformSourceRunnerAction<TSourceRunner>(ChocolateyConfiguration config, Action<TSourceRunner> action, IEnumerable<TSourceRunner> alternativeSourceRunners, bool throwOnException = false)
+            where TSourceRunner : class, IAlternativeSourceRunner
+        {
+            var runner = GetSourceRunner<TSourceRunner>(config.SourceType, alternativeSourceRunners);
             if (runner != null && action != null)
             {
+                if (runner is IBootstrappableSourceRunner bootstrapper)
+                {
+                    bootstrapper.EnsureSourceAppInstalled(config, (packageResult, configuration) => HandlePackageResult(packageResult, configuration, CommandNameType.Install));
+                }
+
                 action.Invoke(runner);
             }
             else
             {
-                this.Log().Warn("No runner was found that implements source type '{0}' or action was missing".FormatWith(config.SourceType));
+                if (throwOnException)
+                {
+                    throw new NotSupportedException("No runner was found that implements source type '{0}' or action was missing".FormatWith(config.SourceType));
+                }
+                else
+                {
+                    this.Log().Warn("No runner was found that implements source type '{0}' or action was missing".FormatWith(config.SourceType));
+                }
             }
         }
 
-        private T PerformSourceRunnerFunction<T>(ChocolateyConfiguration config, Func<ISourceRunner, T> function)
+        private TResult PerformSourceRunnerFunction<TSourceRunner, TResult>(ChocolateyConfiguration config, Func<TSourceRunner, TResult> function, bool throwOnException = false)
+            where TSourceRunner : class, IAlternativeSourceRunner
         {
-            var runner = GetSourceRunner(config.SourceType);
+            var alternativeSourceRunners = _containerResolver.ResolveAll<TSourceRunner>();
+            return PerformSourceRunnerFunction(config, function, alternativeSourceRunners, throwOnException);
+        }
+
+        private TResult PerformSourceRunnerFunction<TSourceRunner, TResult>(ChocolateyConfiguration config, Func<TSourceRunner, TResult> function, IEnumerable<TSourceRunner> alternativeSourceRunners, bool throwOnException = false)
+            where TSourceRunner : class, IAlternativeSourceRunner
+        {
+            var runner = GetSourceRunner<TSourceRunner>(config.SourceType, alternativeSourceRunners);
             if (runner != null && function != null)
             {
+                if (runner is IBootstrappableSourceRunner bootstrapper)
+                {
+                    bootstrapper.EnsureSourceAppInstalled(config, (packageResult, configuration) => HandlePackageResult(packageResult, configuration, CommandNameType.Install));
+                }
+
                 return function.Invoke(runner);
             }
 
-            this.Log().Warn("No runner was found that implements source type '{0}' or function was missing.".FormatWith(config.SourceType));
-            return default(T);
+            if (throwOnException)
+            {
+                throw new NotSupportedException("No runner was found that implements source type '{0}' or, it does not support requested functionality.".FormatWith(config.SourceType));
+            }
+            else
+            {
+                this.Log().Warn("No runner was found that implements source type '{0}' or, it does not support requested functionality.".FormatWith(config.SourceType));
+            }
+
+            return default(TResult);
         }
 
         public void ListDryRun(ChocolateyConfiguration config)
         {
-            PerformSourceRunnerAction(
-                config,
-                runner =>
-                {
-                    if (runner is IListSourceRunner sr)
-                    {
-                        sr.ListDryRun(config);
-                    }
-                    else
-                    {
-                       this.Log().Warn(ChocolateyLoggers.Important, "The '{0}' source does not support listing packages.", runner.SourceType);
-                    }
-                }
-            );
+            if (string.IsNullOrWhiteSpace(config.Sources) && !config.ListCommand.LocalOnly)
+            {
+                this.Log().Error(ChocolateyLoggers.Important, @"Unable to search for packages when there are no sources enabled for
+ packages and none were passed as arguments.");
+                Environment.ExitCode = 1;
+                return;
+            }
+
+            config.Noop = true;
+
+            if (config.ListCommand.LocalOnly && !config.SourceType.IsEqualTo(SourceTypes.Normal))
+            {
+                PerformSourceRunnerAction<IListSourceRunner>(config, runner => runner.ListDryRun(config));
+            }
+            else if (config.SourceType.IsEqualTo(SourceTypes.Normal))
+            {
+                _nugetService.ListDryRun(config);
+            }
+            else
+            {
+                PerformSourceRunnerAction<ISearchableSourceRunner>(config, runner => runner.SearchDryRun(config));
+            }
 
             RandomlyNotifyAboutLicensedFeatures(config, ProBusinessListMessage);
         }
@@ -208,13 +251,26 @@ Did you know Pro / Business automatically syncs with Programs and
 
             var packages = new List<PackageResult>();
 
-            var results = PerformSourceRunnerFunction(
-                config,
-                runner => runner is IListSourceRunner sr
-                    ? string.IsNullOrWhiteSpace(config.Input) || sr is ISearchableSourceRunner
-                        ? sr.List(config)
-                        : throw new NotSupportedException("The '{0}' source does not support searching for specific packages.".FormatWith(runner.SourceType))
-                    : throw new NotSupportedException("The '{0}' source does not support listing or searching for packages.".FormatWith(runner.SourceType)));
+            IEnumerable<PackageResult> results;
+
+            if (config.ListCommand.LocalOnly && !config.SourceType.IsEqualTo(SourceTypes.Normal))
+            {
+                results = PerformSourceRunnerFunction<IListSourceRunner, IEnumerable<PackageResult>>(config, runner => runner.List(config));
+            }
+            else if (config.SourceType.IsEqualTo(SourceTypes.Normal))
+            {
+                results = _nugetService.List(config).OrEmpty();
+            }
+            else
+            {
+                results = PerformSourceRunnerFunction<ISearchableSourceRunner, IEnumerable<PackageResult>>(config, runner => runner.Search(config));
+            }
+
+            if (results is null)
+            {
+                var message = config.ListCommand.LocalOnly ? "The '{0}' source does not support listing of packages".FormatWith(config.SourceType) : "The '{0}' source does not support searching for packages".FormatWith(config.SourceType);
+                throw new NotSupportedException(message);
+            }
 
             foreach (PackageResult package in results)
             {
@@ -327,29 +383,22 @@ Did you know Pro / Business automatically syncs with Programs and
         {
             ValidatePackageNames(config);
 
+            var installSourceRunners = _containerResolver.ResolveAll<IInstallSourceRunner>();
+
             // each package can specify its own configuration values
-            foreach (var packageConfig in GetConfigFromInputAndPackageConfigInput(config, new ConcurrentDictionary<string, PackageResult>()).OrEmpty())
+            foreach (var packageConfig in GetConfigFromInputAndPackageConfigInput(config, new ConcurrentDictionary<string, PackageResult>(), installSourceRunners).OrEmpty())
             {
-                Action<PackageResult, ChocolateyConfiguration> action = null;
+                config.Noop = true;
+
                 if (packageConfig.SourceType.IsEqualTo(SourceTypes.Normal))
                 {
-                    action = (pkg,configuration) => _powershellService.InstallDryRun(pkg);
+                    Action<PackageResult, ChocolateyConfiguration> action = (pkg, configuration) => _powershellService.InstallDryRun(pkg);
+                    _nugetService.InstallDryRun(packageConfig, action);
                 }
-
-                PerformSourceRunnerAction(
-                    packageConfig,
-                    runner =>
-                    {
-                        if (runner is IInstallSourceRunner sr)
-                        {
-                            sr.InstallDryRun(packageConfig, action);
-                        }
-                        else
-                        {
-                            this.Log().Warn(ChocolateyLoggers.Important, "The '{0}' source doesn't support installing packages.", runner.SourceType);
-                        }
-                    }
-                );
+                else
+                {
+                    PerformSourceRunnerAction(config, runner => runner.InstallDryRun(packageConfig, null), installSourceRunners);
+                }
             }
 
             RandomlyNotifyAboutLicensedFeatures(config);
@@ -641,22 +690,30 @@ package '{0}' - stopping further execution".FormatWith(packageResult.Name));
 
             GetInitialEnvironment(config, allowLogging: true);
 
+            var installSourceRunners = _containerResolver.ResolveAll<IInstallSourceRunner>();
+
             try
             {
-                foreach (var packageConfig in GetConfigFromInputAndPackageConfigInput(config, packageInstalls).OrEmpty())
+                foreach (var packageConfig in GetConfigFromInputAndPackageConfigInput(config, packageInstalls, installSourceRunners).OrEmpty())
                 {
-                    Action<PackageResult, ChocolateyConfiguration> action = null;
+                    ConcurrentDictionary<string, PackageResult> results;
+
                     if (packageConfig.SourceType.IsEqualTo(SourceTypes.Normal))
                     {
-                        action = (packageResult, configuration) => HandlePackageResult(packageResult, configuration, CommandNameType.Install);
+                        var action = new Action<PackageResult, ChocolateyConfiguration>((packageResult, configuration) => HandlePackageResult(packageResult, configuration, CommandNameType.Install));
+                        var beforeModifyAction = new Action<PackageResult, ChocolateyConfiguration>((packageResult, configuration) => BeforeModifyAction(packageResult, configuration));
+
+                        results = _nugetService.Install(packageConfig, action, beforeModifyAction);
+                    }
+                    else
+                    {
+                        results = PerformSourceRunnerFunction<IInstallSourceRunner, ConcurrentDictionary<string, PackageResult>>(packageConfig, runner => runner.Install(packageConfig, null));
                     }
 
-                    var beforeModifyAction = new Action<PackageResult, ChocolateyConfiguration>((packageResult, configuration) => BeforeModifyAction(packageResult, configuration));
-                    var results = PerformSourceRunnerFunction(
-                        packageConfig,
-                        runner => runner is IInstallSourceRunner sr
-                            ? sr.Install(packageConfig, action, beforeModifyAction)
-                            : throw new NotSupportedException("The '{0}' source does not support installing packages.".FormatWith(runner.SourceType)));
+                    if (results is null)
+                    {
+                        throw new NotSupportedException("The '{0}' source does not support installing packages".FormatWith(config.SourceType));
+                    }
 
                     foreach (var result in results)
                     {
@@ -735,14 +792,14 @@ Would have determined packages that are out of date based on what is
             RandomlyNotifyAboutLicensedFeatures(config);
         }
 
-        private IEnumerable<ChocolateyConfiguration> GetConfigFromInputAndPackageConfigInput(ChocolateyConfiguration config, ConcurrentDictionary<string, PackageResult> packageInstalls)
+        private IEnumerable<ChocolateyConfiguration> GetConfigFromInputAndPackageConfigInput(ChocolateyConfiguration config, ConcurrentDictionary<string, PackageResult> packageInstalls, IEnumerable<IAlternativeSourceRunner> alternativeSourceRunners)
         {
             // if there are any .config files, split those off of the config. Then return the config without those package names.
             foreach (var packageConfigFile in config.PackageNames.Split(new[] { ApplicationParameters.PackageNamesSeparator }, StringSplitOptions.RemoveEmptyEntries).OrEmpty().Where(p => p.EndsWith(".config")).ToList())
             {
                 config.PackageNames = config.PackageNames.Replace(packageConfigFile, string.Empty);
 
-                foreach (var packageConfig in GetPackagesFromConfigFile(packageConfigFile, config, packageInstalls).OrEmpty())
+                foreach (var packageConfig in GetPackagesFromConfigFile(packageConfigFile, config, packageInstalls, alternativeSourceRunners).OrEmpty())
                 {
                     yield return packageConfig;
                 }
@@ -756,7 +813,7 @@ Would have determined packages that are out of date based on what is
             return packageNames.ToStringSafe().EndsWith(".config", StringComparison.OrdinalIgnoreCase) && !packageNames.ToStringSafe().ContainsSafe(";");
         }
 
-        private IEnumerable<ChocolateyConfiguration> GetPackagesFromConfigFile(string packageConfigFile, ChocolateyConfiguration config, ConcurrentDictionary<string, PackageResult> packageInstalls)
+        private IEnumerable<ChocolateyConfiguration> GetPackagesFromConfigFile(string packageConfigFile, ChocolateyConfiguration config, ConcurrentDictionary<string, PackageResult> packageInstalls, IEnumerable<IAlternativeSourceRunner> alternativeSourceRunners)
         {
             IList<ChocolateyConfiguration> packageConfigs = new List<ChocolateyConfiguration>();
 
@@ -787,7 +844,7 @@ Would have determined packages that are out of date based on what is
                     if (pkgSettings.ApplyInstallArgumentsToDependencies) packageConfig.ApplyInstallArgumentsToDependencies = true;
                     if (pkgSettings.ApplyPackageParametersToDependencies) packageConfig.ApplyPackageParametersToDependencies = true;
 
-                    if (!string.IsNullOrWhiteSpace(pkgSettings.Source) && HasSourceType(pkgSettings.Source))
+                    if (!string.IsNullOrWhiteSpace(pkgSettings.Source) && HasSourceType(pkgSettings.Source, alternativeSourceRunners))
                     {
                         packageConfig.SourceType = pkgSettings.Source;
                     }
@@ -848,27 +905,21 @@ Would have determined packages that are out of date based on what is
         {
             ValidatePackageNames(config);
 
-            Action<PackageResult, ChocolateyConfiguration> action = null;
+            var upgradeSourceRunners = _containerResolver.ResolveAll<IUpgradeSourceRunner>();
+
+            config.Noop = true;
+
+            ConcurrentDictionary<string, PackageResult> noopUpgrades;
+
             if (config.SourceType.IsEqualTo(SourceTypes.Normal))
             {
-                action = (pkg, configuration) => _powershellService.InstallDryRun(pkg);
+                Action<PackageResult, ChocolateyConfiguration> action = (pkg, configuration) => _powershellService.InstallDryRun(pkg);
+                noopUpgrades = _nugetService.UpgradeDryRun(config, action);
             }
-
-            var noopUpgrades = PerformSourceRunnerFunction(
-                config,
-                runner =>
-                {
-                    if (runner is IUpgradeSourceRunner sr)
-                    {
-                        return runner.UpgradeDryRun(config, action);
-                    }
-                    else
-                    {
-                        this.Log().Warn(ChocolateyLoggers.Important, "The '{0}' source does not support upgrading packages.", runner.SourceType);
-                        return new ConcurrentDictionary<string, PackageResult>(StringComparer.InvariantCultureIgnoreCase);
-                    }
-                }
-            );
+            else
+            {
+                noopUpgrades = PerformSourceRunnerFunction(config, runner => runner.UpgradeDryRun(config, null), upgradeSourceRunners);
+            }
 
             if (config.RegularOutput)
             {
@@ -904,20 +955,26 @@ Would have determined packages that are out of date based on what is
 
             try
             {
-                Action<PackageResult, ChocolateyConfiguration> action = null;
-                if (config.SourceType.IsEqualTo(SourceTypes.Normal))
-                {
-                    action = (packageResult, configuration) => HandlePackageResult(packageResult, configuration, CommandNameType.Upgrade);
-                }
-
                 GetInitialEnvironment(config, allowLogging: true);
 
-                var beforeUpgradeAction = new Action<PackageResult, ChocolateyConfiguration>((packageResult, configuration) => BeforeModifyAction(packageResult, configuration));
-                var results = PerformSourceRunnerFunction(
-                    config,
-                    runner => runner is IUpgradeSourceRunner sr
-                        ? sr.Upgrade(config, action, beforeUpgradeAction)
-                        : throw new NotSupportedException("The '{0}' source does not support upgrading packages.".FormatWith(runner.SourceType)));
+                ConcurrentDictionary<string, PackageResult> results;
+
+                if (config.SourceType.IsEqualTo(SourceTypes.Normal))
+                {
+                    var action = new Action<PackageResult, ChocolateyConfiguration>((packageResult, configuration) => HandlePackageResult(packageResult, configuration, CommandNameType.Upgrade));
+                    var beforeUpgradeAction = new Action<PackageResult, ChocolateyConfiguration>((packageResult, configuration) => BeforeModifyAction(packageResult, configuration));
+
+                    results = _nugetService.Upgrade(config, action, beforeUpgradeAction);
+                }
+                else
+                {
+                    results = PerformSourceRunnerFunction<IUpgradeSourceRunner, ConcurrentDictionary<string, PackageResult>>(config, runner => runner.Upgrade(config, null));
+                }
+
+                if (results is null)
+                {
+                    throw new NotSupportedException("The '{0}' source does not support upgrading packages".FormatWith(config.SourceType));
+                }
 
                 foreach (var result in results)
                 {
@@ -952,30 +1009,23 @@ Would have determined packages that are out of date based on what is
 
         public void UninstallDryRun(ChocolateyConfiguration config)
         {
-            Action<PackageResult, ChocolateyConfiguration> action = null;
+            var uninstallSourceRunners = _containerResolver.ResolveAll<IUninstallSourceRunner>();
+
+            config.Noop = true;
+
             if (config.SourceType.IsEqualTo(SourceTypes.Normal))
             {
-                action = (pkg, configuration) =>
+                Action<PackageResult, ChocolateyConfiguration> action = (pkg, configuration) =>
                 {
                     _powershellService.BeforeModifyDryRun(pkg);
                     _powershellService.UninstallDryRun(pkg);
                 };
+                _nugetService.UninstallDryRun(config, action);
             }
-
-            PerformSourceRunnerAction(
-                config,
-                runner =>
-                {
-                    if (runner is IUninstallSourceRunner sr)
-                    {
-                        runner.UninstallDryRun(config, action);
-                    }
-                    else
-                    {
-                        this.Log().Warn(ChocolateyLoggers.Important, "The '{0}' source does not support uninstall packages.", runner.SourceType);
-                    }
-                }
-            );
+            else
+            {
+                PerformSourceRunnerAction(config, runner => runner.UninstallDryRun(config, null), uninstallSourceRunners);
+            }
 
             RandomlyNotifyAboutLicensedFeatures(config);
         }
@@ -994,19 +1044,26 @@ Would have determined packages that are out of date based on what is
 
             try
             {
-                Action<PackageResult, ChocolateyConfiguration> action = null;
+                var environmentBefore = GetInitialEnvironment(config);
+
+                ConcurrentDictionary<string, PackageResult> results;
+
                 if (config.SourceType.IsEqualTo(SourceTypes.Normal))
                 {
-                    action = HandlePackageUninstall;
+                    var action = new Action<PackageResult, ChocolateyConfiguration>(HandlePackageUninstall);
+                    var beforeUninstallAction = new Action<PackageResult, ChocolateyConfiguration>(BeforeModifyAction);
+
+                    results = _nugetService.Uninstall(config, action, beforeUninstallAction);
+                }
+                else
+                {
+                    results = PerformSourceRunnerFunction<IUninstallSourceRunner, ConcurrentDictionary<string, PackageResult>>(config, runner => runner.Uninstall(config, null));
                 }
 
-                var environmentBefore = GetInitialEnvironment(config);
-                var beforeUninstallAction = new Action<PackageResult, ChocolateyConfiguration>(BeforeModifyAction);
-                var results = PerformSourceRunnerFunction(
-                    config,
-                    runner => runner is IUninstallSourceRunner sr
-                        ? sr.Uninstall(config, action, beforeUninstallAction)
-                        : throw new NotSupportedException("The '{0}' source does not support uninstalling packages.".FormatWith(runner.SourceType)));
+                if (results is null)
+                {
+                    throw new NotSupportedException("The '{0}' source does not support uninstalling packages".FormatWith(config.SourceType));
+                }
 
                 foreach (var result in results)
                 {
@@ -1517,9 +1574,9 @@ ATTENTION: You must take manual action to remove {1} from
             }
         }
 
-        private bool HasSourceType(string sourceType)
+        private bool HasSourceType(string sourceType, IEnumerable<IAlternativeSourceRunner> alternativeSourceRunners)
         {
-            return _sourceRunners.Any(s => s.SourceType == sourceType || s.SourceType == sourceType + "s");
+            return alternativeSourceRunners.Any(s => s.SourceType == sourceType || s.SourceType == sourceType + "s");
         }
 
         private void MovePackageToFailedPackagesLocation(PackageResult packageResult)
@@ -1735,11 +1792,19 @@ ATTENTION: You must take manual action to remove {1} from
             }
         }
 
-        private ISourceRunner GetSourceRunner(string sourceType)
+        private TSourceRunner GetSourceRunner<TSourceRunner>(string sourceType)
+            where TSourceRunner : class, IAlternativeSourceRunner
         {
             // We add the trailing s to the check in case of windows feature which can be specified both with and without
             // the s.
-            return _sourceRunners.FirstOrDefault(s => s.SourceType == sourceType || s.SourceType == sourceType + "s");
+            var sourceRunners = _containerResolver.ResolveAll<TSourceRunner>();
+            return GetSourceRunner(sourceType, sourceRunners);
+        }
+
+        private TSourceRunner GetSourceRunner<TSourceRunner>(string sourceType, IEnumerable<TSourceRunner> alternativeSourceRunners)
+            where TSourceRunner : class, IAlternativeSourceRunner
+        {
+            return alternativeSourceRunners.FirstOrDefault(s => s.SourceType == sourceType || s.SourceType == sourceType + "s");
         }
 
         // This should probably be split into install(/upgrade)/uninstall methods with shared logic placed in helper method(s).
@@ -1789,10 +1854,6 @@ ATTENTION: You must take manual action to remove {1} from
         }
 
 #pragma warning disable IDE1006
-        [Obsolete("This overload is deprecated and will be removed in v3.")]
-        public virtual void ensure_source_app_installed(ChocolateyConfiguration config)
-            => EnsureSourceAppInstalled(config);
-
         [Obsolete("This overload is deprecated and will be removed in v3.")]
         public virtual int count_run(ChocolateyConfiguration config)
             => Count(config);

--- a/src/chocolatey/infrastructure.app/services/CygwinService.cs
+++ b/src/chocolatey/infrastructure.app/services/CygwinService.cs
@@ -36,7 +36,7 @@ namespace chocolatey.infrastructure.app.services
     /// <remarks>
     ///   https://cygwin.com/faq/faq.html#faq.setup.cli
     /// </remarks>
-    public sealed class CygwinService : ISourceRunner
+    public sealed class CygwinService : ISourceRunner, IBootstrappableSourceRunner, IInstallSourceRunner
     {
         private readonly ICommandExecutor _commandExecutor;
         private readonly INugetService _nugetService;

--- a/src/chocolatey/infrastructure.app/services/CygwinService.cs
+++ b/src/chocolatey/infrastructure.app/services/CygwinService.cs
@@ -36,7 +36,7 @@ namespace chocolatey.infrastructure.app.services
     /// <remarks>
     ///   https://cygwin.com/faq/faq.html#faq.setup.cli
     /// </remarks>
-    public sealed class CygwinService : ISourceRunner, IBootstrappableSourceRunner, IInstallSourceRunner
+    public sealed class CygwinService : IBootstrappableSourceRunner, IInstallSourceRunner
     {
         private readonly ICommandExecutor _commandExecutor;
         private readonly INugetService _nugetService;
@@ -171,11 +171,6 @@ namespace chocolatey.infrastructure.app.services
             }
         }
 
-        public int Count(ChocolateyConfiguration config)
-        {
-            throw new NotImplementedException("Count is not supported for this source runner.");
-        }
-
         private string GetRootDirectory()
         {
             var setupKey = _registryService.GetKey(RegistryHive.LocalMachine, "SOFTWARE\\Cygwin\\setup");
@@ -193,16 +188,6 @@ namespace chocolatey.infrastructure.app.services
         private string GetCygwinPath(string rootpath)
         {
             return _fileSystem.CombinePaths(rootpath, "cygwinsetup.exe");
-        }
-
-        public void ListDryRun(ChocolateyConfiguration config)
-        {
-            this.Log().Warn(ChocolateyLoggers.Important, "{0} does not implement list".FormatWith(AppName));
-        }
-
-        public IEnumerable<PackageResult> List(ChocolateyConfiguration config)
-        {
-            throw new NotImplementedException("{0} does not implement list".FormatWith(AppName));
         }
 
         private string BuildArgs(ChocolateyConfiguration config, IDictionary<string, ExternalCommandArgument> argsDictionary)
@@ -272,27 +257,6 @@ namespace chocolatey.infrastructure.app.services
             return packageResults;
         }
 
-        public ConcurrentDictionary<string, PackageResult> UpgradeDryRun(ChocolateyConfiguration config, Action<PackageResult, ChocolateyConfiguration> continueAction)
-        {
-            this.Log().Warn(ChocolateyLoggers.Important, "{0} does not implement upgrade".FormatWith(AppName));
-            return new ConcurrentDictionary<string, PackageResult>(StringComparer.InvariantCultureIgnoreCase);
-        }
-
-        public ConcurrentDictionary<string, PackageResult> Upgrade(ChocolateyConfiguration config, Action<PackageResult, ChocolateyConfiguration> continueAction, Action<PackageResult, ChocolateyConfiguration> beforeUpgradeAction = null)
-        {
-            throw new NotImplementedException("{0} does not implement upgrade".FormatWith(AppName));
-        }
-
-        public void UninstallDryRun(ChocolateyConfiguration config, Action<PackageResult, ChocolateyConfiguration> continueAction)
-        {
-            this.Log().Warn(ChocolateyLoggers.Important, "{0} does not implement uninstall".FormatWith(AppName));
-        }
-
-        public ConcurrentDictionary<string, PackageResult> Uninstall(ChocolateyConfiguration config, Action<PackageResult, ChocolateyConfiguration> continueAction, Action<PackageResult, ChocolateyConfiguration> beforeUninstallAction = null)
-        {
-            throw new NotImplementedException("{0} does not implement upgrade".FormatWith(AppName));
-        }
-
         /// <summary>
         ///   Grabs a value from the output based on the regex.
         /// </summary>
@@ -326,18 +290,6 @@ namespace chocolatey.infrastructure.app.services
             => EnsureSourceAppInstalled(config, ensureAction);
 
         [Obsolete("This overload is deprecated and will be removed in v3.")]
-        public int count_run(ChocolateyConfiguration config)
-            => Count(config);
-
-        [Obsolete("This overload is deprecated and will be removed in v3.")]
-        public void list_noop(ChocolateyConfiguration config)
-            => ListDryRun(config);
-
-        [Obsolete("This overload is deprecated and will be removed in v3.")]
-        public IEnumerable<PackageResult> list_run(ChocolateyConfiguration config)
-            => List(config);
-
-        [Obsolete("This overload is deprecated and will be removed in v3.")]
         public void install_noop(ChocolateyConfiguration config, Action<PackageResult, ChocolateyConfiguration> continueAction)
             => InstallDryRun(config, continueAction);
 
@@ -348,22 +300,6 @@ namespace chocolatey.infrastructure.app.services
         [Obsolete("This overload is deprecated and will be removed in v3.")]
         public ConcurrentDictionary<string, PackageResult> install_run(ChocolateyConfiguration config, Action<PackageResult, ChocolateyConfiguration> continueAction, Action<PackageResult, ChocolateyConfiguration> beforeModifyAction)
             => Install(config, continueAction, beforeModifyAction);
-
-        [Obsolete("This overload is deprecated and will be removed in v3.")]
-        public ConcurrentDictionary<string, PackageResult> upgrade_noop(ChocolateyConfiguration config, Action<PackageResult, ChocolateyConfiguration> continueAction)
-            => UpgradeDryRun(config, continueAction);
-
-        [Obsolete("This overload is deprecated and will be removed in v3.")]
-        public ConcurrentDictionary<string, PackageResult> upgrade_run(ChocolateyConfiguration config, Action<PackageResult, ChocolateyConfiguration> continueAction, Action<PackageResult, ChocolateyConfiguration> beforeUpgradeAction = null)
-            => Upgrade(config, continueAction, beforeUpgradeAction);
-
-        [Obsolete("This overload is deprecated and will be removed in v3.")]
-        public void uninstall_noop(ChocolateyConfiguration config, Action<PackageResult, ChocolateyConfiguration> continueAction)
-            => UninstallDryRun(config, continueAction);
-
-        [Obsolete("This overload is deprecated and will be removed in v3.")]
-        public ConcurrentDictionary<string, PackageResult> uninstall_run(ChocolateyConfiguration config, Action<PackageResult, ChocolateyConfiguration> continueAction, Action<PackageResult, ChocolateyConfiguration> beforeUninstallAction = null)
-            => Uninstall(config, continueAction, beforeUninstallAction);
 #pragma warning restore IDE1006
     }
 }

--- a/src/chocolatey/infrastructure.app/services/IChocolateyPackageService.cs
+++ b/src/chocolatey/infrastructure.app/services/IChocolateyPackageService.cs
@@ -27,13 +27,6 @@ namespace chocolatey.infrastructure.app.services
     /// </summary>
     public interface IChocolateyPackageService
     {
-
-        /// <summary>
-        ///   Ensures the application that controls a source is installed
-        /// </summary>
-        /// <param name="config">The configuration.</param>
-        void EnsureSourceAppInstalled(ChocolateyConfiguration config);
-
         /// <summary>
         ///   Retrieves the count of items that meet the search criteria.
         /// </summary>
@@ -131,8 +124,6 @@ namespace chocolatey.infrastructure.app.services
 
 
 #pragma warning disable IDE1006
-        [Obsolete("This overload is deprecated and will be removed in v3.")]
-        void ensure_source_app_installed(ChocolateyConfiguration config);
         [Obsolete("This overload is deprecated and will be removed in v3.")]
         int count_run(ChocolateyConfiguration config);
         [Obsolete("This overload is deprecated and will be removed in v3.")]

--- a/src/chocolatey/infrastructure.app/services/ISourceRunner.cs
+++ b/src/chocolatey/infrastructure.app/services/ISourceRunner.cs
@@ -25,99 +25,9 @@ namespace chocolatey.infrastructure.app.services
     using results;
 
     [MultiService]
-    public interface ISourceRunner
+    [Obsolete("This interface is deprecated and will be removed in v3.")]
+    public interface ISourceRunner : IBootstrappableSourceRunner, ICountSourceRunner, IListSourceRunner, IInstallSourceRunner, IUpgradeSourceRunner, IUninstallSourceRunner
     {
-        /// <summary>
-        ///   Gets the source type the source runner implements
-        /// </summary>
-        /// <value>
-        ///   The type of the source.
-        /// </value>
-        string SourceType { get; }
-
-        /// <summary>
-        ///   Ensures the application that controls a source is installed
-        /// </summary>
-        /// <param name="config">The configuration.</param>
-        /// <param name="ensureAction">The action to continue with as part of the install</param>
-        void EnsureSourceAppInstalled(ChocolateyConfiguration config, Action<PackageResult, ChocolateyConfiguration> ensureAction);
-
-        /// <summary>
-        ///     Retrieve the listed packages from the source feed cout
-        /// </summary>
-        /// <param name="config">The configuration.</param>
-        /// <returns>Packages count</returns>
-        int Count(ChocolateyConfiguration config);
-
-        /// <summary>
-        ///   Run list in noop mode
-        /// </summary>
-        /// <param name="config">The configuration.</param>
-        void ListDryRun(ChocolateyConfiguration config);
-
-        /// <summary>
-        ///   Lists/searches for packages from the source feed
-        /// </summary>
-        /// <param name="config">The configuration.</param>
-        /// <returns></returns>
-        IEnumerable<PackageResult> List(ChocolateyConfiguration config);
-
-        /// <summary>
-        ///   Run install in noop mode
-        /// </summary>
-        /// <param name="config">The configuration.</param>
-        /// <param name="continueAction">The action to continue with for each noop test install.</param>
-        void InstallDryRun(ChocolateyConfiguration config, Action<PackageResult, ChocolateyConfiguration> continueAction);
-
-        /// <summary>
-        ///   Installs packages from the source feed
-        /// </summary>
-        /// <param name="config">The configuration.</param>
-        /// <param name="continueAction">The action to continue with when install is successful.</param>
-        /// <returns>results of installs</returns>
-        ConcurrentDictionary<string, PackageResult> Install(ChocolateyConfiguration config, Action<PackageResult, ChocolateyConfiguration> continueAction);
-
-        /// <summary>
-        ///   Installs packages from the source feed
-        /// </summary>
-        /// <param name="config">The configuration.</param>
-        /// <param name="continueAction">The action to continue with when install is successful.</param>
-        /// <param name="beforeModifyAction">The action (if any) to run on any currently installed package dependencies before triggering the install or updating those dependencies.</param>
-        /// <returns>results of installs</returns>
-        ConcurrentDictionary<string, PackageResult> Install(ChocolateyConfiguration config, Action<PackageResult, ChocolateyConfiguration> continueAction, Action<PackageResult, ChocolateyConfiguration> beforeModifyAction);
-
-        /// <summary>
-        ///   Run upgrade in noop mode
-        /// </summary>
-        /// <param name="config">The configuration.</param>
-        /// <param name="continueAction">The action to continue with for each noop test upgrade.</param>
-        ConcurrentDictionary<string, PackageResult> UpgradeDryRun(ChocolateyConfiguration config, Action<PackageResult, ChocolateyConfiguration> continueAction);
-
-        /// <summary>
-        ///   Upgrades packages from NuGet related feeds
-        /// </summary>
-        /// <param name="config">The configuration.</param>
-        /// <param name="continueAction">The action to continue with when upgrade is successful.</param>
-        /// <param name="beforeUpgradeAction">The action (if any) to run on any currently installed package or its dependencies before triggering the upgrade.</param>
-        /// <returns>results of installs</returns>
-        ConcurrentDictionary<string, PackageResult> Upgrade(ChocolateyConfiguration config, Action<PackageResult, ChocolateyConfiguration> continueAction, Action<PackageResult, ChocolateyConfiguration> beforeUpgradeAction = null);
-
-        /// <summary>
-        ///   Run uninstall in noop mode
-        /// </summary>
-        /// <param name="config">The configuration.</param>
-        /// <param name="continueAction">The action to continue with for each noop test upgrade.</param>
-        void UninstallDryRun(ChocolateyConfiguration config, Action<PackageResult, ChocolateyConfiguration> continueAction);
-
-        /// <summary>
-        ///   Uninstalls packages from NuGet related feeds
-        /// </summary>
-        /// <param name="config">The configuration.</param>
-        /// <param name="continueAction">The action to continue with when upgrade is successful.</param>
-        /// <param name="beforeUninstallAction">The action (if any) to run on any currently installed package before triggering the uninstall.</param>
-        /// <returns>results of installs</returns>
-        ConcurrentDictionary<string, PackageResult> Uninstall(ChocolateyConfiguration config, Action<PackageResult, ChocolateyConfiguration> continueAction, Action<PackageResult, ChocolateyConfiguration> beforeUninstallAction = null);
-
 #pragma warning disable IDE1006
         [Obsolete("This overload is deprecated and will be removed in v3.")]
         void ensure_source_app_installed(ChocolateyConfiguration config, Action<PackageResult, ChocolateyConfiguration> ensureAction);
@@ -144,36 +54,47 @@ namespace chocolatey.infrastructure.app.services
 #pragma warning restore IDE1006
     }
 
-    public interface IBootstrappableSourceRunner
+    public interface IAlternativeSourceRunner
     {
         /// <summary>
-        ///   Ensures the application that controls a source is installed
+        ///   Gets the source type the source runner implements.
+        /// </summary>
+        /// <value>
+        ///   The type of the source.
+        /// </value>
+        string SourceType { get; }
+    }
+
+    public interface IBootstrappableSourceRunner : IAlternativeSourceRunner
+    {
+        /// <summary>
+        ///   Ensures the application that controls a source is installed.
         /// </summary>
         /// <param name="config">The configuration.</param>
-        /// <param name="ensureAction">The action to continue with as part of the install</param>
+        /// <param name="ensureAction">The action to continue with as part of the install.</param>
         void EnsureSourceAppInstalled(ChocolateyConfiguration config, Action<PackageResult, ChocolateyConfiguration> ensureAction);
     }
 
-    public interface ICountSourceRunner
+    public interface ICountSourceRunner : IAlternativeSourceRunner
     {
         /// <summary>
-        ///     Retrieve the listed packages from the source feed cout
+        ///   Retrieve the count of the listed packages from the source.
         /// </summary>
         /// <param name="config">The configuration.</param>
-        /// <returns>Packages count</returns>
+        /// <returns>Packages count.</returns>
         int Count(ChocolateyConfiguration config);
     }
 
-    public interface IListSourceRunner
+    public interface IListSourceRunner : IAlternativeSourceRunner
     {
         /// <summary>
-        ///   Run list in noop mode
+        ///   Run list in noop mode.
         /// </summary>
         /// <param name="config">The configuration.</param>
         void ListDryRun(ChocolateyConfiguration config);
 
         /// <summary>
-        ///   Lists/searches for packages from the source feed
+        ///   Lists for packages from the source feed.
         /// </summary>
         /// <param name="config">The configuration.</param>
         /// <returns></returns>
@@ -184,73 +105,84 @@ namespace chocolatey.infrastructure.app.services
     /// This interface is a 'marker' type that indicates that the List action on the current source runner
     /// supports searching for specific packages.
     /// </summary>
-    public interface ISearchableSourceRunner : IListSourceRunner
-    {
-    }
-
-    public interface IInstallSourceRunner
+    public interface ISearchableSourceRunner : IAlternativeSourceRunner
     {
         /// <summary>
-        ///   Run install in noop mode
+        ///   Run search in noop mode.
+        /// </summary>
+        /// <param name="config">The configuration.</param>
+        void SearchDryRun(ChocolateyConfiguration config);
+
+        /// <summary>
+        ///   Searches for packages from the source feed.
+        /// </summary>
+        /// <param name="config">The configuration.</param>
+        /// <returns></returns>
+        IEnumerable<PackageResult> Search(ChocolateyConfiguration config);
+    }
+
+    public interface IInstallSourceRunner : IAlternativeSourceRunner
+    {
+        /// <summary>
+        ///   Run install in noop mode.
         /// </summary>
         /// <param name="config">The configuration.</param>
         /// <param name="continueAction">The action to continue with for each noop test install.</param>
         void InstallDryRun(ChocolateyConfiguration config, Action<PackageResult, ChocolateyConfiguration> continueAction);
 
         /// <summary>
-        ///   Installs packages from the source feed
+        ///   Installs packages from the source feed.
         /// </summary>
         /// <param name="config">The configuration.</param>
         /// <param name="continueAction">The action to continue with when install is successful.</param>
-        /// <returns>results of installs</returns>
+        /// <returns>Results of installs.</returns>
         ConcurrentDictionary<string, PackageResult> Install(ChocolateyConfiguration config, Action<PackageResult, ChocolateyConfiguration> continueAction);
 
         /// <summary>
-        ///   Installs packages from the source feed
+        ///   Installs packages from the source feed.
         /// </summary>
         /// <param name="config">The configuration.</param>
         /// <param name="continueAction">The action to continue with when install is successful.</param>
         /// <param name="beforeModifyAction">The action (if any) to run on any currently installed package dependencies before triggering the install or updating those dependencies.</param>
-        /// <returns>results of installs</returns>
+        /// <returns>Results of installs.</returns>
         ConcurrentDictionary<string, PackageResult> Install(ChocolateyConfiguration config, Action<PackageResult, ChocolateyConfiguration> continueAction, Action<PackageResult, ChocolateyConfiguration> beforeModifyAction);
     }
 
-    public interface IUpgradeSourceRunner
+    public interface IUpgradeSourceRunner : IAlternativeSourceRunner
     {
         /// <summary>
-        ///   Run upgrade in noop mode
+        ///   Run upgrade in noop mode.
         /// </summary>
         /// <param name="config">The configuration.</param>
         /// <param name="continueAction">The action to continue with for each noop test upgrade.</param>
         ConcurrentDictionary<string, PackageResult> UpgradeDryRun(ChocolateyConfiguration config, Action<PackageResult, ChocolateyConfiguration> continueAction);
 
         /// <summary>
-        ///   Upgrades packages from NuGet related feeds
+        ///   Upgrades packages from NuGet related feeds.
         /// </summary>
         /// <param name="config">The configuration.</param>
         /// <param name="continueAction">The action to continue with when upgrade is successful.</param>
         /// <param name="beforeUpgradeAction">The action (if any) to run on any currently installed package or its dependencies before triggering the upgrade.</param>
-        /// <returns>results of installs</returns>
+        /// <returns>Results of upgrades.</returns>
         ConcurrentDictionary<string, PackageResult> Upgrade(ChocolateyConfiguration config, Action<PackageResult, ChocolateyConfiguration> continueAction, Action<PackageResult, ChocolateyConfiguration> beforeUpgradeAction = null);
     }
 
-    public interface IUninstallSourceRunner
+    public interface IUninstallSourceRunner : IAlternativeSourceRunner
     {
         /// <summary>
-        ///   Run uninstall in noop mode
+        ///   Run uninstall in noop mode.
         /// </summary>
         /// <param name="config">The configuration.</param>
         /// <param name="continueAction">The action to continue with for each noop test upgrade.</param>
         void UninstallDryRun(ChocolateyConfiguration config, Action<PackageResult, ChocolateyConfiguration> continueAction);
 
         /// <summary>
-        ///   Uninstalls packages from NuGet related feeds
+        ///   Uninstalls packages from NuGet related feeds.
         /// </summary>
         /// <param name="config">The configuration.</param>
         /// <param name="continueAction">The action to continue with when upgrade is successful.</param>
         /// <param name="beforeUninstallAction">The action (if any) to run on any currently installed package before triggering the uninstall.</param>
-        /// <returns>results of installs</returns>
+        /// <returns>Results of uninstalls.</returns>
         ConcurrentDictionary<string, PackageResult> Uninstall(ChocolateyConfiguration config, Action<PackageResult, ChocolateyConfiguration> continueAction, Action<PackageResult, ChocolateyConfiguration> beforeUninstallAction = null);
-
     }
 }

--- a/src/chocolatey/infrastructure.app/services/ISourceRunner.cs
+++ b/src/chocolatey/infrastructure.app/services/ISourceRunner.cs
@@ -143,4 +143,114 @@ namespace chocolatey.infrastructure.app.services
         ConcurrentDictionary<string, PackageResult> uninstall_run(ChocolateyConfiguration config, Action<PackageResult, ChocolateyConfiguration> continueAction, Action<PackageResult, ChocolateyConfiguration> beforeUninstallAction = null);
 #pragma warning restore IDE1006
     }
+
+    public interface IBootstrappableSourceRunner
+    {
+        /// <summary>
+        ///   Ensures the application that controls a source is installed
+        /// </summary>
+        /// <param name="config">The configuration.</param>
+        /// <param name="ensureAction">The action to continue with as part of the install</param>
+        void EnsureSourceAppInstalled(ChocolateyConfiguration config, Action<PackageResult, ChocolateyConfiguration> ensureAction);
+    }
+
+    public interface ICountSourceRunner
+    {
+        /// <summary>
+        ///     Retrieve the listed packages from the source feed cout
+        /// </summary>
+        /// <param name="config">The configuration.</param>
+        /// <returns>Packages count</returns>
+        int Count(ChocolateyConfiguration config);
+    }
+
+    public interface IListSourceRunner
+    {
+        /// <summary>
+        ///   Run list in noop mode
+        /// </summary>
+        /// <param name="config">The configuration.</param>
+        void ListDryRun(ChocolateyConfiguration config);
+
+        /// <summary>
+        ///   Lists/searches for packages from the source feed
+        /// </summary>
+        /// <param name="config">The configuration.</param>
+        /// <returns></returns>
+        IEnumerable<PackageResult> List(ChocolateyConfiguration config);
+    }
+
+    /// <summary>
+    /// This interface is a 'marker' type that indicates that the List action on the current source runner
+    /// supports searching for specific packages.
+    /// </summary>
+    public interface ISearchableSourceRunner : IListSourceRunner
+    {
+    }
+
+    public interface IInstallSourceRunner
+    {
+        /// <summary>
+        ///   Run install in noop mode
+        /// </summary>
+        /// <param name="config">The configuration.</param>
+        /// <param name="continueAction">The action to continue with for each noop test install.</param>
+        void InstallDryRun(ChocolateyConfiguration config, Action<PackageResult, ChocolateyConfiguration> continueAction);
+
+        /// <summary>
+        ///   Installs packages from the source feed
+        /// </summary>
+        /// <param name="config">The configuration.</param>
+        /// <param name="continueAction">The action to continue with when install is successful.</param>
+        /// <returns>results of installs</returns>
+        ConcurrentDictionary<string, PackageResult> Install(ChocolateyConfiguration config, Action<PackageResult, ChocolateyConfiguration> continueAction);
+
+        /// <summary>
+        ///   Installs packages from the source feed
+        /// </summary>
+        /// <param name="config">The configuration.</param>
+        /// <param name="continueAction">The action to continue with when install is successful.</param>
+        /// <param name="beforeModifyAction">The action (if any) to run on any currently installed package dependencies before triggering the install or updating those dependencies.</param>
+        /// <returns>results of installs</returns>
+        ConcurrentDictionary<string, PackageResult> Install(ChocolateyConfiguration config, Action<PackageResult, ChocolateyConfiguration> continueAction, Action<PackageResult, ChocolateyConfiguration> beforeModifyAction);
+    }
+
+    public interface IUpgradeSourceRunner
+    {
+        /// <summary>
+        ///   Run upgrade in noop mode
+        /// </summary>
+        /// <param name="config">The configuration.</param>
+        /// <param name="continueAction">The action to continue with for each noop test upgrade.</param>
+        ConcurrentDictionary<string, PackageResult> UpgradeDryRun(ChocolateyConfiguration config, Action<PackageResult, ChocolateyConfiguration> continueAction);
+
+        /// <summary>
+        ///   Upgrades packages from NuGet related feeds
+        /// </summary>
+        /// <param name="config">The configuration.</param>
+        /// <param name="continueAction">The action to continue with when upgrade is successful.</param>
+        /// <param name="beforeUpgradeAction">The action (if any) to run on any currently installed package or its dependencies before triggering the upgrade.</param>
+        /// <returns>results of installs</returns>
+        ConcurrentDictionary<string, PackageResult> Upgrade(ChocolateyConfiguration config, Action<PackageResult, ChocolateyConfiguration> continueAction, Action<PackageResult, ChocolateyConfiguration> beforeUpgradeAction = null);
+    }
+
+    public interface IUninstallSourceRunner
+    {
+        /// <summary>
+        ///   Run uninstall in noop mode
+        /// </summary>
+        /// <param name="config">The configuration.</param>
+        /// <param name="continueAction">The action to continue with for each noop test upgrade.</param>
+        void UninstallDryRun(ChocolateyConfiguration config, Action<PackageResult, ChocolateyConfiguration> continueAction);
+
+        /// <summary>
+        ///   Uninstalls packages from NuGet related feeds
+        /// </summary>
+        /// <param name="config">The configuration.</param>
+        /// <param name="continueAction">The action to continue with when upgrade is successful.</param>
+        /// <param name="beforeUninstallAction">The action (if any) to run on any currently installed package before triggering the uninstall.</param>
+        /// <returns>results of installs</returns>
+        ConcurrentDictionary<string, PackageResult> Uninstall(ChocolateyConfiguration config, Action<PackageResult, ChocolateyConfiguration> continueAction, Action<PackageResult, ChocolateyConfiguration> beforeUninstallAction = null);
+
+    }
 }

--- a/src/chocolatey/infrastructure.app/services/NugetService.cs
+++ b/src/chocolatey/infrastructure.app/services/NugetService.cs
@@ -53,7 +53,7 @@ namespace chocolatey.infrastructure.app.services
 
     //todo: #2575 - this monolith is too large. Refactor once test coverage is up.
 
-    public class NugetService : INugetService
+    public class NugetService : INugetService, IListSourceRunner, ISearchableSourceRunner, ICountSourceRunner, IInstallSourceRunner, IUpgradeSourceRunner, IUninstallSourceRunner
     {
         private readonly IFileSystem _fileSystem;
         private readonly ILogger _nugetLogger;

--- a/src/chocolatey/infrastructure.app/services/NugetService.cs
+++ b/src/chocolatey/infrastructure.app/services/NugetService.cs
@@ -53,7 +53,7 @@ namespace chocolatey.infrastructure.app.services
 
     //todo: #2575 - this monolith is too large. Refactor once test coverage is up.
 
-    public class NugetService : INugetService, IListSourceRunner, ISearchableSourceRunner, ICountSourceRunner, IInstallSourceRunner, IUpgradeSourceRunner, IUninstallSourceRunner
+    public class NugetService : INugetService
     {
         private readonly IFileSystem _fileSystem;
         private readonly ILogger _nugetLogger;

--- a/src/chocolatey/infrastructure.app/services/PythonService.cs
+++ b/src/chocolatey/infrastructure.app/services/PythonService.cs
@@ -34,7 +34,7 @@ namespace chocolatey.infrastructure.app.services
     /// <summary>
     ///   Alternative Source for Installing Python packages
     /// </summary>
-    public sealed class PythonService : ISourceRunner
+    public sealed class PythonService : ISourceRunner, IBootstrappableSourceRunner, IListSourceRunner, IInstallSourceRunner, IUpgradeSourceRunner, IUninstallSourceRunner
     {
         private readonly ICommandExecutor _commandExecutor;
         private readonly INugetService _nugetService;

--- a/src/chocolatey/infrastructure.app/services/PythonService.cs
+++ b/src/chocolatey/infrastructure.app/services/PythonService.cs
@@ -34,7 +34,7 @@ namespace chocolatey.infrastructure.app.services
     /// <summary>
     ///   Alternative Source for Installing Python packages
     /// </summary>
-    public sealed class PythonService : ISourceRunner, IBootstrappableSourceRunner, IListSourceRunner, IInstallSourceRunner, IUpgradeSourceRunner, IUninstallSourceRunner
+    public sealed class PythonService : IBootstrappableSourceRunner, IListSourceRunner, IInstallSourceRunner, IUpgradeSourceRunner, IUninstallSourceRunner
     {
         private readonly ICommandExecutor _commandExecutor;
         private readonly INugetService _nugetService;
@@ -208,11 +208,6 @@ namespace chocolatey.infrastructure.app.services
                     config.PromptForConfirmation = prompt;
                 }
             }
-        }
-
-        public int Count(ChocolateyConfiguration config)
-        {
-            throw new NotImplementedException("Count is not supported for this source runner.");
         }
 
         private void EnsureExecutablePathSet()
@@ -589,10 +584,6 @@ namespace chocolatey.infrastructure.app.services
         [Obsolete("This overload is deprecated and will be removed in v3.")]
         public void ensure_source_app_installed(ChocolateyConfiguration config, Action<PackageResult, ChocolateyConfiguration> ensureAction)
             => EnsureSourceAppInstalled(config, ensureAction);
-
-        [Obsolete("This overload is deprecated and will be removed in v3.")]
-        public int count_run(ChocolateyConfiguration config)
-            => Count(config);
 
         [Obsolete("This overload is deprecated and will be removed in v3.")]
         public void set_executable_path_if_not_set()

--- a/src/chocolatey/infrastructure.app/services/RubyGemsService.cs
+++ b/src/chocolatey/infrastructure.app/services/RubyGemsService.cs
@@ -28,7 +28,7 @@ namespace chocolatey.infrastructure.app.services
     using results;
     using platforms;
 
-    public sealed class RubyGemsService : ISourceRunner, IBootstrappableSourceRunner, IListSourceRunner, IInstallSourceRunner
+    public sealed class RubyGemsService : IBootstrappableSourceRunner, IListSourceRunner, IInstallSourceRunner
     {
         private readonly ICommandExecutor _commandExecutor;
         private readonly INugetService _nugetService;
@@ -147,11 +147,6 @@ namespace chocolatey.infrastructure.app.services
             }
         }
 
-        public int Count(ChocolateyConfiguration config)
-        {
-            throw new NotImplementedException("Count is not supported for this source runner.");
-        }
-
         public void ListDryRun(ChocolateyConfiguration config)
         {
             var args = ExternalCommandArgsBuilder.BuildArguments(config, _listArguments);
@@ -266,27 +261,6 @@ namespace chocolatey.infrastructure.app.services
             return packageResults;
         }
 
-        public ConcurrentDictionary<string, PackageResult> UpgradeDryRun(ChocolateyConfiguration config, Action<PackageResult, ChocolateyConfiguration> continueAction)
-        {
-            this.Log().Warn(ChocolateyLoggers.Important, "{0} does not implement upgrade".FormatWith(AppName));
-            return new ConcurrentDictionary<string, PackageResult>(StringComparer.InvariantCultureIgnoreCase);
-        }
-
-        public ConcurrentDictionary<string, PackageResult> Upgrade(ChocolateyConfiguration config, Action<PackageResult, ChocolateyConfiguration> continueAction, Action<PackageResult, ChocolateyConfiguration> beforeUpgradeAction = null)
-        {
-            throw new NotImplementedException("{0} does not implement upgrade".FormatWith(AppName));
-        }
-
-        public void UninstallDryRun(ChocolateyConfiguration config, Action<PackageResult, ChocolateyConfiguration> continueAction)
-        {
-            this.Log().Warn(ChocolateyLoggers.Important, "{0} does not implement uninstall".FormatWith(AppName));
-        }
-
-        public ConcurrentDictionary<string, PackageResult> Uninstall(ChocolateyConfiguration config, Action<PackageResult, ChocolateyConfiguration> continueAction, Action<PackageResult, ChocolateyConfiguration> beforeUninstallAction = null)
-        {
-            throw new NotImplementedException("{0} does not implement uninstall".FormatWith(AppName));
-        }
-
         /// <summary>
         ///   Grabs a value from the output based on the regex.
         /// </summary>
@@ -330,10 +304,6 @@ namespace chocolatey.infrastructure.app.services
             => EnsureSourceAppInstalled(config, ensureAction);
 
         [Obsolete("This overload is deprecated and will be removed in v3.")]
-        public int count_run(ChocolateyConfiguration config)
-            => Count(config);
-
-        [Obsolete("This overload is deprecated and will be removed in v3.")]
         public void list_noop(ChocolateyConfiguration config)
             => ListDryRun(config);
 
@@ -352,22 +322,6 @@ namespace chocolatey.infrastructure.app.services
         [Obsolete("This overload is deprecated and will be removed in v3.")]
         public ConcurrentDictionary<string, PackageResult> install_run(ChocolateyConfiguration config, Action<PackageResult, ChocolateyConfiguration> continueAction, Action<PackageResult, ChocolateyConfiguration> beforeModifyAction)
             => Install(config, continueAction, beforeModifyAction);
-
-        [Obsolete("This overload is deprecated and will be removed in v3.")]
-        public ConcurrentDictionary<string, PackageResult> upgrade_noop(ChocolateyConfiguration config, Action<PackageResult, ChocolateyConfiguration> continueAction)
-            => UpgradeDryRun(config, continueAction);
-
-        [Obsolete("This overload is deprecated and will be removed in v3.")]
-        public ConcurrentDictionary<string, PackageResult> upgrade_run(ChocolateyConfiguration config, Action<PackageResult, ChocolateyConfiguration> continueAction, Action<PackageResult, ChocolateyConfiguration> beforeUpgradeAction = null)
-            => Upgrade(config, continueAction, beforeUpgradeAction);
-
-        [Obsolete("This overload is deprecated and will be removed in v3.")]
-        public void uninstall_noop(ChocolateyConfiguration config, Action<PackageResult, ChocolateyConfiguration> continueAction)
-            => UninstallDryRun(config, continueAction);
-
-        [Obsolete("This overload is deprecated and will be removed in v3.")]
-        public ConcurrentDictionary<string, PackageResult> uninstall_run(ChocolateyConfiguration config, Action<PackageResult, ChocolateyConfiguration> continueAction, Action<PackageResult, ChocolateyConfiguration> beforeUninstallAction = null)
-            => Uninstall(config, continueAction, beforeUninstallAction);
 #pragma warning restore IDE1006
     }
 }

--- a/src/chocolatey/infrastructure.app/services/RubyGemsService.cs
+++ b/src/chocolatey/infrastructure.app/services/RubyGemsService.cs
@@ -28,7 +28,7 @@ namespace chocolatey.infrastructure.app.services
     using results;
     using platforms;
 
-    public sealed class RubyGemsService : ISourceRunner
+    public sealed class RubyGemsService : ISourceRunner, IBootstrappableSourceRunner, IListSourceRunner, IInstallSourceRunner
     {
         private readonly ICommandExecutor _commandExecutor;
         private readonly INugetService _nugetService;

--- a/src/chocolatey/infrastructure.app/services/WindowsFeatureService.cs
+++ b/src/chocolatey/infrastructure.app/services/WindowsFeatureService.cs
@@ -37,7 +37,7 @@ namespace chocolatey.infrastructure.app.services
     ///   Win 7 - https://technet.microsoft.com/en-us/library/dd744311.aspx
     ///   Maybe Win2003/2008 - http://www.wincert.net/forum/files/file/8-deployment-image-servicing-and-management-dism/ | http://wincert.net/leli55PK/DISM/
     /// </remarks>
-    public sealed class WindowsFeatureService : ISourceRunner, IBootstrappableSourceRunner, IListSourceRunner, ISearchableSourceRunner, IInstallSourceRunner, IUninstallSourceRunner
+    public sealed class WindowsFeatureService : IBootstrappableSourceRunner, IListSourceRunner, ISearchableSourceRunner, IInstallSourceRunner, IUninstallSourceRunner
     {
         private readonly ICommandExecutor _commandExecutor;
         private readonly INugetService _nugetService;
@@ -163,11 +163,6 @@ namespace chocolatey.infrastructure.app.services
             EnsureExecutablePathSet();
         }
 
-        public int Count(ChocolateyConfiguration config)
-        {
-            throw new NotImplementedException("Count is not supported for this source runner.");
-        }
-
         private void EnsureExecutablePathSet()
         {
             if (!string.IsNullOrWhiteSpace(_exePath)) return;
@@ -225,6 +220,16 @@ namespace chocolatey.infrastructure.app.services
                 );
 
             return packageResults;
+        }
+
+        public void SearchDryRun(ChocolateyConfiguration config)
+        {
+            ListDryRun(config);
+        }
+
+        public IEnumerable<PackageResult> Search(ChocolateyConfiguration config)
+        {
+            return List(config);
         }
 
         private string BuildArguments(ChocolateyConfiguration config, IDictionary<string, ExternalCommandArgument> argsDictionary)
@@ -327,19 +332,6 @@ namespace chocolatey.infrastructure.app.services
             return packageResults;
         }
 
-        public ConcurrentDictionary<string, PackageResult> UpgradeDryRun(ChocolateyConfiguration config, Action<PackageResult, ChocolateyConfiguration> continueAction)
-        {
-            EnsureExecutablePathSet();
-            this.Log().Warn(ChocolateyLoggers.Important, "{0} does not implement upgrade".FormatWith(AppName));
-            return new ConcurrentDictionary<string, PackageResult>(StringComparer.InvariantCultureIgnoreCase);
-        }
-
-        public ConcurrentDictionary<string, PackageResult> Upgrade(ChocolateyConfiguration config, Action<PackageResult, ChocolateyConfiguration> continueAction, Action<PackageResult, ChocolateyConfiguration> beforeUpgradeAction = null)
-        {
-            EnsureExecutablePathSet();
-            throw new NotImplementedException("{0} does not implement upgrade".FormatWith(AppName));
-        }
-
         public void UninstallDryRun(ChocolateyConfiguration config, Action<PackageResult, ChocolateyConfiguration> continueAction)
         {
             EnsureExecutablePathSet();
@@ -426,10 +418,6 @@ namespace chocolatey.infrastructure.app.services
             => EnsureSourceAppInstalled(config, ensureAction);
 
         [Obsolete("This overload is deprecated and will be removed in v3.")]
-        public int count_run(ChocolateyConfiguration config)
-            => Count(config);
-
-        [Obsolete("This overload is deprecated and will be removed in v3.")]
         public void set_executable_path_if_not_set()
             => EnsureExecutablePathSet();
 
@@ -456,14 +444,6 @@ namespace chocolatey.infrastructure.app.services
         [Obsolete("This overload is deprecated and will be removed in v3.")]
         public ConcurrentDictionary<string, PackageResult> install_run(ChocolateyConfiguration config, Action<PackageResult, ChocolateyConfiguration> continueAction, Action<PackageResult, ChocolateyConfiguration> beforeModifyAction)
             => Install(config, continueAction, beforeModifyAction);
-
-        [Obsolete("This overload is deprecated and will be removed in v3.")]
-        public ConcurrentDictionary<string, PackageResult> upgrade_noop(ChocolateyConfiguration config, Action<PackageResult, ChocolateyConfiguration> continueAction)
-            => UpgradeDryRun(config, continueAction);
-
-        [Obsolete("This overload is deprecated and will be removed in v3.")]
-        public ConcurrentDictionary<string, PackageResult> upgrade_run(ChocolateyConfiguration config, Action<PackageResult, ChocolateyConfiguration> continueAction, Action<PackageResult, ChocolateyConfiguration> beforeUpgradeAction = null)
-            => Upgrade(config, continueAction, beforeUpgradeAction);
 
         [Obsolete("This overload is deprecated and will be removed in v3.")]
         public void uninstall_noop(ChocolateyConfiguration config, Action<PackageResult, ChocolateyConfiguration> continueAction)

--- a/src/chocolatey/infrastructure.app/services/WindowsFeatureService.cs
+++ b/src/chocolatey/infrastructure.app/services/WindowsFeatureService.cs
@@ -37,7 +37,7 @@ namespace chocolatey.infrastructure.app.services
     ///   Win 7 - https://technet.microsoft.com/en-us/library/dd744311.aspx
     ///   Maybe Win2003/2008 - http://www.wincert.net/forum/files/file/8-deployment-image-servicing-and-management-dism/ | http://wincert.net/leli55PK/DISM/
     /// </remarks>
-    public sealed class WindowsFeatureService : ISourceRunner
+    public sealed class WindowsFeatureService : ISourceRunner, IBootstrappableSourceRunner, IListSourceRunner, ISearchableSourceRunner, IInstallSourceRunner, IUninstallSourceRunner
     {
         private readonly ICommandExecutor _commandExecutor;
         private readonly INugetService _nugetService;


### PR DESCRIPTION
## Description Of Changes

- Restore `--source` param for `choco list`
- Add a handful of interfaces for the functionally different pieces of `ISourceRunner`
- Add appropriate interfaces for each currently available ISourceRunner
- Add pre-checks into ChocolateyPackageService which verifies which methods that the source runner it's trying to invoke supports and throws an error (or warning, in the case of `DryRun` / `--noop` operations) before ever trying to run it if the source runner doesn't support that operation.
- Update a few affected mocks in tests to ensure they still work correctly.

## Motivation and Context
Since alternate sources can list installed packages separately to our normal package list, we need to allow list to specify --source. This will have no effect for normal sources, but will select alternate source runners if specified.

Additionally, the early checks for each source runner as to which operations they support was implemented in a way that allows us to gut ISourceRunner in a later version and fall back to having the supported methods for each source runner enforced by the type system, so we have a clear indication as to which source runners support each kind of operation via an appropriate interface cast. I haven't added obsoletions to ISourceRunner's main methods just yet, but that might be something we want to do in future.

## Testing

- Check that `choco list --source windowsfeatures` works
- Check that `choco search --source windowsfeatures` works
- Check that `choco list --source cygwin` reports as not supported _without_ first installing cygwin if it's not yet installed
- Ensure that supported operations for list and for search for each source work as expected (currently afaik only the windowsfeatures source does any actual searching, the rest only do listing for local or remote packages).

### Operating Systems Testing

Win11

## Change Types Made
<!-- Tick the boxes for the type of changes that have been made -->

* [x] Bug fix (non-breaking change).
* [x] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [x] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue

Restoring some functionality that was impacted by our changes when resolving #158 