### PR TITLE
(maint) Fix grammatical issue in pending reboot warning message

### DIFF
--- a/src/chocolatey/infrastructure.app/validations/SystemStateValidation.cs
+++ b/src/chocolatey/infrastructure.app/validations/SystemStateValidation.cs
@@ -69,7 +69,7 @@ namespace chocolatey.infrastructure.app.validations
                     validationResults.Add(new ValidationResult
                     {
                         Message = @"A pending system reboot request has been detected, however, this is
-   being ignored due to the current command being used '{0}'.
+   being ignored due to the current command '{0}' being used.
    It is recommended that you reboot at your earliest convenience.
 ".FormatWith(config.CommandName),
                         Status = ValidationStatus.Warning,


### PR DESCRIPTION
## Description Of Changes
Changed 'Pending Reboot' warning message to be more accurate grammatically.

## Motivation and Context

## Testing

### Operating Systems Testing

## Change Types Made

* [ ] Bug fix (non-breaking change).
* [x] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [x] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue

Fixes no issue
