### PR TITLE
(#158) Relegate the -lo/-li warning to log-file-only

### DIFF
--- a/src/chocolatey.tests/infrastructure.app/commands/ChocolateyListCommandSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/commands/ChocolateyListCommandSpecs.cs
@@ -147,7 +147,7 @@ namespace chocolatey.tests.infrastructure.app.commands
                     _because();
                     MockLogger.Messages.Keys.ShouldContain("Warn");
                     MockLogger.Messages["Warn"].ShouldContain(@"
-UNSUPPORTED ARGUMENT: Ignoring the argument {0}. This argument is unsupported for locally installed packages, and will be treated as a package name in Chocolatey CLI v3!".FormatWith(argument));
+Ignoring the argument {0}. This argument is unsupported for locally installed packages.".FormatWith(argument));
                 }
 
                 [NUnit.Framework.TestCase("-li")]
@@ -157,7 +157,7 @@ UNSUPPORTED ARGUMENT: Ignoring the argument {0}. This argument is unsupported fo
                     _because();
                     MockLogger.Messages.Keys.ShouldContain("Warn");
                     MockLogger.Messages["Warn"].ShouldContain(@"
-UNSUPPORTED ARGUMENT: Ignoring the argument {0}. This argument is unsupported for locally installed packages, and will be treated as a package name in Chocolatey CLI v3!".FormatWith(argument));
+Ignoring the argument {0}. This argument is unsupported for locally installed packages.".FormatWith(argument));
                     Configuration.ListCommand.IncludeRegistryPrograms.ShouldBeTrue();
                 }
             }

--- a/src/chocolatey/infrastructure.app/commands/ChocolateyListCommand.cs
+++ b/src/chocolatey/infrastructure.app/commands/ChocolateyListCommand.cs
@@ -148,18 +148,18 @@ namespace chocolatey.infrastructure.app.commands
         public virtual void ParseAdditionalArguments(IList<string> unparsedArguments, ChocolateyConfiguration configuration)
         {
             var argumentsWithoutLocalOnly = new List<string>(unparsedArguments.Count);
+            const string unsupportedArgumentMessage = @"
+Ignoring the argument {0}. This argument is unsupported for locally installed packages.";
 
             foreach (var argument in unparsedArguments)
             {
                 if (_unsupportedArguments.Contains(argument, StringComparer.OrdinalIgnoreCase))
                 {
-                    this.Log().Warn(ChocolateyLoggers.Important, @"
-UNSUPPORTED ARGUMENT: Ignoring the argument {0}. This argument is unsupported for locally installed packages, and will be treated as a package name in Chocolatey CLI v3!", argument);
+                    this.Log().Warn(ChocolateyLoggers.LogFileOnly, unsupportedArgumentMessage, argument);
                 }
                 else if (_unsupportedIncludeRegistryProgramsArguments.Contains(argument, StringComparer.OrdinalIgnoreCase))
                 {
-                    this.Log().Warn(ChocolateyLoggers.Important, @"
-UNSUPPORTED ARGUMENT: Ignoring the argument {0}. This argument is unsupported for locally installed packages, and will be treated as a package name in Chocolatey CLI v3!", argument);
+                    this.Log().Warn(ChocolateyLoggers.LogFileOnly, unsupportedArgumentMessage, argument);
                     configuration.ListCommand.IncludeRegistryPrograms = true;
                 }
                 else

--- a/tests/chocolatey-tests/commands/choco-list.Tests.ps1
+++ b/tests/chocolatey-tests/commands/choco-list.Tests.ps1
@@ -99,17 +99,29 @@ Describe "choco list" -Tag Chocolatey, ListCommand {
         }
     }
 
-    Context "Listing local packages with unsupported argument outputs warning" -ForEach @('-l', '-lo', '--lo', '--local', '--localonly', '--local-only', '--order-by-popularity', '-a', '--all', '--allversions', '--all-versions', '-li', '-il', '-lai', '-lia', '-ali', '-ail', '-ial', '-ila') {
+    Context "Listing local packages with unsupported argument outputs warning to log file only" -ForEach @('-l', '-lo', '--lo', '--local', '--localonly', '--local-only', '--order-by-popularity', '-a', '--all', '--allversions', '--all-versions', '-li', '-il', '-lai', '-lia', '-ali', '-ail', '-ial', '-ila') {
         BeforeAll {
+            $LogPath = "$env:ChocolateyInstall\logs\chocolatey.log"
+            $OldLogContent = Get-Content $LogPath
+            Remove-Item -Path $LogPath
+
             $Output = Invoke-Choco list $_
+            $LogFile = Get-Content -Path $LogPath
+
+            # Logs are picked up by CI for investigation if needed, so we'll keep both full sets of logs.
+            @(
+                $OldLogContent
+                $LogFile
+            ) | Set-Content -Path $LogPath
         }
 
         It "Exits with Success (0)" {
             $Output.ExitCode | Should -Be 0
         }
 
-        It "Should contain expected warning message" {
-            $Output.Lines | Should -Contain "UNSUPPORTED ARGUMENT: Ignoring the argument $_. This argument is unsupported for locally installed packages, and will be treated as a package name in Chocolatey CLI v3!"
+        It "Should contain expected warning message in the logs" {
+            @($LogFile) -match "Ignoring the argument $_. This argument is unsupported for locally installed packages." |
+                Should -Not -BeNullOrEmpty
         }
     }
 }


### PR DESCRIPTION
## Description Of Changes

- Relegate the warnings for `-lo` / `-li` etc to log file only.
- Update relevant tests

## Motivation and Context

After some discussion internally we determined that for folks to have smooth migration paths a log-file-only warning makes the most sense.

## Testing

1. Run `choco list -lo`
2. Verify no warning is shown
3. Check the log file
4. The logs should contain a warning about the unsupported option
5. Repeat with `-li` instead of `-lo`


### Operating Systems Testing

Win11

## Change Types Made
<!-- Tick the boxes for the type of changes that have been made -->

* [x] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [x] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue
<!-- Make sure you have raised an issue for this pull request before
continuing. -->

Fixes #158

<!-- PLEASE REMOVE ALL COMMENTS BEFORE SUBMITTING -->
