### PR TITLE
(#158) Restore `list -lo` warning when not using -r

### DIFF
--- a/src/chocolatey.tests/infrastructure.app/commands/ChocolateyListCommandSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/commands/ChocolateyListCommandSpecs.cs
@@ -147,7 +147,7 @@ namespace chocolatey.tests.infrastructure.app.commands
                     _because();
                     MockLogger.Messages.Keys.ShouldContain("Warn");
                     MockLogger.Messages["Warn"].ShouldContain(@"
-Ignoring the argument {0}. This argument is unsupported for locally installed packages.".FormatWith(argument));
+Invalid argument {0}. This argument has been removed from the list command and cannot be used.".FormatWith(argument));
                 }
 
                 [NUnit.Framework.TestCase("-li")]
@@ -157,7 +157,7 @@ Ignoring the argument {0}. This argument is unsupported for locally installed pa
                     _because();
                     MockLogger.Messages.Keys.ShouldContain("Warn");
                     MockLogger.Messages["Warn"].ShouldContain(@"
-Ignoring the argument {0}. This argument is unsupported for locally installed packages.".FormatWith(argument));
+Invalid argument {0}. This argument has been removed from the list command and cannot be used.".FormatWith(argument));
                     Configuration.ListCommand.IncludeRegistryPrograms.ShouldBeTrue();
                 }
             }


### PR DESCRIPTION
## Description Of Changes

- Ensure the warning for using `-lo` is visible when not using `-r`
- Add an exit code along with the visible warning (not added when using `-r`)
- Update tests accordingly

## Motivation and Context

Because we do want people to see it, but we don't necessarily want it getting in the way of automation tools.

## Testing

1. `choco list -lo`
2. Warning should be shown, and the exit code should be `1`
3. `choco list -lo -r`
4. Warning should not be shown, and the exit code should be `0`
5. Check the log file and ensure the warning still appears in logs.

### Operating Systems Testing

Win11

## Change Types Made
<!-- Tick the boxes for the type of changes that have been made -->

* [X] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [x] Tests to cover my changes, have been added.
* [X] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue
<!-- Make sure you have raised an issue for this pull request before
continuing. -->

#158

<!-- PLEASE REMOVE ALL COMMENTS BEFORE SUBMITTING -->
