### PR TITLE
(#948) Add user as sensitive argument

### DIFF
--- a/src/chocolatey/infrastructure.app/utility/ArgumentsUtility.cs
+++ b/src/chocolatey/infrastructure.app/utility/ArgumentsUtility.cs
@@ -43,6 +43,10 @@ namespace chocolatey.infrastructure.app.utility
              || commandArguments.ContainsSafe("-key=")
              || commandArguments.ContainsSafe("-apikey")
              || commandArguments.ContainsSafe("-api-key")
+             || commandArguments.ContainsSafe("-u ")
+             || commandArguments.ContainsSafe("-u=")
+             || commandArguments.ContainsSafe("-user ")
+             || commandArguments.ContainsSafe("-user=")
             ;
         }
 


### PR DESCRIPTION
## Description Of Changes

This commit adds the various forms that the user option can be passed
to the Chocolatey CLI, to ensure that it is always caught.

## Motivation and Context

Since user is one half of the information that is needed for a
credential, let's treat the user as sensitive information, in the same
way that we treat password.

## Testing

Follow the steps in this PR: https://github.com/chocolatey/ChocolateyGUI/pull/1002 and ensure that both user and password are not displayed.

This will require running the `Get-ChocoUpdatedDebugVersion.ps1` script to pull through the latest version of Chocolatey CLI through to Chocolatey GUI.

### Operating Systems Testing

Windows 10

## Change Types Made

* [ ] Bug fix (non-breaking change).
* [x] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [x] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue

Relates to #948 where this functionality was first introduced.