### PR TITLE
(#158) Error on list -lo without -r

### DIFF
--- a/src/chocolatey/infrastructure.app/commands/ChocolateyListCommand.cs
+++ b/src/chocolatey/infrastructure.app/commands/ChocolateyListCommand.cs
@@ -156,25 +156,17 @@ namespace chocolatey.infrastructure.app.commands
 
                 if (isUnsupportedArgument || isUnsupportedRegistryProgramsArgument)
                 {
+                    if (configuration.RegularOutput)
+                    {
+                        throw new ApplicationException("Invalid argument {0}. This argument has been removed from the list command and cannot be used.".FormatWith(argument));
+                    }
+
                     if (isUnsupportedRegistryProgramsArgument)
                     {
                         configuration.ListCommand.IncludeRegistryPrograms = true;
                     }
 
-                    if (configuration.RegularOutput)
-                    {
-                        this.Log().Warn(ChocolateyLoggers.Important, @"
-Invalid argument {0}. This argument has been removed from the list command and cannot be used.", argument);
-
-                        // Give an error code to make the warning more notable; as this could potentially cause issues if these are used in v3
-                        // we want folks to take note that they need to be careful about using these unsupported arguments.
-                        Environment.ExitCode = 1;
-                    }
-                    else
-                    {
-                        this.Log().Warn(ChocolateyLoggers.LogFileOnly, @"
-Ignoring the argument {0}. This argument is unsupported for locally installed packages.", argument);
-                    }
+                    this.Log().Warn(ChocolateyLoggers.LogFileOnly, "Ignoring the argument {0}. This argument is unsupported for locally installed packages.", argument);
                 }
                 else
                 {

--- a/tests/chocolatey-tests/commands/choco-list.Tests.ps1
+++ b/tests/chocolatey-tests/commands/choco-list.Tests.ps1
@@ -99,7 +99,7 @@ Describe "choco list" -Tag Chocolatey, ListCommand {
         }
     }
 
-    Context "Listing local packages with unsupported argument outputs a warning" -ForEach @('-l', '-lo', '--lo', '--local', '--localonly', '--local-only', '--order-by-popularity', '-a', '--all', '--allversions', '--all-versions', '-li', '-il', '-lai', '-lia', '-ali', '-ail', '-ial', '-ila') {
+    Context "Listing local packages with unsupported argument errors out" -ForEach @('-l', '-lo', '--lo', '--local', '--localonly', '--local-only', '--order-by-popularity', '-a', '--all', '--allversions', '--all-versions', '-li', '-il', '-lai', '-lia', '-ali', '-ail', '-ial', '-ila') {
         BeforeAll {
             $Output = Invoke-Choco list $_
         }
@@ -108,12 +108,12 @@ Describe "choco list" -Tag Chocolatey, ListCommand {
             $Output.ExitCode | Should -Be 1
         }
 
-        It "Should output expected warning message" {
+        It "Should output expected error message" {
             $Output.Lines | Should -Contain "Invalid argument $_. This argument has been removed from the list command and cannot be used." -Because $Output.String
         }
     }
 
-    Context "Listing local packages with unsupported argument and --limit-output does not output a warning" -Foreach @('-l', '-lo', '--lo', '--local', '--localonly', '--local-only', '--order-by-popularity', '-a', '--all', '--allversions', '--all-versions', '-li', '-il', '-lai', '-lia', '-ali', '-ail', '-ial', '-ila') {
+    Context "Listing local packages with unsupported argument and --limit-output allows listing packages" -Foreach @('-l', '-lo', '--lo', '--local', '--localonly', '--local-only', '--order-by-popularity', '-a', '--all', '--allversions', '--all-versions', '-li', '-il', '-lai', '-lia', '-ali', '-ail', '-ial', '-ila') {
         BeforeAll {
             $Output = Invoke-Choco list $_ --limit-output
         }
@@ -122,7 +122,7 @@ Describe "choco list" -Tag Chocolatey, ListCommand {
             $Output.ExitCode | Should -Be 0
         }
 
-        It "Should not output the warning message" {
+        It "Should not output the error message" {
             $Output.Lines | Should -Not -Contain "Invalid argument $_. This argument has been removed from the list command and cannot be used." -Because $Output.String
         }
     }


### PR DESCRIPTION
## Description Of Changes

- `list -lo` without `-r` is a hard error
- `list -lo -r` is a quiet warning (to logs only) and allows the command to continue unaffected
- `list -li -r` similarly to the above, but also includes installed programs from programs and features

## Motivation and Context

For compat with existing tooling, we want -r to keep working, but for interactive use we want to error so users are properly aware that this functionality has changed.

## Testing

1. Run `choco list -lo -r`
2. Ensure the list comes back without issue
3. Inspect the log file to be sure the warning is emitted correctly, there should be no linebreak between the log label and the warning
4. Run `choco list -lo`
5. A hard error should be emitted and choco should exit with `1`
6. Run `choco list -li -r`
7. The list of packages should be returned and choco should exit cleanly (`-r` doesn't really support add/remove programs)

### Operating Systems Testing

Win11

## Change Types Made
<!-- Tick the boxes for the type of changes that have been made -->

* [ ] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [x] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [x] Tests to cover my changes, have been added.
* [x] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue

#158
