### PR TITLE
(#3174) Apply version number normalizing consistently

### DIFF
--- a/src/chocolatey.tests.integration/scenarios/InstallScenarios.cs
+++ b/src/chocolatey.tests.integration/scenarios/InstallScenarios.cs
@@ -196,7 +196,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, Configuration.PackageNames + NuGetConstants.PackageExtension);
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToStringSafe().ShouldEqual(TestVersion());
+                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().ShouldEqual(TestVersion());
                 }
             }
 
@@ -556,7 +556,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, Configuration.PackageNames + NuGetConstants.PackageExtension);
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToStringSafe().ShouldEqual("1.0.0");
+                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().ShouldEqual("1.0.0");
                 }
             }
 
@@ -641,7 +641,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, Configuration.PackageNames + NuGetConstants.PackageExtension);
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToStringSafe().ShouldEqual("1.0.0");
+                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().ShouldEqual("1.0.0");
                 }
             }
 
@@ -834,7 +834,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, Configuration.PackageNames + NuGetConstants.PackageExtension);
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToStringSafe().ShouldEqual("1.0.0");
+                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().ShouldEqual("1.0.0");
                 }
             }
 
@@ -934,7 +934,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, Configuration.PackageNames + NuGetConstants.PackageExtension);
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToStringSafe().ShouldEqual("1.0.0");
+                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().ShouldEqual("1.0.0");
                 }
             }
 
@@ -1479,7 +1479,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", "isdependency", "isdependency.nupkg");
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToStringSafe().ShouldEqual("1.0.0");
+                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().ShouldEqual("1.0.0");
                 }
             }
 
@@ -1575,7 +1575,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, Configuration.PackageNames + NuGetConstants.PackageExtension);
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToStringSafe().ShouldEqual("1.0.0");
+                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().ShouldEqual("1.0.0");
                 }
             }
 
@@ -1593,7 +1593,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", "isdependency", "isdependency.nupkg");
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToStringSafe().ShouldEqual("1.0.0");
+                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().ShouldEqual("1.0.0");
                 }
             }
 
@@ -1696,7 +1696,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, Configuration.PackageNames + NuGetConstants.PackageExtension);
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToStringSafe().ShouldEqual("1.0.0");
+                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().ShouldEqual("1.0.0");
                 }
             }
 
@@ -1723,7 +1723,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", "isdependency", "isdependency.nupkg");
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToStringSafe().ShouldEqual("1.0.0");
+                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().ShouldEqual("1.0.0");
                 }
             }
 
@@ -1733,7 +1733,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", "isexactversiondependency", "isexactversiondependency.nupkg");
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToStringSafe().ShouldEqual("1.0.0");
+                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().ShouldEqual("1.0.0");
                 }
             }
 
@@ -1821,7 +1821,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, Configuration.PackageNames + NuGetConstants.PackageExtension);
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToStringSafe().ShouldEqual("1.0.0");
+                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().ShouldEqual("1.0.0");
                 }
             }
 
@@ -1839,7 +1839,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", "isdependency", "isdependency.nupkg");
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToStringSafe().ShouldEqual("1.0.0");
+                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().ShouldEqual("1.0.0");
                 }
             }
 
@@ -1849,7 +1849,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", "isexactversiondependency", "isexactversiondependency.nupkg");
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToStringSafe().ShouldEqual("1.0.0");
+                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().ShouldEqual("1.0.0");
                 }
             }
 
@@ -1938,7 +1938,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, Configuration.PackageNames + NuGetConstants.PackageExtension);
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToStringSafe().ShouldEqual("1.0.0");
+                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().ShouldEqual("1.0.0");
                 }
             }
 
@@ -2142,7 +2142,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, Configuration.PackageNames + NuGetConstants.PackageExtension);
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToStringSafe().ShouldEqual("2.1.0");
+                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().ShouldEqual("2.1.0");
                 }
             }
 
@@ -2232,7 +2232,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, Configuration.PackageNames + NuGetConstants.PackageExtension);
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToStringSafe().ShouldEqual("1.6.0");
+                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().ShouldEqual("1.6.0");
                 }
             }
 
@@ -2250,7 +2250,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", "isdependency", "isdependency.nupkg");
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToStringSafe().ShouldEqual("1.1.0");
+                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().ShouldEqual("1.1.0");
                 }
             }
 
@@ -2400,7 +2400,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, Configuration.PackageNames + NuGetConstants.PackageExtension);
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToStringSafe().ShouldEqual("1.6.0");
+                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().ShouldEqual("1.6.0");
                 }
             }
 
@@ -2477,7 +2477,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", "isdependency", "isdependency.nupkg");
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToStringSafe().ShouldEqual("1.0.0");
+                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().ShouldEqual("1.0.0");
                 }
             }
 
@@ -2601,7 +2601,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", "isdependency", "isdependency.nupkg");
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToStringSafe().ShouldEqual("1.0.1");
+                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().ShouldEqual("1.0.1");
                 }
             }
 
@@ -2687,7 +2687,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", "isdependency", "isdependency.nupkg");
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToStringSafe().ShouldEqual("1.0.0");
+                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().ShouldEqual("1.0.0");
                 }
             }
 
@@ -2697,7 +2697,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", "isexactversiondependency", "isexactversiondependency.nupkg");
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToStringSafe().ShouldEqual("1.0.0");
+                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().ShouldEqual("1.0.0");
                 }
             }
 
@@ -2799,7 +2799,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", "isexactversiondependency", "isexactversiondependency.nupkg");
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToStringSafe().ShouldEqual("2.0.0");
+                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().ShouldEqual("2.0.0");
                 }
             }
 
@@ -2916,7 +2916,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", "childdependencywithlooserversiondependency", "childdependencywithlooserversiondependency.nupkg");
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToStringSafe().ShouldEqual("1.0.0");
+                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().ShouldEqual("1.0.0");
                 }
             }
 
@@ -2926,7 +2926,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", "isexactversiondependency", "isexactversiondependency.nupkg");
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToStringSafe().ShouldEqual("1.0.0");
+                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().ShouldEqual("1.0.0");
                 }
             }
 
@@ -3323,7 +3323,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, Configuration.PackageNames + NuGetConstants.PackageExtension);
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToStringSafe().ShouldEqual("1.0.0");
+                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().ShouldEqual("1.0.0");
                 }
             }
 
@@ -3439,7 +3439,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, Configuration.PackageNames + NuGetConstants.PackageExtension);
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToStringSafe().ShouldEqual("1.0.0");
+                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().ShouldEqual("1.0.0");
                 }
             }
 
@@ -3552,7 +3552,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, Configuration.PackageNames + NuGetConstants.PackageExtension);
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToStringSafe().ShouldEqual("1.0.0");
+                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().ShouldEqual("1.0.0");
                 }
             }
 
@@ -3808,7 +3808,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, Configuration.PackageNames + NuGetConstants.PackageExtension);
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToStringSafe().ShouldEqual("1.0.0");
+                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().ShouldEqual("1.0.0");
                 }
             }
 
@@ -4510,7 +4510,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, Configuration.PackageNames + NuGetConstants.PackageExtension);
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToStringSafe().ShouldEqual("1.0.0");
+                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().ShouldEqual("1.0.0");
                 }
             }
 
@@ -4618,7 +4618,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, Configuration.PackageNames + NuGetConstants.PackageExtension);
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToStringSafe().ShouldEqual("1.0.0");
+                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().ShouldEqual("1.0.0");
                 }
             }
 
@@ -4799,7 +4799,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Result_should_have_the_correct_version()
             {
-                _packageResult.Version.ShouldEqual(NonNormalizedVersion);
+                _packageResult.Version.ShouldEqual(NormalizedVersion);
             }
 
             [Fact]
@@ -4807,7 +4807,7 @@ namespace chocolatey.tests.integration.scenarios
             [Platform(Exclude = "Mono")]
             public void Should_have_executed_chocolateyInstall_script()
             {
-                var message = "installpackage v{0} has been installed".FormatWith(NonNormalizedVersion);
+                var message = "installpackage v{0} has been installed".FormatWith(NormalizedVersion);
 
                 MockLogger.ContainsMessage(message, LogLevel.Info).ShouldBeTrue();
             }
@@ -4984,7 +4984,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", TargetPackageName, "{0}.nupkg".FormatWith(TargetPackageName));
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToStringSafe().ShouldEqual("2.0.0");
+                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().ShouldEqual("2.0.0");
                 }
             }
 
@@ -4994,7 +4994,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", DependencyName, "{0}.nupkg".FormatWith(DependencyName));
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToStringSafe().ShouldEqual("2.0.0");
+                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().ShouldEqual("2.0.0");
                 }
             }
 

--- a/src/chocolatey.tests.integration/scenarios/UninstallScenarios.cs
+++ b/src/chocolatey.tests.integration/scenarios/UninstallScenarios.cs
@@ -1448,7 +1448,8 @@ namespace chocolatey.tests.integration.scenarios
         {
             private PackageResult packageResult;
 
-            private string NonNormalizedVersion = "0004.0004.00005.00";
+            private const string NonNormalizedVersion = "0004.0004.00005.00";
+            private const string NormalizedVersion = "4.4.5";
 
             public override void Context()
             {
@@ -1550,7 +1551,7 @@ namespace chocolatey.tests.integration.scenarios
             [Platform(Exclude = "Mono")]
             public void Should_have_executed_chocolateyBeforeModify_script()
             {
-                MockLogger.ContainsMessage("upgradepackage {0} Before Modification".FormatWith(NonNormalizedVersion), LogLevel.Info).ShouldBeTrue();
+                MockLogger.ContainsMessage("upgradepackage {0} Before Modification".FormatWith(NormalizedVersion), LogLevel.Info).ShouldBeTrue();
             }
 
             [Fact]
@@ -1558,7 +1559,7 @@ namespace chocolatey.tests.integration.scenarios
             [Platform(Exclude = "Mono")]
             public void Should_have_executed_chocolateyUninstall_script()
             {
-                MockLogger.ContainsMessage("upgradepackage {0} Uninstalled".FormatWith(NonNormalizedVersion), LogLevel.Info).ShouldBeTrue();
+                MockLogger.ContainsMessage("upgradepackage {0} Uninstalled".FormatWith(NormalizedVersion), LogLevel.Info).ShouldBeTrue();
             }
         }
 

--- a/src/chocolatey.tests.integration/scenarios/UpgradeScenarios.cs
+++ b/src/chocolatey.tests.integration/scenarios/UpgradeScenarios.cs
@@ -248,7 +248,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, Configuration.PackageNames +  NuGetConstants.PackageExtension);
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToStringSafe().ShouldEqual("1.1.0");
+                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().ShouldEqual("1.1.0");
                 }
             }
 
@@ -507,7 +507,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, Configuration.PackageNames +  NuGetConstants.PackageExtension);
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToStringSafe().ShouldEqual("1.1.0");
+                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().ShouldEqual("1.1.0");
                 }
             }
 
@@ -908,7 +908,7 @@ namespace chocolatey.tests.integration.scenarios
 
                     version.Version.ToStringSafe().ShouldEqual("1.1.1.0");
                     version.OriginalVersion.ToStringSafe().ShouldEqual("1.1.1-beta2");
-                    version.ToStringSafe().ShouldEqual("1.1.1-beta2");
+                    version.ToNormalizedStringChecked().ShouldEqual("1.1.1-beta2");
                 }
             }
 
@@ -1066,7 +1066,7 @@ namespace chocolatey.tests.integration.scenarios
 
                     version.Version.ToStringSafe().ShouldEqual("1.1.1.0");
                     version.OriginalVersion.ToStringSafe().ShouldEqual("1.1.1-beta.1");
-                    version.ToStringSafe().ShouldEqual("1.1.1-beta.1");
+                    version.ToNormalizedStringChecked().ShouldEqual("1.1.1-beta.1");
                 }
             }
 
@@ -1223,7 +1223,7 @@ namespace chocolatey.tests.integration.scenarios
 
                     version.Version.ToStringSafe().ShouldEqual("1.1.1.0");
                     version.OriginalVersion.ToStringSafe().ShouldEqual("1.1.1-beta2");
-                    version.ToStringSafe().ShouldEqual("1.1.1-beta2");
+                    version.ToNormalizedStringChecked().ShouldEqual("1.1.1-beta2");
                 }
             }
 
@@ -1389,7 +1389,7 @@ namespace chocolatey.tests.integration.scenarios
                     var version = packageReader.NuspecReader.GetVersion();
                     version.Version.ToStringSafe().ShouldEqual("1.1.1.0");
                     version.OriginalVersion.ShouldEqual("1.1.1-beta");
-                    version.ToStringSafe().ShouldEqual("1.1.1-beta");
+                    version.ToNormalizedStringChecked().ShouldEqual("1.1.1-beta");
                 }
             }
 
@@ -1487,7 +1487,7 @@ namespace chocolatey.tests.integration.scenarios
                     var version = packageReader.NuspecReader.GetVersion();
                     version.Version.ToStringSafe().ShouldEqual("1.1.1.0");
                     version.OriginalVersion.ShouldEqual("1.1.1-beta");
-                    version.ToStringSafe().ShouldEqual("1.1.1-beta");
+                    version.ToNormalizedStringChecked().ShouldEqual("1.1.1-beta");
                 }
             }
 
@@ -1552,7 +1552,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, Configuration.PackageNames +  NuGetConstants.PackageExtension);
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToStringSafe().ShouldEqual("1.1.0");
+                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().ShouldEqual("1.1.0");
                 }
             }
 
@@ -1692,7 +1692,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, Configuration.PackageNames +  NuGetConstants.PackageExtension);
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToStringSafe().ShouldEqual("1.0.0");
+                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().ShouldEqual("1.0.0");
                 }
             }
 
@@ -1784,7 +1784,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, Configuration.PackageNames +  NuGetConstants.PackageExtension);
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToStringSafe().ShouldEqual("1.0.0");
+                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().ShouldEqual("1.0.0");
                 }
             }
 
@@ -1875,7 +1875,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, Configuration.PackageNames +  NuGetConstants.PackageExtension);
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToStringSafe().ShouldEqual("1.1.0");
+                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().ShouldEqual("1.1.0");
                 }
             }
 
@@ -1989,7 +1989,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, Configuration.PackageNames +  NuGetConstants.PackageExtension);
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToStringSafe().ShouldEqual("1.1.0");
+                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().ShouldEqual("1.1.0");
                 }
             }
 
@@ -2125,7 +2125,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, Configuration.PackageNames +  NuGetConstants.PackageExtension);
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToStringSafe().ShouldEqual("1.0.0");
+                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().ShouldEqual("1.0.0");
                 }
             }
 
@@ -2211,7 +2211,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, Configuration.PackageNames +  NuGetConstants.PackageExtension);
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToStringSafe().ShouldEqual("1.1.0");
+                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().ShouldEqual("1.1.0");
                 }
             }
 
@@ -2294,7 +2294,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, Configuration.PackageNames +  NuGetConstants.PackageExtension);
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToStringSafe().ShouldEqual("1.1.0");
+                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().ShouldEqual("1.1.0");
                 }
             }
 
@@ -2626,7 +2626,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, Configuration.PackageNames +  NuGetConstants.PackageExtension);
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToStringSafe().ShouldEqual("1.0.0");
+                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().ShouldEqual("1.0.0");
                 }
             }
 
@@ -2644,7 +2644,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib-bad", Configuration.PackageNames, "2.0.0", Configuration.PackageNames +  NuGetConstants.PackageExtension);
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToStringSafe().ShouldEqual("2.0.0");
+                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().ShouldEqual("2.0.0");
                 }
             }
 
@@ -2741,7 +2741,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", "hasdependency", "hasdependency.nupkg");
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToStringSafe().ShouldEqual("2.1.0");
+                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().ShouldEqual("2.1.0");
                 }
             }
 
@@ -2751,7 +2751,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", "isdependency", "isdependency.nupkg");
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToStringSafe().ShouldEqual("2.1.0");
+                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().ShouldEqual("2.1.0");
                 }
             }
 
@@ -2761,7 +2761,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", "isexactversiondependency", "isexactversiondependency.nupkg");
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToStringSafe().ShouldEqual("2.0.0");
+                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().ShouldEqual("2.0.0");
                 }
             }
 
@@ -2829,7 +2829,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", "hasdependency", "hasdependency.nupkg");
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToStringSafe().ShouldEqual("1.0.0");
+                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().ShouldEqual("1.0.0");
                 }
             }
 
@@ -2839,7 +2839,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", "isdependency", "isdependency.nupkg");
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToStringSafe().ShouldEqual("1.0.0");
+                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().ShouldEqual("1.0.0");
                 }
             }
 
@@ -2849,7 +2849,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", "isexactversiondependency", "isexactversiondependency.nupkg");
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToStringSafe().ShouldEqual("1.0.0");
+                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().ShouldEqual("1.0.0");
                 }
             }
 
@@ -2956,7 +2956,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", "hasdependency", "hasdependency.nupkg");
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToStringSafe().ShouldEqual("2.1.0");
+                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().ShouldEqual("2.1.0");
                 }
             }
 
@@ -2966,7 +2966,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", "isdependency", "isdependency.nupkg");
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToStringSafe().ShouldEqual("1.0.0");
+                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().ShouldEqual("1.0.0");
                 }
             }
 
@@ -2976,7 +2976,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", "isexactversiondependency", "isexactversiondependency.nupkg");
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToStringSafe().ShouldEqual("1.0.0");
+                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().ShouldEqual("1.0.0");
                 }
             }
 
@@ -3044,7 +3044,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", "isdependency", "isdependency.nupkg");
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToStringSafe().ShouldEqual("1.1.0");
+                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().ShouldEqual("1.1.0");
                 }
             }
 
@@ -3054,7 +3054,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", "hasdependency", "hasdependency.nupkg");
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToStringSafe().ShouldEqual("1.0.0");
+                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().ShouldEqual("1.0.0");
                 }
             }
 
@@ -3064,7 +3064,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", "isexactversiondependency", "isexactversiondependency.nupkg");
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToStringSafe().ShouldEqual("1.0.0");
+                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().ShouldEqual("1.0.0");
                 }
             }
 
@@ -3132,7 +3132,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", "isdependency", "isdependency.nupkg");
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToStringSafe().ShouldEqual("2.1.0");
+                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().ShouldEqual("2.1.0");
                 }
             }
 
@@ -3142,7 +3142,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", "hasdependency", "hasdependency.nupkg");
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToStringSafe().ShouldEqual("2.1.0");
+                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().ShouldEqual("2.1.0");
                 }
             }
 
@@ -3152,7 +3152,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", "isexactversiondependency", "isexactversiondependency.nupkg");
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToStringSafe().ShouldEqual("2.0.0");
+                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().ShouldEqual("2.0.0");
                 }
             }
 
@@ -3222,7 +3222,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", "isdependency", "isdependency.nupkg");
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToStringSafe().ShouldEqual("2.1.0");
+                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().ShouldEqual("2.1.0");
                 }
             }
 
@@ -3232,7 +3232,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", "hasdependency", "hasdependency.nupkg");
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToStringSafe().ShouldEqual("2.1.0");
+                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().ShouldEqual("2.1.0");
                 }
             }
 
@@ -3242,7 +3242,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", "isexactversiondependency", "isexactversiondependency.nupkg");
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToStringSafe().ShouldEqual("2.0.0");
+                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().ShouldEqual("2.0.0");
                 }
             }
 
@@ -3312,7 +3312,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", "isdependency", "isdependency.nupkg");
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToStringSafe().ShouldEqual("1.1.0");
+                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().ShouldEqual("1.1.0");
                 }
             }
 
@@ -3322,7 +3322,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", "hasdependency", "hasdependency.nupkg");
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToStringSafe().ShouldEqual("1.0.0");
+                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().ShouldEqual("1.0.0");
                 }
             }
 
@@ -3332,7 +3332,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", "isexactversiondependency", "isexactversiondependency.nupkg");
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToStringSafe().ShouldEqual("1.0.0");
+                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().ShouldEqual("1.0.0");
                 }
             }
 
@@ -3420,7 +3420,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", "isdependency", "isdependency.nupkg");
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToStringSafe().ShouldEqual("1.1.0");
+                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().ShouldEqual("1.1.0");
                 }
             }
 
@@ -3430,7 +3430,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", "hasdependency", "hasdependency.nupkg");
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToStringSafe().ShouldEqual("1.0.0");
+                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().ShouldEqual("1.0.0");
                 }
             }
 
@@ -3440,7 +3440,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", "isexactversiondependency", "isexactversiondependency.nupkg");
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToStringSafe().ShouldEqual("1.0.0");
+                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().ShouldEqual("1.0.0");
                 }
             }
 
@@ -3529,7 +3529,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", "isdependency", "isdependency.nupkg");
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToStringSafe().ShouldEqual("1.1.0");
+                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().ShouldEqual("1.1.0");
                 }
             }
 
@@ -3539,7 +3539,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", "hasdependency", "hasdependency.nupkg");
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToStringSafe().ShouldEqual("1.0.0");
+                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().ShouldEqual("1.0.0");
                 }
             }
 
@@ -3549,7 +3549,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", "isexactversiondependency", "isexactversiondependency.nupkg");
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToStringSafe().ShouldEqual("1.0.0");
+                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().ShouldEqual("1.0.0");
                 }
             }
 
@@ -3636,7 +3636,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", "isdependency", "isdependency.nupkg");
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToStringSafe().ShouldEqual("1.0.0");
+                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().ShouldEqual("1.0.0");
                 }
             }
 
@@ -3646,7 +3646,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", "hasdependency", "hasdependency.nupkg");
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToStringSafe().ShouldEqual("1.0.0");
+                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().ShouldEqual("1.0.0");
                 }
             }
 
@@ -3656,7 +3656,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", "isexactversiondependency", "isexactversiondependency.nupkg");
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToStringSafe().ShouldEqual("1.0.0");
+                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().ShouldEqual("1.0.0");
                 }
             }
 
@@ -3740,7 +3740,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, Configuration.PackageNames +  NuGetConstants.PackageExtension);
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToStringSafe().ShouldEqual("1.1.0");
+                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().ShouldEqual("1.1.0");
                 }
             }
 
@@ -3843,7 +3843,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, Configuration.PackageNames +  NuGetConstants.PackageExtension);
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToStringSafe().ShouldEqual("1.1.0");
+                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().ShouldEqual("1.1.0");
                 }
             }
 
@@ -4022,7 +4022,7 @@ namespace chocolatey.tests.integration.scenarios
                     var version = packageReader.NuspecReader.GetVersion();
                     version.Version.ToStringSafe().ShouldEqual("1.1.1.0");
                     version.OriginalVersion.ShouldEqual("1.1.1-beta2");
-                    version.ToStringSafe().ShouldEqual("1.1.1-beta2");
+                    version.ToNormalizedStringChecked().ShouldEqual("1.1.1-beta2");
                 }
             }
 
@@ -4077,7 +4077,7 @@ namespace chocolatey.tests.integration.scenarios
                     var version = packageReader.NuspecReader.GetVersion();
                     version.Version.ToStringSafe().ShouldEqual("1.1.1.0");
                     version.OriginalVersion.ShouldEqual("1.1.1-beta");
-                    version.ToStringSafe().ShouldEqual("1.1.1-beta");
+                    version.ToNormalizedStringChecked().ShouldEqual("1.1.1-beta");
                 }
             }
 
@@ -4153,7 +4153,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, Configuration.PackageNames + NuGetConstants.PackageExtension);
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToStringSafe().ShouldEqual("1.1.1-beta.1");
+                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().ShouldEqual("1.1.1-beta.1");
                 }
             }
 
@@ -4332,7 +4332,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, Configuration.PackageNames + NuGetConstants.PackageExtension);
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToStringSafe().ShouldEqual("2.0.0");
+                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().ShouldEqual("2.0.0");
                 }
             }
 
@@ -4478,7 +4478,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, Configuration.PackageNames + NuGetConstants.PackageExtension);
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToStringSafe().ShouldEqual("1.1.0");
+                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().ShouldEqual("1.1.0");
                 }
             }
 
@@ -4688,7 +4688,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, Configuration.PackageNames + NuGetConstants.PackageExtension);
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToStringSafe().ShouldEqual("1.1.0");
+                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().ShouldEqual("1.1.0");
                 }
             }
 
@@ -4824,7 +4824,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, Configuration.PackageNames + NuGetConstants.PackageExtension);
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToStringSafe().ShouldEqual("1.1.0");
+                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().ShouldEqual("1.1.0");
                 }
             }
 
@@ -5039,7 +5039,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_match_the_upgrade_version()
             {
-                _packageResult.Version.ShouldEqual(NonNormalizedVersion);
+                _packageResult.Version.ShouldEqual(NormalizedVersion);
             }
 
             [Fact]
@@ -5057,7 +5057,7 @@ namespace chocolatey.tests.integration.scenarios
             {
                 MockLogger.MessagesFor(LogLevel.Info).OrEmpty()
                     .SkipWhile(p => !p.Contains("upgradepackage 1.0.0 Before Modification"))
-                    .Any(p => p.EndsWith("upgradepackage {0} Installed".FormatWith(NonNormalizedVersion)))
+                    .Any(p => p.EndsWith("upgradepackage {0} Installed".FormatWith(NormalizedVersion)))
                     .ShouldBeTrue();
             }
 
@@ -5070,7 +5070,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_not_have_executed_chocolateyBeforeModify_script_for_new_package()
             {
-                MockLogger.ContainsMessage("upgradepackage {0} Before Modification".FormatWith(NonNormalizedVersion), LogLevel.Info).ShouldBeFalse();
+                MockLogger.ContainsMessage("upgradepackage {0} Before Modification".FormatWith(NormalizedVersion), LogLevel.Info).ShouldBeFalse();
             }
 
             [Fact]
@@ -5078,7 +5078,7 @@ namespace chocolatey.tests.integration.scenarios
             [Platform(Exclude = "Mono")]
             public void Should_have_executed_chocolateyInstall_script_for_new_package()
             {
-                MockLogger.ContainsMessage("upgradepackage {0} Installed".FormatWith(NonNormalizedVersion), LogLevel.Info).ShouldBeTrue();
+                MockLogger.ContainsMessage("upgradepackage {0} Installed".FormatWith(NormalizedVersion), LogLevel.Info).ShouldBeTrue();
             }
         }
 
@@ -5167,7 +5167,7 @@ namespace chocolatey.tests.integration.scenarios
                 var packageFile = Path.Combine(Scenario.get_top_level(), "lib", DependencyName, "{0}.nupkg".FormatWith(DependencyName));
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
-                    packageReader.NuspecReader.GetVersion().ToStringSafe().ShouldEqual("2.0.0");
+                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().ShouldEqual("2.0.0");
                 }
             }
 

--- a/src/chocolatey/infrastructure.app/services/AutomaticUninstallerService.cs
+++ b/src/chocolatey/infrastructure.app/services/AutomaticUninstallerService.cs
@@ -102,7 +102,7 @@ namespace chocolatey.infrastructure.app.services
 
             foreach (var key in registryKeys.OrEmpty())
             {
-                var packageCacheLocation = _fileSystem.CombinePaths(_fileSystem.GetFullPath(config.CacheLocation), package.Id, package.Version.ToStringSafe());
+                var packageCacheLocation = _fileSystem.CombinePaths(_fileSystem.GetFullPath(config.CacheLocation), package.Id, package.Version.ToNormalizedStringChecked());
                 Remove(key, config, packageResult, packageCacheLocation);
             }
         }

--- a/src/chocolatey/infrastructure.app/services/ChocolateyPackageInformationService.cs
+++ b/src/chocolatey/infrastructure.app/services/ChocolateyPackageInformationService.cs
@@ -225,7 +225,7 @@ A corrupt .registry file exists at {0}.
             {
                 var versionOverrideFile = _fileSystem.CombinePaths(pkgStorePath, VersionOverrideFile);
                 if (_fileSystem.FileExists(versionOverrideFile)) _fileSystem.DeleteFile(versionOverrideFile);
-                _fileSystem.WriteFile(versionOverrideFile, packageInformation.VersionOverride.ToStringSafe());
+                _fileSystem.WriteFile(versionOverrideFile, packageInformation.VersionOverride.ToNormalizedStringChecked());
             }
             else
             {
@@ -265,6 +265,9 @@ A corrupt .registry file exists at {0}.
             {
                 return preferredStorePath;
             }
+
+            // Legacy handling for old package versions that was installed prior to v2.0.0.
+            // Do not remove the call to `ToStringSafe`.
 
             var pkgStorePath = fileSystem.CombinePaths(ApplicationParameters.ChocolateyPackageInfoStoreLocation, "{0}.{1}".FormatWith(id, version.ToStringSafe()));
 

--- a/src/chocolatey/infrastructure.app/services/ChocolateyPackageService.cs
+++ b/src/chocolatey/infrastructure.app/services/ChocolateyPackageService.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2023 Chocolatey Software, Inc
+// Copyright © 2017 - 2023 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -1312,11 +1312,6 @@ The recent package changes indicate a reboot is necessary.
 
         public virtual void HandlePackageUninstall(PackageResult packageResult, ChocolateyConfiguration config)
         {
-            if (!_fileSystem.DirectoryExists(packageResult.InstallLocation))
-            {
-                packageResult.InstallLocation += ".{0}".FormatWith(packageResult.PackageMetadata.Version.ToStringSafe());
-            }
-
             //These items only apply to windows systems.
             if (config.Information.PlatformType == PlatformType.Windows)
             {

--- a/src/chocolatey/infrastructure.app/services/NugetService.cs
+++ b/src/chocolatey/infrastructure.app/services/NugetService.cs
@@ -1136,7 +1136,7 @@ Please see https://docs.chocolatey.org/en-us/troubleshooting for more
                             }
                             else
                             {
-                                this.Log().Info("{0}|{1}|{2}|{3}".FormatWith(installedPackage.PackageMetadata.Id, installedPackage.Version, availablePackage.Identity.Version, isPinned.ToStringSafe().ToLowerSafe()));
+                                this.Log().Info("{0}|{1}|{2}|{3}".FormatWith(installedPackage.PackageMetadata.Id, installedPackage.Version, availablePackage.Identity.Version.ToNormalizedStringChecked(), isPinned.ToStringSafe().ToLowerSafe()));
                             }
                         }
 
@@ -1858,7 +1858,7 @@ Please see https://docs.chocolatey.org/en-us/troubleshooting for more
         {
             if (packageInfo == null || packageInfo.Package == null) return;
 
-            var version = packageInfo.Package.Version.ToStringSafe();
+            var version = packageInfo.Package.Version.ToNormalizedStringChecked();
 
             if (packageInfo.FilesSnapshot == null || packageInfo.FilesSnapshot.Files.Count == 0)
             {
@@ -1923,7 +1923,7 @@ Please see https://docs.chocolatey.org/en-us/troubleshooting for more
         private void RemovePackageFromCache(ChocolateyConfiguration config, IPackageMetadata installedPackage)
         {
             this.Log().Debug(ChocolateyLoggers.Verbose, "Ensuring removal of package cache files.");
-            var cacheDirectory = _fileSystem.CombinePaths(config.CacheLocation, installedPackage.Id, installedPackage.Version.ToStringSafe());
+            var cacheDirectory = _fileSystem.CombinePaths(config.CacheLocation, installedPackage.Id, installedPackage.Version.ToNormalizedStringChecked());
 
             if (!_fileSystem.DirectoryExists(cacheDirectory)) return;
 
@@ -1952,8 +1952,8 @@ Please see https://docs.chocolatey.org/en-us/troubleshooting for more
             FaultTolerance.TryCatchWithLoggingException(
                 () =>
                 {
-                    var packageFolderPath = _fileSystem.CombinePaths(tempFolder, "{0}/{1}".FormatWith(installedPackage.Identity.Id, installedPackage.Identity.Version.ToStringSafe()));
-                    var nugetCachedFile = _fileSystem.CombinePaths(packageFolderPath, "{0}.{1}.nupkg".FormatWith(installedPackage.Identity.Id, installedPackage.Identity.Version.ToStringSafe()));
+                    var packageFolderPath = _fileSystem.CombinePaths(tempFolder, "{0}/{1}".FormatWith(installedPackage.Identity.Id, installedPackage.Identity.Version.ToNormalizedStringChecked()));
+                    var nugetCachedFile = _fileSystem.CombinePaths(packageFolderPath, "{0}.{1}.nupkg".FormatWith(installedPackage.Identity.Id, installedPackage.Identity.Version.ToNormalizedStringChecked()));
                     var nupkgMetaDataFile = _fileSystem.CombinePaths(packageFolderPath, ".nupkg.metadata");
                     var nupkgShaFile = nugetCachedFile + ".sha512";
 

--- a/src/chocolatey/infrastructure.app/services/PowershellService.cs
+++ b/src/chocolatey/infrastructure.app/services/PowershellService.cs
@@ -444,8 +444,8 @@ namespace chocolatey.infrastructure.app.services
             Environment.SetEnvironmentVariable("packageName", package.Identity.Id);
             Environment.SetEnvironmentVariable("chocolateyPackageTitle", package.Title);
             Environment.SetEnvironmentVariable("packageTitle", package.Title);
-            Environment.SetEnvironmentVariable("chocolateyPackageVersion", package.Identity.Version.ToStringSafe());
-            Environment.SetEnvironmentVariable("packageVersion", package.Identity.Version.ToStringSafe());
+            Environment.SetEnvironmentVariable("chocolateyPackageVersion", package.Identity.Version.ToNormalizedStringChecked());
+            Environment.SetEnvironmentVariable("packageVersion", package.Identity.Version.ToNormalizedStringChecked());
             Environment.SetEnvironmentVariable("chocolateyPackageVersionPrerelease", package.Identity.Version.Release.ToStringSafe());
             Environment.SetEnvironmentVariable("chocolateyPackageVersionPackageRelease", package.Identity.Version.Version.ToStringSafe());
 

--- a/src/chocolatey/infrastructure.app/services/TemplateService.cs
+++ b/src/chocolatey/infrastructure.app/services/TemplateService.cs
@@ -282,7 +282,7 @@ namespace chocolatey.infrastructure.app.services
 
             var templateInstalledViaPackage = (pkg != null);
 
-            var pkgVersion = templateInstalledViaPackage ? pkg.Identity.Version.ToStringSafe() : "0.0.0";
+            var pkgVersion = templateInstalledViaPackage ? pkg.Identity.Version.ToNormalizedStringChecked() : "0.0.0";
             var pkgTitle = templateInstalledViaPackage ? pkg.Title : "{0} (Unmanaged)".FormatWith(configuration.TemplateCommand.Name);
             var pkgSummary = templateInstalledViaPackage ?
                 (pkg.Summary != null && !string.IsNullOrWhiteSpace(pkg.Summary.ToStringSafe()) ? "{0}".FormatWith(pkg.Summary.EscapeCurlyBraces().ToStringSafe()) : string.Empty) : string.Empty;

--- a/src/chocolatey/infrastructure/results/PackageResult.cs
+++ b/src/chocolatey/infrastructure/results/PackageResult.cs
@@ -55,16 +55,16 @@ namespace chocolatey.infrastructure.results
             PackageMetadata = metadata;
             SearchMetadata = search;
             Name = metadata.Id;
-            Version = metadata.Version.ToStringSafe();
+            Version = metadata.Version.ToNormalizedStringChecked();
         }
 
-        public PackageResult(IPackageMetadata packageMetadata, string installLocation, string source = null) : this(packageMetadata.Id, packageMetadata.Version.ToStringSafe(), installLocation)
+        public PackageResult(IPackageMetadata packageMetadata, string installLocation, string source = null) : this(packageMetadata.Id, packageMetadata.Version.ToNormalizedStringChecked(), installLocation)
         {
             PackageMetadata = packageMetadata;
             Source = source;
         }
 
-        public PackageResult(IPackageSearchMetadata packageSearch, string installLocation, string source = null) : this(packageSearch.Identity.Id, packageSearch.Identity.Version.ToStringSafe(), installLocation)
+        public PackageResult(IPackageSearchMetadata packageSearch, string installLocation, string source = null) : this(packageSearch.Identity.Id, packageSearch.Identity.Version.ToNormalizedStringChecked(), installLocation)
         {
             SearchMetadata = packageSearch;
             Source = source;
@@ -103,7 +103,7 @@ namespace chocolatey.infrastructure.results
             */
         }
 
-        public PackageResult(IPackageMetadata packageMetadata, IPackageSearchMetadata packageSearch, string installLocation, string source = null) : this(packageMetadata.Id, packageMetadata.Version.ToStringSafe(), installLocation)
+        public PackageResult(IPackageMetadata packageMetadata, IPackageSearchMetadata packageSearch, string installLocation, string source = null) : this(packageMetadata.Id, packageMetadata.Version.ToNormalizedStringChecked(), installLocation)
         {
             SearchMetadata = packageSearch;
             PackageMetadata = packageMetadata;


### PR DESCRIPTION
## Description Of Changes

Went through all references to `ToStringSafe` which were being called on a NuGetVersion instance and changed them all to `ToNormalizedStringChecked`.

Additionally, found a place in the upgrade dry-run code that was just missing a call to this method and outputting a non-normalized version string and added it.

## Motivation and Context

We should be consistent in how we internally and externally represent versions as strings, so that folks relying on our output for consistent comparisons don't need to think too hard about it.

## Testing

1. `choco install 7zip --ignore-dependencies`
2. `choco upgrade --noop 7zip -r`
3. The output result should display `7zip|22.1.0|22.1.0|false` exactly (unless a new version of 7zip has been installed, so just verify the version numbers match exactly)

We _might_ be able to add a smoke test package for this case, but I've not had the time to look into it as yet. I will update here if I manage to get that done as well.

### Operating Systems Testing

WIn11

## Change Types Made
<!-- Tick the boxes for the type of changes that have been made -->

* [x] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [x] Tests to cover my changes, have been added.
* [x] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue


Fixes #3174

<!-- PLEASE REMOVE ALL COMMENTS BEFORE SUBMITTING -->
