### PR TITLE
(#3196) Pin add/remove use exact package ID

### DIFF
--- a/src/chocolatey/infrastructure.app/commands/ChocolateyPinCommand.cs
+++ b/src/chocolatey/infrastructure.app/commands/ChocolateyPinCommand.cs
@@ -190,9 +190,12 @@ If you find other exit codes that we have not yet documented, please
             config.Input = config.PinCommand.Name;
             config.Version = semanticVersion.ToFullStringChecked();
             config.ListCommand.ByIdOnly = true;
+            var exact = config.ListCommand.Exact;
+            config.ListCommand.Exact = true;
             var quiet = config.QuietOutput;
             config.QuietOutput = true;
             var installedPackage = _nugetService.List(config).FirstOrDefault();
+            config.ListCommand.Exact = exact;
             config.QuietOutput = quiet;
             config.Input = input;
 


### PR DESCRIPTION
## Description Of Changes

For the pin commands add and remove, find the package to pin/unpin
using an exact list, not a normal search, to ensure that only an exact
matching package ID is returned, and therefore pinned/unpinned.

A test is also added for this, using the mingw and gstreamer-mingw
package IDs, which is what was reported causing problems in the issue.

## Motivation and Context

Fix pinning/unpinning.

After some testing, the problem affects both pinning, not just unpinning. 

## Testing

Ran:
```
.\choco.exe install mingw -n
.\choco.exe pin add -n mingw
.\choco.exe install gstreamer-mingw -n
.\choco.exe pin add -n gstreamer-mingw
.\choco.exe pin remove -n mingw
```

Then ensured that the `mingw` package was unpinned, not the `gstreamer-ming` package.

As a second test, unpinned both `mingw` and `gstreamer-mingw` and tried `.\choco.exe pin add -n mingw` (with both packages installed), and ensured that it was `mingw` that was pinned.

### Operating Systems Testing
- Windows 10

## Change Types Made

* [x] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [x] Tests to cover my changes, have been added.
* [x] All new and existing tests passed?
* [x] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue

Fixes #3196