### PR TITLE
(#3182) Fix rule distinction comparison

### DIFF
--- a/src/chocolatey.tests/TinySpec.cs
+++ b/src/chocolatey.tests/TinySpec.cs
@@ -187,6 +187,15 @@ namespace chocolatey.tests
         }
 
         [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = false)]
+        public sealed class RuleEngine : CategoryAttribute
+        {
+            public RuleEngine()
+                : base("Rule Engine")
+            {
+            }
+        }
+
+        [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = false)]
         public sealed class LegacySemVerAttribute : CategoryAttribute
         {
             public LegacySemVerAttribute()

--- a/src/chocolatey/infrastructure.app/services/RuleService.cs
+++ b/src/chocolatey/infrastructure.app/services/RuleService.cs
@@ -104,11 +104,26 @@ namespace chocolatey.infrastructure.app.services
         {
             public bool Equals(ImmutableRule x, ImmutableRule y)
             {
-                return ReferenceEquals(x, y) || x.Id.IsEqualTo(x.Id);
+                // When the id is empty on both classes, we need to compare
+                // using the summary to detect if the rules are unique or not.
+                if (string.IsNullOrEmpty(x.Id) && string.IsNullOrEmpty(y.Id))
+                {
+                    return x.Summary.IsEqualTo(y.Summary);
+                }
+
+                return x.Id.IsEqualTo(y.Id);
             }
 
             public int GetHashCode(ImmutableRule obj)
             {
+                // When the id is empty, we need to compare
+                // using the summary to detect if the rules are unique or not.
+
+                if (string.IsNullOrEmpty(obj.Id))
+                {
+                    return obj.Summary?.GetHashCode() ?? 0;
+                }
+
                 return obj.Id.GetHashCode();
             }
         }


### PR DESCRIPTION
## Description Of Changes

When finding the distinct rules that are available in Chocolatey CLI
and its extensions, the equals and GetHashCode was incorrectly
implemented which in some cases causes the incorrect rules to be
returned, or not returned.

This commit updates these two methods to handle the check for
getting the hash code, and comparing immutable rules in the way
that we expect them to behave.

## Motivation and Context

To have a functional way to get all available rules in Chocolatey CLI and its extensions.

## Testing

1. Run unit tests.

### Operating Systems Testing

- Windows 10

## Change Types Made
<!-- Tick the boxes for the type of changes that have been made -->

* [x] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [x] Tests to cover my changes, have been added.
* [x] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue

Fixes #3182
