### PR TITLE
(#3190) Fix threshold warning missing on multi-source

### DIFF
--- a/src/chocolatey.tests.integration/Scenario.cs
+++ b/src/chocolatey.tests.integration/Scenario.cs
@@ -319,6 +319,8 @@ namespace chocolatey.tests.integration
             config.PinCommand.Name = string.Empty;
             config.PinCommand.Command = PinCommandType.Unknown;
             config.ListCommand.IdOnly = false;
+            config.ListCommand.PageSize = 25;
+            config.ListCommand.ExplicitPageSize = false;
             config.MachineSources.Clear();
 
             return config;

--- a/src/chocolatey/infrastructure.app/nuget/NugetList.cs
+++ b/src/chocolatey/infrastructure.app/nuget/NugetList.cs
@@ -165,8 +165,8 @@ namespace chocolatey.infrastructure.app.nuget
                             latestResults.AddRange(partResults);
                         } while (partResults.Count >= takeNumber && skipNumber < totalToGet);
 
-                        ThresholdHit = perSourceThresholdLimit <= 0;
-                        LowerThresholdHit = perSourceThresholdMinLimit <= 0;
+                        ThresholdHit = ThresholdHit || perSourceThresholdLimit <= 0;
+                        LowerThresholdHit = LowerThresholdHit || perSourceThresholdMinLimit <= 0;
 
                         if (configuration.AllVersions)
                         {


### PR DESCRIPTION
## Description Of Changes

There was a threshold warning added to Chocolatey CLI v2.0.0 that
would warn users about searches issued when one of the sources used
has equal or more packages available than what the threshold is set to.

Unfortunately this was only working when a single source was being used
in Chocolatey CLI v2.0.0.
The changes in this PR makes the necessary changes to have this
functionality work as expected again for multiple sources.

## Motivation and Context

We want the threshold warning to show up when the user hits this threshold, both when a single source is used and when multiple sources are used.

## Testing

1. Create the directory "C:\testing"
2. Ensure the `chocolatey` source is enabled.
3. Add the testing directory as a new source (`choco source add -n local -s C:\testing`)
4. Run `choco search 7zip --page-size 2`
5. Verify a warning about the threshold is found
6. Run `choco search 7zip`
7. Verify no warning about the threshold is found
8. Run unit tests

### Operating Systems Testing

- Windows 10

## Change Types Made
<!-- Tick the boxes for the type of changes that have been made -->

* [x] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [x] Tests to cover my changes, have been added.
* [x] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue

Fixes #3190