### PR TITLE
(#3193) Add ability to ignore current http cache

### DIFF
--- a/src/chocolatey.resources/helpers/ChocolateyTabExpansion.ps1
+++ b/src/chocolatey.resources/helpers/ChocolateyTabExpansion.ps1
@@ -38,7 +38,7 @@ function script:chocoCmdOperations($commands, $command, $filter, $currentArgumen
 $script:chocoCommands = @('-?','search','list','info','install','outdated','upgrade','uninstall','new','pack','push','-h','--help','pin','source','config','feature','apikey','export','help','template','--version')
 
 # ensure these all have a space to start, or they will cause issues
-$allcommands = " --debug --verbose --trace --noop --help -? --online --accept-license --confirm --limit-output --no-progress --log-file='' --execution-timeout='' --cache-location='' --proxy='' --proxy-user='' --proxy-password='' --proxy-bypass-list='' --proxy-bypass-on-local --force --no-color --skip-compatibility-checks"
+$allcommands = " --debug --verbose --trace --noop --help -? --online --accept-license --confirm --limit-output --no-progress --log-file='' --execution-timeout='' --cache-location='' --proxy='' --proxy-user='' --proxy-password='' --proxy-bypass-list='' --proxy-bypass-on-local --force --no-color --skip-compatibility-checks --ignore-http-cache"
 
 $commandOptions = @{
     list      = "--id-only --pre --exact --by-id-only --id-starts-with --detailed --prerelease --include-programs --source='' --page='' --page-size=''"

--- a/src/chocolatey/infrastructure.app/builders/ConfigurationBuilder.cs
+++ b/src/chocolatey/infrastructure.app/builders/ConfigurationBuilder.cs
@@ -441,6 +441,15 @@ namespace chocolatey.infrastructure.app.builders
                         .Add("skipcompatibilitychecks|skip-compatibility-checks",
                             "SkipCompatibilityChecks - Prevent warnings being shown before and after command execution when a runtime compatibility problem is found between the version of Chocolatey and the Chocolatey Licensed Extension. Available in 1.1.0+",
                             option => config.DisableCompatibilityChecks = option != null)
+                        .Add("ignore-http-cache",
+                            "IgnoreHttpCache - Ignore any HTTP caches that have previously been created when querying sources, and create new caches. Available in 2.1.0+",
+                            option =>
+                            {
+                                if (option != null)
+                                {
+                                    config.CacheExpirationInMinutes = -1;
+                                }
+                            });
                         ;
                 },
                 (unparsedArgs) =>

--- a/src/chocolatey/infrastructure.app/configuration/ChocolateyConfiguration.cs
+++ b/src/chocolatey/infrastructure.app/configuration/ChocolateyConfiguration.cs
@@ -38,6 +38,7 @@ namespace chocolatey.infrastructure.app.configuration
             RegularOutput = true;
             PromptForConfirmation = true;
             DisableCompatibilityChecks = false;
+            CacheExpirationInMinutes = 30;
             SourceType = SourceTypes.Normal;
             Information = new InformationCommandConfiguration();
             Features = new FeaturesConfiguration();
@@ -339,6 +340,15 @@ NOTE: Hiding sensitive configuration data! Please double and triple
         public bool ApplyPackageParametersToDependencies { get; set; }
         public bool ApplyInstallArgumentsToDependencies { get; set; }
         public bool IgnoreDependencies { get; set; }
+
+        /// <summary>
+        /// Gets or sets the time before the cache is considered to have expired in minutes.
+        /// </summary>
+        /// <value>
+        /// The cache expiration in minutes.
+        /// </value>
+        /// <remarks>specifying a negative number disables the caching completely.</remarks>
+        public int CacheExpirationInMinutes { get; set; }
 
         public bool AllowDowngrade { get; set; }
         public bool ForceDependencies { get; set; }

--- a/src/chocolatey/infrastructure.app/configuration/ConfigurationOptions.cs
+++ b/src/chocolatey/infrastructure.app/configuration/ConfigurationOptions.cs
@@ -79,7 +79,7 @@ namespace chocolatey.infrastructure.app.configuration
                         "Prints out the help menu.",
                         option => configuration.HelpRequested = option != null)
                     .Add("online",
-                        "Online - Open help for specified command in default browser application. This option only works when used in combintation with the -?/--help/-h option.",
+                        "Online - Open help for specified command in default browser application. This option only works when used in combintation with the -?/--help/-h option.  Available in 2.0.0+",
                         option => configuration.ShowOnlineHelp = option != null);
             }
 

--- a/src/chocolatey/infrastructure.app/nuget/ChocolateySourceCacheContext.cs
+++ b/src/chocolatey/infrastructure.app/nuget/ChocolateySourceCacheContext.cs
@@ -1,14 +1,9 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace chocolatey.infrastructure.app.nuget
+﻿namespace chocolatey.infrastructure.app.nuget
 {
+    using System;
     using System.Threading;
     using Alphaleonis.Win32.Filesystem;
-    using configuration;
+    using chocolatey.infrastructure.app.configuration;
     using NuGet.Protocol.Core.Types;
 
     public class ChocolateySourceCacheContext : SourceCacheContext
@@ -22,6 +17,16 @@ namespace chocolatey.infrastructure.app.nuget
         public ChocolateySourceCacheContext(ChocolateyConfiguration config)
         {
             _chocolateyCacheLocation = config.CacheLocation;
+
+            if (config.CacheExpirationInMinutes <= 0)
+            {
+                MaxAge = DateTime.UtcNow;
+                RefreshMemoryCache = true;
+            }
+            else
+            {
+                MaxAge = DateTime.UtcNow.AddMinutes(-config.CacheExpirationInMinutes);
+            }
         }
 
         public override string GeneratedTempFolder


### PR DESCRIPTION
## Description Of Changes

The changes here will add a global option that can be used
by the user to ignore any existing http cache that has been
created prior to the execution of the current command.

Using the option will still create a new cache for the running
execution and reuse that created cache in the current context,
and can be reused normally when not using the argument in the
future.

## Motivation and Context

To give the user the ability to bypass the cache when needed, as well as being able to bypass the cache in other products we have.

## Testing

1. Run `choco outdated` (To generate an up to date cache)
2. Open up fiddler
3. Run `choco outdated --ignore-http-cache`
4. Verify requests are sent out for each package.
5. Remove items in the folders `C:\ProgramData\ChocolateyHttpCache` and `C:\Users\<YOUR_USERNAME>\.chocolatey\http-cache`
6. Run `choco outdated --ignore-http-cache` (To ensure that cache is created again, but from this call).
7. Open up fiddler/clear requests in fiddler.
8. Run `choco outdated`
9. Verify no requests was sent out through fiddler.
10. Repeat previous steps using `choco search chocolatey` instead of `choco outdated`.

### Operating Systems Testing

- Windows 10

## Change Types Made
<!-- Tick the boxes for the type of changes that have been made -->

* [ ] Bug fix (non-breaking change).
* [x] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [ ] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue

Fixes #3193