### PR TITLE
(#3201 #3225) Re-instate setting of config properties

### DIFF
--- a/src/chocolatey/infrastructure.app/builders/ConfigurationBuilder.cs
+++ b/src/chocolatey/infrastructure.app/builders/ConfigurationBuilder.cs
@@ -217,6 +217,15 @@ namespace chocolatey.infrastructure.app.builders
 
         private static void SetAllConfigItems(ChocolateyConfiguration config, ConfigFileSettings configFileSettings, IFileSystem fileSystem)
         {
+            config.CacheLocation = Environment.ExpandEnvironmentVariables(
+                SetConfigItem(
+                    ApplicationParameters.ConfigSettings.CacheLocation,
+                    configFileSettings,
+                    string.Empty,
+                    "Cache location if not TEMP folder. Replaces `$env:TEMP` value for choco.exe process. It is highly recommended this be set to make Chocolatey more deterministic in cleanup."
+                    )
+                );
+
             if (string.IsNullOrWhiteSpace(config.CacheLocation))
             {
                 config.CacheLocation = fileSystem.GetTempPath(); // System.Environment.GetEnvironmentVariable("TEMP");
@@ -233,10 +242,12 @@ namespace chocolatey.infrastructure.app.builders
             if (string.IsNullOrWhiteSpace(config.CacheLocation)) config.CacheLocation = fileSystem.CombinePaths(ApplicationParameters.InstallLocation, "temp");
 
             var commandExecutionTimeoutSeconds = 0;
-            var commandExecutionTimeout = configFileSettings.ConfigSettings
-                .Where(f => f.Key.IsEqualTo(ApplicationParameters.ConfigSettings.CommandExecutionTimeoutSeconds))
-                .Select(c => c.Value)
-                .FirstOrDefault();
+            var commandExecutionTimeout = SetConfigItem(
+                ApplicationParameters.ConfigSettings.CommandExecutionTimeoutSeconds,
+                configFileSettings,
+                ApplicationParameters.DefaultWaitForExitInSeconds.ToStringSafe(),
+                "Default timeout for command execution. '0' for infinite."
+            );
 
             int.TryParse(commandExecutionTimeout, out commandExecutionTimeoutSeconds);
             config.CommandExecutionTimeoutSeconds = commandExecutionTimeoutSeconds;

--- a/tests/chocolatey-tests/features/EnvironmentVariables.Tests.ps1
+++ b/tests/chocolatey-tests/features/EnvironmentVariables.Tests.ps1
@@ -1,0 +1,43 @@
+Describe "Ensuring Chocolatey Environment variables are correct (<_>)" -ForEach @(
+    "config"
+    "cli"
+) -Tag EnvironmentVariables, Chocolatey {
+    BeforeDiscovery {
+        $TestedVariables = @(
+            @{ Name = 'TEMP' ; Value = "C:\Temp\$PID" }
+            @{ Name = 'TMP' ; Value = "C:\Temp\$PID" }
+            @{ Name = 'ChocolateyPackageFolder' ; Value = '{0}\lib\test-environment' }
+            @{ Name = 'ChocolateyPackageName' ; Value = 'test-environment' }
+            @{ Name = 'ChocolateyPackageTitle' ; Value = 'test-environment (Install)' }
+            @{ Name = 'ChocolateyPackageVersion' ; Value = '1.0.0' }
+        )
+    }
+
+    BeforeAll {
+        Initialize-ChocolateyTestInstall
+        New-ChocolateyInstallSnapshot
+        $cacheDir = "C:\Temp\$PID"
+        switch ($_) {
+            'config' {
+                Invoke-Choco config set --name=cachelocation --value $cacheDir
+            }
+            'cli' {
+                $cacheArg = "--cache-location='$cacheDir'"
+            }
+        }
+        $Output = Invoke-Choco install test-environment --version 1.0.0 $cacheArg
+    }
+
+    AfterAll {
+        Remove-ChocolateyTestInstall
+    }
+
+    It "Should exit with success (0)" {
+        $Output.ExitCode | Should -Be 0 -Because $Output.String
+    }
+
+    It 'Should Output the expected value for <Name> environment variable' -ForEach $TestedVariables {
+        $ExpectedLine = "$Name=$Value" -f $env:ChocolateyInstall
+        $Output.Lines | Should -Contain $ExpectedLine -Because $Output.String
+    }
+}


### PR DESCRIPTION
## Description Of Changes

Previously, in this commit:

https://github.com/chocolatey/choco/commit/da19356578e3c90850ac766f150ccebf809c6ce2#diff-cb6a0471e41268b22a928bd57a59d51b70b7024e9beb30e89a330e193a089eba

The usage of the top level CacheLocation and
CommandExecutionTimeoutSeconds values had been removed, since these top
level properties within the chocolatey.config had been replaced with
values contained within the config section of the chocolatey.config
file.

However, the changes in that commit were too aggressive, and removed
the call to the set_config_item (which has subsequently been renamed to
SetConfigItem).  The method call does the work of taking any value that
is defined in the chocolatey.config for a given property name, and
adding it to the ChocolateyConfiguration instance.  When this method
call was removed, it stopped setting the property value on the
instance, and as a result, values that had been configured in the
chocolatey.config file were ignored.  They were still in play when the
configuration was passed in via a command line option, but not when
defining them in the chocolatey.config file.

The removal of this call to the set_config_item method also explains
why it was necessary to apply this bug fix in Chocolatey GUI:

https://github.com/chocolatey/ChocolateyGUI/issues/1003

The method call also had the effect of setting the description on the
configuration value, which would have meant that Chocolatey GUI
wouldn't have thrown a null reference exception.  The change in
Chocolatey GUI is still valid though, as there are times when a config
value can have a missing description, so it makes sense to leave that
fix in place.

## Motivation and Context

Fix a problem that was introduced when usage of the deprecated properties was removed.

## Testing

1. Clone and build the changes in this PR
2. Install the innosetup package
3. Verify that a .InnoInstall.log file is created in the root of the %TEMP% folder
4. Uninstall the innosetup package
5. Once again install the innosetup package, this time adding the `--cache-location c:\choco-cache` option
6. Verify that a .InnoInstall.log file is created in the root of the c:\choco-cache folder
7. Uninstall the innosetup package
8. Run the command `choco config set --name=cachelocation --value c:\choco-cache2`
9.  Once again install the innosetup package
10. Verify that a .InnoInstall.log file is created in the root of the c:\choco-cache2 folder
11. Open up the file %ChocolateyInstall%\config\chocolatey.config
12. See the top three items have descriptions

These steps are working on the assumption that setting the cache-location value to "something" then results in the TEMP environment variable being set with this value, which is then used within the innosetup package to determine where the log file is created.  This previously would not have worked and the log file would never have been created in the choco-cache folder.

### Operating Systems Testing

- Windows 10

## Change Types Made

* [x] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [ ] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue

Fixes #3201
Fixes #3225