### PR TITLE
(#3224) Do not try to use the Licensed Assembly when it is not loaded for compatibility reasons.

### DIFF
--- a/src/chocolatey/infrastructure.app/builders/ConfigurationBuilder.cs
+++ b/src/chocolatey/infrastructure.app/builders/ConfigurationBuilder.cs
@@ -522,6 +522,7 @@ namespace chocolatey.infrastructure.app.builders
         private static void SetLicensedOptions(ChocolateyConfiguration config, ChocolateyLicense license, ConfigFileSettings configFileSettings)
         {
             config.Information.IsLicensedVersion = license.IsLicensedVersion();
+            config.Information.IsLicensedAssemblyLoaded = license.AssemblyLoaded;
             config.Information.LicenseType = license.LicenseType.DescriptionOrValue();
 
             if (license.AssemblyLoaded)

--- a/src/chocolatey/infrastructure.app/configuration/ChocolateyConfiguration.cs
+++ b/src/chocolatey/infrastructure.app/configuration/ChocolateyConfiguration.cs
@@ -527,6 +527,7 @@ NOTE: Hiding sensitive configuration data! Please double and triple
         public bool IsUserRemote { get; set; }
         public bool IsProcessElevated { get; set; }
         public bool IsLicensedVersion { get; set; }
+        public bool IsLicensedAssemblyLoaded { get; set; }
         public string LicenseType { get; set; }
         public string CurrentDirectory { get; set; }
     }

--- a/src/chocolatey/infrastructure.app/configuration/EnvironmentSettings.cs
+++ b/src/chocolatey/infrastructure.app/configuration/EnvironmentSettings.cs
@@ -136,7 +136,10 @@ namespace chocolatey.infrastructure.app.configuration
         {
             Environment.SetEnvironmentVariable("ChocolateyLicenseType", config.Information.LicenseType);
 
-            if (!(config.Information.IsLicensedVersion && config.Information.IsLicensedAssemblyLoaded)) return;
+            if (!(config.Information.IsLicensedVersion && config.Information.IsLicensedAssemblyLoaded))
+            {
+                return;
+            }
 
             var licenseAssembly = AppDomain.CurrentDomain.GetAssemblies().FirstOrDefault(a => a.GetName().Name.IsEqualTo("chocolatey.licensed"));
 

--- a/src/chocolatey/infrastructure.app/configuration/EnvironmentSettings.cs
+++ b/src/chocolatey/infrastructure.app/configuration/EnvironmentSettings.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+// Copyright © 2017 - 2021 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/configuration/EnvironmentSettings.cs
+++ b/src/chocolatey/infrastructure.app/configuration/EnvironmentSettings.cs
@@ -134,9 +134,9 @@ namespace chocolatey.infrastructure.app.configuration
 
         private static void SetLicensedEnvironment(ChocolateyConfiguration config)
         {
-            if (!config.Information.IsLicensedVersion) return;
-
             Environment.SetEnvironmentVariable("ChocolateyLicenseType", config.Information.LicenseType);
+
+            if (!(config.Information.IsLicensedVersion && config.Information.IsLicensedAssemblyLoaded)) return;
 
             var licenseAssembly = AppDomain.CurrentDomain.GetAssemblies().FirstOrDefault(a => a.GetName().Name.IsEqualTo("chocolatey.licensed"));
 

--- a/tests/helpers/common/Chocolatey/Get-ChocolateyVersion.ps1
+++ b/tests/helpers/common/Chocolatey/Get-ChocolateyVersion.ps1
@@ -8,7 +8,7 @@
     [CmdletBinding()]
     param()
     if (-not $script:runningVersion) {
-        [NuGet.Versioning.NuGetVersion]$script:runningVersion = ((Invoke-Choco --version).Lines | Where-Object { $_ -NotMatch "please upgrade" }) -join '`r`n'
+        [NuGet.Versioning.NuGetVersion]$script:runningVersion = (Invoke-Choco --version).Lines | Where-Object { $_ -Match "^\d+\.[\d\.]+" } | Select-Object -First 1
     }
 
     $script:runningVersion


### PR DESCRIPTION
## Description Of Changes

Update the logic used to determine if Chocolatey should set the Licensed Environment to include if the Assembly is loaded.

## Motivation and Context

If the assembly has not been loaded, we should consider Chocolatey Licensed Extension unavailable.

## Testing

1. Follow the Manual Testing steps for an [Incompatible Chocolatey Licensed Extension](https://chocolatey.atlassian.net/wiki/spaces/DEV/pages/1562771487/Manual+Testing+Process+-+Chocolatey#Testing-Incompatible-Chocolatey-Licensed-Extension-with-Chocolatey).
2. Run some manual commands with `--skip-compatibility-check`.
3. Ensure that you get an exception about unable to load chocolatey.lib with the official strongname public key.
4. Enable the feature (`choco feature enable -n disableCompatibilityChecks`) to disable the check and run some manual commands.
5. Ensure that you get an exception about unable to load chocolatey.lib with the official strongname public key.

Examples of some commands to run: `choco list`, `choco search chocolatey`, `choco feature disable -n disableCompatibilityChecks`.


### Operating Systems Testing

- Windows Server 2019
- Windows Server 2016

## Change Types Made

* [x] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [x] Tests to cover my changes, have been added.
* [x] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue

Fixes #3224 
