### PR TITLE
(#3174) Store non-normalized package version

### DIFF
--- a/src/chocolatey/StringResources.cs
+++ b/src/chocolatey/StringResources.cs
@@ -1,0 +1,60 @@
+﻿// Copyright © 2023-Present Chocolatey Software, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace chocolatey
+{
+    using System.ComponentModel;
+
+    public static class StringResources
+    {
+        /// <summary>
+        /// Resources for the names of available environment variables
+        /// that will be created or used as part of executing
+        /// Chocolatey CLI.
+        /// </summary>
+        /// <remarks>
+        /// DEV NOTICE: Mark anything that is not meant for public consumption as
+        /// internal constants and not browsable, even if used in other projects.
+        /// </remarks>
+        public static class EnvironmentVariables
+        {
+            /// <summary>
+            /// The version of the package that is being handled as it is defined in the embedded
+            /// nuspec file.
+            /// </summary>
+            /// <remarks>
+            /// Will be sets during package installs, upgrades and uninstalls.
+            /// Environment variable is only for internal uses.
+            /// </remarks>
+            /// <seealso cref="PackageNuspecVersion" />
+            [EditorBrowsable(EditorBrowsableState.Never)]
+            [Browsable(false)]
+            internal const string ChocolateyPackageNuspecVersion = "chocolateyPackageNuspecVersion";
+
+            /// <summary>
+            /// The version of the package that is being handled as it is defined in the embedded
+            /// nuspec file.
+            /// </summary>
+            /// <remarks>
+            /// Will be sets during package installs, upgrades and uninstalls.
+            /// Environment variable is only for internal uses.
+            /// </remarks>
+            /// <seealso cref="ChocolateyPackageNuspecVersion" />
+            [EditorBrowsable(EditorBrowsableState.Never)]
+            [Browsable(false)]
+            internal const string PackageNuspecVersion = "packageNuspecVersion";
+        }
+    }
+}

--- a/src/chocolatey/chocolatey.csproj
+++ b/src/chocolatey/chocolatey.csproj
@@ -475,6 +475,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="RuleResultExtensions.cs" />
     <Compile Include="StringExtensions.cs" />
+    <Compile Include="StringResources.cs" />
     <Compile Include="TypeExtensions.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/chocolatey/infrastructure.app/nuget/NugetCommon.cs
+++ b/src/chocolatey/infrastructure.app/nuget/NugetCommon.cs
@@ -137,7 +137,7 @@ namespace chocolatey.infrastructure.app.nuget
             var updatedSources = new StringBuilder();
             foreach (var sourceValue in sources.OrEmpty())
             {
-var source = sourceValue;
+                var source = sourceValue;
                 var bypassProxy = false;
 
                 var sourceClientCertificates = new List<X509Certificate>();

--- a/src/chocolatey/infrastructure.app/services/PowershellService.cs
+++ b/src/chocolatey/infrastructure.app/services/PowershellService.cs
@@ -446,6 +446,10 @@ namespace chocolatey.infrastructure.app.services
             Environment.SetEnvironmentVariable("packageTitle", package.Title);
             Environment.SetEnvironmentVariable("chocolateyPackageVersion", package.Identity.Version.ToNormalizedStringChecked());
             Environment.SetEnvironmentVariable("packageVersion", package.Identity.Version.ToNormalizedStringChecked());
+            // We use ToStringSafe on purpose here. There is a need for the version
+            // the package specified, not the normalized version we want users to use.
+            Environment.SetEnvironmentVariable(StringResources.EnvironmentVariables.ChocolateyPackageNuspecVersion, package.Identity.Version.ToStringSafe());
+            Environment.SetEnvironmentVariable(StringResources.EnvironmentVariables.PackageNuspecVersion, package.Identity.Version.ToStringSafe());
             Environment.SetEnvironmentVariable("chocolateyPackageVersionPrerelease", package.Identity.Version.Release.ToStringSafe());
 
             Environment.SetEnvironmentVariable("chocolateyPackageFolder", packageDirectory);

--- a/src/chocolatey/infrastructure.app/templates/ChocolateyReadMeTemplate.cs
+++ b/src/chocolatey/infrastructure.app/templates/ChocolateyReadMeTemplate.cs
@@ -84,7 +84,7 @@ Chocolatey makes a number of environment variables available (You can access any
  * ChocolateyInstall - Top level folder where Chocolatey is installed
  * ChocolateyPackageName - The name of the package, equivalent to the `<id />` field in the nuspec
  * ChocolateyPackageTitle - The title of the package, equivalent to the `<title />` field in the nuspec
- * ChocolateyPackageVersion - The version of the package, equivalent to the `<version />` field in the nuspec
+ * ChocolateyPackageVersion - The normalized version of the package, equivalent to a normalized edition of the `<version />` field in the nuspec
  * ChocolateyPackageFolder - The top level location of the package folder  - the folder where Chocolatey has downloaded and extracted the NuGet package, typically `C:\ProgramData\chocolatey\lib\packageName`.
 
 #### Advanced Environment Variables

--- a/tests/chocolatey-tests/commands/choco-install.Tests.ps1
+++ b/tests/chocolatey-tests/commands/choco-install.Tests.ps1
@@ -1863,6 +1863,39 @@ To install a local, or remote file, you may use:
         }
     }
 
+    # Tagged as Internal as this package needs to be packaged by an older version of Chocolatey CLI to have the nuspec version
+    # not be normalized.
+    Context 'Installing non-normalized package outputting all environment variables' -Tag Internal {
+        BeforeAll {
+            Restore-ChocolateyInstallSnapshot
+
+            $Output = Invoke-Choco install test-environment --version 0.9 --confirm
+        }
+
+        It 'Exits with Success (0)' {
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
+        }
+
+        It 'Outputs <Name> as <Value>' -ForEach @(@{
+            Name = 'chocolateyPackageVersion'
+            Value= '0.9.0'
+        }
+        @{
+            Name = 'packageVersion'
+            Value= '0.9.0'
+        }
+        @{
+            Name = 'chocolateyPackageNuspecVersion'
+            Value= '0.9'
+        }
+        @{
+            Name = 'packageNuspecVersion'
+            Value= '0.9'
+        }) {
+            $Output.Lines | Should -Contain "$Name=$Value"
+        }
+    }
+
     # This needs to be the last test in this block, to ensure NuGet configurations aren't being created.
     # Any tests after this block are expected to generate the configuration as they're explicitly using the NuGet CLI
     Test-NuGetPaths


### PR DESCRIPTION
## Description Of Changes

In a previous change we normalized all versions that was being used
in Chocolatey CLI. This caused certain packages that uses non-normalized
version numbers to start failing to look up additional information in other
products.

To work around this problem we need to store the non-normalized version
of the package when scripts are being ran. This is done by adding a new
environment variable that can be used, this environment variable is considered
private and is not for public consumption.

## Motivation and Context

To be able to look up the proper information for legacy packages.

## Testing

Enable the hermes choco-test-packages source.

1. Run `choco install test-environment --version 0.9`
2. Verify `chocolateyPackageVersion=0.9.0` is outputted.
3. Verify `packageVersion=0.9.0` is outputted.
4. Verify `chocolateyPackageVersionOriginal=0.9` is outputted.
5. Verify `packageVersionOriginal=0.9` is outputted.
6. Run `choco upgrade test-environment`
7. Verify in the before modify script
   - Verify `chocolateyPackageVersion=0.9.0` is outputted.
   - Verify `packageVersion=0.9.0` is outputted.
   - Verify `chocolateyPackageVersionOriginal=0.9` is outputted.
   - Verify `packageVersionOriginal=0.9` is outputted.
8. Verify in the install script
   - Verify `chocolateyPackageVersion=1.0.0` is outputted.
   - Verify `packageVersion=1.0.0` is outputted.
   - Verify `chocolateyPackageVersionOriginal=1.0.0` is outputted.
   - Verify `packageVersionOriginal=1.0.0` is outputted.

Rerun tests with licensed extension installed.

### Operating Systems Testing

- Windows 10
- Windows Server 2022

## Change Types Made

* [x] Bug fix (non-breaking change).
* [x] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [ ] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue

#3174
