### PR TITLE
(maint) Fix incorrect naming style uses

### DIFF
--- a/src/chocolatey.tests.integration/Scenario.cs
+++ b/src/chocolatey.tests.integration/Scenario.cs
@@ -39,26 +39,26 @@ namespace chocolatey.tests.integration
 
         private static readonly DotNetFileSystem _fileSystem = new DotNetFileSystem();
 
-        public static string get_top_level()
+        public static string GetTopLevel()
         {
             return _fileSystem.GetDirectoryName(_fileSystem.GetCurrentAssemblyPath());
         }
 
-        public static string get_package_install_path()
+        public static string GetPackageInstallPath()
         {
-            return _fileSystem.CombinePaths(get_top_level(), "lib");
+            return _fileSystem.CombinePaths(GetTopLevel(), "lib");
         }
 
-        public static IEnumerable<string> get_installed_package_paths()
+        public static IEnumerable<string> GetInstalledPackagePaths()
         {
-            return _fileSystem.GetFiles(get_package_install_path(), "*" + NuGetConstants.PackageExtension, SearchOption.AllDirectories);
+            return _fileSystem.GetFiles(GetPackageInstallPath(), "*" + NuGetConstants.PackageExtension, SearchOption.AllDirectories);
         }
 
-        public static void reset(ChocolateyConfiguration config)
+        public static void Reset(ChocolateyConfiguration config)
         {
-            string packagesInstallPath = get_package_install_path();
-            string badPackagesPath = get_package_install_path() + "-bad";
-            string backupPackagesPath = get_package_install_path() + "-bkp";
+            string packagesInstallPath = GetPackageInstallPath();
+            string badPackagesPath = GetPackageInstallPath() + "-bad";
+            string backupPackagesPath = GetPackageInstallPath() + "-bkp";
             string shimsPath = ApplicationParameters.ShimsLocation;
             string hooksPath = ApplicationParameters.HooksLocation;
 
@@ -68,8 +68,8 @@ namespace chocolatey.tests.integration
             _fileSystem.DeleteDirectoryChecked(shimsPath, recursive: true, overrideAttributes: true);
             _fileSystem.DeleteDirectoryChecked(badPackagesPath, recursive: true, overrideAttributes: true);
             _fileSystem.DeleteDirectoryChecked(backupPackagesPath, recursive: true, overrideAttributes: true);
-            _fileSystem.DeleteDirectoryChecked(_fileSystem.CombinePaths(get_top_level(), ".chocolatey"), recursive: true, overrideAttributes: true);
-            _fileSystem.DeleteDirectoryChecked(_fileSystem.CombinePaths(get_top_level(), "extensions"), recursive: true, overrideAttributes: true);
+            _fileSystem.DeleteDirectoryChecked(_fileSystem.CombinePaths(GetTopLevel(), ".chocolatey"), recursive: true, overrideAttributes: true);
+            _fileSystem.DeleteDirectoryChecked(_fileSystem.CombinePaths(GetTopLevel(), "extensions"), recursive: true, overrideAttributes: true);
             _fileSystem.DeleteDirectoryChecked(hooksPath, recursive: true, overrideAttributes: true);
 
             _fileSystem.CreateDirectory(config.CacheLocation);
@@ -78,16 +78,16 @@ namespace chocolatey.tests.integration
             _fileSystem.CreateDirectory(shimsPath);
             _fileSystem.CreateDirectory(badPackagesPath);
             _fileSystem.CreateDirectory(backupPackagesPath);
-            _fileSystem.CreateDirectory(_fileSystem.CombinePaths(get_top_level(), ".chocolatey"));
-            _fileSystem.CreateDirectory(_fileSystem.CombinePaths(get_top_level(), "extensions"));
+            _fileSystem.CreateDirectory(_fileSystem.CombinePaths(GetTopLevel(), ".chocolatey"));
+            _fileSystem.CreateDirectory(_fileSystem.CombinePaths(GetTopLevel(), "extensions"));
 
             PowershellExecutor.AllowUseWindow = false;
         }
 
-        public static void add_packages_to_source_location(ChocolateyConfiguration config, string pattern)
+        public static void AddPackagesToSourceLocation(ChocolateyConfiguration config, string pattern)
         {
             _fileSystem.EnsureDirectoryExists(config.Sources);
-            var contextDir = _fileSystem.CombinePaths(get_top_level(), "context");
+            var contextDir = _fileSystem.CombinePaths(GetTopLevel(), "context");
             var files = _fileSystem.GetFiles(contextDir, pattern, SearchOption.AllDirectories);
 
             foreach (var file in files.OrEmpty())
@@ -96,11 +96,11 @@ namespace chocolatey.tests.integration
             }
         }
 
-        public static void add_machine_source(ChocolateyConfiguration config, string name, string path = null, int priority = 0, bool createDirectory = true)
+        public static void AddMachineSource(ChocolateyConfiguration config, string name, string path = null, int priority = 0, bool createDirectory = true)
         {
             if (string.IsNullOrEmpty(path))
             {
-                path = _fileSystem.CombinePaths(get_top_level(), "PrioritySources", name);
+                path = _fileSystem.CombinePaths(GetTopLevel(), "PrioritySources", name);
             }
 
             if (createDirectory)
@@ -117,14 +117,14 @@ namespace chocolatey.tests.integration
             config.MachineSources.Add(newSource);
         }
 
-        public static string add_packages_to_priority_source_location(ChocolateyConfiguration config, string pattern, int priority = 0, string name = null)
+        public static string AddPackagesToPrioritySourceLocation(ChocolateyConfiguration config, string pattern, int priority = 0, string name = null)
         {
             if (name == null)
             {
                 name = "Priority" + priority;
             }
 
-            var prioritySourceDirectory = _fileSystem.CombinePaths(get_top_level(), "PrioritySources", name);
+            var prioritySourceDirectory = _fileSystem.CombinePaths(GetTopLevel(), "PrioritySources", name);
 
             var machineSource = config.MachineSources.FirstOrDefault(m => m.Name.IsEqualTo(name));
 
@@ -145,7 +145,7 @@ namespace chocolatey.tests.integration
 
             _fileSystem.EnsureDirectoryExists(prioritySourceDirectory);
 
-            var contextDir = _fileSystem.CombinePaths(get_top_level(), "context");
+            var contextDir = _fileSystem.CombinePaths(GetTopLevel(), "context");
             var files = _fileSystem.GetFiles(contextDir, pattern, SearchOption.AllDirectories).OrEmpty().ToList();
 
             if (files.Count == 0)
@@ -161,7 +161,7 @@ namespace chocolatey.tests.integration
             return machineSource.Name;
         }
 
-        public static void remove_packages_from_destination_location(ChocolateyConfiguration config, string pattern)
+        public static void RemovePackagesFromDestinationLocation(ChocolateyConfiguration config, string pattern)
         {
             if (!_fileSystem.DirectoryExists(config.Sources))
             {
@@ -176,7 +176,7 @@ namespace chocolatey.tests.integration
             }
         }
 
-        public static void install_package(ChocolateyConfiguration config, string packageId, string version)
+        public static void InstallPackage(ChocolateyConfiguration config, string packageId, string version)
         {
             if (_service == null)
             {
@@ -192,7 +192,7 @@ namespace chocolatey.tests.integration
             NUnitSetup.MockLogger.Messages.Clear();
         }
 
-        public static void add_files(IEnumerable<Tuple<string, string>> files)
+        public static void AddFiles(IEnumerable<Tuple<string, string>> files)
         {
             foreach (var file in files)
             {
@@ -204,26 +204,26 @@ namespace chocolatey.tests.integration
             }
         }
 
-        public static void create_directory(string directoryPath)
+        public static void CreateDirectory(string directoryPath)
         {
             _fileSystem.CreateDirectory(directoryPath);
         }
 
-        public static void add_changed_version_package_to_source_location(ChocolateyConfiguration config, string pattern, string newVersion)
+        public static void AddChangedVersionPackageToSourceLocation(ChocolateyConfiguration config, string pattern, string newVersion)
         {
             _fileSystem.EnsureDirectoryExists(config.Sources);
-            var contextDir = _fileSystem.CombinePaths(get_top_level(), "context");
+            var contextDir = _fileSystem.CombinePaths(GetTopLevel(), "context");
             var files = _fileSystem.GetFiles(contextDir, pattern, SearchOption.AllDirectories);
 
             foreach (var file in files.OrEmpty())
             {
                 var copyToPath = _fileSystem.CombinePaths(config.Sources, _fileSystem.GetFileName(file));
                 _fileSystem.CopyFile(_fileSystem.GetFullPath(file), copyToPath, overwriteExisting: true);
-                change_package_version(copyToPath, newVersion);
+                ChangePackageVersion(copyToPath, newVersion);
             }
         }
 
-        public static void change_package_version(string existingPackagePath, string newVersion)
+        public static void ChangePackageVersion(string existingPackagePath, string newVersion)
         {
             string packageId;
             XDocument nuspecXml;
@@ -256,9 +256,9 @@ namespace chocolatey.tests.integration
             _fileSystem.MoveFile(existingPackagePath, renamedPath);
         }
 
-        private static ChocolateyConfiguration baseline_configuration()
+        private static ChocolateyConfiguration BaselineConfiguration()
         {
-            delete_test_package_directories();
+            DeleteTestPackageDirectories();
 
             // note that this does not mean an empty configuration. It does get influenced by
             // prior commands, so ensure that all items go back to the default values here
@@ -279,7 +279,7 @@ namespace chocolatey.tests.integration
             config.Information.IsLicensedVersion = false;
             config.AcceptLicense = true;
             config.AllowUnofficialBuild = true;
-            config.CacheLocation = _fileSystem.GetFullPath(_fileSystem.CombinePaths(get_top_level(), "cache"));
+            config.CacheLocation = _fileSystem.GetFullPath(_fileSystem.CombinePaths(GetTopLevel(), "cache"));
             config.CommandExecutionTimeoutSeconds = 2700;
             config.Force = false;
             config.ForceDependencies = false;
@@ -297,7 +297,7 @@ namespace chocolatey.tests.integration
             config.PromptForConfirmation = false;
             config.RegularOutput = true;
             config.SkipPackageInstallProvider = false;
-            config.Sources = _fileSystem.GetFullPath(_fileSystem.CombinePaths(get_top_level(), "packages"));
+            config.Sources = _fileSystem.GetFullPath(_fileSystem.CombinePaths(GetTopLevel(), "packages"));
             config.Version = null;
             config.Debug = true;
             config.AllVersions = false;
@@ -326,49 +326,49 @@ namespace chocolatey.tests.integration
             return config;
         }
 
-        public static ChocolateyConfiguration install()
+        public static ChocolateyConfiguration Install()
         {
-            var config = baseline_configuration();
+            var config = BaselineConfiguration();
             config.CommandName = CommandNameType.Install.ToStringSafe();
 
             return config;
         }
 
-        public static ChocolateyConfiguration upgrade()
+        public static ChocolateyConfiguration Upgrade()
         {
-            var config = baseline_configuration();
+            var config = BaselineConfiguration();
             config.CommandName = CommandNameType.Upgrade.ToStringSafe();
 
             return config;
         }
 
-        public static ChocolateyConfiguration uninstall()
+        public static ChocolateyConfiguration Uninstall()
         {
-            var config = baseline_configuration();
+            var config = BaselineConfiguration();
             config.CommandName = CommandNameType.Uninstall.ToStringSafe();
 
             return config;
         }
 
-        public static ChocolateyConfiguration list()
+        public static ChocolateyConfiguration List()
         {
-            var config = baseline_configuration();
+            var config = BaselineConfiguration();
             config.CommandName = "list";
 
             return config;
         }
 
-        public static ChocolateyConfiguration search()
+        public static ChocolateyConfiguration Search()
         {
-            var config = baseline_configuration();
+            var config = BaselineConfiguration();
             config.CommandName = "search";
 
             return config;
         }
 
-        public static ChocolateyConfiguration info()
+        public static ChocolateyConfiguration Info()
         {
-            var config = baseline_configuration();
+            var config = BaselineConfiguration();
             config.CommandName = "info";
             config.Verbose = true;
             config.ListCommand.Exact = true;
@@ -376,30 +376,30 @@ namespace chocolatey.tests.integration
             return config;
         }
 
-        public static ChocolateyConfiguration pin()
+        public static ChocolateyConfiguration Pin()
         {
-            var config = baseline_configuration();
+            var config = BaselineConfiguration();
             config.CommandName = "pin";
 
             return config;
         }
 
-        public static ChocolateyConfiguration pack()
+        public static ChocolateyConfiguration Pack()
         {
-            var config = baseline_configuration();
+            var config = BaselineConfiguration();
             config.CommandName = "pack";
 
             return config;
         }
 
-        public static ChocolateyConfiguration proxy()
+        public static ChocolateyConfiguration Proxy()
         {
-            return baseline_configuration();
+            return BaselineConfiguration();
         }
 
-        public static void set_configuration_file_setting(string name, string value)
+        public static void SetConfigurationFileSetting(string name, string value)
         {
-            var config = baseline_configuration();
+            var config = BaselineConfiguration();
             config.ConfigCommand.Name = name;
             config.ConfigCommand.ConfigValue = value;
             config.ConfigCommand.Command = ConfigCommandType.Set;
@@ -407,9 +407,9 @@ namespace chocolatey.tests.integration
             configService.SetConfig(config);
         }
 
-        private static void delete_test_package_directories()
+        private static void DeleteTestPackageDirectories()
         {
-            var topDirectory = get_top_level();
+            var topDirectory = GetTopLevel();
 
             var directoriesToClean = new[]
             {

--- a/src/chocolatey.tests.integration/infrastructure.app/builders/ConfigurationBuilderSpecs.cs
+++ b/src/chocolatey.tests.integration/infrastructure.app/builders/ConfigurationBuilderSpecs.cs
@@ -67,10 +67,10 @@ namespace chocolatey.tests.integration.infrastructure.app.builders
 
             public override void Context()
             {
-                Configuration = Scenario.proxy();
-                Scenario.set_configuration_file_setting(ConfigurationFileProxySettingName, string.Empty);
-                Scenario.set_configuration_file_setting(ConfigurationFileProxyBypassSettingName, string.Empty);
-                Scenario.reset(Configuration);
+                Configuration = Scenario.Proxy();
+                Scenario.SetConfigurationFileSetting(ConfigurationFileProxySettingName, string.Empty);
+                Scenario.SetConfigurationFileSetting(ConfigurationFileProxyBypassSettingName, string.Empty);
+                Scenario.Reset(Configuration);
                 Container = NUnitSetup.Container;
                 License = new ChocolateyLicense();
                 Environment = new Mock<IEnvironment>();
@@ -125,7 +125,7 @@ namespace chocolatey.tests.integration.infrastructure.app.builders
 
                 if (ConfigSet)
                 {
-                    Scenario.set_configuration_file_setting(ConfigurationFileProxySettingName, ConfigurationFileProxyValue);
+                    Scenario.SetConfigurationFileSetting(ConfigurationFileProxySettingName, ConfigurationFileProxyValue);
                 }
 
                 if (ArgumentSet)
@@ -187,7 +187,7 @@ namespace chocolatey.tests.integration.infrastructure.app.builders
 
                 if (ConfigSet)
                 {
-                    Scenario.set_configuration_file_setting(ConfigurationFileProxyBypassSettingName, ConfigurationFileProxyValue);
+                    Scenario.SetConfigurationFileSetting(ConfigurationFileProxyBypassSettingName, ConfigurationFileProxyValue);
                 }
 
                 if (EnvironmentVariableSet)

--- a/src/chocolatey.tests.integration/infrastructure/commands/CommandExecutorSpecs.cs
+++ b/src/chocolatey.tests.integration/infrastructure/commands/CommandExecutorSpecs.cs
@@ -27,12 +27,12 @@ namespace chocolatey.tests.integration.infrastructure.commands
     {
         public abstract class CommandExecutorSpecsBase : TinySpec
         {
-            protected readonly IFileSystem fileSystem = new DotNetFileSystem();
-            protected CommandExecutor commandExecutor;
+            protected readonly IFileSystem FileSystem = new DotNetFileSystem();
+            protected CommandExecutor CommandExecutor;
 
             public override void Context()
             {
-                commandExecutor = new CommandExecutor(fileSystem);
+                CommandExecutor = new CommandExecutor(FileSystem);
             }
         }
 
@@ -40,8 +40,8 @@ namespace chocolatey.tests.integration.infrastructure.commands
         [Platform(Exclude = "Mono")]
         public class When_CommandExecutor_errors : CommandExecutorSpecsBase
         {
-            private int result;
-            private string errorOutput;
+            private int _result;
+            private string _errorOutput;
 
             public override void Context()
             {
@@ -50,13 +50,13 @@ namespace chocolatey.tests.integration.infrastructure.commands
 
             public override void Because()
             {
-                result = commandExecutor.Execute(
+                _result = CommandExecutor.Execute(
                     "cmd.exe",
                     "/c bob123123",
                     ApplicationParameters.DefaultWaitForExitInSeconds,
-                    fileSystem.GetCurrentDirectory(),
+                    FileSystem.GetCurrentDirectory(),
                     null,
-                    (s, e) => { errorOutput += e.Data; },
+                    (s, e) => { _errorOutput += e.Data; },
                     updateProcessPath: false,
                     allowUseWindow: false);
             }
@@ -64,19 +64,19 @@ namespace chocolatey.tests.integration.infrastructure.commands
             [Fact]
             public void Should_not_return_an_exit_code_of_zero()
             {
-                result.Should().NotBe(0);
+                _result.Should().NotBe(0);
             }
 
             [Fact]
             public void Should_contain_error_output()
             {
-                errorOutput.Should().NotBeNull();
+                _errorOutput.Should().NotBeNull();
             }
 
             [Fact]
             public void Should_message_the_error()
             {
-                errorOutput.Should().Be("'bob123123' is not recognized as an internal or external command,operable program or batch file.");
+                _errorOutput.Should().Be("'bob123123' is not recognized as an internal or external command,operable program or batch file.");
             }
         }
 
@@ -84,25 +84,25 @@ namespace chocolatey.tests.integration.infrastructure.commands
         [Platform(Exclude = "Mono")]
         public class When_CommandExecutor_is_given_a_nonexisting_process : CommandExecutorSpecsBase
         {
-            private string result;
-            private string errorOutput;
+            private string _result;
+            private string _errorOutput;
 
             public override void Because()
             {
                 try
                 {
-                    commandExecutor.Execute("noprocess.exe", "/c bob123123", ApplicationParameters.DefaultWaitForExitInSeconds, null, (s, e) => { errorOutput += e.Data; });
+                    CommandExecutor.Execute("noprocess.exe", "/c bob123123", ApplicationParameters.DefaultWaitForExitInSeconds, null, (s, e) => { _errorOutput += e.Data; });
                 }
                 catch (Exception e)
                 {
-                    result = e.Message;
+                    _result = e.Message;
                 }
             }
 
             [Fact]
             public void Should_have_an_error_message()
             {
-                result.Should().NotBeNull();
+                _result.Should().NotBeNull();
             }
         }
     }

--- a/src/chocolatey.tests.integration/infrastructure/cryptography/CryptoHashProviderSpecs.cs
+++ b/src/chocolatey.tests.integration/infrastructure/cryptography/CryptoHashProviderSpecs.cs
@@ -41,26 +41,26 @@ namespace chocolatey.tests.integration.infrastructure.cryptography
 
         public class When_HashProvider_provides_a_hash : CryptoHashProviderSpecsBase
         {
-            private string result;
-            private string filePath;
+            private string _result;
+            private string _filePath;
 
             public override void Context()
             {
                 base.Context();
-                filePath = FileSystem.CombinePaths(ContextDirectory, "testing.packages.config");
+                _filePath = FileSystem.CombinePaths(ContextDirectory, "testing.packages.config");
             }
 
             public override void Because()
             {
-                result = Provider.ComputeFileHash(filePath);
+                _result = Provider.ComputeFileHash(_filePath);
             }
 
             [Fact]
             public void Should_provide_the_correct_hash_based_on_a_checksum()
             {
-                var expected = BitConverter.ToString(SHA256.Create().ComputeHash(File.ReadAllBytes(filePath))).Replace("-", string.Empty);
+                var expected = BitConverter.ToString(SHA256.Create().ComputeHash(File.ReadAllBytes(_filePath))).Replace("-", string.Empty);
 
-                result.Should().Be(expected);
+                _result.Should().Be(expected);
             }
         }
     }

--- a/src/chocolatey.tests.integration/scenarios/InfoScenarios.cs
+++ b/src/chocolatey.tests.integration/scenarios/InfoScenarios.cs
@@ -31,8 +31,8 @@ namespace chocolatey.tests.integration.scenarios
 
             public override void Context()
             {
-                Configuration = Scenario.info();
-                Scenario.reset(Configuration);
+                Configuration = Scenario.Info();
+                Scenario.Reset(Configuration);
 
                 Service = NUnitSetup.Container.GetInstance<IChocolateyPackageService>();
             }
@@ -53,8 +53,8 @@ namespace chocolatey.tests.integration.scenarios
 
             public override void Context()
             {
-                Configuration = Scenario.info();
-                Scenario.reset(Configuration);
+                Configuration = Scenario.Info();
+                Scenario.Reset(Configuration);
 
                 Command = NUnitSetup.Container.GetAllInstances<ICommand>()
                     .Where(c => c.GetType() == typeof(ChocolateyInfoCommand)).First();
@@ -77,7 +77,7 @@ namespace chocolatey.tests.integration.scenarios
                 Configuration.PackageNames = Configuration.Input = "installpackage";
 
                 Configuration.Sources = "PackageOutput";
-                Scenario.add_packages_to_source_location(Configuration, "installpackage.*" + NuGetConstants.PackageExtension);
+                Scenario.AddPackagesToSourceLocation(Configuration, "installpackage.*" + NuGetConstants.PackageExtension);
             }
 
             [Fact]
@@ -114,7 +114,7 @@ namespace chocolatey.tests.integration.scenarios
                 Configuration.PackageNames = Configuration.Input = "installpackage";
 
                 Configuration.Sources = "PackageOutput";
-                Scenario.add_packages_to_source_location(Configuration, "installpackage.*" + NuGetConstants.PackageExtension);
+                Scenario.AddPackagesToSourceLocation(Configuration, "installpackage.*" + NuGetConstants.PackageExtension);
 
                 Configuration.Version = "1.0.0";
             }
@@ -153,7 +153,7 @@ namespace chocolatey.tests.integration.scenarios
                 Configuration.PackageNames = Configuration.Input = "installpackage";
 
                 Configuration.Sources = "PackageOutput";
-                Scenario.add_packages_to_source_location(Configuration, "installpackage.*" + NuGetConstants.PackageExtension);
+                Scenario.AddPackagesToSourceLocation(Configuration, "installpackage.*" + NuGetConstants.PackageExtension);
 
                 Configuration.Version = "01.0.0.0";
             }
@@ -196,7 +196,7 @@ namespace chocolatey.tests.integration.scenarios
 
                 Configuration.Sources = "PackageOutput";
 
-                Scenario.add_changed_version_package_to_source_location(Configuration, "installpackage.1.0.0" + NuGetConstants.PackageExtension, NonNormalizedVersion);
+                Scenario.AddChangedVersionPackageToSourceLocation(Configuration, "installpackage.1.0.0" + NuGetConstants.PackageExtension, NonNormalizedVersion);
             }
 
             [Fact]
@@ -237,7 +237,7 @@ namespace chocolatey.tests.integration.scenarios
 
                 Configuration.Sources = "PackageOutput";
 
-                Scenario.add_changed_version_package_to_source_location(Configuration, "installpackage.1.0.0" + NuGetConstants.PackageExtension, NonNormalizedVersion);
+                Scenario.AddChangedVersionPackageToSourceLocation(Configuration, "installpackage.1.0.0" + NuGetConstants.PackageExtension, NonNormalizedVersion);
 
                 Configuration.Version = "4.0.1";
             }
@@ -280,7 +280,7 @@ namespace chocolatey.tests.integration.scenarios
 
                 Configuration.Sources = "PackageOutput";
 
-                Scenario.add_changed_version_package_to_source_location(Configuration, "installpackage.1.0.0" + NuGetConstants.PackageExtension, NonNormalizedVersion);
+                Scenario.AddChangedVersionPackageToSourceLocation(Configuration, "installpackage.1.0.0" + NuGetConstants.PackageExtension, NonNormalizedVersion);
 
                 Configuration.Version = NonNormalizedVersion;
             }
@@ -366,7 +366,7 @@ namespace chocolatey.tests.integration.scenarios
 
                 Configuration.PackageNames = Configuration.Input = "installpackage";
                 Configuration.Sources = "PackageOutput";
-                Scenario.add_packages_to_source_location(Configuration, "installpackage.*" + NuGetConstants.PackageExtension);
+                Scenario.AddPackagesToSourceLocation(Configuration, "installpackage.*" + NuGetConstants.PackageExtension);
             }
 
             [Fact]
@@ -416,7 +416,7 @@ namespace chocolatey.tests.integration.scenarios
                 base.Context();
 
                 Configuration.PackageNames = Configuration.Input = "test-package";
-                Configuration.Sources = Scenario.add_packages_to_priority_source_location(Configuration, "test-package.*" + NuGetConstants.PackageExtension, priority: 1);
+                Configuration.Sources = Scenario.AddPackagesToPrioritySourceLocation(Configuration, "test-package.*" + NuGetConstants.PackageExtension, priority: 1);
             }
 
             [Fact]
@@ -447,7 +447,7 @@ namespace chocolatey.tests.integration.scenarios
             public void Should_set_source_to_expected_value()
             {
                 var expectedSource = "file:///" + Path.Combine(
-                    Scenario.get_top_level(),
+                    Scenario.GetTopLevel(),
                     "PrioritySources",
                     "Priority1").Replace('\\', '/');
 
@@ -470,8 +470,8 @@ namespace chocolatey.tests.integration.scenarios
 
                 Configuration.PackageNames = Configuration.Input = "upgradepackage";
                 Configuration.Sources = string.Join(",",
-                    Scenario.add_packages_to_priority_source_location(Configuration, "upgradepackage.1.0.0" + NuGetConstants.PackageExtension, priority: 1),
-                    Scenario.add_packages_to_priority_source_location(Configuration,
+                    Scenario.AddPackagesToPrioritySourceLocation(Configuration, "upgradepackage.1.0.0" + NuGetConstants.PackageExtension, priority: 1),
+                    Scenario.AddPackagesToPrioritySourceLocation(Configuration,
                       "upgradepackage.1.1.0" + NuGetConstants.PackageExtension, priority: 0));
             }
 
@@ -503,7 +503,7 @@ namespace chocolatey.tests.integration.scenarios
             public void Should_set_source_to_expected_value()
             {
                 var expectedSource = "file:///" + Path.Combine(
-                    Scenario.get_top_level(),
+                    Scenario.GetTopLevel(),
                     "PrioritySources",
                     "Priority1").Replace('\\', '/');
 

--- a/src/chocolatey.tests.integration/scenarios/InstallScenarios.cs
+++ b/src/chocolatey.tests.integration/scenarios/InstallScenarios.cs
@@ -48,11 +48,11 @@ namespace chocolatey.tests.integration.scenarios
 
             public override void Context()
             {
-                Configuration = Scenario.install();
-                Scenario.reset(Configuration);
+                Configuration = Scenario.Install();
+                Scenario.Reset(Configuration);
                 Configuration.PackageNames = Configuration.Input = "installpackage";
-                Scenario.add_packages_to_source_location(Configuration, Configuration.Input + "*" + NuGetConstants.PackageExtension);
-                Scenario.add_packages_to_source_location(Configuration, "badpackage.1*" + NuGetConstants.PackageExtension);
+                Scenario.AddPackagesToSourceLocation(Configuration, Configuration.Input + "*" + NuGetConstants.PackageExtension);
+                Scenario.AddPackagesToSourceLocation(Configuration, "badpackage.1*" + NuGetConstants.PackageExtension);
 
                 Service = NUnitSetup.Container.GetInstance<IChocolateyPackageService>();
 
@@ -76,7 +76,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_not_install_a_package_in_the_lib_directory()
             {
-                var packageDir = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames);
+                var packageDir = Path.Combine(Scenario.GetTopLevel(), "lib", Configuration.PackageNames);
 
                 DirectoryAssert.DoesNotExist(packageDir);
             }
@@ -124,7 +124,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_not_install_a_package_in_the_lib_directory()
             {
-                var packageDir = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames);
+                var packageDir = Path.Combine(Scenario.GetTopLevel(), "lib", Configuration.PackageNames);
 
                 DirectoryAssert.DoesNotExist(packageDir);
             }
@@ -147,7 +147,7 @@ namespace chocolatey.tests.integration.scenarios
 
         public class When_installing_a_package_happy_path : ScenariosBase
         {
-            private PackageResult packageResult;
+            private PackageResult _packageResult;
 
             protected virtual string TestSemVersion => "1.0.0";
 
@@ -164,19 +164,19 @@ namespace chocolatey.tests.integration.scenarios
             public override void Because()
             {
                 Results = Service.Install(Configuration);
-                packageResult = Results.FirstOrDefault().Value;
+                _packageResult = Results.FirstOrDefault().Value;
             }
 
             [Fact]
             public void Should_install_where_install_location_reports()
             {
-                DirectoryAssert.Exists(packageResult.InstallLocation);
+                DirectoryAssert.Exists(_packageResult.InstallLocation);
             }
 
             [Fact]
             public void Should_install_the_package_in_the_lib_directory()
             {
-                var packageDir = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames);
+                var packageDir = Path.Combine(Scenario.GetTopLevel(), "lib", Configuration.PackageNames);
 
                 DirectoryAssert.Exists(packageDir);
             }
@@ -184,7 +184,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_install_the_expected_version_of_the_package()
             {
-                var packageFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, Configuration.PackageNames + NuGetConstants.PackageExtension);
+                var packageFile = Path.Combine(Scenario.GetTopLevel(), "lib", Configuration.PackageNames, Configuration.PackageNames + NuGetConstants.PackageExtension);
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
                     packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().Should().Be(TestVersion());
@@ -196,7 +196,7 @@ namespace chocolatey.tests.integration.scenarios
             [Platform(Exclude = "Mono")]
             public void Should_create_a_shim_for_console_in_the_bin_directory()
             {
-                var shimfile = Path.Combine(Scenario.get_top_level(), "bin", "console.exe");
+                var shimfile = Path.Combine(Scenario.GetTopLevel(), "bin", "console.exe");
 
                 FileAssert.Exists(shimfile);
             }
@@ -206,7 +206,7 @@ namespace chocolatey.tests.integration.scenarios
             [Platform(Exclude = "Mono")]
             public void Should_create_a_shim_for_graphical_in_the_bin_directory()
             {
-                var shimfile = Path.Combine(Scenario.get_top_level(), "bin", "graphical.exe");
+                var shimfile = Path.Combine(Scenario.GetTopLevel(), "bin", "graphical.exe");
 
                 FileAssert.Exists(shimfile);
             }
@@ -214,7 +214,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_not_create_a_shim_for_ignored_executable_in_the_bin_directory()
             {
-                var shimfile = Path.Combine(Scenario.get_top_level(), "bin", "not.installed.exe");
+                var shimfile = Path.Combine(Scenario.GetTopLevel(), "bin", "not.installed.exe");
 
                 FileAssert.DoesNotExist(shimfile);
             }
@@ -222,7 +222,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_not_create_a_shim_for_mismatched_case_ignored_executable_in_the_bin_directory()
             {
-                var shimfile = Path.Combine(Scenario.get_top_level(), "bin", "casemismatch.exe");
+                var shimfile = Path.Combine(Scenario.GetTopLevel(), "bin", "casemismatch.exe");
 
                 FileAssert.DoesNotExist(shimfile);
             }
@@ -230,7 +230,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_not_create_an_extensions_folder_for_the_package()
             {
-                var extensionsDirectory = Path.Combine(Scenario.get_top_level(), "extensions", Configuration.PackageNames);
+                var extensionsDirectory = Path.Combine(Scenario.GetTopLevel(), "extensions", Configuration.PackageNames);
 
                 DirectoryAssert.DoesNotExist(extensionsDirectory);
             }
@@ -238,7 +238,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_not_create_an_hooks_folder_for_the_package()
             {
-                var hooksDirectory = Path.Combine(Scenario.get_top_level(), "hooks", Configuration.PackageNames);
+                var hooksDirectory = Path.Combine(Scenario.GetTopLevel(), "hooks", Configuration.PackageNames);
 
                 DirectoryAssert.DoesNotExist(hooksDirectory);
             }
@@ -250,7 +250,7 @@ namespace chocolatey.tests.integration.scenarios
             {
                 var messages = new List<string>();
 
-                var shimfile = Path.Combine(Scenario.get_top_level(), "bin", "console.exe");
+                var shimfile = Path.Combine(Scenario.GetTopLevel(), "bin", "console.exe");
                 CommandExecutor.Execute(
                     shimfile,
                     "--shimgen-noop",
@@ -271,7 +271,7 @@ namespace chocolatey.tests.integration.scenarios
             {
                 var messages = new List<string>();
 
-                var shimfile = Path.Combine(Scenario.get_top_level(), "bin", "graphical.exe");
+                var shimfile = Path.Combine(Scenario.GetTopLevel(), "bin", "graphical.exe");
                 CommandExecutor.Execute(
                     shimfile,
                     "--shimgen-noop",
@@ -296,31 +296,31 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_have_a_successful_package_result()
             {
-                packageResult.Success.Should().BeTrue();
+                _packageResult.Success.Should().BeTrue();
             }
 
             [Fact]
             public void Should_not_have_inconclusive_package_result()
             {
-                packageResult.Inconclusive.Should().BeFalse();
+                _packageResult.Inconclusive.Should().BeFalse();
             }
 
             [Fact]
             public void Should_not_have_warning_package_result()
             {
-                packageResult.Warning.Should().BeFalse();
+                _packageResult.Warning.Should().BeFalse();
             }
 
             [Fact]
             public void Config_should_match_package_result_name()
             {
-                packageResult.Name.Should().Be(Configuration.PackageNames);
+                _packageResult.Name.Should().Be(Configuration.PackageNames);
             }
 
             [Fact]
             public void Should_have_a_version_of_one_dot_zero_dot_zero()
             {
-                packageResult.Version.Should().Be(TestVersion());
+                _packageResult.Version.Should().Be(TestVersion());
             }
 
             [Fact]
@@ -365,12 +365,12 @@ namespace chocolatey.tests.integration.scenarios
             public override void Context()
             {
                 base.Context();
-                var packagesConfig = "{0}{1}context{1}testing.packages.config".FormatWith(Scenario.get_top_level(), Path.DirectorySeparatorChar);
+                var packagesConfig = "{0}{1}context{1}testing.packages.config".FormatWith(Scenario.GetTopLevel(), Path.DirectorySeparatorChar);
                 Configuration.PackageNames = Configuration.Input = packagesConfig;
-                Scenario.add_packages_to_source_location(Configuration, "hasdependency.1.0.0*" + NuGetConstants.PackageExtension);
-                Scenario.add_packages_to_source_location(Configuration, "isdependency.1.0.0*" + NuGetConstants.PackageExtension);
-                Scenario.add_packages_to_source_location(Configuration, "isexactversiondependency*" + NuGetConstants.PackageExtension);
-                Scenario.add_packages_to_source_location(Configuration, "upgradepackage*" + NuGetConstants.PackageExtension);
+                Scenario.AddPackagesToSourceLocation(Configuration, "hasdependency.1.0.0*" + NuGetConstants.PackageExtension);
+                Scenario.AddPackagesToSourceLocation(Configuration, "isdependency.1.0.0*" + NuGetConstants.PackageExtension);
+                Scenario.AddPackagesToSourceLocation(Configuration, "isexactversiondependency*" + NuGetConstants.PackageExtension);
+                Scenario.AddPackagesToSourceLocation(Configuration, "upgradepackage*" + NuGetConstants.PackageExtension);
             }
 
             public override void Because()
@@ -401,7 +401,7 @@ namespace chocolatey.tests.integration.scenarios
                 };
                 foreach (var package in packagesExpected)
                 {
-                    var packageDir = Path.Combine(Scenario.get_top_level(), "lib", package);
+                    var packageDir = Path.Combine(Scenario.GetTopLevel(), "lib", package);
                     DirectoryAssert.Exists(packageDir);
                 }
             }
@@ -409,7 +409,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_install_the_dependency_in_the_lib_directory()
             {
-                var packageDir = Path.Combine(Scenario.get_top_level(), "lib", "isdependency");
+                var packageDir = Path.Combine(Scenario.GetTopLevel(), "lib", "isdependency");
 
                 DirectoryAssert.Exists(packageDir);
             }
@@ -471,24 +471,24 @@ namespace chocolatey.tests.integration.scenarios
 
         public class When_installing_an_already_installed_package : ScenariosBase
         {
-            private PackageResult packageResult;
+            private PackageResult _packageResult;
 
             public override void Context()
             {
                 base.Context();
-                Scenario.install_package(Configuration, "installpackage", "1.0.0");
+                Scenario.InstallPackage(Configuration, "installpackage", "1.0.0");
             }
 
             public override void Because()
             {
                 Results = Service.Install(Configuration);
-                packageResult = Results.FirstOrDefault().Value;
+                _packageResult = Results.FirstOrDefault().Value;
             }
 
             [Fact]
             public void Should_still_have_a_package_in_the_lib_directory()
             {
-                var packageDir = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames);
+                var packageDir = Path.Combine(Scenario.GetTopLevel(), "lib", Configuration.PackageNames);
 
                 DirectoryAssert.Exists(packageDir);
             }
@@ -496,7 +496,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_still_have_the_expected_version_of_the_package_installed()
             {
-                var packageFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, Configuration.PackageNames + NuGetConstants.PackageExtension);
+                var packageFile = Path.Combine(Scenario.GetTopLevel(), "lib", Configuration.PackageNames, Configuration.PackageNames + NuGetConstants.PackageExtension);
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
                     packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().Should().Be("1.0.0");
@@ -521,27 +521,27 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_have_inconclusive_package_result()
             {
-                packageResult.Inconclusive.Should().BeTrue();
+                _packageResult.Inconclusive.Should().BeTrue();
             }
 
             [Fact]
             public void Should_ave_warning_package_result()
             {
-                packageResult.Warning.Should().BeTrue();
+                _packageResult.Warning.Should().BeTrue();
             }
         }
 
         public class When_force_installing_an_already_installed_package : ScenariosBase
         {
-            private PackageResult packageResult;
-            private readonly string modifiedText = "bob";
+            private PackageResult _packageResult;
+            private readonly string _modifiedText = "bob";
 
             public override void Context()
             {
                 base.Context();
-                Scenario.install_package(Configuration, "installpackage", "1.0.0");
-                var fileToModify = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, "tools", "chocolateyinstall.ps1");
-                File.WriteAllText(fileToModify, modifiedText);
+                Scenario.InstallPackage(Configuration, "installpackage", "1.0.0");
+                var fileToModify = Path.Combine(Scenario.GetTopLevel(), "lib", Configuration.PackageNames, "tools", "chocolateyinstall.ps1");
+                File.WriteAllText(fileToModify, _modifiedText);
 
                 Configuration.Force = true;
             }
@@ -549,19 +549,19 @@ namespace chocolatey.tests.integration.scenarios
             public override void Because()
             {
                 Results = Service.Install(Configuration);
-                packageResult = Results.FirstOrDefault().Value;
+                _packageResult = Results.FirstOrDefault().Value;
             }
 
             [Fact]
             public void Should_install_where_install_location_reports()
             {
-                DirectoryAssert.Exists(packageResult.InstallLocation);
+                DirectoryAssert.Exists(_packageResult.InstallLocation);
             }
 
             [Fact]
             public void Should_install_the_package_in_the_lib_directory()
             {
-                var packageDir = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames);
+                var packageDir = Path.Combine(Scenario.GetTopLevel(), "lib", Configuration.PackageNames);
 
                 DirectoryAssert.Exists(packageDir);
             }
@@ -569,7 +569,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_install_the_same_version_of_the_package()
             {
-                var packageFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, Configuration.PackageNames + NuGetConstants.PackageExtension);
+                var packageFile = Path.Combine(Scenario.GetTopLevel(), "lib", Configuration.PackageNames, Configuration.PackageNames + NuGetConstants.PackageExtension);
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
                     packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().Should().Be("1.0.0");
@@ -579,14 +579,14 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_remove_and_re_add_the_package_files_in_the_lib_directory()
             {
-                var modifiedFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, "tools", "chocolateyinstall.ps1");
-                File.ReadAllText(modifiedFile).Should().NotBe(modifiedText);
+                var modifiedFile = Path.Combine(Scenario.GetTopLevel(), "lib", Configuration.PackageNames, "tools", "chocolateyinstall.ps1");
+                File.ReadAllText(modifiedFile).Should().NotBe(_modifiedText);
             }
 
             [Fact]
             public void Should_delete_the_rollback()
             {
-                var packageDir = Path.Combine(Scenario.get_top_level(), "lib-bkp", Configuration.PackageNames);
+                var packageDir = Path.Combine(Scenario.GetTopLevel(), "lib-bkp", Configuration.PackageNames);
 
                 DirectoryAssert.DoesNotExist(packageDir);
             }
@@ -601,31 +601,31 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_have_a_successful_package_result()
             {
-                packageResult.Success.Should().BeTrue();
+                _packageResult.Success.Should().BeTrue();
             }
 
             [Fact]
             public void Should_not_have_inconclusive_package_result()
             {
-                packageResult.Inconclusive.Should().BeFalse();
+                _packageResult.Inconclusive.Should().BeFalse();
             }
 
             [Fact]
             public void Should_not_have_warning_package_result()
             {
-                packageResult.Warning.Should().BeFalse();
+                _packageResult.Warning.Should().BeFalse();
             }
 
             [Fact]
             public void Config_should_match_package_result_name()
             {
-                packageResult.Name.Should().Be(Configuration.PackageNames);
+                _packageResult.Name.Should().Be(Configuration.PackageNames);
             }
 
             [Fact]
             public void Should_have_a_version_of_one_dot_zero_dot_zero()
             {
-                packageResult.Version.Should().Be("1.0.0");
+                _packageResult.Version.Should().Be("1.0.0");
             }
         }
 
@@ -633,32 +633,32 @@ namespace chocolatey.tests.integration.scenarios
         [Platform(Exclude = "Mono")]
         public class When_force_installing_an_already_installed_package_that_errors : ScenariosBase
         {
-            private PackageResult packageResult;
-            private readonly string modifiedText = "bob";
+            private PackageResult _packageResult;
+            private readonly string _modifiedText = "bob";
 
             public override void Context()
             {
                 base.Context();
                 Configuration.PackageNames = Configuration.Input = "badpackage";
                 Configuration.SkipPackageInstallProvider = true;
-                Scenario.install_package(Configuration, "badpackage", "1.0");
+                Scenario.InstallPackage(Configuration, "badpackage", "1.0");
                 Configuration.SkipPackageInstallProvider = false;
                 Configuration.Force = true;
 
-                var fileToModify = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, "tools", "chocolateyInstall.ps1");
-                File.WriteAllText(fileToModify, modifiedText);
+                var fileToModify = Path.Combine(Scenario.GetTopLevel(), "lib", Configuration.PackageNames, "tools", "chocolateyInstall.ps1");
+                File.WriteAllText(fileToModify, _modifiedText);
             }
 
             public override void Because()
             {
                 Results = Service.Install(Configuration);
-                packageResult = Results.FirstOrDefault().Value;
+                _packageResult = Results.FirstOrDefault().Value;
             }
 
             [Fact]
             public void Should_restore_the_backup_version_of_the_package()
             {
-                var packageFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, Configuration.PackageNames + NuGetConstants.PackageExtension);
+                var packageFile = Path.Combine(Scenario.GetTopLevel(), "lib", Configuration.PackageNames, Configuration.PackageNames + NuGetConstants.PackageExtension);
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
                     packageReader.NuspecReader.GetVersion().ToNormalizedString().Should().Be("1.0.0");
@@ -668,14 +668,14 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_restore_the_original_files_in_the_package_lib_folder()
             {
-                var modifiedFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, "tools", "chocolateyInstall.ps1");
-                File.ReadAllText(modifiedFile).Should().Be(modifiedText);
+                var modifiedFile = Path.Combine(Scenario.GetTopLevel(), "lib", Configuration.PackageNames, "tools", "chocolateyInstall.ps1");
+                File.ReadAllText(modifiedFile).Should().Be(_modifiedText);
             }
 
             [Fact]
             public void Should_delete_the_rollback()
             {
-                var packageDir = Path.Combine(Scenario.get_top_level(), "lib-bkp", Configuration.PackageNames);
+                var packageDir = Path.Combine(Scenario.GetTopLevel(), "lib-bkp", Configuration.PackageNames);
 
                 DirectoryAssert.DoesNotExist(packageDir);
             }
@@ -690,19 +690,19 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_not_have_a_successful_package_result()
             {
-                packageResult.Success.Should().BeFalse();
+                _packageResult.Success.Should().BeFalse();
             }
 
             [Fact]
             public void Should_not_have_inconclusive_package_result()
             {
-                packageResult.Inconclusive.Should().BeFalse();
+                _packageResult.Inconclusive.Should().BeFalse();
             }
 
             [Fact]
             public void Should_not_have_warning_package_result()
             {
-                packageResult.Warning.Should().BeFalse();
+                _packageResult.Warning.Should().BeFalse();
             }
         }
 
@@ -710,41 +710,41 @@ namespace chocolatey.tests.integration.scenarios
         [Platform(Exclude = "Mono")]
         public class When_force_installing_an_already_installed_package_with_a_read_and_delete_share_locked_file : ScenariosBase
         {
-            private PackageResult packageResult;
-            private FileStream fileStream;
+            private PackageResult _packageResult;
+            private FileStream _fileStream;
 
             public override void Context()
             {
                 base.Context();
-                Scenario.install_package(Configuration, "installpackage", "1.0.0");
+                Scenario.InstallPackage(Configuration, "installpackage", "1.0.0");
                 Configuration.Force = true;
-                var fileToOpen = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, "tools", "chocolateyInstall.ps1");
-                fileStream = new FileStream(fileToOpen, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.Read | FileShare.Delete);
+                var fileToOpen = Path.Combine(Scenario.GetTopLevel(), "lib", Configuration.PackageNames, "tools", "chocolateyInstall.ps1");
+                _fileStream = new FileStream(fileToOpen, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.Read | FileShare.Delete);
             }
 
             public override void AfterObservations()
             {
                 base.AfterObservations();
-                fileStream.Close();
-                fileStream.Dispose();
+                _fileStream.Close();
+                _fileStream.Dispose();
             }
 
             public override void Because()
             {
                 Results = Service.Install(Configuration);
-                packageResult = Results.FirstOrDefault().Value;
+                _packageResult = Results.FirstOrDefault().Value;
             }
 
             [Fact]
             public void Should_install_where_install_location_reports()
             {
-                DirectoryAssert.Exists(packageResult.InstallLocation);
+                DirectoryAssert.Exists(_packageResult.InstallLocation);
             }
 
             [Fact]
             public void Should_reinstall_the_package_in_the_lib_directory()
             {
-                var packageDir = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames);
+                var packageDir = Path.Combine(Scenario.GetTopLevel(), "lib", Configuration.PackageNames);
 
                 DirectoryAssert.Exists(packageDir);
             }
@@ -752,7 +752,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_reinstall_the_same_version_of_the_package()
             {
-                var packageFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, Configuration.PackageNames + NuGetConstants.PackageExtension);
+                var packageFile = Path.Combine(Scenario.GetTopLevel(), "lib", Configuration.PackageNames, Configuration.PackageNames + NuGetConstants.PackageExtension);
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
                     packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().Should().Be("1.0.0");
@@ -764,7 +764,7 @@ namespace chocolatey.tests.integration.scenarios
             [Broken]
             public void Should_not_be_able_delete_the_rollback()
             {
-                var packageDir = Path.Combine(Scenario.get_top_level(), "lib-bkp", Configuration.PackageNames);
+                var packageDir = Path.Combine(Scenario.GetTopLevel(), "lib-bkp", Configuration.PackageNames);
 
                 DirectoryAssert.Exists(packageDir);
             }
@@ -779,31 +779,31 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_have_a_successful_package_result()
             {
-                packageResult.Success.Should().BeTrue();
+                _packageResult.Success.Should().BeTrue();
             }
 
             [Fact]
             public void Should_not_have_inconclusive_package_result()
             {
-                packageResult.Inconclusive.Should().BeFalse();
+                _packageResult.Inconclusive.Should().BeFalse();
             }
 
             [Fact]
             public void Should_not_have_warning_package_result()
             {
-                packageResult.Warning.Should().BeFalse();
+                _packageResult.Warning.Should().BeFalse();
             }
 
             [Fact]
             public void Config_should_match_package_result_name()
             {
-                packageResult.Name.Should().Be(Configuration.PackageNames);
+                _packageResult.Name.Should().Be(Configuration.PackageNames);
             }
 
             [Fact]
             public void Should_have_a_version_of_one_dot_zero_dot_zero()
             {
-                packageResult.Version.Should().Be("1.0.0");
+                _packageResult.Version.Should().Be("1.0.0");
             }
         }
 
@@ -811,35 +811,35 @@ namespace chocolatey.tests.integration.scenarios
         [Platform(Exclude = "Mono")]
         public class When_force_installing_an_already_installed_package_with_with_an_exclusively_locked_file : ScenariosBase
         {
-            private PackageResult packageResult;
-            private FileStream fileStream;
+            private PackageResult _packageResult;
+            private FileStream _fileStream;
 
             public override void Context()
             {
                 base.Context();
-                Scenario.install_package(Configuration, "installpackage", "1.0.0");
+                Scenario.InstallPackage(Configuration, "installpackage", "1.0.0");
                 Configuration.Force = true;
-                var fileToOpen = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, "tools", "chocolateyInstall.ps1");
-                fileStream = new FileStream(fileToOpen, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.None);
+                var fileToOpen = Path.Combine(Scenario.GetTopLevel(), "lib", Configuration.PackageNames, "tools", "chocolateyInstall.ps1");
+                _fileStream = new FileStream(fileToOpen, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.None);
             }
 
             public override void AfterObservations()
             {
                 base.AfterObservations();
-                fileStream.Close();
-                fileStream.Dispose();
+                _fileStream.Close();
+                _fileStream.Dispose();
             }
 
             public override void Because()
             {
                 Results = Service.Install(Configuration);
-                packageResult = Results.FirstOrDefault().Value;
+                _packageResult = Results.FirstOrDefault().Value;
             }
 
             [Fact]
             public void Should_have_a_package_installed_in_the_lib_directory()
             {
-                var packageDir = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames);
+                var packageDir = Path.Combine(Scenario.GetTopLevel(), "lib", Configuration.PackageNames);
 
                 DirectoryAssert.Exists(packageDir);
             }
@@ -847,7 +847,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_still_have_the_package_installed_with_the_expected_version_of_the_package()
             {
-                var packageFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, Configuration.PackageNames + NuGetConstants.PackageExtension);
+                var packageFile = Path.Combine(Scenario.GetTopLevel(), "lib", Configuration.PackageNames, Configuration.PackageNames + NuGetConstants.PackageExtension);
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
                     packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().Should().Be("1.0.0");
@@ -857,7 +857,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_delete_the_rollback()
             {
-                var packageDir = Path.Combine(Scenario.get_top_level(), "lib-bkp", Configuration.PackageNames);
+                var packageDir = Path.Combine(Scenario.GetTopLevel(), "lib-bkp", Configuration.PackageNames);
 
                 DirectoryAssert.DoesNotExist(packageDir);
             }
@@ -872,25 +872,25 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_not_have_a_successful_package_result()
             {
-                packageResult.Success.Should().BeFalse();
+                _packageResult.Success.Should().BeFalse();
             }
 
             [Fact]
             public void Should_have_inconclusive_package_result()
             {
-                packageResult.Inconclusive.Should().BeTrue();
+                _packageResult.Inconclusive.Should().BeTrue();
             }
 
             [Fact]
             public void Should_not_have_warning_package_result()
             {
-                packageResult.Warning.Should().BeFalse();
+                _packageResult.Warning.Should().BeFalse();
             }
         }
 
         public class When_installing_a_package_that_exists_but_a_version_that_does_not_exist : ScenariosBase
         {
-            private PackageResult packageResult;
+            private PackageResult _packageResult;
 
             public override void Context()
             {
@@ -901,13 +901,13 @@ namespace chocolatey.tests.integration.scenarios
             public override void Because()
             {
                 Results = Service.Install(Configuration);
-                packageResult = Results.FirstOrDefault().Value;
+                _packageResult = Results.FirstOrDefault().Value;
             }
 
             [Fact]
             public void Should_not_install_a_package_in_the_lib_directory()
             {
-                var packageDir = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames);
+                var packageDir = Path.Combine(Scenario.GetTopLevel(), "lib", Configuration.PackageNames);
 
                 DirectoryAssert.DoesNotExist(packageDir);
             }
@@ -922,25 +922,25 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_not_have_a_successful_package_result()
             {
-                packageResult.Success.Should().BeFalse();
+                _packageResult.Success.Should().BeFalse();
             }
 
             [Fact]
             public void Should_not_have_inconclusive_package_result()
             {
-                packageResult.Inconclusive.Should().BeFalse();
+                _packageResult.Inconclusive.Should().BeFalse();
             }
 
             [Fact]
             public void Should_not_have_warning_package_result()
             {
-                packageResult.Warning.Should().BeFalse();
+                _packageResult.Warning.Should().BeFalse();
             }
 
             [Fact]
             public void Should_have_an_error_package_result()
             {
-                packageResult.Messages.Should().Contain(m => m.MessageType == ResultType.Error);
+                _packageResult.Messages.Should().Contain(m => m.MessageType == ResultType.Error);
             }
 
             [Fact]
@@ -955,13 +955,13 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_have_a_version_of_one_dot_zero_dot_one()
             {
-                packageResult.Version.Should().Be("1.0.1");
+                _packageResult.Version.Should().Be("1.0.1");
             }
         }
 
         public class When_installing_a_package_that_does_not_exist : ScenariosBase
         {
-            private PackageResult packageResult;
+            private PackageResult _packageResult;
 
             public override void Context()
             {
@@ -972,13 +972,13 @@ namespace chocolatey.tests.integration.scenarios
             public override void Because()
             {
                 Results = Service.Install(Configuration);
-                packageResult = Results.FirstOrDefault().Value;
+                _packageResult = Results.FirstOrDefault().Value;
             }
 
             [Fact]
             public void Should_not_install_a_package_in_the_lib_directory()
             {
-                var packageDir = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames);
+                var packageDir = Path.Combine(Scenario.GetTopLevel(), "lib", Configuration.PackageNames);
 
                 DirectoryAssert.DoesNotExist(packageDir);
             }
@@ -993,25 +993,25 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_not_have_a_successful_package_result()
             {
-                packageResult.Success.Should().BeFalse();
+                _packageResult.Success.Should().BeFalse();
             }
 
             [Fact]
             public void Should_not_have_inconclusive_package_result()
             {
-                packageResult.Inconclusive.Should().BeFalse();
+                _packageResult.Inconclusive.Should().BeFalse();
             }
 
             [Fact]
             public void Should_not_have_warning_package_result()
             {
-                packageResult.Warning.Should().BeFalse();
+                _packageResult.Warning.Should().BeFalse();
             }
 
             [Fact]
             public void Should_have_an_error_package_result()
             {
-                packageResult.Messages.Should().Contain(m => m.MessageType == ResultType.Error);
+                _packageResult.Messages.Should().Contain(m => m.MessageType == ResultType.Error);
             }
 
             [Fact]
@@ -1028,7 +1028,7 @@ namespace chocolatey.tests.integration.scenarios
         [Platform(Exclude = "Mono")]
         public class When_installing_a_package_that_errors : ScenariosBase
         {
-            private PackageResult packageResult;
+            private PackageResult _packageResult;
 
             public override void Context()
             {
@@ -1039,13 +1039,13 @@ namespace chocolatey.tests.integration.scenarios
             public override void Because()
             {
                 Results = Service.Install(Configuration);
-                packageResult = Results.FirstOrDefault().Value;
+                _packageResult = Results.FirstOrDefault().Value;
             }
 
             [Fact]
             public void Should_not_install_a_package_in_the_lib_directory()
             {
-                var packageDir = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames);
+                var packageDir = Path.Combine(Scenario.GetTopLevel(), "lib", Configuration.PackageNames);
 
                 DirectoryAssert.DoesNotExist(packageDir);
             }
@@ -1053,7 +1053,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_put_a_package_in_the_lib_bad_directory()
             {
-                var packageDir = Path.Combine(Scenario.get_top_level(), "lib-bad", Configuration.PackageNames);
+                var packageDir = Path.Combine(Scenario.GetTopLevel(), "lib-bad", Configuration.PackageNames);
 
                 DirectoryAssert.Exists(packageDir);
             }
@@ -1068,25 +1068,25 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_not_have_a_successful_package_result()
             {
-                packageResult.Success.Should().BeFalse();
+                _packageResult.Success.Should().BeFalse();
             }
 
             [Fact]
             public void Should_not_have_inconclusive_package_result()
             {
-                packageResult.Inconclusive.Should().BeFalse();
+                _packageResult.Inconclusive.Should().BeFalse();
             }
 
             [Fact]
             public void Should_not_have_warning_package_result()
             {
-                packageResult.Warning.Should().BeFalse();
+                _packageResult.Warning.Should().BeFalse();
             }
 
             [Fact]
             public void Should_have_an_error_package_result()
             {
-                packageResult.Messages.Should().Contain(m => m.MessageType == ResultType.Error);
+                _packageResult.Messages.Should().Contain(m => m.MessageType == ResultType.Error);
             }
 
             [Fact]
@@ -1101,7 +1101,7 @@ namespace chocolatey.tests.integration.scenarios
 
         public class When_installing_a_package_that_has_nonterminating_errors : ScenariosBase
         {
-            private PackageResult packageResult;
+            private PackageResult _packageResult;
 
             public override void Context()
             {
@@ -1109,25 +1109,25 @@ namespace chocolatey.tests.integration.scenarios
                 Configuration.PackageNames = Configuration.Input = "nonterminatingerror";
                 Configuration.Features.FailOnStandardError = false; //the default
 
-                Scenario.add_packages_to_source_location(Configuration, Configuration.Input + "*" + NuGetConstants.PackageExtension);
+                Scenario.AddPackagesToSourceLocation(Configuration, Configuration.Input + "*" + NuGetConstants.PackageExtension);
             }
 
             public override void Because()
             {
                 Results = Service.Install(Configuration);
-                packageResult = Results.FirstOrDefault().Value;
+                _packageResult = Results.FirstOrDefault().Value;
             }
 
             [Fact]
             public void Should_install_where_install_location_reports()
             {
-                DirectoryAssert.Exists(packageResult.InstallLocation);
+                DirectoryAssert.Exists(_packageResult.InstallLocation);
             }
 
             [Fact]
             public void Should_install_the_package_in_the_lib_directory()
             {
-                var packageDir = Path.Combine(Scenario.get_top_level(), "lib", Configuration.Input);
+                var packageDir = Path.Combine(Scenario.GetTopLevel(), "lib", Configuration.Input);
 
                 DirectoryAssert.Exists(packageDir);
             }
@@ -1135,7 +1135,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_install_the_expected_version_of_the_package()
             {
-                var packageFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.Input, Configuration.Input + NuGetConstants.PackageExtension);
+                var packageFile = Path.Combine(Scenario.GetTopLevel(), "lib", Configuration.Input, Configuration.Input + NuGetConstants.PackageExtension);
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
                     packageReader.NuspecReader.GetVersion().ToNormalizedString().Should().Be("1.0.0");
@@ -1152,31 +1152,31 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_have_a_successful_package_result()
             {
-                packageResult.Success.Should().BeTrue();
+                _packageResult.Success.Should().BeTrue();
             }
 
             [Fact]
             public void Should_not_have_inconclusive_package_result()
             {
-                packageResult.Inconclusive.Should().BeFalse();
+                _packageResult.Inconclusive.Should().BeFalse();
             }
 
             [Fact]
             public void Should_not_have_warning_package_result()
             {
-                packageResult.Warning.Should().BeFalse();
+                _packageResult.Warning.Should().BeFalse();
             }
 
             [Fact]
             public void Config_should_match_package_result_name()
             {
-                packageResult.Name.Should().Be(Configuration.Input);
+                _packageResult.Name.Should().Be(Configuration.Input);
             }
 
             [Fact]
             public void Should_have_a_version_of_one_dot_zero_dot_zero()
             {
-                packageResult.Version.Should().Be("1.0.0");
+                _packageResult.Version.Should().Be("1.0.0");
             }
         }
 
@@ -1184,7 +1184,7 @@ namespace chocolatey.tests.integration.scenarios
         [Platform(Exclude = "Mono")]
         public class When_installing_a_package_that_has_nonterminating_errors_with_fail_on_stderr : ScenariosBase
         {
-            private PackageResult packageResult;
+            private PackageResult _packageResult;
 
             public override void Context()
             {
@@ -1192,19 +1192,19 @@ namespace chocolatey.tests.integration.scenarios
                 Configuration.PackageNames = Configuration.Input = "nonterminatingerror";
                 Configuration.Features.FailOnStandardError = true;
 
-                Scenario.add_packages_to_source_location(Configuration, Configuration.Input + "*" + NuGetConstants.PackageExtension);
+                Scenario.AddPackagesToSourceLocation(Configuration, Configuration.Input + "*" + NuGetConstants.PackageExtension);
             }
 
             public override void Because()
             {
                 Results = Service.Install(Configuration);
-                packageResult = Results.FirstOrDefault().Value;
+                _packageResult = Results.FirstOrDefault().Value;
             }
 
             [Fact]
             public void Should_not_install_a_package_in_the_lib_directory()
             {
-                var packageDir = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames);
+                var packageDir = Path.Combine(Scenario.GetTopLevel(), "lib", Configuration.PackageNames);
 
                 DirectoryAssert.DoesNotExist(packageDir);
             }
@@ -1212,7 +1212,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_put_a_package_in_the_lib_bad_directory()
             {
-                var packageDir = Path.Combine(Scenario.get_top_level(), "lib-bad", Configuration.PackageNames);
+                var packageDir = Path.Combine(Scenario.GetTopLevel(), "lib-bad", Configuration.PackageNames);
 
                 DirectoryAssert.Exists(packageDir);
             }
@@ -1227,25 +1227,25 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_not_have_a_successful_package_result()
             {
-                packageResult.Success.Should().BeFalse();
+                _packageResult.Success.Should().BeFalse();
             }
 
             [Fact]
             public void Should_not_have_inconclusive_package_result()
             {
-                packageResult.Inconclusive.Should().BeFalse();
+                _packageResult.Inconclusive.Should().BeFalse();
             }
 
             [Fact]
             public void Should_not_have_warning_package_result()
             {
-                packageResult.Warning.Should().BeFalse();
+                _packageResult.Warning.Should().BeFalse();
             }
 
             [Fact]
             public void Should_have_an_error_package_result()
             {
-                packageResult.Messages.Should().Contain(m => m.MessageType == ResultType.Error);
+                _packageResult.Messages.Should().Contain(m => m.MessageType == ResultType.Error);
             }
 
             [Fact]
@@ -1264,9 +1264,9 @@ namespace chocolatey.tests.integration.scenarios
             {
                 base.Context();
                 Configuration.PackageNames = Configuration.Input = "hasdependency";
-                Scenario.add_packages_to_source_location(Configuration, "hasdependency.1.0.0*" + NuGetConstants.PackageExtension);
-                Scenario.add_packages_to_source_location(Configuration, "isdependency.1.0.0*" + NuGetConstants.PackageExtension);
-                Scenario.add_packages_to_source_location(Configuration, "isexactversiondependency*" + NuGetConstants.PackageExtension);
+                Scenario.AddPackagesToSourceLocation(Configuration, "hasdependency.1.0.0*" + NuGetConstants.PackageExtension);
+                Scenario.AddPackagesToSourceLocation(Configuration, "isdependency.1.0.0*" + NuGetConstants.PackageExtension);
+                Scenario.AddPackagesToSourceLocation(Configuration, "isexactversiondependency*" + NuGetConstants.PackageExtension);
             }
 
             public override void Because()
@@ -1286,7 +1286,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_install_a_package_in_the_lib_directory()
             {
-                var packageDir = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames);
+                var packageDir = Path.Combine(Scenario.GetTopLevel(), "lib", Configuration.PackageNames);
 
                 DirectoryAssert.Exists(packageDir);
             }
@@ -1294,7 +1294,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_install_the_dependency_in_the_lib_directory()
             {
-                var packageDir = Path.Combine(Scenario.get_top_level(), "lib", "isdependency");
+                var packageDir = Path.Combine(Scenario.GetTopLevel(), "lib", "isdependency");
 
                 DirectoryAssert.Exists(packageDir);
             }
@@ -1302,7 +1302,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_install_the_expected_version_of_the_dependency()
             {
-                var packageFile = Path.Combine(Scenario.get_top_level(), "lib", "isdependency", "isdependency.nupkg");
+                var packageFile = Path.Combine(Scenario.GetTopLevel(), "lib", "isdependency", "isdependency.nupkg");
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
                     packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().Should().Be("1.0.0");
@@ -1348,11 +1348,11 @@ namespace chocolatey.tests.integration.scenarios
                 base.Context();
 
                 Configuration.PackageNames = Configuration.Input = "hasdependency";
-                Scenario.add_packages_to_source_location(Configuration, "hasdependency.1*" + NuGetConstants.PackageExtension);
-                Scenario.add_packages_to_source_location(Configuration, "isdependency.1.0.0*" + NuGetConstants.PackageExtension);
-                Scenario.add_packages_to_source_location(Configuration, "isexactversiondependency*" + NuGetConstants.PackageExtension);
-                Scenario.install_package(Configuration, "hasdependency", "1.0.0");
-                Scenario.add_packages_to_source_location(Configuration, "isdependency*" + NuGetConstants.PackageExtension);
+                Scenario.AddPackagesToSourceLocation(Configuration, "hasdependency.1*" + NuGetConstants.PackageExtension);
+                Scenario.AddPackagesToSourceLocation(Configuration, "isdependency.1.0.0*" + NuGetConstants.PackageExtension);
+                Scenario.AddPackagesToSourceLocation(Configuration, "isexactversiondependency*" + NuGetConstants.PackageExtension);
+                Scenario.InstallPackage(Configuration, "hasdependency", "1.0.0");
+                Scenario.AddPackagesToSourceLocation(Configuration, "isdependency*" + NuGetConstants.PackageExtension);
                 Configuration.Force = true;
             }
 
@@ -1373,7 +1373,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_install_a_package_in_the_lib_directory()
             {
-                var packageDir = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames);
+                var packageDir = Path.Combine(Scenario.GetTopLevel(), "lib", Configuration.PackageNames);
 
                 DirectoryAssert.Exists(packageDir);
             }
@@ -1381,7 +1381,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_reinstall_the_exact_same_version_of_the_package()
             {
-                var packageFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, Configuration.PackageNames + NuGetConstants.PackageExtension);
+                var packageFile = Path.Combine(Scenario.GetTopLevel(), "lib", Configuration.PackageNames, Configuration.PackageNames + NuGetConstants.PackageExtension);
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
                     packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().Should().Be("1.0.0");
@@ -1391,7 +1391,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_still_have_the_dependency_in_the_lib_directory()
             {
-                var packageDir = Path.Combine(Scenario.get_top_level(), "lib", "isdependency");
+                var packageDir = Path.Combine(Scenario.GetTopLevel(), "lib", "isdependency");
 
                 DirectoryAssert.Exists(packageDir);
             }
@@ -1399,7 +1399,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_not_upgrade_the_dependency()
             {
-                var packageFile = Path.Combine(Scenario.get_top_level(), "lib", "isdependency", "isdependency.nupkg");
+                var packageFile = Path.Combine(Scenario.GetTopLevel(), "lib", "isdependency", "isdependency.nupkg");
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
                     packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().Should().Be("1.0.0");
@@ -1445,16 +1445,16 @@ namespace chocolatey.tests.integration.scenarios
             {
                 base.Context();
 
-                Scenario.add_packages_to_source_location(Configuration, "installpackage*" + NuGetConstants.PackageExtension);
-                Scenario.install_package(Configuration, "installpackage", "1.0.0");
+                Scenario.AddPackagesToSourceLocation(Configuration, "installpackage*" + NuGetConstants.PackageExtension);
+                Scenario.InstallPackage(Configuration, "installpackage", "1.0.0");
 
                 Configuration.PackageNames = Configuration.Input = "hasdependency";
-                Scenario.add_packages_to_source_location(Configuration, "hasdependency.1*" + NuGetConstants.PackageExtension);
-                Scenario.add_packages_to_source_location(Configuration, "isdependency.1.0.0*" + NuGetConstants.PackageExtension);
-                Scenario.add_packages_to_source_location(Configuration, "isexactversiondependency*" + NuGetConstants.PackageExtension);
-                Scenario.install_package(Configuration, "hasdependency", "1.0.0");
-                Scenario.add_packages_to_source_location(Configuration, "isdependency*" + NuGetConstants.PackageExtension);
-                _installedPackagePaths = Scenario.get_installed_package_paths().ToList();
+                Scenario.AddPackagesToSourceLocation(Configuration, "hasdependency.1*" + NuGetConstants.PackageExtension);
+                Scenario.AddPackagesToSourceLocation(Configuration, "isdependency.1.0.0*" + NuGetConstants.PackageExtension);
+                Scenario.AddPackagesToSourceLocation(Configuration, "isexactversiondependency*" + NuGetConstants.PackageExtension);
+                Scenario.InstallPackage(Configuration, "hasdependency", "1.0.0");
+                Scenario.AddPackagesToSourceLocation(Configuration, "isdependency*" + NuGetConstants.PackageExtension);
+                _installedPackagePaths = Scenario.GetInstalledPackagePaths().ToList();
 
                 Configuration.Force = true;
                 Configuration.ForceDependencies = true;
@@ -1477,7 +1477,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_install_a_package_in_the_lib_directory()
             {
-                var packageDir = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames);
+                var packageDir = Path.Combine(Scenario.GetTopLevel(), "lib", Configuration.PackageNames);
 
                 DirectoryAssert.Exists(packageDir);
             }
@@ -1485,7 +1485,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_reinstall_the_exact_same_version_of_the_package()
             {
-                var packageFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, Configuration.PackageNames + NuGetConstants.PackageExtension);
+                var packageFile = Path.Combine(Scenario.GetTopLevel(), "lib", Configuration.PackageNames, Configuration.PackageNames + NuGetConstants.PackageExtension);
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
                     packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().Should().Be("1.0.0");
@@ -1504,7 +1504,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_install_the_dependency_in_the_lib_directory()
             {
-                var packageDir = Path.Combine(Scenario.get_top_level(), "lib", "isdependency");
+                var packageDir = Path.Combine(Scenario.GetTopLevel(), "lib", "isdependency");
 
                 DirectoryAssert.Exists(packageDir);
             }
@@ -1512,7 +1512,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_reinstall_the_floating_dependency_with_the_latest_version_that_satisfies_the_dependency()
             {
-                var packageFile = Path.Combine(Scenario.get_top_level(), "lib", "isdependency", "isdependency.nupkg");
+                var packageFile = Path.Combine(Scenario.GetTopLevel(), "lib", "isdependency", "isdependency.nupkg");
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
                     packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().Should().Be("1.0.0");
@@ -1522,7 +1522,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_reinstall_the_exact_same_version_of_the_exact_dependency()
             {
-                var packageFile = Path.Combine(Scenario.get_top_level(), "lib", "isexactversiondependency", "isexactversiondependency.nupkg");
+                var packageFile = Path.Combine(Scenario.GetTopLevel(), "lib", "isexactversiondependency", "isexactversiondependency.nupkg");
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
                     packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().Should().Be("1.0.0");
@@ -1562,11 +1562,11 @@ namespace chocolatey.tests.integration.scenarios
                 base.Context();
 
                 Configuration.PackageNames = Configuration.Input = "hasdependency";
-                Scenario.add_packages_to_source_location(Configuration, "hasdependency.1*" + NuGetConstants.PackageExtension);
-                Scenario.add_packages_to_source_location(Configuration, "isdependency.1.0.0*" + NuGetConstants.PackageExtension);
-                Scenario.add_packages_to_source_location(Configuration, "isexactversiondependency*" + NuGetConstants.PackageExtension);
-                Scenario.install_package(Configuration, "hasdependency", "1.0.0");
-                Scenario.add_packages_to_source_location(Configuration, "isdependency*" + NuGetConstants.PackageExtension);
+                Scenario.AddPackagesToSourceLocation(Configuration, "hasdependency.1*" + NuGetConstants.PackageExtension);
+                Scenario.AddPackagesToSourceLocation(Configuration, "isdependency.1.0.0*" + NuGetConstants.PackageExtension);
+                Scenario.AddPackagesToSourceLocation(Configuration, "isexactversiondependency*" + NuGetConstants.PackageExtension);
+                Scenario.InstallPackage(Configuration, "hasdependency", "1.0.0");
+                Scenario.AddPackagesToSourceLocation(Configuration, "isdependency*" + NuGetConstants.PackageExtension);
                 Configuration.Force = true;
                 Configuration.IgnoreDependencies = true;
             }
@@ -1588,7 +1588,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_install_a_package_in_the_lib_directory()
             {
-                var packageDir = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames);
+                var packageDir = Path.Combine(Scenario.GetTopLevel(), "lib", Configuration.PackageNames);
 
                 DirectoryAssert.Exists(packageDir);
             }
@@ -1596,7 +1596,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_reinstall_the_exact_same_version_of_the_package()
             {
-                var packageFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, Configuration.PackageNames + NuGetConstants.PackageExtension);
+                var packageFile = Path.Combine(Scenario.GetTopLevel(), "lib", Configuration.PackageNames, Configuration.PackageNames + NuGetConstants.PackageExtension);
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
                     packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().Should().Be("1.0.0");
@@ -1606,7 +1606,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_install_the_dependency_in_the_lib_directory()
             {
-                var packageDir = Path.Combine(Scenario.get_top_level(), "lib", "isdependency");
+                var packageDir = Path.Combine(Scenario.GetTopLevel(), "lib", "isdependency");
 
                 DirectoryAssert.Exists(packageDir);
             }
@@ -1614,7 +1614,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_not_touch_the_floating_dependency()
             {
-                var packageFile = Path.Combine(Scenario.get_top_level(), "lib", "isdependency", "isdependency.nupkg");
+                var packageFile = Path.Combine(Scenario.GetTopLevel(), "lib", "isdependency", "isdependency.nupkg");
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
                     packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().Should().Be("1.0.0");
@@ -1624,7 +1624,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_not_touch_the_exact_dependency()
             {
-                var packageFile = Path.Combine(Scenario.get_top_level(), "lib", "isexactversiondependency", "isexactversiondependency.nupkg");
+                var packageFile = Path.Combine(Scenario.GetTopLevel(), "lib", "isexactversiondependency", "isexactversiondependency.nupkg");
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
                     packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().Should().Be("1.0.0");
@@ -1664,11 +1664,11 @@ namespace chocolatey.tests.integration.scenarios
                 base.Context();
 
                 Configuration.PackageNames = Configuration.Input = "hasdependency";
-                Scenario.add_packages_to_source_location(Configuration, "hasdependency.1*" + NuGetConstants.PackageExtension);
-                Scenario.add_packages_to_source_location(Configuration, "isdependency.1.0.0*" + NuGetConstants.PackageExtension);
-                Scenario.add_packages_to_source_location(Configuration, "isexactversiondependency*" + NuGetConstants.PackageExtension);
-                Scenario.install_package(Configuration, "hasdependency", "1.0.0");
-                Scenario.add_packages_to_source_location(Configuration, "isdependency*" + NuGetConstants.PackageExtension);
+                Scenario.AddPackagesToSourceLocation(Configuration, "hasdependency.1*" + NuGetConstants.PackageExtension);
+                Scenario.AddPackagesToSourceLocation(Configuration, "isdependency.1.0.0*" + NuGetConstants.PackageExtension);
+                Scenario.AddPackagesToSourceLocation(Configuration, "isexactversiondependency*" + NuGetConstants.PackageExtension);
+                Scenario.InstallPackage(Configuration, "hasdependency", "1.0.0");
+                Scenario.AddPackagesToSourceLocation(Configuration, "isdependency*" + NuGetConstants.PackageExtension);
                 Configuration.Force = true;
                 Configuration.ForceDependencies = true;
                 Configuration.IgnoreDependencies = true;
@@ -1691,7 +1691,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_install_a_package_in_the_lib_directory()
             {
-                var packageDir = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames);
+                var packageDir = Path.Combine(Scenario.GetTopLevel(), "lib", Configuration.PackageNames);
 
                 DirectoryAssert.Exists(packageDir);
             }
@@ -1699,7 +1699,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_reinstall_the_exact_same_version_of_the_package()
             {
-                var packageFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, Configuration.PackageNames + NuGetConstants.PackageExtension);
+                var packageFile = Path.Combine(Scenario.GetTopLevel(), "lib", Configuration.PackageNames, Configuration.PackageNames + NuGetConstants.PackageExtension);
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
                     packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().Should().Be("1.0.0");
@@ -1709,14 +1709,14 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_remove_the_floating_dependency()
             {
-                var dependency = Path.Combine(Scenario.get_top_level(), "lib", "isdependency");
+                var dependency = Path.Combine(Scenario.GetTopLevel(), "lib", "isdependency");
                 DirectoryAssert.DoesNotExist(dependency);
             }
 
             [Fact]
             public void Should_remove_the_exact_dependency()
             {
-                var dependency = Path.Combine(Scenario.get_top_level(), "lib", "isexactversiondependency");
+                var dependency = Path.Combine(Scenario.GetTopLevel(), "lib", "isexactversiondependency");
                 DirectoryAssert.DoesNotExist(dependency);
             }
 
@@ -1752,7 +1752,7 @@ namespace chocolatey.tests.integration.scenarios
             {
                 base.Context();
                 Configuration.PackageNames = Configuration.Input = "hasdependency";
-                Scenario.add_packages_to_source_location(Configuration, "hasdependency*" + NuGetConstants.PackageExtension);
+                Scenario.AddPackagesToSourceLocation(Configuration, "hasdependency*" + NuGetConstants.PackageExtension);
             }
 
             public override void Because()
@@ -1763,7 +1763,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_not_install_a_package_in_the_lib_directory()
             {
-                var packageDir = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames);
+                var packageDir = Path.Combine(Scenario.GetTopLevel(), "lib", Configuration.PackageNames);
 
                 DirectoryAssert.DoesNotExist(packageDir);
             }
@@ -1771,7 +1771,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_not_install_the_dependency_in_the_lib_directory()
             {
-                var packageDir = Path.Combine(Scenario.get_top_level(), "lib", "isdependency");
+                var packageDir = Path.Combine(Scenario.GetTopLevel(), "lib", "isdependency");
 
                 DirectoryAssert.DoesNotExist(packageDir);
             }
@@ -1820,32 +1820,32 @@ namespace chocolatey.tests.integration.scenarios
 
         public class When_installing_a_package_ignoring_dependencies_that_cannot_be_found : ScenariosBase
         {
-            private PackageResult packageResult;
+            private PackageResult _packageResult;
 
             public override void Context()
             {
                 base.Context();
                 Configuration.PackageNames = Configuration.Input = "hasdependency";
-                Scenario.add_packages_to_source_location(Configuration, "hasdependency*" + NuGetConstants.PackageExtension);
+                Scenario.AddPackagesToSourceLocation(Configuration, "hasdependency*" + NuGetConstants.PackageExtension);
                 Configuration.IgnoreDependencies = true;
             }
 
             public override void Because()
             {
                 Results = Service.Install(Configuration);
-                packageResult = Results.FirstOrDefault().Value;
+                _packageResult = Results.FirstOrDefault().Value;
             }
 
             [Fact]
             public void Should_install_where_install_location_reports()
             {
-                DirectoryAssert.Exists(packageResult.InstallLocation);
+                DirectoryAssert.Exists(_packageResult.InstallLocation);
             }
 
             [Fact]
             public void Should_install_a_package_in_the_lib_directory()
             {
-                var packageDir = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames);
+                var packageDir = Path.Combine(Scenario.GetTopLevel(), "lib", Configuration.PackageNames);
 
                 DirectoryAssert.Exists(packageDir);
             }
@@ -1853,7 +1853,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_install_the_expected_version_of_the_package()
             {
-                var packageFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, Configuration.PackageNames + NuGetConstants.PackageExtension);
+                var packageFile = Path.Combine(Scenario.GetTopLevel(), "lib", Configuration.PackageNames, Configuration.PackageNames + NuGetConstants.PackageExtension);
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
                     packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().Should().Be("2.1.0");
@@ -1863,7 +1863,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_not_install_the_dependency_in_the_lib_directory()
             {
-                var packageDir = Path.Combine(Scenario.get_top_level(), "lib", "isdependency");
+                var packageDir = Path.Combine(Scenario.GetTopLevel(), "lib", "isdependency");
 
                 DirectoryAssert.DoesNotExist(packageDir);
             }
@@ -1878,25 +1878,25 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_have_a_successful_package_result()
             {
-                packageResult.Success.Should().BeTrue();
+                _packageResult.Success.Should().BeTrue();
             }
 
             [Fact]
             public void Should_not_have_inconclusive_package_result()
             {
-                packageResult.Inconclusive.Should().BeFalse();
+                _packageResult.Inconclusive.Should().BeFalse();
             }
 
             [Fact]
             public void Should_not_have_warning_package_result()
             {
-                packageResult.Warning.Should().BeFalse();
+                _packageResult.Warning.Should().BeFalse();
             }
 
             [Fact]
             public void Config_should_match_package_result_name()
             {
-                packageResult.Name.Should().Be(Configuration.PackageNames);
+                _packageResult.Name.Should().Be(Configuration.PackageNames);
             }
         }
 
@@ -1906,11 +1906,11 @@ namespace chocolatey.tests.integration.scenarios
             {
                 base.Context();
                 Configuration.PackageNames = Configuration.Input = "hasdependency";
-                Scenario.add_packages_to_source_location(Configuration, "hasdependency.1.6.0*" + NuGetConstants.PackageExtension);
-                Scenario.add_packages_to_source_location(Configuration, "isdependency.1.0.0*" + NuGetConstants.PackageExtension);
-                Scenario.add_packages_to_source_location(Configuration, "isdependency.1.1.0*" + NuGetConstants.PackageExtension);
-                Scenario.add_packages_to_source_location(Configuration, "isexactversiondependency*" + NuGetConstants.PackageExtension);
-                Scenario.install_package(Configuration, "isdependency", "1.0.0");
+                Scenario.AddPackagesToSourceLocation(Configuration, "hasdependency.1.6.0*" + NuGetConstants.PackageExtension);
+                Scenario.AddPackagesToSourceLocation(Configuration, "isdependency.1.0.0*" + NuGetConstants.PackageExtension);
+                Scenario.AddPackagesToSourceLocation(Configuration, "isdependency.1.1.0*" + NuGetConstants.PackageExtension);
+                Scenario.AddPackagesToSourceLocation(Configuration, "isexactversiondependency*" + NuGetConstants.PackageExtension);
+                Scenario.InstallPackage(Configuration, "isdependency", "1.0.0");
             }
 
             public override void Because()
@@ -1930,7 +1930,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_install_a_package_in_the_lib_directory()
             {
-                var packageDir = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames);
+                var packageDir = Path.Combine(Scenario.GetTopLevel(), "lib", Configuration.PackageNames);
 
                 DirectoryAssert.Exists(packageDir);
             }
@@ -1938,7 +1938,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_install_the_expected_version_of_the_package()
             {
-                var packageFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, Configuration.PackageNames + NuGetConstants.PackageExtension);
+                var packageFile = Path.Combine(Scenario.GetTopLevel(), "lib", Configuration.PackageNames, Configuration.PackageNames + NuGetConstants.PackageExtension);
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
                     packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().Should().Be("1.6.0");
@@ -1948,7 +1948,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_install_the_dependency_in_the_lib_directory()
             {
-                var packageDir = Path.Combine(Scenario.get_top_level(), "lib", "isdependency");
+                var packageDir = Path.Combine(Scenario.GetTopLevel(), "lib", "isdependency");
 
                 DirectoryAssert.Exists(packageDir);
             }
@@ -1956,7 +1956,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_upgrade_the_dependency()
             {
-                var packageFile = Path.Combine(Scenario.get_top_level(), "lib", "isdependency", "isdependency.nupkg");
+                var packageFile = Path.Combine(Scenario.GetTopLevel(), "lib", "isdependency", "isdependency.nupkg");
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
                     packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().Should().Be("1.1.0");
@@ -1995,10 +1995,10 @@ namespace chocolatey.tests.integration.scenarios
             {
                 base.Context();
                 Configuration.PackageNames = Configuration.Input = "hasdependency";
-                Scenario.add_packages_to_source_location(Configuration, "hasdependency.1.6.0*" + NuGetConstants.PackageExtension);
-                Scenario.add_packages_to_source_location(Configuration, "isdependency.1.0.0*" + NuGetConstants.PackageExtension);
-                Scenario.add_packages_to_source_location(Configuration, "isexactversiondependency*" + NuGetConstants.PackageExtension);
-                Scenario.install_package(Configuration, "isdependency", "1.0.0");
+                Scenario.AddPackagesToSourceLocation(Configuration, "hasdependency.1.6.0*" + NuGetConstants.PackageExtension);
+                Scenario.AddPackagesToSourceLocation(Configuration, "isdependency.1.0.0*" + NuGetConstants.PackageExtension);
+                Scenario.AddPackagesToSourceLocation(Configuration, "isexactversiondependency*" + NuGetConstants.PackageExtension);
+                Scenario.InstallPackage(Configuration, "isdependency", "1.0.0");
             }
 
             public override void Because()
@@ -2009,7 +2009,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_not_install_the_package_in_the_lib_directory()
             {
-                var packageDir = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames);
+                var packageDir = Path.Combine(Scenario.GetTopLevel(), "lib", Configuration.PackageNames);
 
                 DirectoryAssert.DoesNotExist(packageDir);
             }
@@ -2046,10 +2046,10 @@ namespace chocolatey.tests.integration.scenarios
             {
                 base.Context();
                 Configuration.PackageNames = Configuration.Input = "hasdependency";
-                Scenario.add_packages_to_source_location(Configuration, "hasdependency.1.6.0*" + NuGetConstants.PackageExtension);
-                Scenario.add_packages_to_source_location(Configuration, "isdependency.1.0.0*" + NuGetConstants.PackageExtension);
-                Scenario.add_packages_to_source_location(Configuration, "isexactversiondependency*" + NuGetConstants.PackageExtension);
-                Scenario.install_package(Configuration, "isdependency", "1.0.0");
+                Scenario.AddPackagesToSourceLocation(Configuration, "hasdependency.1.6.0*" + NuGetConstants.PackageExtension);
+                Scenario.AddPackagesToSourceLocation(Configuration, "isdependency.1.0.0*" + NuGetConstants.PackageExtension);
+                Scenario.AddPackagesToSourceLocation(Configuration, "isexactversiondependency*" + NuGetConstants.PackageExtension);
+                Scenario.InstallPackage(Configuration, "isdependency", "1.0.0");
                 Configuration.IgnoreDependencies = true;
             }
 
@@ -2070,7 +2070,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_install_a_package_in_the_lib_directory()
             {
-                var packageDir = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames);
+                var packageDir = Path.Combine(Scenario.GetTopLevel(), "lib", Configuration.PackageNames);
 
                 DirectoryAssert.Exists(packageDir);
             }
@@ -2078,7 +2078,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_install_the_expected_version_of_the_package()
             {
-                var packageFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, Configuration.PackageNames + NuGetConstants.PackageExtension);
+                var packageFile = Path.Combine(Scenario.GetTopLevel(), "lib", Configuration.PackageNames, Configuration.PackageNames + NuGetConstants.PackageExtension);
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
                     packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().Should().Be("1.6.0");
@@ -2117,10 +2117,10 @@ namespace chocolatey.tests.integration.scenarios
             {
                 base.Context();
                 Configuration.PackageNames = Configuration.Input = "hasdependency";
-                Scenario.add_packages_to_source_location(Configuration, "hasdependency.1.6.0*" + NuGetConstants.PackageExtension);
-                Scenario.add_packages_to_source_location(Configuration, "isdependency.1.0.0*" + NuGetConstants.PackageExtension);
-                Scenario.add_packages_to_source_location(Configuration, "isexactversiondependency*" + NuGetConstants.PackageExtension);
-                Scenario.install_package(Configuration, "isdependency", "1.0.0");
+                Scenario.AddPackagesToSourceLocation(Configuration, "hasdependency.1.6.0*" + NuGetConstants.PackageExtension);
+                Scenario.AddPackagesToSourceLocation(Configuration, "isdependency.1.0.0*" + NuGetConstants.PackageExtension);
+                Scenario.AddPackagesToSourceLocation(Configuration, "isexactversiondependency*" + NuGetConstants.PackageExtension);
+                Scenario.InstallPackage(Configuration, "isdependency", "1.0.0");
                 Configuration.Force = true;
                 Configuration.ForceDependencies = true;
             }
@@ -2133,7 +2133,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_not_install_a_package_in_the_lib_directory()
             {
-                var packageDir = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames);
+                var packageDir = Path.Combine(Scenario.GetTopLevel(), "lib", Configuration.PackageNames);
 
                 DirectoryAssert.DoesNotExist(packageDir);
             }
@@ -2141,7 +2141,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_not_upgrade_the_dependency()
             {
-                var packageFile = Path.Combine(Scenario.get_top_level(), "lib", "isdependency", "isdependency.nupkg");
+                var packageFile = Path.Combine(Scenario.GetTopLevel(), "lib", "isdependency", "isdependency.nupkg");
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
                     packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().Should().Be("1.0.0");
@@ -2196,12 +2196,12 @@ namespace chocolatey.tests.integration.scenarios
             {
                 base.Context();
                 Configuration.PackageNames = Configuration.Input = "conflictingdependency";
-                Scenario.add_packages_to_source_location(Configuration, "hasdependency.1.0.0*" + NuGetConstants.PackageExtension);
-                Scenario.add_packages_to_source_location(Configuration, "conflictingdependency.1.0.1*" + NuGetConstants.PackageExtension);
-                Scenario.add_packages_to_source_location(Configuration, "isdependency.1.0.*" + NuGetConstants.PackageExtension);
-                Scenario.add_packages_to_source_location(Configuration, "isexactversiondependency*" + NuGetConstants.PackageExtension);
-                Scenario.install_package(Configuration, "isdependency", "1.0.0");
-                Scenario.install_package(Configuration, "hasdependency", "1.0.0");
+                Scenario.AddPackagesToSourceLocation(Configuration, "hasdependency.1.0.0*" + NuGetConstants.PackageExtension);
+                Scenario.AddPackagesToSourceLocation(Configuration, "conflictingdependency.1.0.1*" + NuGetConstants.PackageExtension);
+                Scenario.AddPackagesToSourceLocation(Configuration, "isdependency.1.0.*" + NuGetConstants.PackageExtension);
+                Scenario.AddPackagesToSourceLocation(Configuration, "isexactversiondependency*" + NuGetConstants.PackageExtension);
+                Scenario.InstallPackage(Configuration, "isdependency", "1.0.0");
+                Scenario.InstallPackage(Configuration, "hasdependency", "1.0.0");
             }
 
             public override void Because()
@@ -2221,7 +2221,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_install_a_package_in_the_lib_directory()
             {
-                var packageDir = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames);
+                var packageDir = Path.Combine(Scenario.GetTopLevel(), "lib", Configuration.PackageNames);
 
                 DirectoryAssert.Exists(packageDir);
             }
@@ -2229,7 +2229,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_upgrade_the_dependency()
             {
-                var packageFile = Path.Combine(Scenario.get_top_level(), "lib", "isdependency", "isdependency.nupkg");
+                var packageFile = Path.Combine(Scenario.GetTopLevel(), "lib", "isdependency", "isdependency.nupkg");
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
                     packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().Should().Be("1.0.1");
@@ -2268,12 +2268,12 @@ namespace chocolatey.tests.integration.scenarios
             {
                 base.Context();
                 Configuration.PackageNames = Configuration.Input = "conflictingdependency";
-                Scenario.add_packages_to_source_location(Configuration, "hasdependency.1.0.0*" + NuGetConstants.PackageExtension);
-                Scenario.add_packages_to_source_location(Configuration, "conflictingdependency.2.1.0*" + NuGetConstants.PackageExtension);
-                Scenario.add_packages_to_source_location(Configuration, "isdependency.*" + NuGetConstants.PackageExtension);
-                Scenario.add_packages_to_source_location(Configuration, "isexactversiondependency*" + NuGetConstants.PackageExtension);
-                Scenario.install_package(Configuration, "isdependency", "1.0.0");
-                Scenario.install_package(Configuration, "hasdependency", "1.0.0");
+                Scenario.AddPackagesToSourceLocation(Configuration, "hasdependency.1.0.0*" + NuGetConstants.PackageExtension);
+                Scenario.AddPackagesToSourceLocation(Configuration, "conflictingdependency.2.1.0*" + NuGetConstants.PackageExtension);
+                Scenario.AddPackagesToSourceLocation(Configuration, "isdependency.*" + NuGetConstants.PackageExtension);
+                Scenario.AddPackagesToSourceLocation(Configuration, "isexactversiondependency*" + NuGetConstants.PackageExtension);
+                Scenario.InstallPackage(Configuration, "isdependency", "1.0.0");
+                Scenario.InstallPackage(Configuration, "hasdependency", "1.0.0");
             }
 
             public override void Because()
@@ -2293,7 +2293,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_not_install_the_conflicting_package_in_the_lib_directory()
             {
-                var packageDir = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames);
+                var packageDir = Path.Combine(Scenario.GetTopLevel(), "lib", Configuration.PackageNames);
 
                 DirectoryAssert.DoesNotExist(packageDir);
             }
@@ -2301,7 +2301,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_not_upgrade_the_minimum_version_dependency()
             {
-                var packageFile = Path.Combine(Scenario.get_top_level(), "lib", "isdependency", "isdependency.nupkg");
+                var packageFile = Path.Combine(Scenario.GetTopLevel(), "lib", "isdependency", "isdependency.nupkg");
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
                     packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().Should().Be("1.0.0");
@@ -2311,7 +2311,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_not_upgrade_the_exact_version_dependency()
             {
-                var packageFile = Path.Combine(Scenario.get_top_level(), "lib", "isexactversiondependency", "isexactversiondependency.nupkg");
+                var packageFile = Path.Combine(Scenario.GetTopLevel(), "lib", "isexactversiondependency", "isexactversiondependency.nupkg");
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
                     packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().Should().Be("1.0.0");
@@ -2357,11 +2357,11 @@ namespace chocolatey.tests.integration.scenarios
             {
                 base.Context();
                 Configuration.PackageNames = Configuration.Input = "hasdependency";
-                Scenario.add_packages_to_source_location(Configuration, "hasdependency.1.0.0*" + NuGetConstants.PackageExtension);
-                Scenario.add_packages_to_source_location(Configuration, "conflictingdependency.2.1.0*" + NuGetConstants.PackageExtension);
-                Scenario.add_packages_to_source_location(Configuration, "isdependency.*" + NuGetConstants.PackageExtension);
-                Scenario.add_packages_to_source_location(Configuration, "isexactversiondependency*" + NuGetConstants.PackageExtension);
-                Scenario.install_package(Configuration, "conflictingdependency", "2.1.0");
+                Scenario.AddPackagesToSourceLocation(Configuration, "hasdependency.1.0.0*" + NuGetConstants.PackageExtension);
+                Scenario.AddPackagesToSourceLocation(Configuration, "conflictingdependency.2.1.0*" + NuGetConstants.PackageExtension);
+                Scenario.AddPackagesToSourceLocation(Configuration, "isdependency.*" + NuGetConstants.PackageExtension);
+                Scenario.AddPackagesToSourceLocation(Configuration, "isexactversiondependency*" + NuGetConstants.PackageExtension);
+                Scenario.InstallPackage(Configuration, "conflictingdependency", "2.1.0");
             }
 
             /*
@@ -2379,7 +2379,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_not_install_the_conflicting_package_in_the_lib_directory()
             {
-                var packageDir = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames);
+                var packageDir = Path.Combine(Scenario.GetTopLevel(), "lib", Configuration.PackageNames);
 
                 DirectoryAssert.DoesNotExist(packageDir);
             }
@@ -2387,7 +2387,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_not_downgrade_the_exact_version_dependency()
             {
-                var packageFile = Path.Combine(Scenario.get_top_level(), "lib", "isexactversiondependency", "isexactversiondependency.nupkg");
+                var packageFile = Path.Combine(Scenario.GetTopLevel(), "lib", "isexactversiondependency", "isexactversiondependency.nupkg");
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
                     packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().Should().Be("2.0.0");
@@ -2433,9 +2433,9 @@ namespace chocolatey.tests.integration.scenarios
             {
                 base.Context();
                 Configuration.PackageNames = Configuration.Input = "toplevelhasexactversiondependency";
-                Scenario.add_packages_to_source_location(Configuration, "toplevelhasexactversiondependency*" + NuGetConstants.PackageExtension);
-                Scenario.add_packages_to_source_location(Configuration, "childdependencywithlooserversiondependency*" + NuGetConstants.PackageExtension);
-                Scenario.add_packages_to_source_location(Configuration, "isexactversiondependency*" + NuGetConstants.PackageExtension);
+                Scenario.AddPackagesToSourceLocation(Configuration, "toplevelhasexactversiondependency*" + NuGetConstants.PackageExtension);
+                Scenario.AddPackagesToSourceLocation(Configuration, "childdependencywithlooserversiondependency*" + NuGetConstants.PackageExtension);
+                Scenario.AddPackagesToSourceLocation(Configuration, "isexactversiondependency*" + NuGetConstants.PackageExtension);
             }
 
             public override void Because()
@@ -2462,7 +2462,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_install_a_package_in_the_lib_directory()
             {
-                var packageDir = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames);
+                var packageDir = Path.Combine(Scenario.GetTopLevel(), "lib", Configuration.PackageNames);
 
                 DirectoryAssert.Exists(packageDir);
             }
@@ -2470,7 +2470,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_install_the_dependency_in_the_lib_directory()
             {
-                var packageDir = Path.Combine(Scenario.get_top_level(), "lib", "childdependencywithlooserversiondependency");
+                var packageDir = Path.Combine(Scenario.GetTopLevel(), "lib", "childdependencywithlooserversiondependency");
 
                 DirectoryAssert.Exists(packageDir);
             }
@@ -2478,7 +2478,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_install_the_expected_version_of_the_dependency()
             {
-                var packageFile = Path.Combine(Scenario.get_top_level(), "lib", "childdependencywithlooserversiondependency", "childdependencywithlooserversiondependency.nupkg");
+                var packageFile = Path.Combine(Scenario.GetTopLevel(), "lib", "childdependencywithlooserversiondependency", "childdependencywithlooserversiondependency.nupkg");
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
                     packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().Should().Be("1.0.0");
@@ -2488,7 +2488,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_install_the_expected_version_of_the_constrained_dependency()
             {
-                var packageFile = Path.Combine(Scenario.get_top_level(), "lib", "isexactversiondependency", "isexactversiondependency.nupkg");
+                var packageFile = Path.Combine(Scenario.GetTopLevel(), "lib", "isexactversiondependency", "isexactversiondependency.nupkg");
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
                     packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().Should().Be("1.0.0");
@@ -2566,7 +2566,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_not_install_the_package_in_the_lib_directory()
             {
-                var packageDir = Path.Combine(Scenario.get_top_level(), "lib", "installpackage");
+                var packageDir = Path.Combine(Scenario.GetTopLevel(), "lib", "installpackage");
 
                 DirectoryAssert.DoesNotExist(packageDir);
             }
@@ -2574,7 +2574,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_not_install_the_package_in_the_lib_bad_directory()
             {
-                var packageDir = Path.Combine(Scenario.get_top_level(), "lib-bad", "installpackage");
+                var packageDir = Path.Combine(Scenario.GetTopLevel(), "lib-bad", "installpackage");
 
                 DirectoryAssert.DoesNotExist(packageDir);
             }
@@ -2582,7 +2582,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_not_install_the_package_in_the_lib_backup_directory()
             {
-                var packageDir = Path.Combine(Scenario.get_top_level(), "lib-bkp", "installpackage");
+                var packageDir = Path.Combine(Scenario.GetTopLevel(), "lib-bkp", "installpackage");
 
                 DirectoryAssert.DoesNotExist(packageDir);
             }
@@ -2633,7 +2633,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_not_install_the_package_in_the_lib_directory()
             {
-                var packageDir = Path.Combine(Scenario.get_top_level(), "lib", "installpackage");
+                var packageDir = Path.Combine(Scenario.GetTopLevel(), "lib", "installpackage");
 
                 DirectoryAssert.DoesNotExist(packageDir);
             }
@@ -2641,7 +2641,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_not_install_the_package_in_the_lib_bad_directory()
             {
-                var packageDir = Path.Combine(Scenario.get_top_level(), "lib-bad", "installpackage");
+                var packageDir = Path.Combine(Scenario.GetTopLevel(), "lib-bad", "installpackage");
 
                 DirectoryAssert.DoesNotExist(packageDir);
             }
@@ -2649,7 +2649,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_not_install_the_package_in_the_lib_backup_directory()
             {
-                var packageDir = Path.Combine(Scenario.get_top_level(), "lib-bkp", "installpackage");
+                var packageDir = Path.Combine(Scenario.GetTopLevel(), "lib-bkp", "installpackage");
 
                 DirectoryAssert.DoesNotExist(packageDir);
             }
@@ -2663,7 +2663,7 @@ namespace chocolatey.tests.integration.scenarios
             public override void Context()
             {
                 base.Context();
-                Configuration.Sources = UNCHelper.convert_local_folder_path_to_ip_based_unc_path(Configuration.Sources);
+                Configuration.Sources = UNCHelper.ConvertLocalFolderPathToIpBasedUncPath(Configuration.Sources);
 
                 Configuration.PackageNames = Configuration.Input = "{0}{1}installpackage.1.0.0.nupkg".FormatWith(Configuration.Sources, Path.DirectorySeparatorChar);
             }
@@ -2703,7 +2703,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_not_install_the_package_in_the_lib_directory()
             {
-                var packageDir = Path.Combine(Scenario.get_top_level(), "lib", "installpackage");
+                var packageDir = Path.Combine(Scenario.GetTopLevel(), "lib", "installpackage");
 
                 DirectoryAssert.DoesNotExist(packageDir);
             }
@@ -2711,7 +2711,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_not_install_the_package_in_the_lib_bad_directory()
             {
-                var packageDir = Path.Combine(Scenario.get_top_level(), "lib-bad", "installpackage");
+                var packageDir = Path.Combine(Scenario.GetTopLevel(), "lib-bad", "installpackage");
 
                 DirectoryAssert.DoesNotExist(packageDir);
             }
@@ -2719,7 +2719,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_not_install_the_package_in_the_lib_backup_directory()
             {
-                var packageDir = Path.Combine(Scenario.get_top_level(), "lib-bkp", "installpackage");
+                var packageDir = Path.Combine(Scenario.GetTopLevel(), "lib-bkp", "installpackage");
 
                 DirectoryAssert.DoesNotExist(packageDir);
             }
@@ -2763,7 +2763,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_not_install_the_package_in_the_lib_directory()
             {
-                var packageDir = Path.Combine(Scenario.get_top_level(), "lib", "installpackage");
+                var packageDir = Path.Combine(Scenario.GetTopLevel(), "lib", "installpackage");
 
                 DirectoryAssert.DoesNotExist(packageDir);
             }
@@ -2771,7 +2771,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_not_install_the_package_in_the_lib_bad_directory()
             {
-                var packageDir = Path.Combine(Scenario.get_top_level(), "lib-bad", "installpackage");
+                var packageDir = Path.Combine(Scenario.GetTopLevel(), "lib-bad", "installpackage");
 
                 DirectoryAssert.DoesNotExist(packageDir);
             }
@@ -2779,7 +2779,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_not_install_the_package_in_the_lib_backup_directory()
             {
-                var packageDir = Path.Combine(Scenario.get_top_level(), "lib-bkp", "installpackage");
+                var packageDir = Path.Combine(Scenario.GetTopLevel(), "lib-bkp", "installpackage");
 
                 DirectoryAssert.DoesNotExist(packageDir);
             }
@@ -2823,7 +2823,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_not_install_the_package_in_the_lib_directory()
             {
-                var packageDir = Path.Combine(Scenario.get_top_level(), "lib", "installpackage");
+                var packageDir = Path.Combine(Scenario.GetTopLevel(), "lib", "installpackage");
 
                 DirectoryAssert.DoesNotExist(packageDir);
             }
@@ -2831,7 +2831,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_not_install_the_package_in_the_lib_bad_directory()
             {
-                var packageDir = Path.Combine(Scenario.get_top_level(), "lib-bad", "installpackage");
+                var packageDir = Path.Combine(Scenario.GetTopLevel(), "lib-bad", "installpackage");
 
                 DirectoryAssert.DoesNotExist(packageDir);
             }
@@ -2839,7 +2839,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_not_install_the_package_in_the_lib_backup_directory()
             {
-                var packageDir = Path.Combine(Scenario.get_top_level(), "lib-bkp", "installpackage");
+                var packageDir = Path.Combine(Scenario.GetTopLevel(), "lib-bkp", "installpackage");
 
                 DirectoryAssert.DoesNotExist(packageDir);
             }
@@ -2847,7 +2847,7 @@ namespace chocolatey.tests.integration.scenarios
 
         public class When_installing_a_package_with_config_transforms : ScenariosBase
         {
-            private PackageResult packageResult;
+            private PackageResult _packageResult;
             private string _xmlFilePath = string.Empty;
             private XPathNavigator _xPathNavigator;
 
@@ -2855,15 +2855,15 @@ namespace chocolatey.tests.integration.scenarios
             {
                 base.Context();
                 Configuration.PackageNames = Configuration.Input = "upgradepackage";
-                Scenario.add_packages_to_source_location(Configuration, "upgradepackage.1.0.0*" + NuGetConstants.PackageExtension);
+                Scenario.AddPackagesToSourceLocation(Configuration, "upgradepackage.1.0.0*" + NuGetConstants.PackageExtension);
 
-                _xmlFilePath = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, "tools", "console.exe.config");
+                _xmlFilePath = Path.Combine(Scenario.GetTopLevel(), "lib", Configuration.PackageNames, "tools", "console.exe.config");
             }
 
             public override void Because()
             {
                 Results = Service.Install(Configuration);
-                packageResult = Results.FirstOrDefault().Value;
+                _packageResult = Results.FirstOrDefault().Value;
                 var xmlDocument = new XPathDocument(_xmlFilePath);
                 _xPathNavigator = xmlDocument.CreateNavigator();
             }
@@ -2871,7 +2871,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_install_the_expected_version_of_the_package()
             {
-                var packageFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, Configuration.PackageNames + NuGetConstants.PackageExtension);
+                var packageFile = Path.Combine(Scenario.GetTopLevel(), "lib", Configuration.PackageNames, Configuration.PackageNames + NuGetConstants.PackageExtension);
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
                     packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().Should().Be("1.0.0");
@@ -2888,25 +2888,25 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_have_a_successful_package_result()
             {
-                packageResult.Success.Should().BeTrue();
+                _packageResult.Success.Should().BeTrue();
             }
 
             [Fact]
             public void Should_not_have_inconclusive_package_result()
             {
-                packageResult.Inconclusive.Should().BeFalse();
+                _packageResult.Inconclusive.Should().BeFalse();
             }
 
             [Fact]
             public void Should_not_have_warning_package_result()
             {
-                packageResult.Warning.Should().BeFalse();
+                _packageResult.Warning.Should().BeFalse();
             }
 
             [Fact]
             public void Should_have_a_version_of_one_dot_zero_dot_zero()
             {
-                packageResult.Version.Should().Be("1.0.0");
+                _packageResult.Version.Should().Be("1.0.0");
             }
 
             [Fact]
@@ -2961,7 +2961,7 @@ namespace chocolatey.tests.integration.scenarios
             {
                 base.Context();
                 Configuration.PackageNames = Configuration.Input = "scriptpackage.hook";
-                Scenario.add_packages_to_source_location(Configuration, Configuration.Input + ".1.0.0" + NuGetConstants.PackageExtension);
+                Scenario.AddPackagesToSourceLocation(Configuration, Configuration.Input + ".1.0.0" + NuGetConstants.PackageExtension);
             }
 
             private PackageResult _packageResult;
@@ -2975,7 +2975,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_install_the_package_in_the_lib_directory()
             {
-                var packageDir = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames);
+                var packageDir = Path.Combine(Scenario.GetTopLevel(), "lib", Configuration.PackageNames);
 
                 DirectoryAssert.Exists(packageDir);
             }
@@ -2983,7 +2983,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_install_the_expected_version_of_the_package()
             {
-                var packageFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, Configuration.PackageNames + NuGetConstants.PackageExtension);
+                var packageFile = Path.Combine(Scenario.GetTopLevel(), "lib", Configuration.PackageNames, Configuration.PackageNames + NuGetConstants.PackageExtension);
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
                     packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().Should().Be("1.0.0");
@@ -2993,7 +2993,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_not_create_an_extensions_folder_for_the_package()
             {
-                var extensionsDirectory = Path.Combine(Scenario.get_top_level(), "extensions", Configuration.PackageNames);
+                var extensionsDirectory = Path.Combine(Scenario.GetTopLevel(), "extensions", Configuration.PackageNames);
 
                 DirectoryAssert.DoesNotExist(extensionsDirectory);
             }
@@ -3001,7 +3001,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_create_a_hooks_folder_for_the_package()
             {
-                var hooksDirectory = Path.Combine(Scenario.get_top_level(), "hooks", Configuration.PackageNames.Replace(".hook", string.Empty));
+                var hooksDirectory = Path.Combine(Scenario.GetTopLevel(), "hooks", Configuration.PackageNames.Replace(".hook", string.Empty));
 
                 DirectoryAssert.Exists(hooksDirectory);
             }
@@ -3012,7 +3012,7 @@ namespace chocolatey.tests.integration.scenarios
                 var hookScripts = new List<string> { "pre-install-all.ps1", "post-install-all.ps1", "pre-upgrade-all.ps1", "post-upgrade-all.ps1", "pre-uninstall-all.ps1", "post-uninstall-all.ps1" };
                 foreach (string scriptName in hookScripts)
                 {
-                    var hookScriptPath = Path.Combine(Scenario.get_top_level(), "hooks", Configuration.PackageNames.Replace(".hook", string.Empty), scriptName);
+                    var hookScriptPath = Path.Combine(Scenario.GetTopLevel(), "hooks", Configuration.PackageNames.Replace(".hook", string.Empty), scriptName);
                     File.ReadAllText(hookScriptPath).Should().Contain("Write-Output");
                 }
             }
@@ -3063,8 +3063,8 @@ namespace chocolatey.tests.integration.scenarios
             public override void Context()
             {
                 base.Context();
-                Scenario.add_packages_to_source_location(Configuration, "scriptpackage.hook" + "*" + NuGetConstants.PackageExtension);
-                Scenario.install_package(Configuration, "scriptpackage.hook", "1.0.0");
+                Scenario.AddPackagesToSourceLocation(Configuration, "scriptpackage.hook" + "*" + NuGetConstants.PackageExtension);
+                Scenario.InstallPackage(Configuration, "scriptpackage.hook", "1.0.0");
                 Configuration.PackageNames = Configuration.Input = "installpackage";
             }
 
@@ -3083,7 +3083,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_install_the_package_in_the_lib_directory()
             {
-                var packageDir = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames);
+                var packageDir = Path.Combine(Scenario.GetTopLevel(), "lib", Configuration.PackageNames);
 
                 DirectoryAssert.Exists(packageDir);
             }
@@ -3091,7 +3091,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_install_the_expected_version_of_the_package()
             {
-                var packageFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, Configuration.PackageNames + NuGetConstants.PackageExtension);
+                var packageFile = Path.Combine(Scenario.GetTopLevel(), "lib", Configuration.PackageNames, Configuration.PackageNames + NuGetConstants.PackageExtension);
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
                     packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().Should().Be("1.0.0");
@@ -3103,7 +3103,7 @@ namespace chocolatey.tests.integration.scenarios
             [Platform(Exclude = "Mono")]
             public void Should_create_a_shim_for_console_in_the_bin_directory()
             {
-                var shimfile = Path.Combine(Scenario.get_top_level(), "bin", "console.exe");
+                var shimfile = Path.Combine(Scenario.GetTopLevel(), "bin", "console.exe");
 
                 FileAssert.Exists(shimfile);
             }
@@ -3113,7 +3113,7 @@ namespace chocolatey.tests.integration.scenarios
             [Platform(Exclude = "Mono")]
             public void Should_create_a_shim_for_graphical_in_the_bin_directory()
             {
-                var shimfile = Path.Combine(Scenario.get_top_level(), "bin", "graphical.exe");
+                var shimfile = Path.Combine(Scenario.GetTopLevel(), "bin", "graphical.exe");
 
                 FileAssert.Exists(shimfile);
             }
@@ -3121,7 +3121,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_not_create_a_shim_for_ignored_executable_in_the_bin_directory()
             {
-                var shimfile = Path.Combine(Scenario.get_top_level(), "bin", "not.installed.exe");
+                var shimfile = Path.Combine(Scenario.GetTopLevel(), "bin", "not.installed.exe");
 
                 FileAssert.DoesNotExist(shimfile);
             }
@@ -3129,7 +3129,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_not_create_a_shim_for_mismatched_case_ignored_executable_in_the_bin_directory()
             {
-                var shimfile = Path.Combine(Scenario.get_top_level(), "bin", "casemismatch.exe");
+                var shimfile = Path.Combine(Scenario.GetTopLevel(), "bin", "casemismatch.exe");
 
                 FileAssert.DoesNotExist(shimfile);
             }
@@ -3137,7 +3137,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_not_create_an_extensions_folder_for_the_package()
             {
-                var extensionsDirectory = Path.Combine(Scenario.get_top_level(), "extensions", Configuration.PackageNames);
+                var extensionsDirectory = Path.Combine(Scenario.GetTopLevel(), "extensions", Configuration.PackageNames);
 
                 DirectoryAssert.DoesNotExist(extensionsDirectory);
             }
@@ -3145,7 +3145,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_not_create_an_hooks_folder_for_the_package()
             {
-                var hooksDirectory = Path.Combine(Scenario.get_top_level(), "hooks", Configuration.PackageNames);
+                var hooksDirectory = Path.Combine(Scenario.GetTopLevel(), "hooks", Configuration.PackageNames);
 
                 DirectoryAssert.DoesNotExist(hooksDirectory);
             }
@@ -3157,7 +3157,7 @@ namespace chocolatey.tests.integration.scenarios
             {
                 var messages = new List<string>();
 
-                var shimfile = Path.Combine(Scenario.get_top_level(), "bin", "console.exe");
+                var shimfile = Path.Combine(Scenario.GetTopLevel(), "bin", "console.exe");
                 CommandExecutor.Execute(
                     shimfile,
                     "--shimgen-noop",
@@ -3178,7 +3178,7 @@ namespace chocolatey.tests.integration.scenarios
             {
                 var messages = new List<string>();
 
-                var shimfile = Path.Combine(Scenario.get_top_level(), "bin", "graphical.exe");
+                var shimfile = Path.Combine(Scenario.GetTopLevel(), "bin", "graphical.exe");
                 CommandExecutor.Execute(
                     shimfile,
                     "--shimgen-noop",
@@ -3309,10 +3309,10 @@ namespace chocolatey.tests.integration.scenarios
             public override void Context()
             {
                 base.Context();
-                Scenario.add_packages_to_source_location(Configuration, "scriptpackage.hook" + ".1.0.0" + NuGetConstants.PackageExtension);
-                Scenario.install_package(Configuration, "scriptpackage.hook", "1.0.0");
+                Scenario.AddPackagesToSourceLocation(Configuration, "scriptpackage.hook" + ".1.0.0" + NuGetConstants.PackageExtension);
+                Scenario.InstallPackage(Configuration, "scriptpackage.hook", "1.0.0");
                 Configuration.PackageNames = Configuration.Input = "portablepackage";
-                Scenario.add_packages_to_source_location(Configuration, Configuration.Input + "*" + NuGetConstants.PackageExtension);
+                Scenario.AddPackagesToSourceLocation(Configuration, Configuration.Input + "*" + NuGetConstants.PackageExtension);
             }
 
             public override void Because()
@@ -3330,7 +3330,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_install_the_package_in_the_lib_directory()
             {
-                var packageDir = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames);
+                var packageDir = Path.Combine(Scenario.GetTopLevel(), "lib", Configuration.PackageNames);
 
                 DirectoryAssert.Exists(packageDir);
             }
@@ -3338,7 +3338,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_install_the_expected_version_of_the_package()
             {
-                var packageFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, Configuration.PackageNames + NuGetConstants.PackageExtension);
+                var packageFile = Path.Combine(Scenario.GetTopLevel(), "lib", Configuration.PackageNames, Configuration.PackageNames + NuGetConstants.PackageExtension);
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
                     packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().Should().Be("1.0.0");
@@ -3350,7 +3350,7 @@ namespace chocolatey.tests.integration.scenarios
             [Platform(Exclude = "Mono")]
             public void Should_create_a_shim_for_console_in_the_bin_directory()
             {
-                var shimfile = Path.Combine(Scenario.get_top_level(), "bin", "console.exe");
+                var shimfile = Path.Combine(Scenario.GetTopLevel(), "bin", "console.exe");
 
                 FileAssert.Exists(shimfile);
             }
@@ -3360,7 +3360,7 @@ namespace chocolatey.tests.integration.scenarios
             [Platform(Exclude = "Mono")]
             public void Should_create_a_shim_for_graphical_in_the_bin_directory()
             {
-                var shimfile = Path.Combine(Scenario.get_top_level(), "bin", "graphical.exe");
+                var shimfile = Path.Combine(Scenario.GetTopLevel(), "bin", "graphical.exe");
 
                 FileAssert.Exists(shimfile);
             }
@@ -3368,7 +3368,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_not_create_a_shim_for_ignored_executable_in_the_bin_directory()
             {
-                var shimfile = Path.Combine(Scenario.get_top_level(), "bin", "not.installed.exe");
+                var shimfile = Path.Combine(Scenario.GetTopLevel(), "bin", "not.installed.exe");
 
                 FileAssert.DoesNotExist(shimfile);
             }
@@ -3376,7 +3376,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_not_create_a_shim_for_mismatched_case_ignored_executable_in_the_bin_directory()
             {
-                var shimfile = Path.Combine(Scenario.get_top_level(), "bin", "casemismatch.exe");
+                var shimfile = Path.Combine(Scenario.GetTopLevel(), "bin", "casemismatch.exe");
 
                 FileAssert.DoesNotExist(shimfile);
             }
@@ -3384,7 +3384,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_not_create_an_extensions_folder_for_the_package()
             {
-                var extensionsDirectory = Path.Combine(Scenario.get_top_level(), "extensions", Configuration.PackageNames);
+                var extensionsDirectory = Path.Combine(Scenario.GetTopLevel(), "extensions", Configuration.PackageNames);
 
                 DirectoryAssert.DoesNotExist(extensionsDirectory);
             }
@@ -3392,7 +3392,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_not_create_an_hooks_folder_for_the_package()
             {
-                var hooksDirectory = Path.Combine(Scenario.get_top_level(), "hooks", Configuration.PackageNames);
+                var hooksDirectory = Path.Combine(Scenario.GetTopLevel(), "hooks", Configuration.PackageNames);
 
                 DirectoryAssert.DoesNotExist(hooksDirectory);
             }
@@ -3404,7 +3404,7 @@ namespace chocolatey.tests.integration.scenarios
             {
                 var messages = new List<string>();
 
-                var shimfile = Path.Combine(Scenario.get_top_level(), "bin", "console.exe");
+                var shimfile = Path.Combine(Scenario.GetTopLevel(), "bin", "console.exe");
                 CommandExecutor.Execute(
                     shimfile,
                     "--shimgen-noop",
@@ -3425,7 +3425,7 @@ namespace chocolatey.tests.integration.scenarios
             {
                 var messages = new List<string>();
 
-                var shimfile = Path.Combine(Scenario.get_top_level(), "bin", "graphical.exe");
+                var shimfile = Path.Combine(Scenario.GetTopLevel(), "bin", "graphical.exe");
                 CommandExecutor.Execute(
                     shimfile,
                     "--shimgen-noop",
@@ -3534,34 +3534,34 @@ namespace chocolatey.tests.integration.scenarios
         [Categories.SourcePriority]
         public class When_installing_package_from_lower_priority_source_with_version_specified : ScenariosBase
         {
-            private PackageResult packageResult;
+            private PackageResult _packageResult;
             public override void Context()
             {
                 base.Context();
                 Configuration.PackageNames = Configuration.Input = "isdependency";
                 Configuration.Version = "2.0.0";
                 Configuration.Sources = string.Join(",",
-                    Scenario.add_packages_to_priority_source_location(Configuration, "isdependency.1.1.0" + NuGetConstants.PackageExtension, priority: 1),
-                    Scenario.add_packages_to_priority_source_location(Configuration, "isdependency.2.0.0" + NuGetConstants.PackageExtension, name: "No-Priority"));
+                    Scenario.AddPackagesToPrioritySourceLocation(Configuration, "isdependency.1.1.0" + NuGetConstants.PackageExtension, priority: 1),
+                    Scenario.AddPackagesToPrioritySourceLocation(Configuration, "isdependency.2.0.0" + NuGetConstants.PackageExtension, name: "No-Priority"));
             }
 
             public override void Because()
             {
                 MockLogger.Reset();
                 Results = Service.Install(Configuration);
-                packageResult = Results.Select(r => r.Value).FirstOrDefault();
+                _packageResult = Results.Select(r => r.Value).FirstOrDefault();
             }
 
             [Fact]
             public void Should_install_where_install_location_reports()
             {
-                DirectoryAssert.Exists(packageResult.InstallLocation);
+                DirectoryAssert.Exists(_packageResult.InstallLocation);
             }
 
             [Fact]
             public void Should_install_the_package_in_the_lib_directory()
             {
-                var packageDir = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames);
+                var packageDir = Path.Combine(Scenario.GetTopLevel(), "lib", Configuration.PackageNames);
 
                 DirectoryAssert.Exists(packageDir);
             }
@@ -3569,7 +3569,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_install_the_expected_version_of_the_package()
             {
-                var packageDirectory = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames);
+                var packageDirectory = Path.Combine(Scenario.GetTopLevel(), "lib", Configuration.PackageNames);
 
                 using (var reader = new PackageFolderReader(packageDirectory))
                 {
@@ -3580,7 +3580,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_not_create_an_extensions_folder_for_the_package()
             {
-                var extensionsDirectory = Path.Combine(Scenario.get_top_level(), "extensions", Configuration.PackageNames);
+                var extensionsDirectory = Path.Combine(Scenario.GetTopLevel(), "extensions", Configuration.PackageNames);
 
                 DirectoryAssert.DoesNotExist(extensionsDirectory);
             }
@@ -3588,7 +3588,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_not_create_an_hooks_folder_for_the_package()
             {
-                var hooksDirectory = Path.Combine(Scenario.get_top_level(), "hooks", Configuration.PackageNames);
+                var hooksDirectory = Path.Combine(Scenario.GetTopLevel(), "hooks", Configuration.PackageNames);
 
                 DirectoryAssert.DoesNotExist(hooksDirectory);
             }
@@ -3603,31 +3603,31 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_have_a_successful_package_result()
             {
-                packageResult.Success.Should().BeTrue();
+                _packageResult.Success.Should().BeTrue();
             }
 
             [Fact]
             public void Should_not_have_inconclusive_package_result()
             {
-                packageResult.Inconclusive.Should().BeFalse();
+                _packageResult.Inconclusive.Should().BeFalse();
             }
 
             [Fact]
             public void Should_not_have_warning_package_result()
             {
-                packageResult.Warning.Should().BeFalse();
+                _packageResult.Warning.Should().BeFalse();
             }
 
             [Fact]
             public void Config_should_match_package_result_name()
             {
-                packageResult.Name.Should().Be(Configuration.PackageNames);
+                _packageResult.Name.Should().Be(Configuration.PackageNames);
             }
 
             [Fact]
             public void Should_have_a_version_of_two_dot_zero_dot_zero()
             {
-                packageResult.Version.Should().Be("2.0.0");
+                _packageResult.Version.Should().Be("2.0.0");
             }
 
             [Fact]
@@ -3647,7 +3647,7 @@ namespace chocolatey.tests.integration.scenarios
             {
                 base.Context();
                 Configuration.PackageNames = Configuration.Input = "non-existing";
-                Scenario.add_machine_source(Configuration, "Priority-Source", priority: 1);
+                Scenario.AddMachineSource(Configuration, "Priority-Source", priority: 1);
                 Configuration.Sources = "Priority-Source";
             }
 
@@ -3666,7 +3666,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_not_install_a_package_in_the_lib_directory()
             {
-                var packageDir = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames);
+                var packageDir = Path.Combine(Scenario.GetTopLevel(), "lib", Configuration.PackageNames);
 
                 DirectoryAssert.DoesNotExist(packageDir);
             }
@@ -3701,12 +3701,12 @@ namespace chocolatey.tests.integration.scenarios
                 base.Context();
                 Configuration.PackageNames = Configuration.Input = "upgradepackage";
                 Configuration.Features.UsePackageRepositoryOptimizations = true;
-                Scenario.add_machine_source(Configuration, "chocolatey", path: "https://community.chocolatey.org/api/v2/", createDirectory: false);
+                Scenario.AddMachineSource(Configuration, "chocolatey", path: "https://community.chocolatey.org/api/v2/", createDirectory: false);
 
                 Configuration.Sources = string.Join(";", new[]
                 {
-                    Scenario.add_packages_to_priority_source_location(Configuration, "upgradepackage.1.1.0" + NuGetConstants.PackageExtension),
-                    Scenario.add_packages_to_priority_source_location(Configuration, "upgradepackage.1.0.0" + NuGetConstants.PackageExtension, priority: 1)
+                    Scenario.AddPackagesToPrioritySourceLocation(Configuration, "upgradepackage.1.1.0" + NuGetConstants.PackageExtension),
+                    Scenario.AddPackagesToPrioritySourceLocation(Configuration, "upgradepackage.1.0.0" + NuGetConstants.PackageExtension, priority: 1)
                 });
             }
 
@@ -3728,7 +3728,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_install_a_package_in_the_lib_directory()
             {
-                var packageDir = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames);
+                var packageDir = Path.Combine(Scenario.GetTopLevel(), "lib", Configuration.PackageNames);
 
                 DirectoryAssert.Exists(packageDir);
             }
@@ -3742,9 +3742,9 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_have_installed_expected_version_in_lib_directory()
             {
-                var installedPath = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames);
+                var installedPath = Path.Combine(Scenario.GetTopLevel(), "lib", Configuration.PackageNames);
 
-                var packageFolder = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames);
+                var packageFolder = Path.Combine(Scenario.GetTopLevel(), "lib", Configuration.PackageNames);
 
                 using (var reader = new PackageFolderReader(packageFolder))
                 {
@@ -3781,8 +3781,8 @@ namespace chocolatey.tests.integration.scenarios
 
                 Configuration.Sources = string.Join(";", new[]
                 {
-                    Scenario.add_packages_to_priority_source_location(Configuration, "upgradepackage.1.1.0" + NuGetConstants.PackageExtension),
-                    Scenario.add_packages_to_priority_source_location(Configuration, "upgradepackage.1.0.0" + NuGetConstants.PackageExtension, priority: 1)
+                    Scenario.AddPackagesToPrioritySourceLocation(Configuration, "upgradepackage.1.1.0" + NuGetConstants.PackageExtension),
+                    Scenario.AddPackagesToPrioritySourceLocation(Configuration, "upgradepackage.1.0.0" + NuGetConstants.PackageExtension, priority: 1)
                 });
             }
 
@@ -3804,14 +3804,14 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_install_a_package_in_the_lib_directory()
             {
-                var packageDir = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames);
+                var packageDir = Path.Combine(Scenario.GetTopLevel(), "lib", Configuration.PackageNames);
                 DirectoryAssert.Exists(packageDir);
             }
 
             [Fact]
             public void Should_have_installed_expected_version_in_lib_directory()
             {
-                var packageFolder = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, Configuration.PackageNames + NuGetConstants.PackageExtension);
+                var packageFolder = Path.Combine(Scenario.GetTopLevel(), "lib", Configuration.PackageNames, Configuration.PackageNames + NuGetConstants.PackageExtension);
 
                 using (var reader = new PackageFolderReader(packageFolder))
                 {
@@ -3874,11 +3874,11 @@ namespace chocolatey.tests.integration.scenarios
 
                 Configuration.Sources = string.Join(";", new[]
                 {
-                    Scenario.add_packages_to_priority_source_location(Configuration, "hasdependency.1.6.0" + NuGetConstants.PackageExtension, priority: 1),
-                    Scenario.add_packages_to_priority_source_location(Configuration, "isdependency.*" + NuGetConstants.PackageExtension, priority: 2),
-                    Scenario.add_packages_to_priority_source_location(Configuration, "isexactversiondependency.1.1.0" + NuGetConstants.PackageExtension)
+                    Scenario.AddPackagesToPrioritySourceLocation(Configuration, "hasdependency.1.6.0" + NuGetConstants.PackageExtension, priority: 1),
+                    Scenario.AddPackagesToPrioritySourceLocation(Configuration, "isdependency.*" + NuGetConstants.PackageExtension, priority: 2),
+                    Scenario.AddPackagesToPrioritySourceLocation(Configuration, "isexactversiondependency.1.1.0" + NuGetConstants.PackageExtension)
                 });
-                Scenario.add_packages_to_priority_source_location(Configuration, "isexactversiondependency.2.0.0" + NuGetConstants.PackageExtension, priority: 1);
+                Scenario.AddPackagesToPrioritySourceLocation(Configuration, "isexactversiondependency.2.0.0" + NuGetConstants.PackageExtension, priority: 1);
             }
 
             public override void Because()
@@ -3899,14 +3899,14 @@ namespace chocolatey.tests.integration.scenarios
             [TestCaseSource(nameof(ExpectedInstallations))]
             public void Should_install_hasdependency_package_to_lib_directory(string name)
             {
-                var expectedPath = Path.Combine(Scenario.get_top_level(), "lib", name);
+                var expectedPath = Path.Combine(Scenario.GetTopLevel(), "lib", name);
                 DirectoryAssert.Exists(expectedPath);
             }
 
             [TestCaseSource(nameof(ExpectedPackageVersions))]
             public void Should_instal_expected_package_version(string name, string version)
             {
-                var path = Path.Combine(Scenario.get_top_level(), "lib", name);
+                var path = Path.Combine(Scenario.GetTopLevel(), "lib", name);
 
                 using (var reader = new PackageFolderReader(path))
                 {
@@ -3947,7 +3947,7 @@ namespace chocolatey.tests.integration.scenarios
             public override void Context()
             {
                 base.Context();
-                Scenario.add_packages_to_source_location(Configuration, "UpperCase.1.0.0" + NuGetConstants.PackageExtension);
+                Scenario.AddPackagesToSourceLocation(Configuration, "UpperCase.1.0.0" + NuGetConstants.PackageExtension);
                 Configuration.PackageNames = Configuration.Input = "UpperCase";
             }
 
@@ -3966,7 +3966,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_install_the_package_in_the_lib_directory()
             {
-                var packageDir = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames);
+                var packageDir = Path.Combine(Scenario.GetTopLevel(), "lib", Configuration.PackageNames);
 
                 DirectoryAssert.Exists(packageDir);
             }
@@ -3974,14 +3974,14 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_have_the_correct_casing_for_the_nuspec()
             {
-                var nuspecFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, Configuration.PackageNames + NuGetConstants.ManifestExtension);
+                var nuspecFile = Path.Combine(Scenario.GetTopLevel(), "lib", Configuration.PackageNames, Configuration.PackageNames + NuGetConstants.ManifestExtension);
                 FileAssert.Exists(nuspecFile);
             }
 
             [Fact]
             public void Should_install_the_expected_version_of_the_package()
             {
-                var packageFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, Configuration.PackageNames + NuGetConstants.PackageExtension);
+                var packageFile = Path.Combine(Scenario.GetTopLevel(), "lib", Configuration.PackageNames, Configuration.PackageNames + NuGetConstants.PackageExtension);
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
                     packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().Should().Be("1.0.0");
@@ -3991,7 +3991,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_not_create_an_extensions_folder_for_the_package()
             {
-                var extensionsDirectory = Path.Combine(Scenario.get_top_level(), "extensions", Configuration.PackageNames);
+                var extensionsDirectory = Path.Combine(Scenario.GetTopLevel(), "extensions", Configuration.PackageNames);
 
                 DirectoryAssert.DoesNotExist(extensionsDirectory);
             }
@@ -3999,7 +3999,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_not_create_an_hooks_folder_for_the_package()
             {
-                var hooksDirectory = Path.Combine(Scenario.get_top_level(), "hooks", Configuration.PackageNames);
+                var hooksDirectory = Path.Combine(Scenario.GetTopLevel(), "hooks", Configuration.PackageNames);
 
                 DirectoryAssert.DoesNotExist(hooksDirectory);
             }
@@ -4058,7 +4058,7 @@ namespace chocolatey.tests.integration.scenarios
             public override void Context()
             {
                 base.Context();
-                Scenario.add_packages_to_source_location(Configuration, "unsupportedelements" + ".1.0.0" + NuGetConstants.PackageExtension);
+                Scenario.AddPackagesToSourceLocation(Configuration, "unsupportedelements" + ".1.0.0" + NuGetConstants.PackageExtension);
                 Configuration.PackageNames = Configuration.Input = "unsupportedelements";
             }
 
@@ -4077,7 +4077,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_install_the_package_in_the_lib_directory()
             {
-                var packageDir = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames);
+                var packageDir = Path.Combine(Scenario.GetTopLevel(), "lib", Configuration.PackageNames);
 
                 DirectoryAssert.Exists(packageDir);
             }
@@ -4085,7 +4085,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_install_the_expected_version_of_the_package()
             {
-                var packageFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, Configuration.PackageNames + NuGetConstants.PackageExtension);
+                var packageFile = Path.Combine(Scenario.GetTopLevel(), "lib", Configuration.PackageNames, Configuration.PackageNames + NuGetConstants.PackageExtension);
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
                     packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().Should().Be("1.0.0");
@@ -4095,7 +4095,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_not_create_an_extensions_folder_for_the_package()
             {
-                var extensionsDirectory = Path.Combine(Scenario.get_top_level(), "extensions", Configuration.PackageNames);
+                var extensionsDirectory = Path.Combine(Scenario.GetTopLevel(), "extensions", Configuration.PackageNames);
 
                 DirectoryAssert.DoesNotExist(extensionsDirectory);
             }
@@ -4103,7 +4103,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_not_create_an_hooks_folder_for_the_package()
             {
-                var hooksDirectory = Path.Combine(Scenario.get_top_level(), "hooks", Configuration.PackageNames);
+                var hooksDirectory = Path.Combine(Scenario.GetTopLevel(), "hooks", Configuration.PackageNames);
 
                 DirectoryAssert.DoesNotExist(hooksDirectory);
             }
@@ -4172,7 +4172,7 @@ namespace chocolatey.tests.integration.scenarios
             public override void Context()
             {
                 base.Context();
-                Scenario.add_changed_version_package_to_source_location(Configuration, "installpackage.1.0.0" + NuGetConstants.PackageExtension, NonNormalizedVersion);
+                Scenario.AddChangedVersionPackageToSourceLocation(Configuration, "installpackage.1.0.0" + NuGetConstants.PackageExtension, NonNormalizedVersion);
                 Configuration.PackageNames = Configuration.Input = "installpackage";
             }
 
@@ -4191,7 +4191,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_install_the_package_in_the_lib_directory()
             {
-                var packageDir = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames);
+                var packageDir = Path.Combine(Scenario.GetTopLevel(), "lib", Configuration.PackageNames);
 
                 DirectoryAssert.Exists(packageDir);
             }
@@ -4199,7 +4199,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_install_the_expected_version_of_the_package()
             {
-                var packageFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, Configuration.PackageNames + NuGetConstants.PackageExtension);
+                var packageFile = Path.Combine(Scenario.GetTopLevel(), "lib", Configuration.PackageNames, Configuration.PackageNames + NuGetConstants.PackageExtension);
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
                     packageReader.NuspecReader.GetVersion().ToStringSafe().Should().Be(NonNormalizedVersion);
@@ -4209,7 +4209,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_not_create_an_extensions_folder_for_the_package()
             {
-                var extensionsDirectory = Path.Combine(Scenario.get_top_level(), "extensions", Configuration.PackageNames);
+                var extensionsDirectory = Path.Combine(Scenario.GetTopLevel(), "extensions", Configuration.PackageNames);
 
                 DirectoryAssert.DoesNotExist(extensionsDirectory);
             }
@@ -4217,7 +4217,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_not_create_an_hooks_folder_for_the_package()
             {
-                var hooksDirectory = Path.Combine(Scenario.get_top_level(), "hooks", Configuration.PackageNames);
+                var hooksDirectory = Path.Combine(Scenario.GetTopLevel(), "hooks", Configuration.PackageNames);
 
                 DirectoryAssert.DoesNotExist(hooksDirectory);
             }
@@ -4275,7 +4275,7 @@ namespace chocolatey.tests.integration.scenarios
             [Platform(Exclude = "Mono")]
             public void Should_create_a_shim_for_console_in_the_bin_directory()
             {
-                var shimfile = Path.Combine(Scenario.get_top_level(), "bin", "console.exe");
+                var shimfile = Path.Combine(Scenario.GetTopLevel(), "bin", "console.exe");
 
                 FileAssert.Exists(shimfile);
             }
@@ -4285,7 +4285,7 @@ namespace chocolatey.tests.integration.scenarios
             [Platform(Exclude = "Mono")]
             public void Should_create_a_shim_for_graphical_in_the_bin_directory()
             {
-                var shimfile = Path.Combine(Scenario.get_top_level(), "bin", "graphical.exe");
+                var shimfile = Path.Combine(Scenario.GetTopLevel(), "bin", "graphical.exe");
 
                 FileAssert.Exists(shimfile);
             }
@@ -4293,7 +4293,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_not_create_a_shim_for_ignored_executable_in_the_bin_directory()
             {
-                var shimfile = Path.Combine(Scenario.get_top_level(), "bin", "not.installed.exe");
+                var shimfile = Path.Combine(Scenario.GetTopLevel(), "bin", "not.installed.exe");
 
                 FileAssert.DoesNotExist(shimfile);
             }
@@ -4301,7 +4301,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_not_create_a_shim_for_mismatched_case_ignored_executable_in_the_bin_directory()
             {
-                var shimfile = Path.Combine(Scenario.get_top_level(), "bin", "casemismatch.exe");
+                var shimfile = Path.Combine(Scenario.GetTopLevel(), "bin", "casemismatch.exe");
 
                 FileAssert.DoesNotExist(shimfile);
             }
@@ -4313,7 +4313,7 @@ namespace chocolatey.tests.integration.scenarios
             {
                 var messages = new List<string>();
 
-                var shimfile = Path.Combine(Scenario.get_top_level(), "bin", "console.exe");
+                var shimfile = Path.Combine(Scenario.GetTopLevel(), "bin", "console.exe");
                 CommandExecutor.Execute(
                     shimfile,
                     "--shimgen-noop",
@@ -4334,7 +4334,7 @@ namespace chocolatey.tests.integration.scenarios
             {
                 var messages = new List<string>();
 
-                var shimfile = Path.Combine(Scenario.get_top_level(), "bin", "graphical.exe");
+                var shimfile = Path.Combine(Scenario.GetTopLevel(), "bin", "graphical.exe");
                 CommandExecutor.Execute(
                     shimfile,
                     "--shimgen-noop",
@@ -4412,9 +4412,9 @@ namespace chocolatey.tests.integration.scenarios
             {
                 base.Context();
 
-                Scenario.add_packages_to_source_location(Configuration, "{0}.*".FormatWith(TargetPackageName) + NuGetConstants.PackageExtension);
-                Scenario.add_packages_to_source_location(Configuration, "{0}.*".FormatWith(DependencyName) + NuGetConstants.PackageExtension);
-                Scenario.install_package(Configuration, DependencyName, "1.0.0");
+                Scenario.AddPackagesToSourceLocation(Configuration, "{0}.*".FormatWith(TargetPackageName) + NuGetConstants.PackageExtension);
+                Scenario.AddPackagesToSourceLocation(Configuration, "{0}.*".FormatWith(DependencyName) + NuGetConstants.PackageExtension);
+                Scenario.InstallPackage(Configuration, DependencyName, "1.0.0");
 
                 Configuration.PackageNames = Configuration.Input = TargetPackageName;
             }
@@ -4427,7 +4427,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_install_the_package()
             {
-                var packageFile = Path.Combine(Scenario.get_top_level(), "lib", TargetPackageName, "{0}.nupkg".FormatWith(TargetPackageName));
+                var packageFile = Path.Combine(Scenario.GetTopLevel(), "lib", TargetPackageName, "{0}.nupkg".FormatWith(TargetPackageName));
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
                     packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().Should().Be("2.0.0");
@@ -4437,7 +4437,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_upgrade_the_minimum_version_dependency()
             {
-                var packageFile = Path.Combine(Scenario.get_top_level(), "lib", DependencyName, "{0}.nupkg".FormatWith(DependencyName));
+                var packageFile = Path.Combine(Scenario.GetTopLevel(), "lib", DependencyName, "{0}.nupkg".FormatWith(DependencyName));
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
                     packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().Should().Be("2.0.0");

--- a/src/chocolatey.tests.integration/scenarios/ListScenarios.cs
+++ b/src/chocolatey.tests.integration/scenarios/ListScenarios.cs
@@ -35,12 +35,12 @@ namespace chocolatey.tests.integration.scenarios
 
             public override void Context()
             {
-                Configuration = Scenario.list();
-                Scenario.reset(Configuration);
-                Scenario.add_packages_to_source_location(Configuration, Configuration.Input + "*" + NuGetConstants.PackageExtension);
-                Scenario.add_packages_to_source_location(Configuration, "installpackage*" + NuGetConstants.PackageExtension);
-                Scenario.install_package(Configuration, "installpackage", "1.0.0");
-                Scenario.install_package(Configuration, "upgradepackage", "1.0.0");
+                Configuration = Scenario.List();
+                Scenario.Reset(Configuration);
+                Scenario.AddPackagesToSourceLocation(Configuration, Configuration.Input + "*" + NuGetConstants.PackageExtension);
+                Scenario.AddPackagesToSourceLocation(Configuration, "installpackage*" + NuGetConstants.PackageExtension);
+                Scenario.InstallPackage(Configuration, "installpackage", "1.0.0");
+                Scenario.InstallPackage(Configuration, "upgradepackage", "1.0.0");
 
                 Service = NUnitSetup.Container.GetInstance<IChocolateyPackageService>();
                 Configuration.ListCommand.LocalOnly = true;
@@ -207,8 +207,8 @@ namespace chocolatey.tests.integration.scenarios
             public override void Context()
             {
                 base.Context();
-                Scenario.add_packages_to_source_location(Configuration, "UpperCase" + "*" + NuGetConstants.PackageExtension);
-                Scenario.install_package(Configuration, "UpperCase", "1.1.0");
+                Scenario.AddPackagesToSourceLocation(Configuration, "UpperCase" + "*" + NuGetConstants.PackageExtension);
+                Scenario.InstallPackage(Configuration, "UpperCase", "1.1.0");
             }
 
             public override void Because()

--- a/src/chocolatey.tests.integration/scenarios/PackScenarios.cs
+++ b/src/chocolatey.tests.integration/scenarios/PackScenarios.cs
@@ -50,8 +50,8 @@ namespace chocolatey.tests.integration.scenarios
 
             public override void BeforeEachSpec()
             {
-                Configuration = Scenario.pack();
-                Scenario.reset(Configuration);
+                Configuration = Scenario.Pack();
+                Scenario.Reset(Configuration);
 
                 Service = NUnitSetup.Container.GetInstance<INugetService>();
                 MockLogger.Reset();
@@ -60,7 +60,7 @@ namespace chocolatey.tests.integration.scenarios
 
             protected void AddFile(string fileName, string fileContent)
             {
-                Scenario.add_files(new[] { new Tuple<string, string>(fileName, fileContent) });
+                Scenario.AddFiles(new[] { new Tuple<string, string>(fileName, fileContent) });
             }
         }
 
@@ -113,7 +113,7 @@ namespace chocolatey.tests.integration.scenarios
                 {
                     if (string.IsNullOrEmpty(ExpectedSubDirectory))
                     {
-                        return Path.Combine(Scenario.get_top_level(), "test-package." + ExpectedPathVersion + ".nupkg");
+                        return Path.Combine(Scenario.GetTopLevel(), "test-package." + ExpectedPathVersion + ".nupkg");
                     }
 
                     return Path.Combine(ExpectedSubDirectory, "test-package." + ExpectedPathVersion + ".nupkg");
@@ -128,14 +128,14 @@ namespace chocolatey.tests.integration.scenarios
 
             public override void Context()
             {
-                Configuration = Scenario.pack();
-                Scenario.reset(Configuration);
-                Scenario.add_files(new[] { new Tuple<string, string>("myPackage.nuspec", GetNuspecContent()) });
+                Configuration = Scenario.Pack();
+                Scenario.Reset(Configuration);
+                Scenario.AddFiles(new[] { new Tuple<string, string>("myPackage.nuspec", GetNuspecContent()) });
 
                 if (!string.IsNullOrEmpty(ExpectedSubDirectory))
                 {
                     Configuration.OutputDirectory = ExpectedSubDirectory;
-                    Scenario.create_directory(Configuration.OutputDirectory);
+                    Scenario.CreateDirectory(Configuration.OutputDirectory);
                 }
 
                 Service = NUnitSetup.Container.GetInstance<INugetService>();
@@ -182,7 +182,7 @@ namespace chocolatey.tests.integration.scenarios
             {
                 if (string.IsNullOrEmpty(ExpectedSubDirectory))
                 {
-                    Configuration.Sources.Should().Be(Scenario.get_top_level());
+                    Configuration.Sources.Should().Be(Scenario.GetTopLevel());
                 }
                 else
                 {
@@ -415,10 +415,10 @@ namespace chocolatey.tests.integration.scenarios
             {
                 base.Context();
 
-                Scenario.reset(Configuration);
+                Scenario.Reset(Configuration);
                 Configuration.Version = "0.1.0";
                 Configuration.PackCommand.Properties.Add("commitId", "1234abcd");
-                Scenario.add_files(new[] { new Tuple<string, string>("myPackage.nuspec", NuspecContentWithVariables) });
+                Scenario.AddFiles(new[] { new Tuple<string, string>("myPackage.nuspec", NuspecContentWithVariables) });
             }
 
             public override void Because()

--- a/src/chocolatey.tests.integration/scenarios/PinScenarios.cs
+++ b/src/chocolatey.tests.integration/scenarios/PinScenarios.cs
@@ -44,13 +44,13 @@ namespace chocolatey.tests.integration.scenarios
 
             public override void Context()
             {
-                Configuration = Scenario.pin();
-                Scenario.reset(Configuration);
-                Scenario.add_packages_to_source_location(Configuration, Configuration.Input + "*" + NuGetConstants.PackageExtension);
-                Scenario.add_packages_to_source_location(Configuration, "installpackage*" + NuGetConstants.PackageExtension);
-                Scenario.install_package(Configuration, "installpackage", "1.0.0");
-                Scenario.install_package(Configuration, "upgradepackage", "1.0.0");
-                Scenario.install_package(Configuration, "hasdependency", "1.0.0");
+                Configuration = Scenario.Pin();
+                Scenario.Reset(Configuration);
+                Scenario.AddPackagesToSourceLocation(Configuration, Configuration.Input + "*" + NuGetConstants.PackageExtension);
+                Scenario.AddPackagesToSourceLocation(Configuration, "installpackage*" + NuGetConstants.PackageExtension);
+                Scenario.InstallPackage(Configuration, "installpackage", "1.0.0");
+                Scenario.InstallPackage(Configuration, "upgradepackage", "1.0.0");
+                Scenario.InstallPackage(Configuration, "hasdependency", "1.0.0");
 
                 var commands = NUnitSetup.Container.GetAllInstances<ICommand>();
                 Service = commands.Where(

--- a/src/chocolatey.tests.integration/scenarios/SearchScenarios.cs
+++ b/src/chocolatey.tests.integration/scenarios/SearchScenarios.cs
@@ -37,12 +37,12 @@ namespace chocolatey.tests.integration.scenarios
 
             public override void Context()
             {
-                Configuration = Scenario.search();
-                Scenario.reset(Configuration);
-                Scenario.add_packages_to_source_location(Configuration, Configuration.Input + "*" + NuGetConstants.PackageExtension);
-                Scenario.add_packages_to_source_location(Configuration, "installpackage*" + NuGetConstants.PackageExtension);
-                Scenario.install_package(Configuration, "installpackage", "1.0.0");
-                Scenario.install_package(Configuration, "upgradepackage", "1.0.0");
+                Configuration = Scenario.Search();
+                Scenario.Reset(Configuration);
+                Scenario.AddPackagesToSourceLocation(Configuration, Configuration.Input + "*" + NuGetConstants.PackageExtension);
+                Scenario.AddPackagesToSourceLocation(Configuration, "installpackage*" + NuGetConstants.PackageExtension);
+                Scenario.InstallPackage(Configuration, "installpackage", "1.0.0");
+                Scenario.InstallPackage(Configuration, "upgradepackage", "1.0.0");
 
                 Service = NUnitSetup.Container.GetInstance<IChocolateyPackageService>();
             }
@@ -59,8 +59,8 @@ namespace chocolatey.tests.integration.scenarios
 
                 Configuration.Sources = string.Join(";", new[]
                 {
-                    Scenario.add_packages_to_priority_source_location(Configuration, "upgradepackage.1.1.0" + NuGetConstants.PackageExtension, name: "NormalPriority"),
-                    Scenario.add_packages_to_priority_source_location(Configuration, "upgradepackage.1.0.0" + NuGetConstants.PackageExtension, priority: 1)
+                    Scenario.AddPackagesToPrioritySourceLocation(Configuration, "upgradepackage.1.1.0" + NuGetConstants.PackageExtension, name: "NormalPriority"),
+                    Scenario.AddPackagesToPrioritySourceLocation(Configuration, "upgradepackage.1.0.0" + NuGetConstants.PackageExtension, priority: 1)
                 });
 
                 Service = NUnitSetup.Container.GetInstance<IChocolateyPackageService>();
@@ -93,12 +93,12 @@ namespace chocolatey.tests.integration.scenarios
 
                 Configuration.Sources = string.Join(";", new[]
                 {
-                    Scenario.add_packages_to_priority_source_location(Configuration, "upgradepackage.1.1.0" + NuGetConstants.PackageExtension, name: "NormalPriority"),
-                    Scenario.add_packages_to_priority_source_location(Configuration, "upgradepackage.1.0.0" + NuGetConstants.PackageExtension, priority: 1)
+                    Scenario.AddPackagesToPrioritySourceLocation(Configuration, "upgradepackage.1.1.0" + NuGetConstants.PackageExtension, name: "NormalPriority"),
+                    Scenario.AddPackagesToPrioritySourceLocation(Configuration, "upgradepackage.1.0.0" + NuGetConstants.PackageExtension, priority: 1)
                 });
 
-                Scenario.add_packages_to_priority_source_location(Configuration, "upgradepackage.1.1.1-beta2" + NuGetConstants.PackageExtension, name: "NormalPriority");
-                Scenario.add_packages_to_priority_source_location(Configuration, "upgradepackage.1.1.1-beta" + NuGetConstants.PackageExtension, priority: 1);
+                Scenario.AddPackagesToPrioritySourceLocation(Configuration, "upgradepackage.1.1.1-beta2" + NuGetConstants.PackageExtension, name: "NormalPriority");
+                Scenario.AddPackagesToPrioritySourceLocation(Configuration, "upgradepackage.1.1.1-beta" + NuGetConstants.PackageExtension, priority: 1);
 
                 Service = NUnitSetup.Container.GetInstance<IChocolateyPackageService>();
             }
@@ -131,13 +131,13 @@ namespace chocolatey.tests.integration.scenarios
 
                 Configuration.Sources = string.Join(";", new[]
                 {
-                    Scenario.add_packages_to_priority_source_location(Configuration, "hasdependency.*" + NuGetConstants.PackageExtension, name: "NormalPriority"),
-                    Scenario.add_packages_to_priority_source_location(Configuration, "isdependency.*" + NuGetConstants.PackageExtension, priority: 1)
+                    Scenario.AddPackagesToPrioritySourceLocation(Configuration, "hasdependency.*" + NuGetConstants.PackageExtension, name: "NormalPriority"),
+                    Scenario.AddPackagesToPrioritySourceLocation(Configuration, "isdependency.*" + NuGetConstants.PackageExtension, priority: 1)
                 });
 
-                Scenario.add_packages_to_priority_source_location(Configuration, "isexactdependency.1.1.0" + NuGetConstants.PackageExtension, name: "NormalPriority");
-                Scenario.add_packages_to_priority_source_location(Configuration, "isexactdependency.2.0.0" + NuGetConstants.PackageExtension, priority: 1);
-                Scenario.add_packages_to_priority_source_location(Configuration, "conflictingdependency.2.0.0" + NuGetConstants.PackageExtension, priority: 1);
+                Scenario.AddPackagesToPrioritySourceLocation(Configuration, "isexactdependency.1.1.0" + NuGetConstants.PackageExtension, name: "NormalPriority");
+                Scenario.AddPackagesToPrioritySourceLocation(Configuration, "isexactdependency.2.0.0" + NuGetConstants.PackageExtension, priority: 1);
+                Scenario.AddPackagesToPrioritySourceLocation(Configuration, "conflictingdependency.2.0.0" + NuGetConstants.PackageExtension, priority: 1);
 
 
                 Service = NUnitSetup.Container.GetInstance<IChocolateyPackageService>();
@@ -407,9 +407,9 @@ namespace chocolatey.tests.integration.scenarios
         {
             public override void Context()
             {
-                Configuration = Scenario.search();
-                Scenario.reset(Configuration);
-                Scenario.add_packages_to_source_location(Configuration, "exactpackage*" + NuGetConstants.PackageExtension);
+                Configuration = Scenario.Search();
+                Scenario.Reset(Configuration);
+                Scenario.AddPackagesToSourceLocation(Configuration, "exactpackage*" + NuGetConstants.PackageExtension);
                 Service = NUnitSetup.Container.GetInstance<IChocolateyPackageService>();
 
                 Configuration.ListCommand.Exact = true;
@@ -470,9 +470,9 @@ namespace chocolatey.tests.integration.scenarios
         {
             public override void Context()
             {
-                Configuration = Scenario.search();
-                Scenario.reset(Configuration);
-                Scenario.add_packages_to_source_location(Configuration, "exactpackage*" + NuGetConstants.PackageExtension);
+                Configuration = Scenario.Search();
+                Scenario.Reset(Configuration);
+                Scenario.AddPackagesToSourceLocation(Configuration, "exactpackage*" + NuGetConstants.PackageExtension);
                 Service = NUnitSetup.Container.GetInstance<IChocolateyPackageService>();
 
                 Configuration.ListCommand.Exact = true;
@@ -529,9 +529,9 @@ namespace chocolatey.tests.integration.scenarios
         {
             public override void Context()
             {
-                Configuration = Scenario.search();
-                Scenario.reset(Configuration);
-                Scenario.add_packages_to_source_location(Configuration, "exactpackage*" + NuGetConstants.PackageExtension);
+                Configuration = Scenario.Search();
+                Scenario.Reset(Configuration);
+                Scenario.AddPackagesToSourceLocation(Configuration, "exactpackage*" + NuGetConstants.PackageExtension);
                 Service = NUnitSetup.Container.GetInstance<IChocolateyPackageService>();
 
                 Configuration.ListCommand.Exact = true;
@@ -576,12 +576,12 @@ namespace chocolatey.tests.integration.scenarios
         {
             public override void Context()
             {
-                Configuration = Scenario.search();
-                Scenario.reset(Configuration);
-                Scenario.add_packages_to_source_location(Configuration, "upgradepackage*" + NuGetConstants.PackageExtension);
-                Scenario.add_packages_to_source_location(Configuration, "installpackage*" + NuGetConstants.PackageExtension);
-                Scenario.add_packages_to_source_location(Configuration, "isexactversiondependency*" + NuGetConstants.PackageExtension);
-                var secondSource = Path.Combine(Scenario.get_top_level(), "infrastructure");
+                Configuration = Scenario.Search();
+                Scenario.Reset(Configuration);
+                Scenario.AddPackagesToSourceLocation(Configuration, "upgradepackage*" + NuGetConstants.PackageExtension);
+                Scenario.AddPackagesToSourceLocation(Configuration, "installpackage*" + NuGetConstants.PackageExtension);
+                Scenario.AddPackagesToSourceLocation(Configuration, "isexactversiondependency*" + NuGetConstants.PackageExtension);
+                var secondSource = Path.Combine(Scenario.GetTopLevel(), "infrastructure");
                 Configuration.Sources = Configuration.Sources + ";" + secondSource;
                 Service = NUnitSetup.Container.GetInstance<IChocolateyPackageService>();
 
@@ -626,9 +626,9 @@ namespace chocolatey.tests.integration.scenarios
         {
             public override void Context()
             {
-                Configuration = Scenario.search();
-                Scenario.reset(Configuration);
-                Scenario.add_packages_to_source_location(Configuration, "exactpackage*" + NuGetConstants.PackageExtension);
+                Configuration = Scenario.Search();
+                Scenario.Reset(Configuration);
+                Scenario.AddPackagesToSourceLocation(Configuration, "exactpackage*" + NuGetConstants.PackageExtension);
                 Service = NUnitSetup.Container.GetInstance<IChocolateyPackageService>();
 
                 Configuration.ListCommand.Exact = true;

--- a/src/chocolatey.tests.integration/scenarios/UninstallScenarios.cs
+++ b/src/chocolatey.tests.integration/scenarios/UninstallScenarios.cs
@@ -43,14 +43,14 @@ namespace chocolatey.tests.integration.scenarios
 
             public override void Context()
             {
-                Configuration = Scenario.uninstall();
-                Scenario.reset(Configuration);
+                Configuration = Scenario.Uninstall();
+                Scenario.Reset(Configuration);
                 Configuration.PackageNames = Configuration.Input = "installpackage";
-                Scenario.add_packages_to_source_location(Configuration, Configuration.Input + "*" +  NuGetConstants.PackageExtension);
-                Scenario.install_package(Configuration, "installpackage", "1.0.0");
-                Scenario.add_packages_to_source_location(Configuration, "badpackage*" +  NuGetConstants.PackageExtension);
+                Scenario.AddPackagesToSourceLocation(Configuration, Configuration.Input + "*" + NuGetConstants.PackageExtension);
+                Scenario.InstallPackage(Configuration, "installpackage", "1.0.0");
+                Scenario.AddPackagesToSourceLocation(Configuration, "badpackage*" + NuGetConstants.PackageExtension);
                 Configuration.SkipPackageInstallProvider = true;
-                Scenario.install_package(Configuration, "badpackage", "1.0");
+                Scenario.InstallPackage(Configuration, "badpackage", "1.0");
                 Configuration.SkipPackageInstallProvider = false;
 
                 Service = NUnitSetup.Container.GetInstance<IChocolateyPackageService>();
@@ -75,7 +75,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_not_uninstall_a_package_from_the_lib_directory()
             {
-                var packageDir = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames);
+                var packageDir = Path.Combine(Scenario.GetTopLevel(), "lib", Configuration.PackageNames);
 
                 DirectoryAssert.Exists(packageDir);
             }
@@ -128,18 +128,18 @@ namespace chocolatey.tests.integration.scenarios
 
         public class When_uninstalling_a_package_happy_path : ScenariosBase
         {
-            private PackageResult packageResult;
+            private PackageResult _packageResult;
 
             public override void Because()
             {
                 Results = Service.Uninstall(Configuration);
-                packageResult = Results.FirstOrDefault().Value;
+                _packageResult = Results.FirstOrDefault().Value;
             }
 
             [Fact]
             public void Should_remove_the_package_from_the_lib_directory()
             {
-                var packageDir = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames);
+                var packageDir = Path.Combine(Scenario.GetTopLevel(), "lib", Configuration.PackageNames);
 
                 DirectoryAssert.DoesNotExist(packageDir);
             }
@@ -147,7 +147,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_delete_the_rollback()
             {
-                var packageDir = Path.Combine(Scenario.get_top_level(), "lib-bkp", Configuration.PackageNames);
+                var packageDir = Path.Combine(Scenario.GetTopLevel(), "lib-bkp", Configuration.PackageNames);
 
                 DirectoryAssert.DoesNotExist(packageDir);
             }
@@ -157,7 +157,7 @@ namespace chocolatey.tests.integration.scenarios
             [Platform(Exclude = "Mono")]
             public void Should_delete_a_shim_for_console_in_the_bin_directory()
             {
-                var shimfile = Path.Combine(Scenario.get_top_level(), "bin", "console.exe");
+                var shimfile = Path.Combine(Scenario.GetTopLevel(), "bin", "console.exe");
 
                 FileAssert.DoesNotExist(shimfile);
             }
@@ -167,7 +167,7 @@ namespace chocolatey.tests.integration.scenarios
             [Platform(Exclude = "Mono")]
             public void Should_delete_a_shim_for_graphical_in_the_bin_directory()
             {
-                var shimfile = Path.Combine(Scenario.get_top_level(), "bin", "graphical.exe");
+                var shimfile = Path.Combine(Scenario.GetTopLevel(), "bin", "graphical.exe");
 
                 FileAssert.DoesNotExist(shimfile);
             }
@@ -175,7 +175,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_delete_any_files_created_during_the_install()
             {
-                var generatedFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, "simplefile.txt");
+                var generatedFile = Path.Combine(Scenario.GetTopLevel(), "lib", Configuration.PackageNames, "simplefile.txt");
 
                 FileAssert.DoesNotExist(generatedFile);
             }
@@ -190,25 +190,25 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_have_a_successful_package_result()
             {
-                packageResult.Success.Should().BeTrue();
+                _packageResult.Success.Should().BeTrue();
             }
 
             [Fact]
             public void Should_not_have_inconclusive_package_result()
             {
-                packageResult.Inconclusive.Should().BeFalse();
+                _packageResult.Inconclusive.Should().BeFalse();
             }
 
             [Fact]
             public void Should_not_have_warning_package_result()
             {
-                packageResult.Warning.Should().BeFalse();
+                _packageResult.Warning.Should().BeFalse();
             }
 
             [Fact]
             public void Config_should_match_package_result_name()
             {
-                packageResult.Name.Should().Be(Configuration.PackageNames);
+                _packageResult.Name.Should().Be(Configuration.PackageNames);
             }
 
             [Fact]
@@ -232,7 +232,7 @@ namespace chocolatey.tests.integration.scenarios
 
         public class When_force_uninstalling_a_package : ScenariosBase
         {
-            private PackageResult packageResult;
+            private PackageResult _packageResult;
 
             public override void Context()
             {
@@ -243,13 +243,13 @@ namespace chocolatey.tests.integration.scenarios
             public override void Because()
             {
                 Results = Service.Uninstall(Configuration);
-                packageResult = Results.FirstOrDefault().Value;
+                _packageResult = Results.FirstOrDefault().Value;
             }
 
             [Fact]
             public void Should_remove_the_package_from_the_lib_directory()
             {
-                var packageDir = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames);
+                var packageDir = Path.Combine(Scenario.GetTopLevel(), "lib", Configuration.PackageNames);
 
                 DirectoryAssert.DoesNotExist(packageDir);
             }
@@ -257,7 +257,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_delete_the_rollback()
             {
-                var packageDir = Path.Combine(Scenario.get_top_level(), "lib-bkp", Configuration.PackageNames);
+                var packageDir = Path.Combine(Scenario.GetTopLevel(), "lib-bkp", Configuration.PackageNames);
 
                 DirectoryAssert.DoesNotExist(packageDir);
             }
@@ -265,7 +265,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_delete_a_shim_for_console_in_the_bin_directory()
             {
-                var shimfile = Path.Combine(Scenario.get_top_level(), "bin", "console.exe");
+                var shimfile = Path.Combine(Scenario.GetTopLevel(), "bin", "console.exe");
 
                 FileAssert.DoesNotExist(shimfile);
             }
@@ -273,7 +273,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_delete_a_shim_for_graphical_in_the_bin_directory()
             {
-                var shimfile = Path.Combine(Scenario.get_top_level(), "bin", "graphical.exe");
+                var shimfile = Path.Combine(Scenario.GetTopLevel(), "bin", "graphical.exe");
 
                 FileAssert.DoesNotExist(shimfile);
             }
@@ -288,25 +288,25 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_have_a_successful_package_result()
             {
-                packageResult.Success.Should().BeTrue();
+                _packageResult.Success.Should().BeTrue();
             }
 
             [Fact]
             public void Should_not_have_inconclusive_package_result()
             {
-                packageResult.Inconclusive.Should().BeFalse();
+                _packageResult.Inconclusive.Should().BeFalse();
             }
 
             [Fact]
             public void Should_not_have_warning_package_result()
             {
-                packageResult.Warning.Should().BeFalse();
+                _packageResult.Warning.Should().BeFalse();
             }
 
             [Fact]
             public void Config_should_match_package_result_name()
             {
-                packageResult.Name.Should().Be(Configuration.PackageNames);
+                _packageResult.Name.Should().Be(Configuration.PackageNames);
             }
         }
 
@@ -315,7 +315,7 @@ namespace chocolatey.tests.integration.scenarios
             public override void Context()
             {
                 base.Context();
-                var packagesConfig = "{0}{1}context{1}testing.packages.config".FormatWith(Scenario.get_top_level(), Path.DirectorySeparatorChar);
+                var packagesConfig = "{0}{1}context{1}testing.packages.config".FormatWith(Scenario.GetTopLevel(), Path.DirectorySeparatorChar);
                 Configuration.PackageNames = Configuration.Input = packagesConfig;
             }
 
@@ -341,7 +341,7 @@ namespace chocolatey.tests.integration.scenarios
             public override void Context()
             {
                 base.Context();
-                var fileToSetReadOnly = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, "tools", "chocolateyInstall.ps1");
+                var fileToSetReadOnly = Path.Combine(Scenario.GetTopLevel(), "lib", Configuration.PackageNames, "tools", "chocolateyInstall.ps1");
                 var fileSystem = new DotNetFileSystem();
                 fileSystem.EnsureFileAttributeSet(fileToSetReadOnly, FileAttributes.ReadOnly);
             }
@@ -355,7 +355,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_uninstall_the_package_from_the_lib_directory()
             {
-                var packageDir = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames);
+                var packageDir = Path.Combine(Scenario.GetTopLevel(), "lib", Configuration.PackageNames);
 
                 DirectoryAssert.DoesNotExist(packageDir);
             }
@@ -363,7 +363,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_delete_the_rollback()
             {
-                var packageDir = Path.Combine(Scenario.get_top_level(), "lib-bkp", Configuration.PackageNames);
+                var packageDir = Path.Combine(Scenario.GetTopLevel(), "lib-bkp", Configuration.PackageNames);
 
                 DirectoryAssert.DoesNotExist(packageDir);
             }
@@ -400,20 +400,20 @@ namespace chocolatey.tests.integration.scenarios
         {
             private PackageResult _packageResult;
 
-            private FileStream fileStream;
+            private FileStream _fileStream;
 
             public override void Context()
             {
                 base.Context();
-                var fileToOpen = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, "tools", "chocolateyInstall.ps1");
-                fileStream = new FileStream(fileToOpen, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.Read | FileShare.Delete);
+                var fileToOpen = Path.Combine(Scenario.GetTopLevel(), "lib", Configuration.PackageNames, "tools", "chocolateyInstall.ps1");
+                _fileStream = new FileStream(fileToOpen, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.Read | FileShare.Delete);
             }
 
             public override void AfterObservations()
             {
                 base.AfterObservations();
-                fileStream.Close();
-                fileStream.Dispose();
+                _fileStream.Close();
+                _fileStream.Dispose();
             }
 
             public override void Because()
@@ -425,7 +425,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_uninstall_the_package_from_the_lib_directory()
             {
-                var packageDir = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames);
+                var packageDir = Path.Combine(Scenario.GetTopLevel(), "lib", Configuration.PackageNames);
 
                 DirectoryAssert.DoesNotExist(packageDir);
             }
@@ -435,7 +435,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact, Platform(Exclude = "WindowsServer10")]
             public void Should_have_deleted_the_rollback()
             {
-                var packageDir = Path.Combine(Scenario.get_top_level(), "lib-bkp", Configuration.PackageNames);
+                var packageDir = Path.Combine(Scenario.GetTopLevel(), "lib-bkp", Configuration.PackageNames);
 
                 DirectoryAssert.DoesNotExist(packageDir);
             }
@@ -445,7 +445,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact, Platform("WindowsServer10")]
             public void Should_not_have_deleted_the_rollback_on_server()
             {
-                var packageDir = Path.Combine(Scenario.get_top_level(), "lib-bkp", Configuration.PackageNames);
+                var packageDir = Path.Combine(Scenario.GetTopLevel(), "lib-bkp", Configuration.PackageNames);
 
                 DirectoryAssert.Exists(packageDir);
             }
@@ -482,20 +482,20 @@ namespace chocolatey.tests.integration.scenarios
         {
             private PackageResult _packageResult;
 
-            private FileStream fileStream;
+            private FileStream _fileStream;
 
             public override void Context()
             {
                 base.Context();
-                var fileToOpen = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, "tools", "chocolateyInstall.ps1");
-                fileStream = new FileStream(fileToOpen, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.None);
+                var fileToOpen = Path.Combine(Scenario.GetTopLevel(), "lib", Configuration.PackageNames, "tools", "chocolateyInstall.ps1");
+                _fileStream = new FileStream(fileToOpen, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.None);
             }
 
             public override void AfterObservations()
             {
                 base.AfterObservations();
-                fileStream.Close();
-                fileStream.Dispose();
+                _fileStream.Close();
+                _fileStream.Dispose();
             }
 
             public override void Because()
@@ -507,7 +507,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_not_be_able_to_remove_the_package_from_the_lib_directory()
             {
-                var packageDir = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames);
+                var packageDir = Path.Combine(Scenario.GetTopLevel(), "lib", Configuration.PackageNames);
 
                 DirectoryAssert.Exists(packageDir);
             }
@@ -515,7 +515,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_delete_the_rollback()
             {
-                var packageDir = Path.Combine(Scenario.get_top_level(), "lib-bkp", Configuration.PackageNames);
+                var packageDir = Path.Combine(Scenario.GetTopLevel(), "lib-bkp", Configuration.PackageNames);
 
                 DirectoryAssert.DoesNotExist(packageDir);
             }
@@ -523,7 +523,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_not_contain_old_files_in_directory()
             {
-                var shimFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, "tools", "console.exe");
+                var shimFile = Path.Combine(Scenario.GetTopLevel(), "lib", Configuration.PackageNames, "tools", "console.exe");
 
                 FileAssert.DoesNotExist(shimFile);
             }
@@ -531,7 +531,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_keep_locked_file_in_directory()
             {
-                var lockedFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, "tools", "chocolateyInstall.ps1");
+                var lockedFile = Path.Combine(Scenario.GetTopLevel(), "lib", Configuration.PackageNames, "tools", "chocolateyInstall.ps1");
 
                 FileAssert.Exists(lockedFile);
             }
@@ -571,25 +571,25 @@ namespace chocolatey.tests.integration.scenarios
 
         public class When_uninstalling_a_package_with_added_files : ScenariosBase
         {
-            private PackageResult packageResult;
+            private PackageResult _packageResult;
 
             public override void Context()
             {
                 base.Context();
-                var fileAdded = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, "dude.txt");
+                var fileAdded = Path.Combine(Scenario.GetTopLevel(), "lib", Configuration.PackageNames, "dude.txt");
                 File.WriteAllText(fileAdded, "hellow");
             }
 
             public override void Because()
             {
                 Results = Service.Uninstall(Configuration);
-                packageResult = Results.FirstOrDefault().Value;
+                _packageResult = Results.FirstOrDefault().Value;
             }
 
             [Fact]
             public void Should_keep_the_added_file()
             {
-                var fileAdded = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, "dude.txt");
+                var fileAdded = Path.Combine(Scenario.GetTopLevel(), "lib", Configuration.PackageNames, "dude.txt");
 
                 FileAssert.Exists(fileAdded);
             }
@@ -597,7 +597,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_delete_everything_but_the_added_file_from_the_package_directory()
             {
-                var files = Directory.GetFiles(Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames));
+                var files = Directory.GetFiles(Path.Combine(Scenario.GetTopLevel(), "lib", Configuration.PackageNames));
 
                 foreach (var file in files.OrEmpty())
                 {
@@ -608,7 +608,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_delete_the_rollback()
             {
-                var packageDir = Path.Combine(Scenario.get_top_level(), "lib-bkp", Configuration.PackageNames);
+                var packageDir = Path.Combine(Scenario.GetTopLevel(), "lib-bkp", Configuration.PackageNames);
 
                 DirectoryAssert.DoesNotExist(packageDir);
             }
@@ -618,7 +618,7 @@ namespace chocolatey.tests.integration.scenarios
             [Platform(Exclude = "Mono")]
             public void Should_delete_a_shim_for_console_in_the_bin_directory()
             {
-                var shimfile = Path.Combine(Scenario.get_top_level(), "bin", "console.exe");
+                var shimfile = Path.Combine(Scenario.GetTopLevel(), "bin", "console.exe");
 
                 FileAssert.DoesNotExist(shimfile);
             }
@@ -628,7 +628,7 @@ namespace chocolatey.tests.integration.scenarios
             [Platform(Exclude = "Mono")]
             public void Should_delete_a_shim_for_graphical_in_the_bin_directory()
             {
-                var shimfile = Path.Combine(Scenario.get_top_level(), "bin", "graphical.exe");
+                var shimfile = Path.Combine(Scenario.GetTopLevel(), "bin", "graphical.exe");
 
                 FileAssert.DoesNotExist(shimfile);
             }
@@ -643,49 +643,49 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_have_a_successful_package_result()
             {
-                packageResult.Success.Should().BeTrue();
+                _packageResult.Success.Should().BeTrue();
             }
 
             [Fact]
             public void Should_not_have_inconclusive_package_result()
             {
-                packageResult.Inconclusive.Should().BeFalse();
+                _packageResult.Inconclusive.Should().BeFalse();
             }
 
             [Fact]
             public void Should_not_have_warning_package_result()
             {
-                packageResult.Warning.Should().BeFalse();
+                _packageResult.Warning.Should().BeFalse();
             }
 
             [Fact]
             public void Config_should_match_package_result_name()
             {
-                packageResult.Name.Should().Be(Configuration.PackageNames);
+                _packageResult.Name.Should().Be(Configuration.PackageNames);
             }
         }
 
         public class When_uninstalling_a_package_with_changed_files : ScenariosBase
         {
-            private PackageResult packageResult;
+            private PackageResult _packageResult;
 
             public override void Context()
             {
                 base.Context();
-                var fileChanged = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, "tools", "chocolateyinstall.ps1");
+                var fileChanged = Path.Combine(Scenario.GetTopLevel(), "lib", Configuration.PackageNames, "tools", "chocolateyinstall.ps1");
                 File.WriteAllText(fileChanged, "hellow");
             }
 
             public override void Because()
             {
                 Results = Service.Uninstall(Configuration);
-                packageResult = Results.FirstOrDefault().Value;
+                _packageResult = Results.FirstOrDefault().Value;
             }
 
             [Fact]
             public void Should_keep_the_changed_file()
             {
-                var fileChanged = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, "tools", "chocolateyinstall.ps1");
+                var fileChanged = Path.Combine(Scenario.GetTopLevel(), "lib", Configuration.PackageNames, "tools", "chocolateyinstall.ps1");
 
                 FileAssert.Exists(fileChanged);
             }
@@ -693,7 +693,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_delete_everything_but_the_changed_file_from_the_package_directory()
             {
-                var files = Directory.GetFiles(Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames));
+                var files = Directory.GetFiles(Path.Combine(Scenario.GetTopLevel(), "lib", Configuration.PackageNames));
 
                 foreach (var file in files.OrEmpty())
                 {
@@ -704,7 +704,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_delete_the_rollback()
             {
-                var packageDir = Path.Combine(Scenario.get_top_level(), "lib-bkp", Configuration.PackageNames);
+                var packageDir = Path.Combine(Scenario.GetTopLevel(), "lib-bkp", Configuration.PackageNames);
 
                 DirectoryAssert.DoesNotExist(packageDir);
             }
@@ -714,7 +714,7 @@ namespace chocolatey.tests.integration.scenarios
             [Platform(Exclude = "Mono")]
             public void Should_delete_a_shim_for_console_in_the_bin_directory()
             {
-                var shimfile = Path.Combine(Scenario.get_top_level(), "bin", "console.exe");
+                var shimfile = Path.Combine(Scenario.GetTopLevel(), "bin", "console.exe");
 
                 FileAssert.DoesNotExist(shimfile);
             }
@@ -724,7 +724,7 @@ namespace chocolatey.tests.integration.scenarios
             [Platform(Exclude = "Mono")]
             public void Should_delete_a_shim_for_graphical_in_the_bin_directory()
             {
-                var shimfile = Path.Combine(Scenario.get_top_level(), "bin", "graphical.exe");
+                var shimfile = Path.Combine(Scenario.GetTopLevel(), "bin", "graphical.exe");
 
                 FileAssert.DoesNotExist(shimfile);
             }
@@ -739,38 +739,38 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_have_a_successful_package_result()
             {
-                packageResult.Success.Should().BeTrue();
+                _packageResult.Success.Should().BeTrue();
             }
 
             [Fact]
             public void Should_not_have_inconclusive_package_result()
             {
-                packageResult.Inconclusive.Should().BeFalse();
+                _packageResult.Inconclusive.Should().BeFalse();
             }
 
             [Fact]
             public void Should_not_have_warning_package_result()
             {
-                packageResult.Warning.Should().BeFalse();
+                _packageResult.Warning.Should().BeFalse();
             }
 
             [Fact]
             public void Config_should_match_package_result_name()
             {
-                packageResult.Name.Should().Be(Configuration.PackageNames);
+                _packageResult.Name.Should().Be(Configuration.PackageNames);
             }
         }
 
         public class When_force_uninstalling_a_package_with_added_and_changed_files : ScenariosBase
         {
-            private PackageResult packageResult;
+            private PackageResult _packageResult;
 
             public override void Context()
             {
                 base.Context();
-                var fileChanged = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, "tools", "chocolateyinstall.ps1");
+                var fileChanged = Path.Combine(Scenario.GetTopLevel(), "lib", Configuration.PackageNames, "tools", "chocolateyinstall.ps1");
                 File.WriteAllText(fileChanged, "hellow");
-                var fileAdded = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, "dude.txt");
+                var fileAdded = Path.Combine(Scenario.GetTopLevel(), "lib", Configuration.PackageNames, "dude.txt");
                 File.WriteAllText(fileAdded, "hellow");
                 Configuration.Force = true;
             }
@@ -778,13 +778,13 @@ namespace chocolatey.tests.integration.scenarios
             public override void Because()
             {
                 Results = Service.Uninstall(Configuration);
-                packageResult = Results.FirstOrDefault().Value;
+                _packageResult = Results.FirstOrDefault().Value;
             }
 
             [Fact]
             public void Should_remove_the_package_from_the_lib_directory()
             {
-                var packageDir = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames);
+                var packageDir = Path.Combine(Scenario.GetTopLevel(), "lib", Configuration.PackageNames);
 
                 DirectoryAssert.DoesNotExist(packageDir);
             }
@@ -792,7 +792,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_not_keep_the_added_file()
             {
-                var fileChanged = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, "dude.txt");
+                var fileChanged = Path.Combine(Scenario.GetTopLevel(), "lib", Configuration.PackageNames, "dude.txt");
 
                 FileAssert.DoesNotExist(fileChanged);
             }
@@ -800,7 +800,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_not_keep_the_changed_file()
             {
-                var fileChanged = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, "tools", "chocolateyinstall.ps1");
+                var fileChanged = Path.Combine(Scenario.GetTopLevel(), "lib", Configuration.PackageNames, "tools", "chocolateyinstall.ps1");
 
                 FileAssert.DoesNotExist(fileChanged);
             }
@@ -808,7 +808,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_delete_the_rollback()
             {
-                var packageDir = Path.Combine(Scenario.get_top_level(), "lib-bkp", Configuration.PackageNames);
+                var packageDir = Path.Combine(Scenario.GetTopLevel(), "lib-bkp", Configuration.PackageNames);
 
                 DirectoryAssert.DoesNotExist(packageDir);
             }
@@ -818,7 +818,7 @@ namespace chocolatey.tests.integration.scenarios
             [Platform(Exclude = "Mono")]
             public void Should_delete_a_shim_for_console_in_the_bin_directory()
             {
-                var shimfile = Path.Combine(Scenario.get_top_level(), "bin", "console.exe");
+                var shimfile = Path.Combine(Scenario.GetTopLevel(), "bin", "console.exe");
 
                 FileAssert.DoesNotExist(shimfile);
             }
@@ -828,7 +828,7 @@ namespace chocolatey.tests.integration.scenarios
             [Platform(Exclude = "Mono")]
             public void Should_delete_a_shim_for_graphical_in_the_bin_directory()
             {
-                var shimfile = Path.Combine(Scenario.get_top_level(), "bin", "graphical.exe");
+                var shimfile = Path.Combine(Scenario.GetTopLevel(), "bin", "graphical.exe");
 
                 FileAssert.DoesNotExist(shimfile);
             }
@@ -843,31 +843,31 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_have_a_successful_package_result()
             {
-                packageResult.Success.Should().BeTrue();
+                _packageResult.Success.Should().BeTrue();
             }
 
             [Fact]
             public void Should_not_have_inconclusive_package_result()
             {
-                packageResult.Inconclusive.Should().BeFalse();
+                _packageResult.Inconclusive.Should().BeFalse();
             }
 
             [Fact]
             public void Should_not_have_warning_package_result()
             {
-                packageResult.Warning.Should().BeFalse();
+                _packageResult.Warning.Should().BeFalse();
             }
 
             [Fact]
             public void Config_should_match_package_result_name()
             {
-                packageResult.Name.Should().Be(Configuration.PackageNames);
+                _packageResult.Name.Should().Be(Configuration.PackageNames);
             }
         }
 
         public class When_uninstalling_a_package_that_does_not_exist : ScenariosBase
         {
-            private PackageResult packageResult;
+            private PackageResult _packageResult;
 
             public override void Context()
             {
@@ -878,7 +878,7 @@ namespace chocolatey.tests.integration.scenarios
             public override void Because()
             {
                 Results = Service.Uninstall(Configuration);
-                packageResult = Results.FirstOrDefault().Value;
+                _packageResult = Results.FirstOrDefault().Value;
             }
 
             [Fact]
@@ -898,25 +898,25 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_not_have_a_successful_package_result()
             {
-                packageResult.Success.Should().BeFalse();
+                _packageResult.Success.Should().BeFalse();
             }
 
             [Fact]
             public void Should_not_have_inconclusive_package_result()
             {
-                packageResult.Inconclusive.Should().BeFalse();
+                _packageResult.Inconclusive.Should().BeFalse();
             }
 
             [Fact]
             public void Should_not_have_warning_package_result()
             {
-                packageResult.Warning.Should().BeFalse();
+                _packageResult.Warning.Should().BeFalse();
             }
 
             [Fact]
             public void Should_have_an_error_package_result()
             {
-                packageResult.Messages.Should().Contain(m => m.MessageType == ResultType.Error);
+                _packageResult.Messages.Should().Contain(m => m.MessageType == ResultType.Error);
             }
         }
 
@@ -924,7 +924,7 @@ namespace chocolatey.tests.integration.scenarios
         [Platform(Exclude = "Mono")]
         public class When_uninstalling_a_package_that_errors : ScenariosBase
         {
-            private PackageResult packageResult;
+            private PackageResult _packageResult;
 
             public override void Context()
             {
@@ -935,13 +935,13 @@ namespace chocolatey.tests.integration.scenarios
             public override void Because()
             {
                 Results = Service.Uninstall(Configuration);
-                packageResult = Results.FirstOrDefault().Value;
+                _packageResult = Results.FirstOrDefault().Value;
             }
 
             [Fact]
             public void Should_not_remove_package_from_the_lib_directory()
             {
-                var packageDir = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames);
+                var packageDir = Path.Combine(Scenario.GetTopLevel(), "lib", Configuration.PackageNames);
 
                 DirectoryAssert.Exists(packageDir);
             }
@@ -949,14 +949,14 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_still_have_the_package_file_in_the_directory()
             {
-                var packageFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, Configuration.PackageNames +  NuGetConstants.PackageExtension);
+                var packageFile = Path.Combine(Scenario.GetTopLevel(), "lib", Configuration.PackageNames, Configuration.PackageNames + NuGetConstants.PackageExtension);
                 FileAssert.Exists(packageFile);
             }
 
             [Fact]
             public void Should_put_the_package_in_the_lib_bad_directory()
             {
-                var packageDir = Path.Combine(Scenario.get_top_level(), "lib-bad", Configuration.PackageNames);
+                var packageDir = Path.Combine(Scenario.GetTopLevel(), "lib-bad", Configuration.PackageNames);
 
                 DirectoryAssert.Exists(packageDir);
             }
@@ -964,7 +964,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_delete_the_rollback()
             {
-                var packageDir = Path.Combine(Scenario.get_top_level(), "lib-bkp", Configuration.PackageNames);
+                var packageDir = Path.Combine(Scenario.GetTopLevel(), "lib-bkp", Configuration.PackageNames);
 
                 DirectoryAssert.DoesNotExist(packageDir);
             }
@@ -979,25 +979,25 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_not_have_a_successful_package_result()
             {
-                packageResult.Success.Should().BeFalse();
+                _packageResult.Success.Should().BeFalse();
             }
 
             [Fact]
             public void Should_not_have_inconclusive_package_result()
             {
-                packageResult.Inconclusive.Should().BeFalse();
+                _packageResult.Inconclusive.Should().BeFalse();
             }
 
             [Fact]
             public void Should_not_have_warning_package_result()
             {
-                packageResult.Warning.Should().BeFalse();
+                _packageResult.Warning.Should().BeFalse();
             }
 
             [Fact]
             public void Should_have_an_error_package_result()
             {
-                packageResult.Messages.Should().Contain(m => m.MessageType == ResultType.Error);
+                _packageResult.Messages.Should().Contain(m => m.MessageType == ResultType.Error);
             }
 
             [Fact]
@@ -1019,7 +1019,7 @@ namespace chocolatey.tests.integration.scenarios
             {
                 base.Context();
                 Configuration.PackageNames = Configuration.Input = "scriptpackage.hook";
-                Scenario.add_packages_to_source_location(Configuration, Configuration.Input + ".1.0.0" + NuGetConstants.PackageExtension);
+                Scenario.AddPackagesToSourceLocation(Configuration, Configuration.Input + ".1.0.0" + NuGetConstants.PackageExtension);
                 Service.Install(Configuration);
             }
 
@@ -1032,7 +1032,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_remove_the_package_from_the_lib_directory()
             {
-                var packageDir = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames);
+                var packageDir = Path.Combine(Scenario.GetTopLevel(), "lib", Configuration.PackageNames);
 
                 DirectoryAssert.DoesNotExist(packageDir);
             }
@@ -1040,7 +1040,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_delete_the_rollback()
             {
-                var packageDir = Path.Combine(Scenario.get_top_level(), "lib-bkp", Configuration.PackageNames);
+                var packageDir = Path.Combine(Scenario.GetTopLevel(), "lib-bkp", Configuration.PackageNames);
 
                 DirectoryAssert.DoesNotExist(packageDir);
             }
@@ -1079,7 +1079,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_remove_hooks_folder_for_the_package()
             {
-                var hooksDirectory = Path.Combine(Scenario.get_top_level(), "hooks", Configuration.PackageNames.Replace(".hook", string.Empty));
+                var hooksDirectory = Path.Combine(Scenario.GetTopLevel(), "hooks", Configuration.PackageNames.Replace(".hook", string.Empty));
 
                 DirectoryAssert.DoesNotExist(hooksDirectory);
             }
@@ -1092,8 +1092,8 @@ namespace chocolatey.tests.integration.scenarios
             public override void Context()
             {
                 base.Context();
-                Scenario.add_packages_to_source_location(Configuration, "scriptpackage.hook" + "*" + NuGetConstants.PackageExtension);
-                Scenario.install_package(Configuration, "scriptpackage.hook", "1.0.0");
+                Scenario.AddPackagesToSourceLocation(Configuration, "scriptpackage.hook" + "*" + NuGetConstants.PackageExtension);
+                Scenario.InstallPackage(Configuration, "scriptpackage.hook", "1.0.0");
             }
 
             public override void Because()
@@ -1105,7 +1105,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_remove_the_package_from_the_lib_directory()
             {
-                var packageDir = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames);
+                var packageDir = Path.Combine(Scenario.GetTopLevel(), "lib", Configuration.PackageNames);
 
                 DirectoryAssert.DoesNotExist(packageDir);
             }
@@ -1113,7 +1113,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_delete_the_rollback()
             {
-                var packageDir = Path.Combine(Scenario.get_top_level(), "lib-bkp", Configuration.PackageNames);
+                var packageDir = Path.Combine(Scenario.GetTopLevel(), "lib-bkp", Configuration.PackageNames);
 
                 DirectoryAssert.DoesNotExist(packageDir);
             }
@@ -1123,7 +1123,7 @@ namespace chocolatey.tests.integration.scenarios
             [Platform(Exclude = "Mono")]
             public void Should_delete_a_shim_for_console_in_the_bin_directory()
             {
-                var shimfile = Path.Combine(Scenario.get_top_level(), "bin", "console.exe");
+                var shimfile = Path.Combine(Scenario.GetTopLevel(), "bin", "console.exe");
 
                 FileAssert.DoesNotExist(shimfile);
             }
@@ -1133,7 +1133,7 @@ namespace chocolatey.tests.integration.scenarios
             [Platform(Exclude = "Mono")]
             public void Should_delete_a_shim_for_graphical_in_the_bin_directory()
             {
-                var shimfile = Path.Combine(Scenario.get_top_level(), "bin", "graphical.exe");
+                var shimfile = Path.Combine(Scenario.GetTopLevel(), "bin", "graphical.exe");
 
                 FileAssert.DoesNotExist(shimfile);
             }
@@ -1141,7 +1141,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_delete_any_files_created_during_the_install()
             {
-                var generatedFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, "simplefile.txt");
+                var generatedFile = Path.Combine(Scenario.GetTopLevel(), "lib", Configuration.PackageNames, "simplefile.txt");
 
                 FileAssert.DoesNotExist(generatedFile);
             }
@@ -1261,13 +1261,13 @@ namespace chocolatey.tests.integration.scenarios
 
         public class When_uninstalling_a_package_with_uppercase_id : ScenariosBase
         {
-            private PackageResult packageResult;
+            private PackageResult _packageResult;
 
             public override void Context()
             {
                 base.Context();
-                Scenario.add_packages_to_source_location(Configuration, "UpperCase" + "*" + NuGetConstants.PackageExtension);
-                Scenario.install_package(Configuration, "UpperCase", "1.1.0");
+                Scenario.AddPackagesToSourceLocation(Configuration, "UpperCase" + "*" + NuGetConstants.PackageExtension);
+                Scenario.InstallPackage(Configuration, "UpperCase", "1.1.0");
 
                 Configuration.PackageNames = Configuration.Input = "UpperCase";
             }
@@ -1275,13 +1275,13 @@ namespace chocolatey.tests.integration.scenarios
             public override void Because()
             {
                 Results = Service.Uninstall(Configuration);
-                packageResult = Results.FirstOrDefault().Value;
+                _packageResult = Results.FirstOrDefault().Value;
             }
 
             [Fact]
             public void Should_remove_the_package_from_the_lib_directory()
             {
-                var packageDir = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames);
+                var packageDir = Path.Combine(Scenario.GetTopLevel(), "lib", Configuration.PackageNames);
 
                 DirectoryAssert.DoesNotExist(packageDir);
             }
@@ -1289,7 +1289,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_delete_the_rollback()
             {
-                var packageDir = Path.Combine(Scenario.get_top_level(), "lib-bkp", Configuration.PackageNames);
+                var packageDir = Path.Combine(Scenario.GetTopLevel(), "lib-bkp", Configuration.PackageNames);
 
                 DirectoryAssert.DoesNotExist(packageDir);
             }
@@ -1304,25 +1304,25 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_have_a_successful_package_result()
             {
-                packageResult.Success.Should().BeTrue();
+                _packageResult.Success.Should().BeTrue();
             }
 
             [Fact]
             public void Should_not_have_inconclusive_package_result()
             {
-                packageResult.Inconclusive.Should().BeFalse();
+                _packageResult.Inconclusive.Should().BeFalse();
             }
 
             [Fact]
             public void Should_not_have_warning_package_result()
             {
-                packageResult.Warning.Should().BeFalse();
+                _packageResult.Warning.Should().BeFalse();
             }
 
             [Fact]
             public void Config_should_match_package_result_name()
             {
-                packageResult.Name.Should().Be(Configuration.PackageNames);
+                _packageResult.Name.Should().Be(Configuration.PackageNames);
             }
 
             [Fact]
@@ -1346,30 +1346,30 @@ namespace chocolatey.tests.integration.scenarios
 
         public class When_uninstalling_a_package_with_non_normalized_version : ScenariosBase
         {
-            private PackageResult packageResult;
+            private PackageResult _packageResult;
 
-            private string NonNormalizedVersion = "0004.0004.00005.00";
-            private string NormalizedVersion = "4.4.5";
+            private string _nonNormalizedVersion = "0004.0004.00005.00";
+            private string _normalizedVersion = "4.4.5";
 
             public override void Context()
             {
                 base.Context();
 
                 Configuration.PackageNames = Configuration.Input = "upgradepackage";
-                Scenario.add_changed_version_package_to_source_location(Configuration, "upgradepackage.1.1.0" + NuGetConstants.PackageExtension, NonNormalizedVersion);
-                Scenario.install_package(Configuration, "upgradepackage", NonNormalizedVersion);
+                Scenario.AddChangedVersionPackageToSourceLocation(Configuration, "upgradepackage.1.1.0" + NuGetConstants.PackageExtension, _nonNormalizedVersion);
+                Scenario.InstallPackage(Configuration, "upgradepackage", _nonNormalizedVersion);
             }
 
             public override void Because()
             {
                 Results = Service.Uninstall(Configuration);
-                packageResult = Results.FirstOrDefault().Value;
+                _packageResult = Results.FirstOrDefault().Value;
             }
 
             [Fact]
             public void Should_remove_the_package_from_the_lib_directory()
             {
-                var packageDir = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames);
+                var packageDir = Path.Combine(Scenario.GetTopLevel(), "lib", Configuration.PackageNames);
 
                 DirectoryAssert.DoesNotExist(packageDir);
             }
@@ -1377,7 +1377,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_delete_the_rollback()
             {
-                var packageDir = Path.Combine(Scenario.get_top_level(), "lib-bkp", Configuration.PackageNames);
+                var packageDir = Path.Combine(Scenario.GetTopLevel(), "lib-bkp", Configuration.PackageNames);
 
                 DirectoryAssert.DoesNotExist(packageDir);
             }
@@ -1387,7 +1387,7 @@ namespace chocolatey.tests.integration.scenarios
             [Platform(Exclude = "Mono")]
             public void Should_delete_a_shim_for_console_in_the_bin_directory()
             {
-                var shimfile = Path.Combine(Scenario.get_top_level(), "bin", "console.exe");
+                var shimfile = Path.Combine(Scenario.GetTopLevel(), "bin", "console.exe");
 
                 FileAssert.DoesNotExist(shimfile);
             }
@@ -1397,7 +1397,7 @@ namespace chocolatey.tests.integration.scenarios
             [Platform(Exclude = "Mono")]
             public void Should_delete_a_shim_for_graphical_in_the_bin_directory()
             {
-                var shimfile = Path.Combine(Scenario.get_top_level(), "bin", "graphical.exe");
+                var shimfile = Path.Combine(Scenario.GetTopLevel(), "bin", "graphical.exe");
 
                 FileAssert.DoesNotExist(shimfile);
             }
@@ -1405,7 +1405,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_delete_any_files_created_during_the_install()
             {
-                var generatedFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, "simplefile.txt");
+                var generatedFile = Path.Combine(Scenario.GetTopLevel(), "lib", Configuration.PackageNames, "simplefile.txt");
 
                 FileAssert.DoesNotExist(generatedFile);
             }
@@ -1420,25 +1420,25 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_have_a_successful_package_result()
             {
-                packageResult.Success.Should().BeTrue();
+                _packageResult.Success.Should().BeTrue();
             }
 
             [Fact]
             public void Should_not_have_inconclusive_package_result()
             {
-                packageResult.Inconclusive.Should().BeFalse();
+                _packageResult.Inconclusive.Should().BeFalse();
             }
 
             [Fact]
             public void Should_not_have_warning_package_result()
             {
-                packageResult.Warning.Should().BeFalse();
+                _packageResult.Warning.Should().BeFalse();
             }
 
             [Fact]
             public void Config_should_match_package_result_name()
             {
-                packageResult.Name.Should().Be(Configuration.PackageNames);
+                _packageResult.Name.Should().Be(Configuration.PackageNames);
             }
 
             [Fact]
@@ -1447,7 +1447,7 @@ namespace chocolatey.tests.integration.scenarios
             public void Should_have_executed_chocolateyBeforeModify_script()
             {
                 MockLogger.Messages.Should().ContainKey(LogLevel.Info.ToStringSafe())
-                    .WhoseValue.Should().Contain(m => m.Contains("upgradepackage {0} Before Modification".FormatWith(NormalizedVersion)));
+                    .WhoseValue.Should().Contain(m => m.Contains("upgradepackage {0} Before Modification".FormatWith(_normalizedVersion)));
             }
 
             [Fact]
@@ -1456,7 +1456,7 @@ namespace chocolatey.tests.integration.scenarios
             public void Should_have_executed_chocolateyUninstall_script()
             {
                 MockLogger.Messages.Should().ContainKey(LogLevel.Info.ToStringSafe())
-                    .WhoseValue.Should().Contain(m => m.Contains("upgradepackage {0} Uninstalled".FormatWith(NormalizedVersion)));
+                    .WhoseValue.Should().Contain(m => m.Contains("upgradepackage {0} Uninstalled".FormatWith(_normalizedVersion)));
             }
         }
 
@@ -1469,10 +1469,10 @@ namespace chocolatey.tests.integration.scenarios
             {
                 base.Context();
 
-                Scenario.add_packages_to_source_location(Configuration, "{0}.*".FormatWith(TargetPackageName) + NuGetConstants.PackageExtension);
-                Scenario.add_packages_to_source_location(Configuration, "{0}.*".FormatWith(DependencyName) + NuGetConstants.PackageExtension);
-                Scenario.install_package(Configuration, TargetPackageName, "1.0.0");
-                Scenario.install_package(Configuration, DependencyName, "1.0.0");
+                Scenario.AddPackagesToSourceLocation(Configuration, "{0}.*".FormatWith(TargetPackageName) + NuGetConstants.PackageExtension);
+                Scenario.AddPackagesToSourceLocation(Configuration, "{0}.*".FormatWith(DependencyName) + NuGetConstants.PackageExtension);
+                Scenario.InstallPackage(Configuration, TargetPackageName, "1.0.0");
+                Scenario.InstallPackage(Configuration, DependencyName, "1.0.0");
 
                 Configuration.PackageNames = Configuration.Input = TargetPackageName;
                 Configuration.ForceDependencies = true;
@@ -1486,14 +1486,14 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_uninstall_the_package()
             {
-                var packageFile = Path.Combine(Scenario.get_top_level(), "lib", TargetPackageName, "{0}.nupkg".FormatWith(TargetPackageName));
+                var packageFile = Path.Combine(Scenario.GetTopLevel(), "lib", TargetPackageName, "{0}.nupkg".FormatWith(TargetPackageName));
                 FileAssert.DoesNotExist(packageFile);
             }
 
             [Fact]
             public void Should_uninstall_the_dependency()
             {
-                var packageFile = Path.Combine(Scenario.get_top_level(), "lib", DependencyName, "{0}.nupkg".FormatWith(DependencyName));
+                var packageFile = Path.Combine(Scenario.GetTopLevel(), "lib", DependencyName, "{0}.nupkg".FormatWith(DependencyName));
                 FileAssert.DoesNotExist(packageFile);
             }
 

--- a/src/chocolatey.tests.integration/scenarios/UpgradeScenarios.cs
+++ b/src/chocolatey.tests.integration/scenarios/UpgradeScenarios.cs
@@ -46,16 +46,16 @@ namespace chocolatey.tests.integration.scenarios
 
             public override void Context()
             {
-                Configuration = Scenario.upgrade();
-                Scenario.reset(Configuration);
+                Configuration = Scenario.Upgrade();
+                Scenario.Reset(Configuration);
                 Configuration.PackageNames = Configuration.Input = "upgradepackage";
-                Scenario.add_packages_to_source_location(Configuration, Configuration.Input + "*" +  NuGetConstants.PackageExtension);
-                Scenario.add_packages_to_source_location(Configuration, "installpackage*" +  NuGetConstants.PackageExtension);
-                Scenario.add_packages_to_source_location(Configuration, "badpackage*" +  NuGetConstants.PackageExtension);
-                Scenario.install_package(Configuration, "installpackage", "1.0.0");
-                Scenario.install_package(Configuration, "upgradepackage", "1.0.0");
+                Scenario.AddPackagesToSourceLocation(Configuration, Configuration.Input + "*" + NuGetConstants.PackageExtension);
+                Scenario.AddPackagesToSourceLocation(Configuration, "installpackage*" + NuGetConstants.PackageExtension);
+                Scenario.AddPackagesToSourceLocation(Configuration, "badpackage*" + NuGetConstants.PackageExtension);
+                Scenario.InstallPackage(Configuration, "installpackage", "1.0.0");
+                Scenario.InstallPackage(Configuration, "upgradepackage", "1.0.0");
                 Configuration.SkipPackageInstallProvider = true;
-                Scenario.install_package(Configuration, "badpackage", "1.0");
+                Scenario.InstallPackage(Configuration, "badpackage", "1.0");
                 Configuration.SkipPackageInstallProvider = false;
 
                 Service = NUnitSetup.Container.GetInstance<IChocolateyPackageService>();
@@ -78,7 +78,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_contain_older_version_in_directory()
             {
-                var shimFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, "tools", "console.exe");
+                var shimFile = Path.Combine(Scenario.GetTopLevel(), "lib", Configuration.PackageNames, "tools", "console.exe");
 
                 File.ReadAllText(shimFile).Should().Be("1.0.0");
             }
@@ -100,7 +100,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_not_create_a_rollback()
             {
-                var packageDir = Path.Combine(Scenario.get_top_level(), "lib-bkp", Configuration.PackageNames);
+                var packageDir = Path.Combine(Scenario.GetTopLevel(), "lib-bkp", Configuration.PackageNames);
 
                 DirectoryAssert.DoesNotExist(packageDir);
             }
@@ -137,7 +137,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_not_create_a_rollback()
             {
-                var packageDir = Path.Combine(Scenario.get_top_level(), "lib-bkp", Configuration.PackageNames);
+                var packageDir = Path.Combine(Scenario.GetTopLevel(), "lib-bkp", Configuration.PackageNames);
 
                 DirectoryAssert.DoesNotExist(packageDir);
             }
@@ -191,7 +191,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_upgrade_a_package_in_the_lib_directory()
             {
-                var packageDir = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames);
+                var packageDir = Path.Combine(Scenario.GetTopLevel(), "lib", Configuration.PackageNames);
 
                 DirectoryAssert.Exists(packageDir);
             }
@@ -199,7 +199,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_delete_the_rollback()
             {
-                var packageDir = Path.Combine(Scenario.get_top_level(), "lib-bkp", Configuration.PackageNames);
+                var packageDir = Path.Combine(Scenario.GetTopLevel(), "lib-bkp", Configuration.PackageNames);
 
                 DirectoryAssert.DoesNotExist(packageDir);
             }
@@ -207,7 +207,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_contain_newer_version_in_directory()
             {
-                var shimFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, "tools", "console.exe");
+                var shimFile = Path.Combine(Scenario.GetTopLevel(), "lib", Configuration.PackageNames, "tools", "console.exe");
 
                 File.ReadAllText(shimFile).Should().Be("1.1.0");
             }
@@ -215,7 +215,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_upgrade_the_package()
             {
-                var packageFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, Configuration.PackageNames +  NuGetConstants.PackageExtension);
+                var packageFile = Path.Combine(Scenario.GetTopLevel(), "lib", Configuration.PackageNames, Configuration.PackageNames + NuGetConstants.PackageExtension);
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
                     packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().Should().Be("1.1.0");
@@ -321,9 +321,9 @@ namespace chocolatey.tests.integration.scenarios
             {
                 base.Context();
                 Configuration.Sources = string.Join(",",
-                    Scenario.add_packages_to_priority_source_location(Configuration, "upgradepackage.1.0.0" + NuGetConstants.PackageExtension, priority: 1),
-                    Scenario.add_packages_to_priority_source_location(Configuration, "upgradepackage.1.1.0" + NuGetConstants.PackageExtension, priority: 0));
-                Scenario.install_package(Configuration, "upgradepackage", "1.0.0");
+                    Scenario.AddPackagesToPrioritySourceLocation(Configuration, "upgradepackage.1.0.0" + NuGetConstants.PackageExtension, priority: 1),
+                    Scenario.AddPackagesToPrioritySourceLocation(Configuration, "upgradepackage.1.1.0" + NuGetConstants.PackageExtension, priority: 0));
+                Scenario.InstallPackage(Configuration, "upgradepackage", "1.0.0");
             }
 
             public override void Because()
@@ -349,7 +349,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_not_create_a_rollback()
             {
-                var packageDir = Path.Combine(Scenario.get_top_level(), "lib-bkp", Configuration.PackageNames);
+                var packageDir = Path.Combine(Scenario.GetTopLevel(), "lib-bkp", Configuration.PackageNames);
 
                 DirectoryAssert.DoesNotExist(packageDir);
             }
@@ -357,7 +357,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_not_remove_the_package_from_the_lib_directory()
             {
-                var packageDir = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames);
+                var packageDir = Path.Combine(Scenario.GetTopLevel(), "lib", Configuration.PackageNames);
 
                 DirectoryAssert.Exists(packageDir);
             }
@@ -365,7 +365,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_be_the_same_version_of_the_package()
             {
-                var packageFolder = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, Configuration.PackageNames + NuGetConstants.PackageExtension);
+                var packageFolder = Path.Combine(Scenario.GetTopLevel(), "lib", Configuration.PackageNames, Configuration.PackageNames + NuGetConstants.PackageExtension);
 
                 using (var reader = new PackageFolderReader(packageFolder))
                 {
@@ -405,7 +405,7 @@ namespace chocolatey.tests.integration.scenarios
             public override void Context()
             {
                 base.Context();
-                Scenario.install_package(Configuration, "upgradepackage", "1.1.0");
+                Scenario.InstallPackage(Configuration, "upgradepackage", "1.1.0");
             }
 
             public override void Because()
@@ -431,7 +431,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_not_create_a_rollback()
             {
-                var packageDir = Path.Combine(Scenario.get_top_level(), "lib-bkp", Configuration.PackageNames);
+                var packageDir = Path.Combine(Scenario.GetTopLevel(), "lib-bkp", Configuration.PackageNames);
 
                 DirectoryAssert.DoesNotExist(packageDir);
             }
@@ -439,7 +439,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_not_remove_the_package_from_the_lib_directory()
             {
-                var packageDir = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames);
+                var packageDir = Path.Combine(Scenario.GetTopLevel(), "lib", Configuration.PackageNames);
 
                 DirectoryAssert.Exists(packageDir);
             }
@@ -447,7 +447,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_be_the_same_version_of_the_package()
             {
-                var packageFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, Configuration.PackageNames +  NuGetConstants.PackageExtension);
+                var packageFile = Path.Combine(Scenario.GetTopLevel(), "lib", Configuration.PackageNames, Configuration.PackageNames + NuGetConstants.PackageExtension);
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
                     packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().Should().Be("1.1.0");
@@ -504,7 +504,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_upgrade_a_package_in_the_lib_directory()
             {
-                var packageDir = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames);
+                var packageDir = Path.Combine(Scenario.GetTopLevel(), "lib", Configuration.PackageNames);
 
                 DirectoryAssert.Exists(packageDir);
             }
@@ -512,7 +512,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_delete_the_rollback()
             {
-                var packageDir = Path.Combine(Scenario.get_top_level(), "lib-bkp", Configuration.PackageNames);
+                var packageDir = Path.Combine(Scenario.GetTopLevel(), "lib-bkp", Configuration.PackageNames);
 
                 DirectoryAssert.DoesNotExist(packageDir);
             }
@@ -520,7 +520,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_contain_newer_version_in_directory()
             {
-                var shimFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, "tools", "console.exe");
+                var shimFile = Path.Combine(Scenario.GetTopLevel(), "lib", Configuration.PackageNames, "tools", "console.exe");
 
                 File.ReadAllText(shimFile).Should().Be("1.1.1-beta2");
             }
@@ -528,7 +528,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_upgrade_the_package()
             {
-                var packageFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, Configuration.PackageNames + NuGetConstants.PackageExtension);
+                var packageFile = Path.Combine(Scenario.GetTopLevel(), "lib", Configuration.PackageNames, Configuration.PackageNames + NuGetConstants.PackageExtension);
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
                     var version = packageReader.NuspecReader.GetVersion();
@@ -637,7 +637,7 @@ namespace chocolatey.tests.integration.scenarios
             {
                 base.Context();
                 Configuration.Prerelease = true;
-                Scenario.remove_packages_from_destination_location(Configuration, "upgradepackage.1.1.1-beta2.nupkg");
+                Scenario.RemovePackagesFromDestinationLocation(Configuration, "upgradepackage.1.1.1-beta2.nupkg");
             }
 
             public override void Because()
@@ -655,7 +655,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_upgrade_a_package_in_the_lib_directory()
             {
-                var packageDir = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames);
+                var packageDir = Path.Combine(Scenario.GetTopLevel(), "lib", Configuration.PackageNames);
 
                 DirectoryAssert.Exists(packageDir);
             }
@@ -663,7 +663,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_delete_the_rollback()
             {
-                var packageDir = Path.Combine(Scenario.get_top_level(), "lib-bkp", Configuration.PackageNames);
+                var packageDir = Path.Combine(Scenario.GetTopLevel(), "lib-bkp", Configuration.PackageNames);
 
                 DirectoryAssert.DoesNotExist(packageDir);
             }
@@ -671,7 +671,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_contain_newer_version_in_directory()
             {
-                var shimFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, "tools", "console.exe");
+                var shimFile = Path.Combine(Scenario.GetTopLevel(), "lib", Configuration.PackageNames, "tools", "console.exe");
 
                 File.ReadAllText(shimFile).Should().Be("1.1.1-beta.1");
             }
@@ -679,7 +679,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_upgrade_the_package()
             {
-                var packageFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, Configuration.PackageNames + NuGetConstants.PackageExtension);
+                var packageFile = Path.Combine(Scenario.GetTopLevel(), "lib", Configuration.PackageNames, Configuration.PackageNames + NuGetConstants.PackageExtension);
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
                     var version = packageReader.NuspecReader.GetVersion();
@@ -787,7 +787,7 @@ namespace chocolatey.tests.integration.scenarios
             {
                 base.Context();
                 Configuration.Prerelease = true;
-                Scenario.install_package(Configuration, "upgradepackage", "1.1.1-beta");
+                Scenario.InstallPackage(Configuration, "upgradepackage", "1.1.1-beta");
                 Configuration.Prerelease = false;
             }
 
@@ -806,7 +806,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_upgrade_a_package_in_the_lib_directory()
             {
-                var packageDir = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames);
+                var packageDir = Path.Combine(Scenario.GetTopLevel(), "lib", Configuration.PackageNames);
 
                 DirectoryAssert.Exists(packageDir);
             }
@@ -814,7 +814,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_delete_the_rollback()
             {
-                var packageDir = Path.Combine(Scenario.get_top_level(), "lib-bkp", Configuration.PackageNames);
+                var packageDir = Path.Combine(Scenario.GetTopLevel(), "lib-bkp", Configuration.PackageNames);
 
                 DirectoryAssert.DoesNotExist(packageDir);
             }
@@ -822,7 +822,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_contain_newer_version_in_directory()
             {
-                var shimFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, "tools", "console.exe");
+                var shimFile = Path.Combine(Scenario.GetTopLevel(), "lib", Configuration.PackageNames, "tools", "console.exe");
 
                 File.ReadAllText(shimFile).Should().Be("1.1.1-beta2");
             }
@@ -830,7 +830,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_upgrade_the_package()
             {
-                var packageFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, Configuration.PackageNames + NuGetConstants.PackageExtension);
+                var packageFile = Path.Combine(Scenario.GetTopLevel(), "lib", Configuration.PackageNames, Configuration.PackageNames + NuGetConstants.PackageExtension);
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
                     var version = packageReader.NuspecReader.GetVersion();
@@ -937,8 +937,8 @@ namespace chocolatey.tests.integration.scenarios
             {
                 base.Context();
                 Configuration.Prerelease = true;
-                Scenario.install_package(Configuration, "upgradepackage", "1.1.1-beta");
-                Scenario.remove_packages_from_destination_location(Configuration, "upgradepackage.1.1.1-beta2.nupkg");
+                Scenario.InstallPackage(Configuration, "upgradepackage", "1.1.1-beta");
+                Scenario.RemovePackagesFromDestinationLocation(Configuration, "upgradepackage.1.1.1-beta2.nupkg");
                 Configuration.Prerelease = false;
             }
 
@@ -957,7 +957,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_upgrade_a_package_in_the_lib_directory()
             {
-                var packageDir = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames);
+                var packageDir = Path.Combine(Scenario.GetTopLevel(), "lib", Configuration.PackageNames);
 
                 DirectoryAssert.Exists(packageDir);
             }
@@ -965,7 +965,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_delete_the_rollback()
             {
-                var packageDir = Path.Combine(Scenario.get_top_level(), "lib-bkp", Configuration.PackageNames);
+                var packageDir = Path.Combine(Scenario.GetTopLevel(), "lib-bkp", Configuration.PackageNames);
 
                 DirectoryAssert.DoesNotExist(packageDir);
             }
@@ -973,7 +973,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_contain_newer_version_in_directory()
             {
-                var shimFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, "tools", "console.exe");
+                var shimFile = Path.Combine(Scenario.GetTopLevel(), "lib", Configuration.PackageNames, "tools", "console.exe");
 
                 File.ReadAllText(shimFile).Should().Be("1.1.1-beta.1");
             }
@@ -981,7 +981,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_upgrade_the_package()
             {
-                var packageFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, Configuration.PackageNames + NuGetConstants.PackageExtension);
+                var packageFile = Path.Combine(Scenario.GetTopLevel(), "lib", Configuration.PackageNames, Configuration.PackageNames + NuGetConstants.PackageExtension);
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
                     var version = packageReader.NuspecReader.GetVersion();
@@ -1088,7 +1088,7 @@ namespace chocolatey.tests.integration.scenarios
             {
                 base.Context();
                 Configuration.Prerelease = true;
-                Scenario.install_package(Configuration, "upgradepackage", "1.1.1-beta.1");
+                Scenario.InstallPackage(Configuration, "upgradepackage", "1.1.1-beta.1");
                 Configuration.Prerelease = false;
             }
 
@@ -1107,7 +1107,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_upgrade_a_package_in_the_lib_directory()
             {
-                var packageDir = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames);
+                var packageDir = Path.Combine(Scenario.GetTopLevel(), "lib", Configuration.PackageNames);
 
                 DirectoryAssert.Exists(packageDir);
             }
@@ -1115,7 +1115,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_delete_the_rollback()
             {
-                var packageDir = Path.Combine(Scenario.get_top_level(), "lib-bkp", Configuration.PackageNames);
+                var packageDir = Path.Combine(Scenario.GetTopLevel(), "lib-bkp", Configuration.PackageNames);
 
                 DirectoryAssert.DoesNotExist(packageDir);
             }
@@ -1123,7 +1123,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_contain_newer_version_in_directory()
             {
-                var shimFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, "tools", "console.exe");
+                var shimFile = Path.Combine(Scenario.GetTopLevel(), "lib", Configuration.PackageNames, "tools", "console.exe");
 
                 File.ReadAllText(shimFile).Should().Be("1.1.1-beta2");
             }
@@ -1131,7 +1131,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_upgrade_the_package()
             {
-                var packageFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, Configuration.PackageNames + NuGetConstants.PackageExtension);
+                var packageFile = Path.Combine(Scenario.GetTopLevel(), "lib", Configuration.PackageNames, Configuration.PackageNames + NuGetConstants.PackageExtension);
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
                     var version = packageReader.NuspecReader.GetVersion();
@@ -1237,7 +1237,7 @@ namespace chocolatey.tests.integration.scenarios
             {
                 base.Context();
                 Configuration.Prerelease = true;
-                Scenario.install_package(Configuration, "upgradepackage", "1.1.1-beta");
+                Scenario.InstallPackage(Configuration, "upgradepackage", "1.1.1-beta");
                 Configuration.Prerelease = false;
                 Configuration.UpgradeCommand.ExcludePrerelease = true;
             }
@@ -1265,7 +1265,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_not_create_a_rollback()
             {
-                var packageDir = Path.Combine(Scenario.get_top_level(), "lib-bkp", Configuration.PackageNames);
+                var packageDir = Path.Combine(Scenario.GetTopLevel(), "lib-bkp", Configuration.PackageNames);
 
                 DirectoryAssert.DoesNotExist(packageDir);
             }
@@ -1273,7 +1273,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_not_remove_the_package_from_the_lib_directory()
             {
-                var packageDir = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames);
+                var packageDir = Path.Combine(Scenario.GetTopLevel(), "lib", Configuration.PackageNames);
 
                 DirectoryAssert.Exists(packageDir);
             }
@@ -1281,7 +1281,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_be_the_same_version_of_the_package()
             {
-                var packageFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, Configuration.PackageNames +  NuGetConstants.PackageExtension);
+                var packageFile = Path.Combine(Scenario.GetTopLevel(), "lib", Configuration.PackageNames, Configuration.PackageNames + NuGetConstants.PackageExtension);
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
                     var version = packageReader.NuspecReader.GetVersion();
@@ -1324,7 +1324,7 @@ namespace chocolatey.tests.integration.scenarios
             {
                 base.Context();
                 Configuration.Prerelease = true;
-                Scenario.install_package(Configuration, "upgradepackage", "1.1.1-beta");
+                Scenario.InstallPackage(Configuration, "upgradepackage", "1.1.1-beta");
                 Configuration.Prerelease = false;
                 Configuration.UpgradeCommand.ExcludePrerelease = true;
                 Configuration.AllowDowngrade = true;
@@ -1353,7 +1353,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_not_create_a_rollback()
             {
-                var packageDir = Path.Combine(Scenario.get_top_level(), "lib-bkp", Configuration.PackageNames);
+                var packageDir = Path.Combine(Scenario.GetTopLevel(), "lib-bkp", Configuration.PackageNames);
 
                 DirectoryAssert.DoesNotExist(packageDir);
             }
@@ -1361,7 +1361,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_not_remove_the_package_from_the_lib_directory()
             {
-                var packageDir = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames);
+                var packageDir = Path.Combine(Scenario.GetTopLevel(), "lib", Configuration.PackageNames);
 
                 DirectoryAssert.Exists(packageDir);
             }
@@ -1369,7 +1369,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_be_the_same_version_of_the_package()
             {
-                var packageFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, Configuration.PackageNames +  NuGetConstants.PackageExtension);
+                var packageFile = Path.Combine(Scenario.GetTopLevel(), "lib", Configuration.PackageNames, Configuration.PackageNames + NuGetConstants.PackageExtension);
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
                     var version = packageReader.NuspecReader.GetVersion();
@@ -1429,7 +1429,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_upgrade_a_package_in_the_lib_directory()
             {
-                var packageDir = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames);
+                var packageDir = Path.Combine(Scenario.GetTopLevel(), "lib", Configuration.PackageNames);
 
                 DirectoryAssert.Exists(packageDir);
             }
@@ -1437,7 +1437,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_upgrade_the_package()
             {
-                var packageFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, Configuration.PackageNames +  NuGetConstants.PackageExtension);
+                var packageFile = Path.Combine(Scenario.GetTopLevel(), "lib", Configuration.PackageNames, Configuration.PackageNames + NuGetConstants.PackageExtension);
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
                     packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().Should().Be("1.1.0");
@@ -1447,7 +1447,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_delete_the_rollback()
             {
-                var packageDir = Path.Combine(Scenario.get_top_level(), "lib-bkp", Configuration.PackageNames);
+                var packageDir = Path.Combine(Scenario.GetTopLevel(), "lib-bkp", Configuration.PackageNames);
 
                 DirectoryAssert.DoesNotExist(packageDir);
             }
@@ -1455,7 +1455,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_contain_newer_version_in_directory()
             {
-                var shimFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, "tools", "console.exe");
+                var shimFile = Path.Combine(Scenario.GetTopLevel(), "lib", Configuration.PackageNames, "tools", "console.exe");
 
                 File.ReadAllText(shimFile).Should().Be("1.1.0");
             }
@@ -1541,7 +1541,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_not_create_a_rollback()
             {
-                var packageDir = Path.Combine(Scenario.get_top_level(), "lib-bkp", Configuration.PackageNames);
+                var packageDir = Path.Combine(Scenario.GetTopLevel(), "lib-bkp", Configuration.PackageNames);
 
                 DirectoryAssert.DoesNotExist(packageDir);
             }
@@ -1549,7 +1549,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_not_remove_the_package_from_the_lib_directory()
             {
-                var packageDir = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames);
+                var packageDir = Path.Combine(Scenario.GetTopLevel(), "lib", Configuration.PackageNames);
 
                 DirectoryAssert.Exists(packageDir);
             }
@@ -1557,7 +1557,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_be_the_same_version_of_the_package()
             {
-                var packageFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, Configuration.PackageNames +  NuGetConstants.PackageExtension);
+                var packageFile = Path.Combine(Scenario.GetTopLevel(), "lib", Configuration.PackageNames, Configuration.PackageNames + NuGetConstants.PackageExtension);
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
                     packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().Should().Be("1.0.0");
@@ -1623,7 +1623,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_not_create_a_rollback()
             {
-                var packageDir = Path.Combine(Scenario.get_top_level(), "lib-bkp", Configuration.PackageNames);
+                var packageDir = Path.Combine(Scenario.GetTopLevel(), "lib-bkp", Configuration.PackageNames);
 
                 DirectoryAssert.DoesNotExist(packageDir);
             }
@@ -1631,7 +1631,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_not_remove_the_package_from_the_lib_directory()
             {
-                var packageDir = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames);
+                var packageDir = Path.Combine(Scenario.GetTopLevel(), "lib", Configuration.PackageNames);
 
                 DirectoryAssert.Exists(packageDir);
             }
@@ -1639,7 +1639,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_be_the_same_version_of_the_package()
             {
-                var packageFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, Configuration.PackageNames +  NuGetConstants.PackageExtension);
+                var packageFile = Path.Combine(Scenario.GetTopLevel(), "lib", Configuration.PackageNames, Configuration.PackageNames + NuGetConstants.PackageExtension);
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
                     packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().Should().Be("1.0.0");
@@ -1676,7 +1676,7 @@ namespace chocolatey.tests.integration.scenarios
             public override void Context()
             {
                 base.Context();
-                var packagesConfig = "{0}{1}context{1}testing.packages.config".FormatWith(Scenario.get_top_level(), Path.DirectorySeparatorChar);
+                var packagesConfig = "{0}{1}context{1}testing.packages.config".FormatWith(Scenario.GetTopLevel(), Path.DirectorySeparatorChar);
                 Configuration.PackageNames = Configuration.Input = packagesConfig;
             }
 
@@ -1702,7 +1702,7 @@ namespace chocolatey.tests.integration.scenarios
             public override void Context()
             {
                 base.Context();
-                var fileToSetReadOnly = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, "tools", "chocolateyInstall.ps1");
+                var fileToSetReadOnly = Path.Combine(Scenario.GetTopLevel(), "lib", Configuration.PackageNames, "tools", "chocolateyInstall.ps1");
                 var fileSystem = new DotNetFileSystem();
                 fileSystem.EnsureFileAttributeSet(fileToSetReadOnly, FileAttributes.ReadOnly);
             }
@@ -1722,7 +1722,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_upgrade_a_package_in_the_lib_directory()
             {
-                var packageDir = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames);
+                var packageDir = Path.Combine(Scenario.GetTopLevel(), "lib", Configuration.PackageNames);
 
                 DirectoryAssert.Exists(packageDir);
             }
@@ -1730,7 +1730,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_upgrade_the_package()
             {
-                var packageFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, Configuration.PackageNames +  NuGetConstants.PackageExtension);
+                var packageFile = Path.Combine(Scenario.GetTopLevel(), "lib", Configuration.PackageNames, Configuration.PackageNames + NuGetConstants.PackageExtension);
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
                     packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().Should().Be("1.1.0");
@@ -1740,7 +1740,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_delete_the_rollback()
             {
-                var packageDir = Path.Combine(Scenario.get_top_level(), "lib-bkp", Configuration.PackageNames);
+                var packageDir = Path.Combine(Scenario.GetTopLevel(), "lib-bkp", Configuration.PackageNames);
 
                 DirectoryAssert.DoesNotExist(packageDir);
             }
@@ -1748,7 +1748,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_contain_newer_version_in_directory()
             {
-                var shimFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, "tools", "console.exe");
+                var shimFile = Path.Combine(Scenario.GetTopLevel(), "lib", Configuration.PackageNames, "tools", "console.exe");
 
                 File.ReadAllText(shimFile).Should().Be("1.1.0");
             }
@@ -1800,7 +1800,7 @@ namespace chocolatey.tests.integration.scenarios
             public override void Context()
             {
                 base.Context();
-                var fileToOpen = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, "tools", "chocolateyInstall.ps1");
+                var fileToOpen = Path.Combine(Scenario.GetTopLevel(), "lib", Configuration.PackageNames, "tools", "chocolateyInstall.ps1");
                 _fileStream = new FileStream(fileToOpen, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.Read | FileShare.Delete);
             }
 
@@ -1826,7 +1826,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_upgrade_a_package_in_the_lib_directory()
             {
-                var packageDir = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames);
+                var packageDir = Path.Combine(Scenario.GetTopLevel(), "lib", Configuration.PackageNames);
 
                 DirectoryAssert.Exists(packageDir);
             }
@@ -1834,7 +1834,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_upgrade_the_package()
             {
-                var packageFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, Configuration.PackageNames +  NuGetConstants.PackageExtension);
+                var packageFile = Path.Combine(Scenario.GetTopLevel(), "lib", Configuration.PackageNames, Configuration.PackageNames + NuGetConstants.PackageExtension);
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
                     packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().Should().Be("1.1.0");
@@ -1846,7 +1846,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact, Platform(Exclude = "WindowsServer10")]
             public void Should_have_deleted_the_rollback()
             {
-                var packageDir = Path.Combine(Scenario.get_top_level(), "lib-bkp", Configuration.PackageNames);
+                var packageDir = Path.Combine(Scenario.GetTopLevel(), "lib-bkp", Configuration.PackageNames);
 
                 DirectoryAssert.DoesNotExist(packageDir);
             }
@@ -1856,7 +1856,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact, Platform("WindowsServer10")]
             public void Should_not_have_deleted_the_rollback_on_server()
             {
-                var packageDir = Path.Combine(Scenario.get_top_level(), "lib-bkp", Configuration.PackageNames);
+                var packageDir = Path.Combine(Scenario.GetTopLevel(), "lib-bkp", Configuration.PackageNames);
 
                 DirectoryAssert.Exists(packageDir);
             }
@@ -1864,7 +1864,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_contain_newer_version_in_directory()
             {
-                var shimFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, "tools", "console.exe");
+                var shimFile = Path.Combine(Scenario.GetTopLevel(), "lib", Configuration.PackageNames, "tools", "console.exe");
 
                 File.ReadAllText(shimFile).Should().Be("1.1.0");
             }
@@ -1916,7 +1916,7 @@ namespace chocolatey.tests.integration.scenarios
             public override void Context()
             {
                 base.Context();
-                var fileToOpen = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, "tools", "chocolateyInstall.ps1");
+                var fileToOpen = Path.Combine(Scenario.GetTopLevel(), "lib", Configuration.PackageNames, "tools", "chocolateyInstall.ps1");
                 _fileStream = new FileStream(fileToOpen, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.None);
             }
 
@@ -1936,7 +1936,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_have_a_package_installed_in_the_lib_directory()
             {
-                var packageDir = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames);
+                var packageDir = Path.Combine(Scenario.GetTopLevel(), "lib", Configuration.PackageNames);
 
                 DirectoryAssert.Exists(packageDir);
             }
@@ -1944,7 +1944,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_delete_the_rollback()
             {
-                var packageDir = Path.Combine(Scenario.get_top_level(), "lib-bkp", Configuration.PackageNames);
+                var packageDir = Path.Combine(Scenario.GetTopLevel(), "lib-bkp", Configuration.PackageNames);
 
                 DirectoryAssert.DoesNotExist(packageDir);
             }
@@ -1952,7 +1952,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_contain_old_version_in_directory()
             {
-                var shimFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, "tools", "console.exe");
+                var shimFile = Path.Combine(Scenario.GetTopLevel(), "lib", Configuration.PackageNames, "tools", "console.exe");
 
                 File.ReadAllText(shimFile).Should().Be("1.0.0");
             }
@@ -1960,7 +1960,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_not_upgrade_the_package()
             {
-                var packageFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, Configuration.PackageNames +  NuGetConstants.PackageExtension);
+                var packageFile = Path.Combine(Scenario.GetTopLevel(), "lib", Configuration.PackageNames, Configuration.PackageNames + NuGetConstants.PackageExtension);
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
                     packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().Should().Be("1.0.0");
@@ -2007,7 +2007,7 @@ namespace chocolatey.tests.integration.scenarios
             public override void Context()
             {
                 base.Context();
-                var fileAdded = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, "dude.txt");
+                var fileAdded = Path.Combine(Scenario.GetTopLevel(), "lib", Configuration.PackageNames, "dude.txt");
                 File.WriteAllText(fileAdded, "hellow");
             }
 
@@ -2020,7 +2020,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_keep_the_added_file()
             {
-                var fileAdded = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, "dude.txt");
+                var fileAdded = Path.Combine(Scenario.GetTopLevel(), "lib", Configuration.PackageNames, "dude.txt");
 
                 FileAssert.Exists(fileAdded);
             }
@@ -2028,7 +2028,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_contain_newer_version_in_directory()
             {
-                var shimFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, "tools", "console.exe");
+                var shimFile = Path.Combine(Scenario.GetTopLevel(), "lib", Configuration.PackageNames, "tools", "console.exe");
 
                 File.ReadAllText(shimFile).Should().Be("1.1.0");
             }
@@ -2036,7 +2036,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_upgrade_the_package()
             {
-                var packageFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, Configuration.PackageNames +  NuGetConstants.PackageExtension);
+                var packageFile = Path.Combine(Scenario.GetTopLevel(), "lib", Configuration.PackageNames, Configuration.PackageNames + NuGetConstants.PackageExtension);
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
                     packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().Should().Be("1.1.0");
@@ -2085,7 +2085,7 @@ namespace chocolatey.tests.integration.scenarios
             public override void Context()
             {
                 base.Context();
-                var fileChanged = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, "tools", "chocolateyinstall.ps1");
+                var fileChanged = Path.Combine(Scenario.GetTopLevel(), "lib", Configuration.PackageNames, "tools", "chocolateyinstall.ps1");
                 File.WriteAllText(fileChanged, "hellow");
             }
 
@@ -2098,7 +2098,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_update_the_changed_file()
             {
-                var fileChanged = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, "tools", "chocolateyinstall.ps1");
+                var fileChanged = Path.Combine(Scenario.GetTopLevel(), "lib", Configuration.PackageNames, "tools", "chocolateyinstall.ps1");
 
                 File.ReadAllText(fileChanged).Should().NotBe("hellow");
             }
@@ -2106,7 +2106,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_contain_newer_version_in_directory()
             {
-                var shimFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, "tools", "console.exe");
+                var shimFile = Path.Combine(Scenario.GetTopLevel(), "lib", Configuration.PackageNames, "tools", "console.exe");
 
                 File.ReadAllText(shimFile).Should().Be("1.1.0");
             }
@@ -2114,7 +2114,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_upgrade_the_package()
             {
-                var packageFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, Configuration.PackageNames +  NuGetConstants.PackageExtension);
+                var packageFile = Path.Combine(Scenario.GetTopLevel(), "lib", Configuration.PackageNames, Configuration.PackageNames + NuGetConstants.PackageExtension);
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
                     packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().Should().Be("1.1.0");
@@ -2175,7 +2175,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_not_install_a_package_in_the_lib_directory()
             {
-                var packageDir = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames);
+                var packageDir = Path.Combine(Scenario.GetTopLevel(), "lib", Configuration.PackageNames);
 
                 DirectoryAssert.DoesNotExist(packageDir);
             }
@@ -2254,7 +2254,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_install_a_package_in_the_lib_directory()
             {
-                var packageDir = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames);
+                var packageDir = Path.Combine(Scenario.GetTopLevel(), "lib", Configuration.PackageNames);
 
                 DirectoryAssert.Exists(packageDir);
             }
@@ -2262,7 +2262,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_not_have_a_rollback_directory()
             {
-                var packageDir = Path.Combine(Scenario.get_top_level(), "lib-bkp", Configuration.PackageNames);
+                var packageDir = Path.Combine(Scenario.GetTopLevel(), "lib-bkp", Configuration.PackageNames);
 
                 DirectoryAssert.DoesNotExist(packageDir);
             }
@@ -2316,7 +2316,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_not_install_a_package_in_the_lib_directory()
             {
-                var packageDir = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames);
+                var packageDir = Path.Combine(Scenario.GetTopLevel(), "lib", Configuration.PackageNames);
 
                 DirectoryAssert.DoesNotExist(packageDir);
             }
@@ -2383,7 +2383,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_not_remove_package_from_the_lib_directory()
             {
-                var packageDir = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames);
+                var packageDir = Path.Combine(Scenario.GetTopLevel(), "lib", Configuration.PackageNames);
 
                 DirectoryAssert.Exists(packageDir);
             }
@@ -2391,7 +2391,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_not_upgrade_the_package()
             {
-                var packageFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, Configuration.PackageNames +  NuGetConstants.PackageExtension);
+                var packageFile = Path.Combine(Scenario.GetTopLevel(), "lib", Configuration.PackageNames, Configuration.PackageNames + NuGetConstants.PackageExtension);
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
                     packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().Should().Be("1.0.0");
@@ -2401,7 +2401,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_put_the_package_in_the_lib_bad_directory()
             {
-                var packageDir = Path.Combine(Scenario.get_top_level(), "lib-bad", Configuration.PackageNames);
+                var packageDir = Path.Combine(Scenario.GetTopLevel(), "lib-bad", Configuration.PackageNames);
 
                 DirectoryAssert.Exists(packageDir);
             }
@@ -2409,7 +2409,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_have_the_erroring_upgraded_package_in_the_lib_bad_directory()
             {
-                var packageFile = Path.Combine(Scenario.get_top_level(), "lib-bad", Configuration.PackageNames, "2.0.0", Configuration.PackageNames +  NuGetConstants.PackageExtension);
+                var packageFile = Path.Combine(Scenario.GetTopLevel(), "lib-bad", Configuration.PackageNames, "2.0.0", Configuration.PackageNames + NuGetConstants.PackageExtension);
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
                     packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().Should().Be("2.0.0");
@@ -2419,7 +2419,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_delete_the_rollback()
             {
-                var packageDir = Path.Combine(Scenario.get_top_level(), "lib-bkp", Configuration.PackageNames);
+                var packageDir = Path.Combine(Scenario.GetTopLevel(), "lib-bkp", Configuration.PackageNames);
 
                 DirectoryAssert.DoesNotExist(packageDir);
             }
@@ -2471,11 +2471,11 @@ namespace chocolatey.tests.integration.scenarios
             {
                 base.Context();
                 Configuration.PackageNames = Configuration.Input = "hasdependency";
-                Scenario.add_packages_to_source_location(Configuration, "hasdependency.*" +  NuGetConstants.PackageExtension);
-                Scenario.add_packages_to_source_location(Configuration, "isdependency.*" +  NuGetConstants.PackageExtension);
-                Scenario.add_packages_to_source_location(Configuration, "isexactversiondependency*" +  NuGetConstants.PackageExtension);
-                Scenario.install_package(Configuration, "isdependency", "1.0.0");
-                Scenario.install_package(Configuration, "hasdependency", "1.0.0");
+                Scenario.AddPackagesToSourceLocation(Configuration, "hasdependency.*" + NuGetConstants.PackageExtension);
+                Scenario.AddPackagesToSourceLocation(Configuration, "isdependency.*" + NuGetConstants.PackageExtension);
+                Scenario.AddPackagesToSourceLocation(Configuration, "isexactversiondependency*" + NuGetConstants.PackageExtension);
+                Scenario.InstallPackage(Configuration, "isdependency", "1.0.0");
+                Scenario.InstallPackage(Configuration, "hasdependency", "1.0.0");
             }
 
             public override void Because()
@@ -2486,7 +2486,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_upgrade_the_package()
             {
-                var packageFile = Path.Combine(Scenario.get_top_level(), "lib", "hasdependency", "hasdependency.nupkg");
+                var packageFile = Path.Combine(Scenario.GetTopLevel(), "lib", "hasdependency", "hasdependency.nupkg");
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
                     packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().Should().Be("2.1.0");
@@ -2496,7 +2496,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_upgrade_the_minimum_version_dependency()
             {
-                var packageFile = Path.Combine(Scenario.get_top_level(), "lib", "isdependency", "isdependency.nupkg");
+                var packageFile = Path.Combine(Scenario.GetTopLevel(), "lib", "isdependency", "isdependency.nupkg");
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
                     packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().Should().Be("2.1.0");
@@ -2506,7 +2506,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_upgrade_the_exact_version_dependency()
             {
-                var packageFile = Path.Combine(Scenario.get_top_level(), "lib", "isexactversiondependency", "isexactversiondependency.nupkg");
+                var packageFile = Path.Combine(Scenario.GetTopLevel(), "lib", "isexactversiondependency", "isexactversiondependency.nupkg");
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
                     packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().Should().Be("2.0.0");
@@ -2545,11 +2545,11 @@ namespace chocolatey.tests.integration.scenarios
             {
                 base.Context();
                 Configuration.PackageNames = Configuration.Input = "hasdependency";
-                Scenario.add_packages_to_source_location(Configuration, "hasdependency.*" +  NuGetConstants.PackageExtension);
-                Scenario.add_packages_to_source_location(Configuration, "isdependency.*" +  NuGetConstants.PackageExtension);
-                Scenario.add_packages_to_source_location(Configuration, "isexactversiondependency.1*" +  NuGetConstants.PackageExtension);
-                Scenario.install_package(Configuration, "isdependency", "1.0.0");
-                Scenario.install_package(Configuration, "hasdependency", "1.0.0");
+                Scenario.AddPackagesToSourceLocation(Configuration, "hasdependency.*" + NuGetConstants.PackageExtension);
+                Scenario.AddPackagesToSourceLocation(Configuration, "isdependency.*" + NuGetConstants.PackageExtension);
+                Scenario.AddPackagesToSourceLocation(Configuration, "isexactversiondependency.1*" + NuGetConstants.PackageExtension);
+                Scenario.InstallPackage(Configuration, "isdependency", "1.0.0");
+                Scenario.InstallPackage(Configuration, "hasdependency", "1.0.0");
             }
 
             public override void Because()
@@ -2560,7 +2560,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_not_upgrade_the_package()
             {
-                var packageFile = Path.Combine(Scenario.get_top_level(), "lib", "hasdependency", "hasdependency.nupkg");
+                var packageFile = Path.Combine(Scenario.GetTopLevel(), "lib", "hasdependency", "hasdependency.nupkg");
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
                     packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().Should().Be("1.0.0");
@@ -2570,7 +2570,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_not_upgrade_the_minimum_version_dependency()
             {
-                var packageFile = Path.Combine(Scenario.get_top_level(), "lib", "isdependency", "isdependency.nupkg");
+                var packageFile = Path.Combine(Scenario.GetTopLevel(), "lib", "isdependency", "isdependency.nupkg");
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
                     packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().Should().Be("1.0.0");
@@ -2580,7 +2580,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_not_upgrade_the_exact_version_dependency()
             {
-                var packageFile = Path.Combine(Scenario.get_top_level(), "lib", "isexactversiondependency", "isexactversiondependency.nupkg");
+                var packageFile = Path.Combine(Scenario.GetTopLevel(), "lib", "isexactversiondependency", "isexactversiondependency.nupkg");
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
                     packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().Should().Be("1.0.0");
@@ -2635,11 +2635,11 @@ namespace chocolatey.tests.integration.scenarios
             {
                 base.Context();
                 Configuration.PackageNames = Configuration.Input = "hasdependency";
-                Scenario.add_packages_to_source_location(Configuration, "hasdependency.*" +  NuGetConstants.PackageExtension);
-                Scenario.add_packages_to_source_location(Configuration, "isdependency.*" +  NuGetConstants.PackageExtension);
-                Scenario.add_packages_to_source_location(Configuration, "isexactversiondependency.1*" +  NuGetConstants.PackageExtension);
-                Scenario.install_package(Configuration, "isdependency", "1.0.0");
-                Scenario.install_package(Configuration, "hasdependency", "1.0.0");
+                Scenario.AddPackagesToSourceLocation(Configuration, "hasdependency.*" + NuGetConstants.PackageExtension);
+                Scenario.AddPackagesToSourceLocation(Configuration, "isdependency.*" + NuGetConstants.PackageExtension);
+                Scenario.AddPackagesToSourceLocation(Configuration, "isexactversiondependency.1*" + NuGetConstants.PackageExtension);
+                Scenario.InstallPackage(Configuration, "isdependency", "1.0.0");
+                Scenario.InstallPackage(Configuration, "hasdependency", "1.0.0");
                 Configuration.IgnoreDependencies = true;
             }
 
@@ -2651,7 +2651,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_upgrade_the_package()
             {
-                var packageFile = Path.Combine(Scenario.get_top_level(), "lib", "hasdependency", "hasdependency.nupkg");
+                var packageFile = Path.Combine(Scenario.GetTopLevel(), "lib", "hasdependency", "hasdependency.nupkg");
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
                     packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().Should().Be("2.1.0");
@@ -2661,7 +2661,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_not_upgrade_the_minimum_version_dependency()
             {
-                var packageFile = Path.Combine(Scenario.get_top_level(), "lib", "isdependency", "isdependency.nupkg");
+                var packageFile = Path.Combine(Scenario.GetTopLevel(), "lib", "isdependency", "isdependency.nupkg");
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
                     packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().Should().Be("1.0.0");
@@ -2671,7 +2671,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_not_upgrade_the_exact_version_dependency()
             {
-                var packageFile = Path.Combine(Scenario.get_top_level(), "lib", "isexactversiondependency", "isexactversiondependency.nupkg");
+                var packageFile = Path.Combine(Scenario.GetTopLevel(), "lib", "isexactversiondependency", "isexactversiondependency.nupkg");
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
                     packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().Should().Be("1.0.0");
@@ -2710,11 +2710,11 @@ namespace chocolatey.tests.integration.scenarios
             {
                 base.Context();
                 Configuration.PackageNames = Configuration.Input = "isdependency";
-                Scenario.add_packages_to_source_location(Configuration, "hasdependency.*" +  NuGetConstants.PackageExtension);
-                Scenario.add_packages_to_source_location(Configuration, "isdependency.1*" +  NuGetConstants.PackageExtension);
-                Scenario.add_packages_to_source_location(Configuration, "isexactversiondependency*" +  NuGetConstants.PackageExtension);
-                Scenario.install_package(Configuration, "isdependency", "1.0.0");
-                Scenario.install_package(Configuration, "hasdependency", "1.0.0");
+                Scenario.AddPackagesToSourceLocation(Configuration, "hasdependency.*" + NuGetConstants.PackageExtension);
+                Scenario.AddPackagesToSourceLocation(Configuration, "isdependency.1*" + NuGetConstants.PackageExtension);
+                Scenario.AddPackagesToSourceLocation(Configuration, "isexactversiondependency*" + NuGetConstants.PackageExtension);
+                Scenario.InstallPackage(Configuration, "isdependency", "1.0.0");
+                Scenario.InstallPackage(Configuration, "hasdependency", "1.0.0");
             }
 
             public override void Because()
@@ -2725,7 +2725,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_upgrade_the_package()
             {
-                var packageFile = Path.Combine(Scenario.get_top_level(), "lib", "isdependency", "isdependency.nupkg");
+                var packageFile = Path.Combine(Scenario.GetTopLevel(), "lib", "isdependency", "isdependency.nupkg");
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
                     packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().Should().Be("1.1.0");
@@ -2735,7 +2735,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_not_upgrade_the_parent_package()
             {
-                var packageFile = Path.Combine(Scenario.get_top_level(), "lib", "hasdependency", "hasdependency.nupkg");
+                var packageFile = Path.Combine(Scenario.GetTopLevel(), "lib", "hasdependency", "hasdependency.nupkg");
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
                     packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().Should().Be("1.0.0");
@@ -2745,7 +2745,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_not_upgrade_the_exact_version_dependency()
             {
-                var packageFile = Path.Combine(Scenario.get_top_level(), "lib", "isexactversiondependency", "isexactversiondependency.nupkg");
+                var packageFile = Path.Combine(Scenario.GetTopLevel(), "lib", "isexactversiondependency", "isexactversiondependency.nupkg");
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
                     packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().Should().Be("1.0.0");
@@ -2784,11 +2784,11 @@ namespace chocolatey.tests.integration.scenarios
             {
                 base.Context();
                 Configuration.PackageNames = Configuration.Input = "isdependency";
-                Scenario.add_packages_to_source_location(Configuration, "hasdependency.*" +  NuGetConstants.PackageExtension);
-                Scenario.add_packages_to_source_location(Configuration, "isdependency.*" +  NuGetConstants.PackageExtension);
-                Scenario.add_packages_to_source_location(Configuration, "isexactversiondependency*" +  NuGetConstants.PackageExtension);
-                Scenario.install_package(Configuration, "isdependency", "1.0.0");
-                Scenario.install_package(Configuration, "hasdependency", "1.0.0");
+                Scenario.AddPackagesToSourceLocation(Configuration, "hasdependency.*" + NuGetConstants.PackageExtension);
+                Scenario.AddPackagesToSourceLocation(Configuration, "isdependency.*" + NuGetConstants.PackageExtension);
+                Scenario.AddPackagesToSourceLocation(Configuration, "isexactversiondependency*" + NuGetConstants.PackageExtension);
+                Scenario.InstallPackage(Configuration, "isdependency", "1.0.0");
+                Scenario.InstallPackage(Configuration, "hasdependency", "1.0.0");
             }
 
             public override void Because()
@@ -2799,7 +2799,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_upgrade_the_package()
             {
-                var packageFile = Path.Combine(Scenario.get_top_level(), "lib", "isdependency", "isdependency.nupkg");
+                var packageFile = Path.Combine(Scenario.GetTopLevel(), "lib", "isdependency", "isdependency.nupkg");
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
                     packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().Should().Be("2.1.0");
@@ -2809,7 +2809,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_upgrade_the_parent_package_to_highest_version_that_meets_new_dependency_version()
             {
-                var packageFile = Path.Combine(Scenario.get_top_level(), "lib", "hasdependency", "hasdependency.nupkg");
+                var packageFile = Path.Combine(Scenario.GetTopLevel(), "lib", "hasdependency", "hasdependency.nupkg");
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
                     packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().Should().Be("2.1.0");
@@ -2819,7 +2819,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_upgrade_the_exact_version_dependency()
             {
-                var packageFile = Path.Combine(Scenario.get_top_level(), "lib", "isexactversiondependency", "isexactversiondependency.nupkg");
+                var packageFile = Path.Combine(Scenario.GetTopLevel(), "lib", "isexactversiondependency", "isexactversiondependency.nupkg");
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
                     packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().Should().Be("2.0.0");
@@ -2858,12 +2858,12 @@ namespace chocolatey.tests.integration.scenarios
             {
                 base.Context();
                 Configuration.PackageNames = Configuration.Input = "isdependency";
-                Scenario.add_packages_to_source_location(Configuration, "hasdependency.*" + NuGetConstants.PackageExtension);
-                Scenario.add_packages_to_source_location(Configuration, "isdependency.*" + NuGetConstants.PackageExtension);
-                Scenario.add_packages_to_source_location(Configuration, "isexactversiondependency*" + NuGetConstants.PackageExtension);
-                Scenario.install_package(Configuration, "isdependency", "1.0.0");
+                Scenario.AddPackagesToSourceLocation(Configuration, "hasdependency.*" + NuGetConstants.PackageExtension);
+                Scenario.AddPackagesToSourceLocation(Configuration, "isdependency.*" + NuGetConstants.PackageExtension);
+                Scenario.AddPackagesToSourceLocation(Configuration, "isexactversiondependency*" + NuGetConstants.PackageExtension);
+                Scenario.InstallPackage(Configuration, "isdependency", "1.0.0");
                 Configuration.IgnoreDependencies = true;
-                Scenario.install_package(Configuration, "hasdependency", "1.0.0");
+                Scenario.InstallPackage(Configuration, "hasdependency", "1.0.0");
                 Configuration.IgnoreDependencies = false;
             }
 
@@ -2875,7 +2875,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_upgrade_the_package()
             {
-                var packageFile = Path.Combine(Scenario.get_top_level(), "lib", "isdependency", "isdependency.nupkg");
+                var packageFile = Path.Combine(Scenario.GetTopLevel(), "lib", "isdependency", "isdependency.nupkg");
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
                     packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().Should().Be("2.1.0");
@@ -2885,7 +2885,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_upgrade_the_parent_package_to_highest_version_that_meets_new_dependency_version()
             {
-                var packageFile = Path.Combine(Scenario.get_top_level(), "lib", "hasdependency", "hasdependency.nupkg");
+                var packageFile = Path.Combine(Scenario.GetTopLevel(), "lib", "hasdependency", "hasdependency.nupkg");
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
                     packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().Should().Be("2.1.0");
@@ -2895,7 +2895,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_upgrade_the_exact_version_dependency()
             {
-                var packageFile = Path.Combine(Scenario.get_top_level(), "lib", "isexactversiondependency", "isexactversiondependency.nupkg");
+                var packageFile = Path.Combine(Scenario.GetTopLevel(), "lib", "isexactversiondependency", "isexactversiondependency.nupkg");
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
                     packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().Should().Be("2.0.0");
@@ -2934,12 +2934,12 @@ namespace chocolatey.tests.integration.scenarios
             {
                 base.Context();
                 Configuration.PackageNames = Configuration.Input = "isdependency";
-                Scenario.add_packages_to_source_location(Configuration, "hasdependency.*" + NuGetConstants.PackageExtension);
-                Scenario.add_packages_to_source_location(Configuration, "isdependency.*" + NuGetConstants.PackageExtension);
-                Scenario.add_packages_to_source_location(Configuration, "isexactversiondependency*" + NuGetConstants.PackageExtension);
-                Scenario.install_package(Configuration, "isdependency", "1.0.0");
+                Scenario.AddPackagesToSourceLocation(Configuration, "hasdependency.*" + NuGetConstants.PackageExtension);
+                Scenario.AddPackagesToSourceLocation(Configuration, "isdependency.*" + NuGetConstants.PackageExtension);
+                Scenario.AddPackagesToSourceLocation(Configuration, "isexactversiondependency*" + NuGetConstants.PackageExtension);
+                Scenario.InstallPackage(Configuration, "isdependency", "1.0.0");
                 Configuration.PinPackage = true;
-                Scenario.install_package(Configuration, "hasdependency", "1.0.0");
+                Scenario.InstallPackage(Configuration, "hasdependency", "1.0.0");
                 Configuration.PinPackage = false;
             }
 
@@ -2951,7 +2951,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_upgrade_the_package_to_highest_version_in_range()
             {
-                var packageFile = Path.Combine(Scenario.get_top_level(), "lib", "isdependency", "isdependency.nupkg");
+                var packageFile = Path.Combine(Scenario.GetTopLevel(), "lib", "isdependency", "isdependency.nupkg");
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
                     packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().Should().Be("1.1.0");
@@ -2961,7 +2961,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_not_upgrade_parent_package()
             {
-                var packageFile = Path.Combine(Scenario.get_top_level(), "lib", "hasdependency", "hasdependency.nupkg");
+                var packageFile = Path.Combine(Scenario.GetTopLevel(), "lib", "hasdependency", "hasdependency.nupkg");
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
                     packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().Should().Be("1.0.0");
@@ -2971,7 +2971,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_not_upgrade_the_exact_version_dependency()
             {
-                var packageFile = Path.Combine(Scenario.get_top_level(), "lib", "isexactversiondependency", "isexactversiondependency.nupkg");
+                var packageFile = Path.Combine(Scenario.GetTopLevel(), "lib", "isexactversiondependency", "isexactversiondependency.nupkg");
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
                     packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().Should().Be("1.0.0");
@@ -3019,13 +3019,13 @@ namespace chocolatey.tests.integration.scenarios
             {
                 base.Context();
                 Configuration.PackageNames = Configuration.Input = "isdependency";
-                Scenario.add_packages_to_source_location(Configuration, "hasdependency.*" + NuGetConstants.PackageExtension);
-                Scenario.add_packages_to_source_location(Configuration, "isdependency.*" + NuGetConstants.PackageExtension);
-                Scenario.add_packages_to_source_location(Configuration, "isexactversiondependency*" + NuGetConstants.PackageExtension);
-                Scenario.install_package(Configuration, "isdependency", "1.0.0");
+                Scenario.AddPackagesToSourceLocation(Configuration, "hasdependency.*" + NuGetConstants.PackageExtension);
+                Scenario.AddPackagesToSourceLocation(Configuration, "isdependency.*" + NuGetConstants.PackageExtension);
+                Scenario.AddPackagesToSourceLocation(Configuration, "isexactversiondependency*" + NuGetConstants.PackageExtension);
+                Scenario.InstallPackage(Configuration, "isdependency", "1.0.0");
                 Configuration.PinPackage = true;
                 Configuration.IgnoreDependencies = true;
-                Scenario.install_package(Configuration, "hasdependency", "1.0.0");
+                Scenario.InstallPackage(Configuration, "hasdependency", "1.0.0");
                 Configuration.PinPackage = false;
                 Configuration.IgnoreDependencies = false;
             }
@@ -3038,7 +3038,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_upgrade_the_package_to_highest_version_in_range()
             {
-                var packageFile = Path.Combine(Scenario.get_top_level(), "lib", "isdependency", "isdependency.nupkg");
+                var packageFile = Path.Combine(Scenario.GetTopLevel(), "lib", "isdependency", "isdependency.nupkg");
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
                     packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().Should().Be("1.1.0");
@@ -3048,7 +3048,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_not_upgrade_parent_package()
             {
-                var packageFile = Path.Combine(Scenario.get_top_level(), "lib", "hasdependency", "hasdependency.nupkg");
+                var packageFile = Path.Combine(Scenario.GetTopLevel(), "lib", "hasdependency", "hasdependency.nupkg");
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
                     packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().Should().Be("1.0.0");
@@ -3058,7 +3058,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_not_upgrade_the_exact_version_dependency()
             {
-                var packageFile = Path.Combine(Scenario.get_top_level(), "lib", "isexactversiondependency", "isexactversiondependency.nupkg");
+                var packageFile = Path.Combine(Scenario.GetTopLevel(), "lib", "isexactversiondependency", "isexactversiondependency.nupkg");
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
                     packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().Should().Be("1.0.0");
@@ -3107,15 +3107,15 @@ namespace chocolatey.tests.integration.scenarios
             {
                 base.Context();
                 Configuration.PackageNames = Configuration.Input = "isdependency";
-                Scenario.add_packages_to_source_location(Configuration, "hasdependency.*" + NuGetConstants.PackageExtension);
-                Scenario.add_packages_to_source_location(Configuration, "isdependency.*" + NuGetConstants.PackageExtension);
-                Scenario.add_packages_to_source_location(Configuration, "isexactversiondependency*" + NuGetConstants.PackageExtension);
-                Scenario.install_package(Configuration, "isdependency", "1.0.0");
+                Scenario.AddPackagesToSourceLocation(Configuration, "hasdependency.*" + NuGetConstants.PackageExtension);
+                Scenario.AddPackagesToSourceLocation(Configuration, "isdependency.*" + NuGetConstants.PackageExtension);
+                Scenario.AddPackagesToSourceLocation(Configuration, "isexactversiondependency*" + NuGetConstants.PackageExtension);
+                Scenario.InstallPackage(Configuration, "isdependency", "1.0.0");
                 Configuration.PinPackage = true;
-                Scenario.install_package(Configuration, "isexactversiondependency", "1.0.0");
+                Scenario.InstallPackage(Configuration, "isexactversiondependency", "1.0.0");
                 Configuration.PinPackage = false;
-                Scenario.install_package(Configuration, "hasdependency", "1.0.0");
-                Scenario.remove_packages_from_destination_location(Configuration, "hasdependency.2.0.1" + NuGetConstants.PackageExtension);
+                Scenario.InstallPackage(Configuration, "hasdependency", "1.0.0");
+                Scenario.RemovePackagesFromDestinationLocation(Configuration, "hasdependency.2.0.1" + NuGetConstants.PackageExtension);
             }
 
             public override void Because()
@@ -3126,7 +3126,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_upgrade_the_package_to_highest_version_in_range()
             {
-                var packageFile = Path.Combine(Scenario.get_top_level(), "lib", "isdependency", "isdependency.nupkg");
+                var packageFile = Path.Combine(Scenario.GetTopLevel(), "lib", "isdependency", "isdependency.nupkg");
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
                     packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().Should().Be("1.1.0");
@@ -3136,7 +3136,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_not_upgrade_parent_package()
             {
-                var packageFile = Path.Combine(Scenario.get_top_level(), "lib", "hasdependency", "hasdependency.nupkg");
+                var packageFile = Path.Combine(Scenario.GetTopLevel(), "lib", "hasdependency", "hasdependency.nupkg");
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
                     packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().Should().Be("1.0.0");
@@ -3146,7 +3146,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_not_upgrade_the_exact_version_dependency()
             {
-                var packageFile = Path.Combine(Scenario.get_top_level(), "lib", "isexactversiondependency", "isexactversiondependency.nupkg");
+                var packageFile = Path.Combine(Scenario.GetTopLevel(), "lib", "isexactversiondependency", "isexactversiondependency.nupkg");
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
                     packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().Should().Be("1.0.0");
@@ -3194,12 +3194,12 @@ namespace chocolatey.tests.integration.scenarios
             {
                 base.Context();
                 Configuration.PackageNames = Configuration.Input = "isdependency";
-                Scenario.add_packages_to_source_location(Configuration, "hasdependency.*" + NuGetConstants.PackageExtension);
-                Scenario.add_packages_to_source_location(Configuration, "isdependency.*" + NuGetConstants.PackageExtension);
-                Scenario.add_packages_to_source_location(Configuration, "isexactversiondependency*" + NuGetConstants.PackageExtension);
-                Scenario.install_package(Configuration, "isdependency", "1.0.0");
+                Scenario.AddPackagesToSourceLocation(Configuration, "hasdependency.*" + NuGetConstants.PackageExtension);
+                Scenario.AddPackagesToSourceLocation(Configuration, "isdependency.*" + NuGetConstants.PackageExtension);
+                Scenario.AddPackagesToSourceLocation(Configuration, "isexactversiondependency*" + NuGetConstants.PackageExtension);
+                Scenario.InstallPackage(Configuration, "isdependency", "1.0.0");
                 Configuration.PinPackage = true;
-                Scenario.install_package(Configuration, "hasdependency", "1.0.0");
+                Scenario.InstallPackage(Configuration, "hasdependency", "1.0.0");
                 Configuration.PinPackage = false;
                 Configuration.IgnoreDependencies = true;
             }
@@ -3212,7 +3212,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_not_upgrade_the_package()
             {
-                var packageFile = Path.Combine(Scenario.get_top_level(), "lib", "isdependency", "isdependency.nupkg");
+                var packageFile = Path.Combine(Scenario.GetTopLevel(), "lib", "isdependency", "isdependency.nupkg");
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
                     packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().Should().Be("1.0.0");
@@ -3222,7 +3222,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_not_upgrade_parent_package()
             {
-                var packageFile = Path.Combine(Scenario.get_top_level(), "lib", "hasdependency", "hasdependency.nupkg");
+                var packageFile = Path.Combine(Scenario.GetTopLevel(), "lib", "hasdependency", "hasdependency.nupkg");
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
                     packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().Should().Be("1.0.0");
@@ -3232,7 +3232,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_not_upgrade_the_exact_version_dependency()
             {
-                var packageFile = Path.Combine(Scenario.get_top_level(), "lib", "isexactversiondependency", "isexactversiondependency.nupkg");
+                var packageFile = Path.Combine(Scenario.GetTopLevel(), "lib", "isexactversiondependency", "isexactversiondependency.nupkg");
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
                     packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().Should().Be("1.0.0");
@@ -3282,7 +3282,7 @@ namespace chocolatey.tests.integration.scenarios
             {
                 base.Context();
 
-                _xmlFilePath = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, "tools", "console.exe.config");
+                _xmlFilePath = Path.Combine(Scenario.GetTopLevel(), "lib", Configuration.PackageNames, "tools", "console.exe.config");
             }
 
             public override void Because()
@@ -3297,7 +3297,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_upgrade_the_package()
             {
-                var packageFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, Configuration.PackageNames +  NuGetConstants.PackageExtension);
+                var packageFile = Path.Combine(Scenario.GetTopLevel(), "lib", Configuration.PackageNames, Configuration.PackageNames + NuGetConstants.PackageExtension);
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
                     packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().Should().Be("1.1.0");
@@ -3378,7 +3378,7 @@ namespace chocolatey.tests.integration.scenarios
             {
                 base.Context();
 
-                _xmlFilePath = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, "tools", "console.exe.config");
+                _xmlFilePath = Path.Combine(Scenario.GetTopLevel(), "lib", Configuration.PackageNames, "tools", "console.exe.config");
 
                 File.WriteAllText(_xmlFilePath, File.ReadAllText(_xmlFilePath) + CommentAdded);
             }
@@ -3395,7 +3395,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_upgrade_the_package()
             {
-                var packageFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, Configuration.PackageNames +  NuGetConstants.PackageExtension);
+                var packageFile = Path.Combine(Scenario.GetTopLevel(), "lib", Configuration.PackageNames, Configuration.PackageNames + NuGetConstants.PackageExtension);
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
                     packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().Should().Be("1.1.0");
@@ -3540,7 +3540,7 @@ namespace chocolatey.tests.integration.scenarios
             {
                 base.Context();
                 Configuration.Prerelease = true;
-                Scenario.install_package(Configuration, "upgradepackage", "1.1.1-beta");
+                Scenario.InstallPackage(Configuration, "upgradepackage", "1.1.1-beta");
                 Configuration.Prerelease = false;
                 Configuration.PackageNames = Configuration.Input = "all";
             }
@@ -3567,7 +3567,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_upgrade_upgradepackage()
             {
-                var packageFile = Path.Combine(Scenario.get_top_level(), "lib", "upgradepackage", "upgradepackage" +  NuGetConstants.PackageExtension);
+                var packageFile = Path.Combine(Scenario.GetTopLevel(), "lib", "upgradepackage", "upgradepackage" + NuGetConstants.PackageExtension);
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
                     var version = packageReader.NuspecReader.GetVersion();
@@ -3592,7 +3592,7 @@ namespace chocolatey.tests.integration.scenarios
             {
                 base.Context();
                 Configuration.Prerelease = true;
-                Scenario.install_package(Configuration, "upgradepackage", "1.1.1-beta");
+                Scenario.InstallPackage(Configuration, "upgradepackage", "1.1.1-beta");
                 Configuration.Prerelease = false;
 
                 Configuration.PackageNames = Configuration.Input = "all";
@@ -3622,7 +3622,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_not_upgrade_upgradepackage()
             {
-                var packageFile = Path.Combine(Scenario.get_top_level(), "lib", "upgradepackage", "upgradepackage" +  NuGetConstants.PackageExtension);
+                var packageFile = Path.Combine(Scenario.GetTopLevel(), "lib", "upgradepackage", "upgradepackage" + NuGetConstants.PackageExtension);
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
                     var version = packageReader.NuspecReader.GetVersion();
@@ -3675,7 +3675,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_upgrade_a_package_in_the_lib_directory()
             {
-                var packageDir = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames);
+                var packageDir = Path.Combine(Scenario.GetTopLevel(), "lib", Configuration.PackageNames);
 
                 DirectoryAssert.Exists(packageDir);
             }
@@ -3683,7 +3683,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_delete_the_rollback()
             {
-                var packageDir = Path.Combine(Scenario.get_top_level(), "lib-bkp", Configuration.PackageNames);
+                var packageDir = Path.Combine(Scenario.GetTopLevel(), "lib-bkp", Configuration.PackageNames);
 
                 DirectoryAssert.DoesNotExist(packageDir);
             }
@@ -3691,7 +3691,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_contain_newer_version_in_directory()
             {
-                var shimFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, "tools", "console.exe");
+                var shimFile = Path.Combine(Scenario.GetTopLevel(), "lib", Configuration.PackageNames, "tools", "console.exe");
 
                 FileAssert.Exists(shimFile);
 
@@ -3701,7 +3701,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_upgrade_the_package()
             {
-                var packageFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, Configuration.PackageNames + NuGetConstants.PackageExtension);
+                var packageFile = Path.Combine(Scenario.GetTopLevel(), "lib", Configuration.PackageNames, Configuration.PackageNames + NuGetConstants.PackageExtension);
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
                     packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().Should().Be("1.1.1-beta.1");
@@ -3836,10 +3836,10 @@ namespace chocolatey.tests.integration.scenarios
             public override void Context()
             {
                 base.Context();
-                Scenario.add_packages_to_source_location(Configuration, "scriptpackage.hook" + ".1.0.0" + NuGetConstants.PackageExtension);
-                Scenario.install_package(Configuration, "scriptpackage.hook", "1.0.0");
+                Scenario.AddPackagesToSourceLocation(Configuration, "scriptpackage.hook" + ".1.0.0" + NuGetConstants.PackageExtension);
+                Scenario.InstallPackage(Configuration, "scriptpackage.hook", "1.0.0");
                 Configuration.PackageNames = Configuration.Input = "scriptpackage.hook";
-                Scenario.add_packages_to_source_location(Configuration, Configuration.Input + ".2.0.0" + NuGetConstants.PackageExtension);
+                Scenario.AddPackagesToSourceLocation(Configuration, Configuration.Input + ".2.0.0" + NuGetConstants.PackageExtension);
             }
 
             public override void Because()
@@ -3857,7 +3857,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_upgrade_a_package_in_the_lib_directory()
             {
-                var packageDir = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames);
+                var packageDir = Path.Combine(Scenario.GetTopLevel(), "lib", Configuration.PackageNames);
 
                 DirectoryAssert.Exists(packageDir);
             }
@@ -3865,7 +3865,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_delete_the_rollback()
             {
-                var packageDir = Path.Combine(Scenario.get_top_level(), "lib-bkp", Configuration.PackageNames);
+                var packageDir = Path.Combine(Scenario.GetTopLevel(), "lib-bkp", Configuration.PackageNames);
 
                 DirectoryAssert.DoesNotExist(packageDir);
             }
@@ -3873,7 +3873,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_upgrade_the_package()
             {
-                var packageFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, Configuration.PackageNames + NuGetConstants.PackageExtension);
+                var packageFile = Path.Combine(Scenario.GetTopLevel(), "lib", Configuration.PackageNames, Configuration.PackageNames + NuGetConstants.PackageExtension);
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
                     packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().Should().Be("2.0.0");
@@ -3927,7 +3927,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_have_a_hooks_folder_for_the_package()
             {
-                var hooksDirectory = Path.Combine(Scenario.get_top_level(), "hooks", Configuration.PackageNames.Replace(".hook", string.Empty));
+                var hooksDirectory = Path.Combine(Scenario.GetTopLevel(), "hooks", Configuration.PackageNames.Replace(".hook", string.Empty));
 
                 DirectoryAssert.Exists(hooksDirectory);
             }
@@ -3938,7 +3938,7 @@ namespace chocolatey.tests.integration.scenarios
                 var hookScripts = new List<string> { "pre-install-all.ps1", "post-install-all.ps1", "pre-upgrade-all.ps1", "post-upgrade-all.ps1", "pre-uninstall-all.ps1", "post-uninstall-all.ps1" };
                 foreach (string scriptName in hookScripts)
                 {
-                    var hookScriptPath = Path.Combine(Scenario.get_top_level(), "hooks", Configuration.PackageNames.Replace(".hook", string.Empty), scriptName);
+                    var hookScriptPath = Path.Combine(Scenario.GetTopLevel(), "hooks", Configuration.PackageNames.Replace(".hook", string.Empty), scriptName);
                     File.ReadAllText(hookScriptPath).Should().Contain("Write-Output");
                 }
             }
@@ -3946,14 +3946,14 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_remove_files_not_in_upgrade_version()
             {
-                var hookScriptPath = Path.Combine(Scenario.get_top_level(), "hooks", Configuration.PackageNames.Replace(".hook", string.Empty), "pre-install-doesnotexist.ps1");
+                var hookScriptPath = Path.Combine(Scenario.GetTopLevel(), "hooks", Configuration.PackageNames.Replace(".hook", string.Empty), "pre-install-doesnotexist.ps1");
                 FileAssert.DoesNotExist(hookScriptPath);
             }
 
             [Fact]
             public void Should_install_new_files_in_upgrade_version()
             {
-                var hookScriptPath = Path.Combine(Scenario.get_top_level(), "hooks", Configuration.PackageNames.Replace(".hook", string.Empty), "post-install-doesnotexist.ps1");
+                var hookScriptPath = Path.Combine(Scenario.GetTopLevel(), "hooks", Configuration.PackageNames.Replace(".hook", string.Empty), "post-install-doesnotexist.ps1");
                 FileAssert.Exists(hookScriptPath);
             }
         }
@@ -3965,8 +3965,8 @@ namespace chocolatey.tests.integration.scenarios
             public override void Context()
             {
                 base.Context();
-                Scenario.add_packages_to_source_location(Configuration, "scriptpackage.hook" + "*" + NuGetConstants.PackageExtension);
-                Scenario.install_package(Configuration, "scriptpackage.hook", "1.0.0");
+                Scenario.AddPackagesToSourceLocation(Configuration, "scriptpackage.hook" + "*" + NuGetConstants.PackageExtension);
+                Scenario.InstallPackage(Configuration, "scriptpackage.hook", "1.0.0");
                 Configuration.PackageNames = Configuration.Input = "upgradepackage";
             }
 
@@ -3985,7 +3985,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_upgrade_a_package_in_the_lib_directory()
             {
-                var packageDir = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames);
+                var packageDir = Path.Combine(Scenario.GetTopLevel(), "lib", Configuration.PackageNames);
 
                 DirectoryAssert.Exists(packageDir);
             }
@@ -3993,7 +3993,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_delete_the_rollback()
             {
-                var packageDir = Path.Combine(Scenario.get_top_level(), "lib-bkp", Configuration.PackageNames);
+                var packageDir = Path.Combine(Scenario.GetTopLevel(), "lib-bkp", Configuration.PackageNames);
 
                 DirectoryAssert.DoesNotExist(packageDir);
             }
@@ -4001,7 +4001,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_contain_newer_version_in_directory()
             {
-                var shimFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, "tools", "console.exe");
+                var shimFile = Path.Combine(Scenario.GetTopLevel(), "lib", Configuration.PackageNames, "tools", "console.exe");
 
                 File.ReadAllText(shimFile).Should().Be("1.1.0");
             }
@@ -4009,7 +4009,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_upgrade_the_package()
             {
-                var packageFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, Configuration.PackageNames + NuGetConstants.PackageExtension);
+                var packageFile = Path.Combine(Scenario.GetTopLevel(), "lib", Configuration.PackageNames, Configuration.PackageNames + NuGetConstants.PackageExtension);
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
                     packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().Should().Be("1.1.0");
@@ -4184,8 +4184,8 @@ namespace chocolatey.tests.integration.scenarios
             public override void Context()
             {
                 base.Context();
-                Scenario.add_packages_to_source_location(Configuration, "UpperCase" + "*" + NuGetConstants.PackageExtension);
-                Scenario.install_package(Configuration, "UpperCase", "1.0.0");
+                Scenario.AddPackagesToSourceLocation(Configuration, "UpperCase" + "*" + NuGetConstants.PackageExtension);
+                Scenario.InstallPackage(Configuration, "UpperCase", "1.0.0");
 
                 Configuration.PackageNames = Configuration.Input = "UpperCase";
             }
@@ -4199,7 +4199,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_have_the_correct_casing_for_the_nuspec()
             {
-                var nuspecFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, Configuration.PackageNames + NuGetConstants.ManifestExtension);
+                var nuspecFile = Path.Combine(Scenario.GetTopLevel(), "lib", Configuration.PackageNames, Configuration.PackageNames + NuGetConstants.ManifestExtension);
                 FileAssert.Exists(nuspecFile);
             }
 
@@ -4212,7 +4212,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_upgrade_a_package_in_the_lib_directory()
             {
-                var packageDir = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames);
+                var packageDir = Path.Combine(Scenario.GetTopLevel(), "lib", Configuration.PackageNames);
 
                 DirectoryAssert.Exists(packageDir);
             }
@@ -4220,7 +4220,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_upgrade_the_package()
             {
-                var packageFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, Configuration.PackageNames + NuGetConstants.PackageExtension);
+                var packageFile = Path.Combine(Scenario.GetTopLevel(), "lib", Configuration.PackageNames, Configuration.PackageNames + NuGetConstants.PackageExtension);
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
                     packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().Should().Be("1.1.0");
@@ -4321,8 +4321,8 @@ namespace chocolatey.tests.integration.scenarios
             public override void Context()
             {
                 base.Context();
-                Scenario.add_packages_to_source_location(Configuration, "unsupportedelements" + "*" + NuGetConstants.PackageExtension);
-                Scenario.install_package(Configuration, "unsupportedelements", "1.0.0");
+                Scenario.AddPackagesToSourceLocation(Configuration, "unsupportedelements" + "*" + NuGetConstants.PackageExtension);
+                Scenario.InstallPackage(Configuration, "unsupportedelements", "1.0.0");
                 Configuration.PackageNames = Configuration.Input = "unsupportedelements";
             }
 
@@ -4341,7 +4341,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_upgrade_a_package_in_the_lib_directory()
             {
-                var packageDir = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames);
+                var packageDir = Path.Combine(Scenario.GetTopLevel(), "lib", Configuration.PackageNames);
 
                 DirectoryAssert.Exists(packageDir);
             }
@@ -4349,7 +4349,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_upgrade_the_package()
             {
-                var packageFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, Configuration.PackageNames + NuGetConstants.PackageExtension);
+                var packageFile = Path.Combine(Scenario.GetTopLevel(), "lib", Configuration.PackageNames, Configuration.PackageNames + NuGetConstants.PackageExtension);
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
                     packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().Should().Be("1.1.0");
@@ -4460,7 +4460,7 @@ namespace chocolatey.tests.integration.scenarios
             public override void Context()
             {
                 base.Context();
-                Scenario.add_changed_version_package_to_source_location(Configuration, "upgradepackage.1.1.0" + NuGetConstants.PackageExtension, NonNormalizedVersion);
+                Scenario.AddChangedVersionPackageToSourceLocation(Configuration, "upgradepackage.1.1.0" + NuGetConstants.PackageExtension, NonNormalizedVersion);
                 Configuration.PackageNames = Configuration.Input = "upgradepackage";
             }
 
@@ -4479,7 +4479,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_upgrade_a_package_in_the_lib_directory()
             {
-                var packageDir = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames);
+                var packageDir = Path.Combine(Scenario.GetTopLevel(), "lib", Configuration.PackageNames);
 
                 DirectoryAssert.Exists(packageDir);
             }
@@ -4487,7 +4487,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_delete_the_rollback()
             {
-                var packageDir = Path.Combine(Scenario.get_top_level(), "lib-bkp", Configuration.PackageNames);
+                var packageDir = Path.Combine(Scenario.GetTopLevel(), "lib-bkp", Configuration.PackageNames);
 
                 DirectoryAssert.DoesNotExist(packageDir);
             }
@@ -4495,7 +4495,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_upgrade_the_package()
             {
-                var packageFile = Path.Combine(Scenario.get_top_level(), "lib", Configuration.PackageNames, Configuration.PackageNames + NuGetConstants.PackageExtension);
+                var packageFile = Path.Combine(Scenario.GetTopLevel(), "lib", Configuration.PackageNames, Configuration.PackageNames + NuGetConstants.PackageExtension);
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
                     packageReader.NuspecReader.GetVersion().ToStringSafe().Should().Be(NonNormalizedVersion);
@@ -4657,12 +4657,12 @@ namespace chocolatey.tests.integration.scenarios
             {
                 base.Context();
 
-                Scenario.add_packages_to_source_location(Configuration, "{0}.*".FormatWith(TargetPackageName) + NuGetConstants.PackageExtension);
-                Scenario.add_packages_to_source_location(Configuration, "{0}.*".FormatWith(DependencyName) + NuGetConstants.PackageExtension);
-                Scenario.add_packages_to_source_location(Configuration, "scriptpackage.hook" + "*" + NuGetConstants.PackageExtension);
-                Scenario.install_package(Configuration, DependencyName, "1.0.0");
-                Scenario.install_package(Configuration, TargetPackageName, "1.0.0");
-                Scenario.install_package(Configuration, "scriptpackage.hook", "1.0.0");
+                Scenario.AddPackagesToSourceLocation(Configuration, "{0}.*".FormatWith(TargetPackageName) + NuGetConstants.PackageExtension);
+                Scenario.AddPackagesToSourceLocation(Configuration, "{0}.*".FormatWith(DependencyName) + NuGetConstants.PackageExtension);
+                Scenario.AddPackagesToSourceLocation(Configuration, "scriptpackage.hook" + "*" + NuGetConstants.PackageExtension);
+                Scenario.InstallPackage(Configuration, DependencyName, "1.0.0");
+                Scenario.InstallPackage(Configuration, TargetPackageName, "1.0.0");
+                Scenario.InstallPackage(Configuration, "scriptpackage.hook", "1.0.0");
 
                 Configuration.PackageNames = Configuration.Input = TargetPackageName;
             }
@@ -4675,7 +4675,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_upgrade_the_minimum_version_dependency()
             {
-                var packageFile = Path.Combine(Scenario.get_top_level(), "lib", DependencyName, "{0}.nupkg".FormatWith(DependencyName));
+                var packageFile = Path.Combine(Scenario.GetTopLevel(), "lib", DependencyName, "{0}.nupkg".FormatWith(DependencyName));
                 using (var packageReader = new PackageArchiveReader(packageFile))
                 {
                     packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().Should().Be("2.0.0");

--- a/src/chocolatey.tests/TinySpec.cs
+++ b/src/chocolatey.tests/TinySpec.cs
@@ -32,7 +32,7 @@ namespace chocolatey.tests
     {
         public static MockLogger MockLogger { get; set; }
 
-        private static readonly string InstallLocationVariable = Environment.GetEnvironmentVariable(ApplicationParameters.ChocolateyInstallEnvironmentVariableName);
+        private static readonly string _installLocationVariable = Environment.GetEnvironmentVariable(ApplicationParameters.ChocolateyInstallEnvironmentVariableName);
 
         [OneTimeSetUp]
         public virtual void BeforeEverything()
@@ -48,7 +48,7 @@ namespace chocolatey.tests
         [OneTimeTearDown]
         public void AfterEverything()
         {
-            Environment.SetEnvironmentVariable(ApplicationParameters.ChocolateyInstallEnvironmentVariableName, InstallLocationVariable);
+            Environment.SetEnvironmentVariable(ApplicationParameters.ChocolateyInstallEnvironmentVariableName, _installLocationVariable);
         }
     }
 

--- a/src/chocolatey.tests/UNCHelper.cs
+++ b/src/chocolatey.tests/UNCHelper.cs
@@ -6,15 +6,15 @@
 
     public static class UNCHelper
     {
-        public static string convert_local_folder_path_to_ip_based_unc_path(string localFolderName)
+        public static string ConvertLocalFolderPathToIpBasedUncPath(string localFolderName)
         {
             var rootFolder = Path.GetPathRoot(localFolderName);
-            var ipAddress = return_machine_ip();
+            var ipAddress = ReturnMachineId();
 
             return string.Format("\\\\{0}\\\\{1}$\\{2}", ipAddress, rootFolder.TrimEnd('\\', ':'), localFolderName.Substring(rootFolder.Length));
         }
 
-        private static IPAddress return_machine_ip()
+        private static IPAddress ReturnMachineId()
         {
             var hostName = Dns.GetHostName();
             var ipEntry = Dns.GetHostEntry(hostName);

--- a/src/chocolatey.tests/infrastructure.app/attributes/CommandForAttributeSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/attributes/CommandForAttributeSpecs.cs
@@ -23,27 +23,27 @@ namespace chocolatey.tests.infrastructure.app.attributes
     {
         public abstract class CommandForAttributeSpecsBase : TinySpec
         {
-            protected CommandForAttribute attribute;
+            protected CommandForAttribute Attribute;
         }
 
         public class When_CommandForAttribute_is_set_with_string : CommandForAttributeSpecsBase
         {
-            private string result;
+            private string _result;
 
             public override void Context()
             {
-                attribute = new CommandForAttribute("bob", "");
+                Attribute = new CommandForAttribute("bob", "");
             }
 
             public override void Because()
             {
-                result = attribute.CommandName;
+                _result = Attribute.CommandName;
             }
 
             [Fact]
             public void Should_be_set_to_the_string()
             {
-                result.Should().Be("bob");
+                _result.Should().Be("bob");
             }
         }
     }

--- a/src/chocolatey.tests/infrastructure.app/commands/ChocolateyApiKeyCommandSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/commands/ChocolateyApiKeyCommandSpecs.cs
@@ -33,82 +33,82 @@ namespace chocolatey.tests.infrastructure.app.commands
         [ConcernFor("apikey")]
         public abstract class ChocolateyApiKeyCommandSpecsBase : TinySpec
         {
-            protected ChocolateyApiKeyCommand command;
-            protected Mock<IChocolateyConfigSettingsService> configSettingsService = new Mock<IChocolateyConfigSettingsService>();
-            protected ChocolateyConfiguration configuration = new ChocolateyConfiguration();
+            protected ChocolateyApiKeyCommand Command;
+            protected Mock<IChocolateyConfigSettingsService> ConfigSettingsService = new Mock<IChocolateyConfigSettingsService>();
+            protected ChocolateyConfiguration Configuration = new ChocolateyConfiguration();
 
             public override void Context()
             {
-                configuration.Sources = "bob";
-                command = new ChocolateyApiKeyCommand(configSettingsService.Object);
+                Configuration.Sources = "bob";
+                Command = new ChocolateyApiKeyCommand(ConfigSettingsService.Object);
             }
         }
 
         public class When_implementing_command_for : ChocolateyApiKeyCommandSpecsBase
         {
-            private List<string> results;
+            private List<string> _results;
 
             public override void Because()
             {
-                results = command.GetType().GetCustomAttributes(typeof(CommandForAttribute), false).Cast<CommandForAttribute>().Select(a => a.CommandName).ToList();
+                _results = Command.GetType().GetCustomAttributes(typeof(CommandForAttribute), false).Cast<CommandForAttribute>().Select(a => a.CommandName).ToList();
             }
 
             [Fact]
             public void Should_implement_apikey()
             {
-                results.Should().Contain("apikey");
+                _results.Should().Contain("apikey");
             }
 
             [Fact]
             public void Should_implement_setapikey()
             {
-                results.Should().Contain("setapikey");
+                _results.Should().Contain("setapikey");
             }
         }
 
         public class When_configuring_the_argument_parser : ChocolateyApiKeyCommandSpecsBase
         {
-            private OptionSet optionSet;
+            private OptionSet _optionSet;
 
             public override void Context()
             {
                 base.Context();
-                optionSet = new OptionSet();
+                _optionSet = new OptionSet();
             }
 
             public override void Because()
             {
-                command.ConfigureArgumentParser(optionSet, configuration);
+                Command.ConfigureArgumentParser(_optionSet, Configuration);
             }
 
             [Fact]
             public void Should_clear_previously_set_Source()
             {
-                configuration.Sources.Should().BeNull();
+                Configuration.Sources.Should().BeNull();
             }
 
             [Fact]
             public void Should_add_source_to_the_option_set()
             {
-                optionSet.Contains("source").Should().BeTrue();
+                _optionSet.Contains("source").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_short_version_of_source_to_the_option_set()
             {
-                optionSet.Contains("s").Should().BeTrue();
+                _optionSet.Contains("s").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_apikey_to_the_option_set()
             {
-                optionSet.Contains("apikey").Should().BeTrue();
+                _optionSet.Contains("apikey").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_short_version_of_apikey_to_the_option_set()
             {
-                optionSet.Contains("k").Should().BeTrue();
+                _optionSet.Contains("k").Should().BeTrue();
             }
         }
 
@@ -121,14 +121,14 @@ namespace chocolatey.tests.infrastructure.app.commands
             [Fact]
             public void Should_throw_when_key_is_set_without_a_source()
             {
-                configuration.ApiKeyCommand.Key = "bob";
-                configuration.Sources = "";
+                Configuration.ApiKeyCommand.Key = "bob";
+                Configuration.Sources = "";
                 var errored = false;
                 Exception error = null;
 
                 try
                 {
-                    command.Validate(configuration);
+                    Command.Validate(Configuration);
                 }
                 catch (Exception ex)
                 {
@@ -144,30 +144,30 @@ namespace chocolatey.tests.infrastructure.app.commands
             [Fact]
             public void Should_continue_when_source_is_set_but_no_key_set()
             {
-                configuration.ApiKeyCommand.Key = "";
-                configuration.Sources = "bob";
-                command.Validate(configuration);
+                Configuration.ApiKeyCommand.Key = "";
+                Configuration.Sources = "bob";
+                Command.Validate(Configuration);
             }
 
             [Fact]
             public void Should_continue_when_both_source_and_key_are_set()
             {
-                configuration.ApiKeyCommand.Key = "bob";
-                configuration.Sources = "bob";
-                command.Validate(configuration);
+                Configuration.ApiKeyCommand.Key = "bob";
+                Configuration.Sources = "bob";
+                Command.Validate(Configuration);
             }
 
             [Fact]
             public void Should_throw_when_key_is_removed_without_a_source()
             {
-                configuration.ApiKeyCommand.Command = ApiKeyCommandType.Remove;
-                configuration.Sources = "";
+                Configuration.ApiKeyCommand.Command = ApiKeyCommandType.Remove;
+                Configuration.Sources = "";
                 var errored = false;
                 Exception error = null;
 
                 try
                 {
-                    command.Validate(configuration);
+                    Command.Validate(Configuration);
                 }
                 catch (Exception ex)
                 {
@@ -183,9 +183,9 @@ namespace chocolatey.tests.infrastructure.app.commands
             [Fact]
             public void Should_continue_when_removing_and_source_is_set()
             {
-                configuration.ApiKeyCommand.Command = ApiKeyCommandType.Remove;
-                configuration.Sources = "bob";
-                command.Validate(configuration);
+                Configuration.ApiKeyCommand.Command = ApiKeyCommandType.Remove;
+                Configuration.Sources = "bob";
+                Command.Validate(Configuration);
             }
         }
 
@@ -193,13 +193,13 @@ namespace chocolatey.tests.infrastructure.app.commands
         {
             public override void Because()
             {
-                command.DryRun(configuration);
+                Command.DryRun(Configuration);
             }
 
             [Fact]
             public void Should_call_service_noop()
             {
-                configSettingsService.Verify(c => c.DryRun(configuration), Times.Once);
+                ConfigSettingsService.Verify(c => c.DryRun(Configuration), Times.Once);
             }
         }
 
@@ -208,19 +208,19 @@ namespace chocolatey.tests.infrastructure.app.commands
             public override void Context()
             {
                 base.Context();
-                configuration.Sources = "bob";
-                configuration.ApiKeyCommand.Key = "";
+                Configuration.Sources = "bob";
+                Configuration.ApiKeyCommand.Key = "";
             }
 
             public override void Because()
             {
-                command.Run(configuration);
+                Command.Run(Configuration);
             }
 
             [Fact]
             public void Should_call_service_get_api_key()
             {
-                configSettingsService.Verify(c => c.GetApiKey(configuration, It.IsAny<Action<ConfigFileApiKeySetting>>()), Times.Once);
+                ConfigSettingsService.Verify(c => c.GetApiKey(Configuration, It.IsAny<Action<ConfigFileApiKeySetting>>()), Times.Once);
             }
         }
 
@@ -229,20 +229,20 @@ namespace chocolatey.tests.infrastructure.app.commands
             public override void Context()
             {
                 base.Context();
-                configuration.Sources = "bob";
-                configuration.ApiKeyCommand.Key = "bob";
-                configuration.ApiKeyCommand.Command = ApiKeyCommandType.Add;
+                Configuration.Sources = "bob";
+                Configuration.ApiKeyCommand.Key = "bob";
+                Configuration.ApiKeyCommand.Command = ApiKeyCommandType.Add;
             }
 
             public override void Because()
             {
-                command.Run(configuration);
+                Command.Run(Configuration);
             }
 
             [Fact]
             public void Should_call_service_set_api_key()
             {
-                configSettingsService.Verify(c => c.SetApiKey(configuration), Times.Once);
+                ConfigSettingsService.Verify(c => c.SetApiKey(Configuration), Times.Once);
             }
         }
     }

--- a/src/chocolatey.tests/infrastructure.app/commands/ChocolateyExportCommandSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/commands/ChocolateyExportCommandSpecs.cs
@@ -33,93 +33,93 @@ namespace chocolatey.tests.infrastructure.app.commands
         [ConcernFor("export")]
         public abstract class ChocolateyExportCommandSpecsBase : TinySpec
         {
-            protected ChocolateyExportCommand command;
-            protected Mock<INugetService> nugetService = new Mock<INugetService>();
-            protected Mock<IFileSystem> fileSystem = new Mock<IFileSystem>();
-            protected ChocolateyConfiguration configuration = new ChocolateyConfiguration();
+            protected ChocolateyExportCommand Command;
+            protected Mock<INugetService> NugetService = new Mock<INugetService>();
+            protected Mock<IFileSystem> FileSystem = new Mock<IFileSystem>();
+            protected ChocolateyConfiguration Configuration = new ChocolateyConfiguration();
 
             public override void Context()
             {
-                command = new ChocolateyExportCommand(nugetService.Object, fileSystem.Object);
+                Command = new ChocolateyExportCommand(NugetService.Object, FileSystem.Object);
             }
 
             public void Reset()
             {
-                nugetService.ResetCalls();
-                fileSystem.ResetCalls();
+                NugetService.ResetCalls();
+                FileSystem.ResetCalls();
             }
         }
 
         public class When_implementing_command_for : ChocolateyExportCommandSpecsBase
         {
-            private List<string> results;
+            private List<string> _results;
 
             public override void Because()
             {
-                results = command.GetType().GetCustomAttributes(typeof(CommandForAttribute), false).Cast<CommandForAttribute>().Select(a => a.CommandName).ToList();
+                _results = Command.GetType().GetCustomAttributes(typeof(CommandForAttribute), false).Cast<CommandForAttribute>().Select(a => a.CommandName).ToList();
             }
 
             [Fact]
             public void Should_implement_help()
             {
-                results.Should().Contain("export");
+                _results.Should().Contain("export");
             }
         }
 
         public class When_configurating_the_argument_parser : ChocolateyExportCommandSpecsBase
         {
-            private OptionSet optionSet;
+            private OptionSet _optionSet;
 
             public override void Context()
             {
                 base.Context();
-                optionSet = new OptionSet();
+                _optionSet = new OptionSet();
             }
 
             public override void Because()
             {
-                command.ConfigureArgumentParser(optionSet, configuration);
+                Command.ConfigureArgumentParser(_optionSet, Configuration);
             }
 
             [Fact]
             public void Should_add_output_file_path_to_the_option_set()
             {
-                optionSet.Contains("output-file-path").Should().BeTrue();
+                _optionSet.Contains("output-file-path").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_short_version_of_output_file_path_to_the_option_set()
             {
-                optionSet.Contains("o").Should().BeTrue();
+                _optionSet.Contains("o").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_include_version_numbers_to_the_option_set()
             {
-                optionSet.Contains("include-version-numbers").Should().BeTrue();
+                _optionSet.Contains("include-version-numbers").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_include_version_to_the_option_set()
             {
-                optionSet.Contains("include-version").Should().BeTrue();
+                _optionSet.Contains("include-version").Should().BeTrue();
             }
         }
 
         public class When_handling_additional_argument_parsing : ChocolateyExportCommandSpecsBase
         {
-            private readonly IList<string> unparsedArgs = new List<string>();
-            private Action because;
+            private readonly IList<string> _unparsedArgs = new List<string>();
+            private Action _because;
 
             public override void Because()
             {
-                because = () => command.ParseAdditionalArguments(unparsedArgs, configuration);
+                _because = () => Command.ParseAdditionalArguments(_unparsedArgs, Configuration);
             }
 
             public new void Reset()
             {
-                configuration.ExportCommand.OutputFilePath = string.Empty;
-                unparsedArgs.Clear();
+                Configuration.ExportCommand.OutputFilePath = string.Empty;
+                _unparsedArgs.Clear();
                 base.Reset();
             }
 
@@ -127,20 +127,20 @@ namespace chocolatey.tests.infrastructure.app.commands
             public void Should_handle_passing_in_an_empty_string_for_output_file_path()
             {
                 Reset();
-                unparsedArgs.Add(" ");
-                because();
+                _unparsedArgs.Add(" ");
+                _because();
 
-                configuration.ExportCommand.OutputFilePath.Should().Be("packages.config");
+                Configuration.ExportCommand.OutputFilePath.Should().Be("packages.config");
             }
 
             [Fact]
             public void Should_handle_passing_in_a_string_for_output_file_path()
             {
                 Reset();
-                unparsedArgs.Add("custompackages.config");
-                because();
+                _unparsedArgs.Add("custompackages.config");
+                _because();
 
-                configuration.ExportCommand.OutputFilePath.Should().Be("custompackages.config");
+                Configuration.ExportCommand.OutputFilePath.Should().Be("custompackages.config");
             }
         }
 
@@ -148,7 +148,7 @@ namespace chocolatey.tests.infrastructure.app.commands
         {
             public override void Because()
             {
-                command.DryRun(configuration);
+                Command.DryRun(Configuration);
             }
 
             [Fact]
@@ -189,31 +189,31 @@ namespace chocolatey.tests.infrastructure.app.commands
             public void Should_call_nuget_service_get_all_installed_packages()
             {
                 Reset();
-                command.Run(configuration);
+                Command.Run(Configuration);
 
-                nugetService.Verify(n => n.GetInstalledPackages(It.IsAny<ChocolateyConfiguration>()), Times.Once);
+                NugetService.Verify(n => n.GetInstalledPackages(It.IsAny<ChocolateyConfiguration>()), Times.Once);
             }
 
             [Fact]
             public void Should_call_replace_file_when_file_already_exists()
             {
-                fileSystem.Setup(f => f.FileExists(It.IsAny<string>())).Returns(true);
+                FileSystem.Setup(f => f.FileExists(It.IsAny<string>())).Returns(true);
 
                 Reset();
-                command.Run(configuration);
+                Command.Run(Configuration);
 
-                fileSystem.Verify(n => n.ReplaceFile(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()), Times.Once);
+                FileSystem.Verify(n => n.ReplaceFile(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()), Times.Once);
             }
 
             [Fact]
             public void Should_not_call_replace_file_when_file_doesnt_exist()
             {
-                fileSystem.Setup(f => f.FileExists(It.IsAny<string>())).Returns(false);
+                FileSystem.Setup(f => f.FileExists(It.IsAny<string>())).Returns(false);
 
                 Reset();
-                command.Run(configuration);
+                Command.Run(Configuration);
 
-                fileSystem.Verify(n => n.ReplaceFile(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+                FileSystem.Verify(n => n.ReplaceFile(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()), Times.Never);
             }
         }
     }

--- a/src/chocolatey.tests/infrastructure.app/commands/ChocolateyHelpCommandSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/commands/ChocolateyHelpCommandSpecs.cs
@@ -28,28 +28,28 @@ namespace chocolatey.tests.infrastructure.app.commands
         [ConcernFor("help")]
         public abstract class ChocolateyHelpCommandSpecsBase : TinySpec
         {
-            protected ChocolateyHelpCommand command;
-            protected ChocolateyConfiguration configuration = new ChocolateyConfiguration();
+            protected ChocolateyHelpCommand Command;
+            protected ChocolateyConfiguration Configuration = new ChocolateyConfiguration();
 
             public override void Context()
             {
-                command = new ChocolateyHelpCommand(null);
+                Command = new ChocolateyHelpCommand(null);
             }
         }
 
         public class When_implementing_command_for : ChocolateyHelpCommandSpecsBase
         {
-            private List<string> results;
+            private List<string> _results;
 
             public override void Because()
             {
-                results = command.GetType().GetCustomAttributes(typeof(CommandForAttribute), false).Cast<CommandForAttribute>().Select(a => a.CommandName).ToList();
+                _results = Command.GetType().GetCustomAttributes(typeof(CommandForAttribute), false).Cast<CommandForAttribute>().Select(a => a.CommandName).ToList();
             }
 
             [Fact]
             public void Should_implement_help()
             {
-                results.Should().Contain("help");
+                _results.Should().Contain("help");
             }
         }
     }

--- a/src/chocolatey.tests/infrastructure.app/commands/ChocolateyInstallCommandSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/commands/ChocolateyInstallCommandSpecs.cs
@@ -33,249 +33,249 @@ namespace chocolatey.tests.infrastructure.app.commands
         [ConcernFor("install")]
         public abstract class ChocolateyInstallCommandSpecsBase : TinySpec
         {
-            protected ChocolateyInstallCommand command;
-            protected Mock<IChocolateyPackageService> packageService = new Mock<IChocolateyPackageService>();
-            protected ChocolateyConfiguration configuration = new ChocolateyConfiguration();
+            protected ChocolateyInstallCommand Command;
+            protected Mock<IChocolateyPackageService> PackageService = new Mock<IChocolateyPackageService>();
+            protected ChocolateyConfiguration Configuration = new ChocolateyConfiguration();
 
             public override void Context()
             {
-                configuration.Sources = "bob";
-                command = new ChocolateyInstallCommand(packageService.Object);
+                Configuration.Sources = "bob";
+                Command = new ChocolateyInstallCommand(PackageService.Object);
             }
         }
 
         public class When_implementing_command_for : ChocolateyInstallCommandSpecsBase
         {
-            private List<string> results;
+            private List<string> _results;
 
             public override void Because()
             {
-                results = command.GetType().GetCustomAttributes(typeof(CommandForAttribute), false).Cast<CommandForAttribute>().Select(a => a.CommandName).ToList();
+                _results = Command.GetType().GetCustomAttributes(typeof(CommandForAttribute), false).Cast<CommandForAttribute>().Select(a => a.CommandName).ToList();
             }
 
             [Fact]
             public void Should_implement_install()
             {
-                results.Should().Contain("install");
+                _results.Should().Contain("install");
             }
         }
 
         public class When_configurating_the_argument_parser : ChocolateyInstallCommandSpecsBase
         {
-            private OptionSet optionSet;
+            private OptionSet _optionSet;
 
             public override void Context()
             {
                 base.Context();
-                optionSet = new OptionSet();
+                _optionSet = new OptionSet();
             }
 
             public override void Because()
             {
-                command.ConfigureArgumentParser(optionSet, configuration);
+                Command.ConfigureArgumentParser(_optionSet, Configuration);
             }
 
             [Fact]
             public void Should_add_source_to_the_option_set()
             {
-                optionSet.Contains("source").Should().BeTrue();
+                _optionSet.Contains("source").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_short_version_of_source_to_the_option_set()
             {
-                optionSet.Contains("s").Should().BeTrue();
+                _optionSet.Contains("s").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_version_to_the_option_set()
             {
-                optionSet.Contains("version").Should().BeTrue();
+                _optionSet.Contains("version").Should().BeTrue();
             }
 
             [Fact]
             public void Should_allow_insensitive_case_Version_to_the_option_set()
             {
-                optionSet.Contains("Version").Should().BeTrue();
+                _optionSet.Contains("Version").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_prerelease_to_the_option_set()
             {
-                optionSet.Contains("prerelease").Should().BeTrue();
+                _optionSet.Contains("prerelease").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_short_version_of_prerelease_to_the_option_set()
             {
-                optionSet.Contains("pre").Should().BeTrue();
+                _optionSet.Contains("pre").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_installargs_to_the_option_set()
             {
-                optionSet.Contains("installarguments").Should().BeTrue();
+                _optionSet.Contains("installarguments").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_short_version_of_installargs_to_the_option_set()
             {
-                optionSet.Contains("ia").Should().BeTrue();
+                _optionSet.Contains("ia").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_overrideargs_to_the_option_set()
             {
-                optionSet.Contains("overridearguments").Should().BeTrue();
+                _optionSet.Contains("overridearguments").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_short_version_of_overrideargs_to_the_option_set()
             {
-                optionSet.Contains("o").Should().BeTrue();
+                _optionSet.Contains("o").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_notsilent_to_the_option_set()
             {
-                optionSet.Contains("notsilent").Should().BeTrue();
+                _optionSet.Contains("notsilent").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_packageparameters_to_the_option_set()
             {
-                optionSet.Contains("packageparameters").Should().BeTrue();
+                _optionSet.Contains("packageparameters").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_short_version_of_packageparameters_to_the_option_set()
             {
-                optionSet.Contains("params").Should().BeTrue();
+                _optionSet.Contains("params").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_applyPackageParametersToDependencies_to_the_option_set()
             {
-                optionSet.Contains("apply-package-parameters-to-dependencies").Should().BeTrue();
+                _optionSet.Contains("apply-package-parameters-to-dependencies").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_applyInstallArgumentsToDependencies_to_the_option_set()
             {
-                optionSet.Contains("apply-install-arguments-to-dependencies").Should().BeTrue();
+                _optionSet.Contains("apply-install-arguments-to-dependencies").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_ignoredependencies_to_the_option_set()
             {
-                optionSet.Contains("ignoredependencies").Should().BeTrue();
+                _optionSet.Contains("ignoredependencies").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_short_version_of_ignoredependencies_to_the_option_set()
             {
-                optionSet.Contains("i").Should().BeTrue();
+                _optionSet.Contains("i").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_forcedependencies_to_the_option_set()
             {
-                optionSet.Contains("forcedependencies").Should().BeTrue();
+                _optionSet.Contains("forcedependencies").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_short_version_of_forcedependencies_to_the_option_set()
             {
-                optionSet.Contains("x").Should().BeTrue();
+                _optionSet.Contains("x").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_skippowershell_to_the_option_set()
             {
-                optionSet.Contains("skippowershell").Should().BeTrue();
+                _optionSet.Contains("skippowershell").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_short_version_of_skippowershell_to_the_option_set()
             {
-                optionSet.Contains("n").Should().BeTrue();
+                _optionSet.Contains("n").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_user_to_the_option_set()
             {
-                optionSet.Contains("user").Should().BeTrue();
+                _optionSet.Contains("user").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_short_version_of_user_to_the_option_set()
             {
-                optionSet.Contains("u").Should().BeTrue();
+                _optionSet.Contains("u").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_password_to_the_option_set()
             {
-                optionSet.Contains("password").Should().BeTrue();
+                _optionSet.Contains("password").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_short_version_of_password_to_the_option_set()
             {
-                optionSet.Contains("p").Should().BeTrue();
+                _optionSet.Contains("p").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_pin_to_the_option_set()
             {
-                optionSet.Contains("pinpackage").Should().BeTrue();
+                _optionSet.Contains("pinpackage").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_long_version_of_pin_to_the_option_set()
             {
-                optionSet.Contains("pin-package").Should().BeTrue();
+                _optionSet.Contains("pin-package").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_short_version_of_pin_to_the_option_set()
             {
-                optionSet.Contains("pin").Should().BeTrue();
+                _optionSet.Contains("pin").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_skip_hooks_to_the_option_set()
             {
-                optionSet.Contains("skip-hooks").Should().BeTrue();
+                _optionSet.Contains("skip-hooks").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_short_version_of_skip_hooks_to_the_option_set()
             {
-                optionSet.Contains("skiphooks").Should().BeTrue();
+                _optionSet.Contains("skiphooks").Should().BeTrue();
             }
         }
 
         public class When_handling_additional_argument_parsing : ChocolateyInstallCommandSpecsBase
         {
-            private readonly IList<string> unparsedArgs = new List<string>();
+            private readonly IList<string> _unparsedArgs = new List<string>();
 
             public override void Context()
             {
                 base.Context();
-                unparsedArgs.Add("pkg1");
-                unparsedArgs.Add("pkg2");
+                _unparsedArgs.Add("pkg1");
+                _unparsedArgs.Add("pkg2");
             }
 
             public override void Because()
             {
-                command.ParseAdditionalArguments(unparsedArgs, configuration);
+                Command.ParseAdditionalArguments(_unparsedArgs, Configuration);
             }
 
             [Fact]
             public void Should_set_unparsed_arguments_to_the_package_names()
             {
-                configuration.PackageNames.Should().Be("pkg1;pkg2");
+                Configuration.PackageNames.Should().Be("pkg1;pkg2");
             }
         }
 
@@ -288,13 +288,13 @@ namespace chocolatey.tests.infrastructure.app.commands
             [Fact]
             public void Should_throw_when_packagenames_is_not_set()
             {
-                configuration.PackageNames = "";
+                Configuration.PackageNames = "";
                 var errored = false;
                 Exception error = null;
 
                 try
                 {
-                    command.Validate(configuration);
+                    Command.Validate(Configuration);
                 }
                 catch (Exception ex)
                 {
@@ -310,8 +310,8 @@ namespace chocolatey.tests.infrastructure.app.commands
             [Fact]
             public void Should_continue_when_packagenames_is_set()
             {
-                configuration.PackageNames = "bob";
-                command.Validate(configuration);
+                Configuration.PackageNames = "bob";
+                Command.Validate(Configuration);
             }
         }
 
@@ -319,13 +319,13 @@ namespace chocolatey.tests.infrastructure.app.commands
         {
             public override void Because()
             {
-                command.DryRun(configuration);
+                Command.DryRun(Configuration);
             }
 
             [Fact]
             public void Should_call_service_install_noop()
             {
-                packageService.Verify(c => c.InstallDryRun(configuration), Times.Once);
+                PackageService.Verify(c => c.InstallDryRun(Configuration), Times.Once);
             }
         }
 
@@ -333,13 +333,13 @@ namespace chocolatey.tests.infrastructure.app.commands
         {
             public override void Because()
             {
-                command.Run(configuration);
+                Command.Run(Configuration);
             }
 
             [Fact]
             public void Should_call_service_install_run()
             {
-                packageService.Verify(c => c.Install(configuration), Times.Once);
+                PackageService.Verify(c => c.Install(Configuration), Times.Once);
             }
         }
     }

--- a/src/chocolatey.tests/infrastructure.app/commands/ChocolateyNewCommandSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/commands/ChocolateyNewCommandSpecs.cs
@@ -33,117 +33,117 @@ namespace chocolatey.tests.infrastructure.app.commands
         [ConcernFor("new")]
         public abstract class ChocolateyNewCommandSpecsBase : TinySpec
         {
-            protected ChocolateyNewCommand command;
-            protected Mock<ITemplateService> templateService = new Mock<ITemplateService>();
-            protected ChocolateyConfiguration configuration = new ChocolateyConfiguration();
+            protected ChocolateyNewCommand Command;
+            protected Mock<ITemplateService> TemplateService = new Mock<ITemplateService>();
+            protected ChocolateyConfiguration Configuration = new ChocolateyConfiguration();
 
             public override void Context()
             {
-                command = new ChocolateyNewCommand(templateService.Object);
+                Command = new ChocolateyNewCommand(TemplateService.Object);
             }
         }
 
         public class When_implementing_command_for : ChocolateyNewCommandSpecsBase
         {
-            private List<string> results;
+            private List<string> _results;
 
             public override void Because()
             {
-                results = command.GetType().GetCustomAttributes(typeof(CommandForAttribute), false).Cast<CommandForAttribute>().Select(a => a.CommandName).ToList();
+                _results = Command.GetType().GetCustomAttributes(typeof(CommandForAttribute), false).Cast<CommandForAttribute>().Select(a => a.CommandName).ToList();
             }
 
             [Fact]
             public void Should_implement_new()
             {
-                results.Should().Contain("new");
+                _results.Should().Contain("new");
             }
         }
 
         public class When_configurating_the_argument_parser : ChocolateyNewCommandSpecsBase
         {
-            private OptionSet optionSet;
+            private OptionSet _optionSet;
 
             public override void Context()
             {
                 base.Context();
-                optionSet = new OptionSet();
+                _optionSet = new OptionSet();
             }
 
             public override void Because()
             {
-                command.ConfigureArgumentParser(optionSet, configuration);
+                Command.ConfigureArgumentParser(_optionSet, Configuration);
             }
 
             [Fact]
             public void Should_add_automaticpackage_to_the_option_set()
             {
-                optionSet.Contains("automaticpackage").Should().BeTrue();
+                _optionSet.Contains("automaticpackage").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_short_version_of_automaticpackage_to_the_option_set()
             {
-                optionSet.Contains("a").Should().BeTrue();
+                _optionSet.Contains("a").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_name_to_the_option_set()
             {
-                optionSet.Contains("name").Should().BeTrue();
+                _optionSet.Contains("name").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_version_to_the_option_set()
             {
-                optionSet.Contains("version").Should().BeTrue();
+                _optionSet.Contains("version").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_maintainer_to_the_option_set()
             {
-                optionSet.Contains("maintainer").Should().BeTrue();
+                _optionSet.Contains("maintainer").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_outputdirectory_to_the_option_set()
             {
-                optionSet.Contains("outputdirectory").Should().BeTrue();
+                _optionSet.Contains("outputdirectory").Should().BeTrue();
             }
         }
 
         public class When_handling_additional_argument_parsing : ChocolateyNewCommandSpecsBase
         {
-            private readonly IList<string> unparsedArgs = new List<string>();
-            private Action because;
+            private readonly IList<string> _unparsedArgs = new List<string>();
+            private Action _because;
 
             public override void Because()
             {
-                because = () => command.ParseAdditionalArguments(unparsedArgs, configuration);
+                _because = () => Command.ParseAdditionalArguments(_unparsedArgs, Configuration);
             }
 
-            private void reset()
+            private void Reset()
             {
-                configuration.NewCommand.Name = "";
-                unparsedArgs.Clear();
-                configuration.NewCommand.TemplateProperties.Clear();
+                Configuration.NewCommand.Name = "";
+                _unparsedArgs.Clear();
+                Configuration.NewCommand.TemplateProperties.Clear();
             }
 
             [Fact]
             public void Should_not_set_template_properties_if_none_have_been_defined()
             {
-                reset();
-                because();
-                configuration.NewCommand.TemplateProperties.Should().HaveCount(0);
+                Reset();
+                _because();
+                Configuration.NewCommand.TemplateProperties.Should().HaveCount(0);
             }
 
             [Fact]
             public void Should_set_template_properties_when_args_are_separated_by_equals()
             {
-                reset();
-                unparsedArgs.Add("bob=new");
-                because();
+                Reset();
+                _unparsedArgs.Add("bob=new");
+                _because();
 
-                var properties = configuration.NewCommand.TemplateProperties;
+                var properties = Configuration.NewCommand.TemplateProperties;
                 properties.Should().HaveCount(1);
                 var templateProperty = properties.FirstOrDefault();
                 templateProperty.Key.Should().Be("bob");
@@ -153,12 +153,12 @@ namespace chocolatey.tests.infrastructure.app.commands
             [Fact]
             public void Should_set_template_properties_only_once()
             {
-                reset();
-                unparsedArgs.Add("bob=one");
-                unparsedArgs.Add("bob=two");
-                because();
+                Reset();
+                _unparsedArgs.Add("bob=one");
+                _unparsedArgs.Add("bob=two");
+                _because();
 
-                var properties = configuration.NewCommand.TemplateProperties;
+                var properties = Configuration.NewCommand.TemplateProperties;
                 properties.Should().HaveCount(1);
                 var templateProperty = properties.FirstOrDefault();
                 templateProperty.Key.Should().Be("bob");
@@ -168,12 +168,12 @@ namespace chocolatey.tests.infrastructure.app.commands
             [Fact]
             public void Should_ignore_casing_differences_when_setting_template_properties()
             {
-                reset();
-                unparsedArgs.Add("bob=one");
-                unparsedArgs.Add("Bob=two");
-                because();
+                Reset();
+                _unparsedArgs.Add("bob=one");
+                _unparsedArgs.Add("Bob=two");
+                _because();
 
-                var properties = configuration.NewCommand.TemplateProperties;
+                var properties = Configuration.NewCommand.TemplateProperties;
                 properties.Should().HaveCount(1);
                 var templateProperty = properties.FirstOrDefault();
                 templateProperty.Key.Should().Be("bob");
@@ -183,13 +183,13 @@ namespace chocolatey.tests.infrastructure.app.commands
             [Fact]
             public void Should_not_set_template_properties_when_args_are_not_separated_by_equals()
             {
-                reset();
-                configuration.NewCommand.Name = "bill";
-                configuration.NewCommand.TemplateProperties.Add(TemplateValues.NamePropertyName, "bill");
-                unparsedArgs.Add("bob new");
-                because();
+                Reset();
+                Configuration.NewCommand.Name = "bill";
+                Configuration.NewCommand.TemplateProperties.Add(TemplateValues.NamePropertyName, "bill");
+                _unparsedArgs.Add("bob new");
+                _because();
 
-                var properties = configuration.NewCommand.TemplateProperties;
+                var properties = Configuration.NewCommand.TemplateProperties;
                 properties.Should().HaveCount(1);
                 var templateProperty = properties.FirstOrDefault();
                 templateProperty.Key.Should().Be("PackageName");
@@ -199,13 +199,13 @@ namespace chocolatey.tests.infrastructure.app.commands
             [Fact]
             public void Should_not_set_override_configuration_Name_when_unparsed_without_equals()
             {
-                reset();
-                configuration.NewCommand.Name = "bill";
-                configuration.NewCommand.TemplateProperties.Add(TemplateValues.NamePropertyName, "bill");
-                unparsedArgs.Add("bob");
-                because();
+                Reset();
+                Configuration.NewCommand.Name = "bill";
+                Configuration.NewCommand.TemplateProperties.Add(TemplateValues.NamePropertyName, "bill");
+                _unparsedArgs.Add("bob");
+                _because();
 
-                var properties = configuration.NewCommand.TemplateProperties;
+                var properties = Configuration.NewCommand.TemplateProperties;
                 properties.Should().HaveCount(1);
                 var templateProperty = properties.FirstOrDefault();
                 templateProperty.Key.Should().Be("PackageName");
@@ -215,13 +215,13 @@ namespace chocolatey.tests.infrastructure.app.commands
             [Fact]
             public void Should_not_set_override_configuration_Name_when_package_name_is_also_passed()
             {
-                reset();
-                configuration.NewCommand.Name = "bill";
-                configuration.NewCommand.TemplateProperties.Add(TemplateValues.NamePropertyName, "bill");
-                unparsedArgs.Add(TemplateValues.NamePropertyName + "=bob");
-                because();
+                Reset();
+                Configuration.NewCommand.Name = "bill";
+                Configuration.NewCommand.TemplateProperties.Add(TemplateValues.NamePropertyName, "bill");
+                _unparsedArgs.Add(TemplateValues.NamePropertyName + "=bob");
+                _because();
 
-                var properties = configuration.NewCommand.TemplateProperties;
+                var properties = Configuration.NewCommand.TemplateProperties;
                 var templateProperty = properties.FirstOrDefault();
                 templateProperty.Key.Should().Be("PackageName");
                 templateProperty.Value.Should().Be("bill");
@@ -230,11 +230,11 @@ namespace chocolatey.tests.infrastructure.app.commands
             [Fact]
             public void Should_set_template_properties_when_args_are_separated_by_equals_with_spaces()
             {
-                reset();
-                unparsedArgs.Add("bob = new");
-                because();
+                Reset();
+                _unparsedArgs.Add("bob = new");
+                _because();
 
-                var properties = configuration.NewCommand.TemplateProperties;
+                var properties = Configuration.NewCommand.TemplateProperties;
                 properties.Should().HaveCount(1);
                 var templateProperty = properties.FirstOrDefault();
                 templateProperty.Key.Should().Be("bob");
@@ -244,11 +244,11 @@ namespace chocolatey.tests.infrastructure.app.commands
             [Fact]
             public void Should_set_template_properties_without_surrounding_quotes()
             {
-                reset();
-                unparsedArgs.Add("bob = \"new this\"");
-                because();
+                Reset();
+                _unparsedArgs.Add("bob = \"new this\"");
+                _because();
 
-                var properties = configuration.NewCommand.TemplateProperties;
+                var properties = Configuration.NewCommand.TemplateProperties;
                 properties.Should().HaveCount(1);
                 var templateProperty = properties.FirstOrDefault();
                 templateProperty.Key.Should().Be("bob");
@@ -258,10 +258,10 @@ namespace chocolatey.tests.infrastructure.app.commands
             [Fact]
             public void Should_set_template_properties_without_removing_quote()
             {
-                reset();
-                unparsedArgs.Add("bob = 'new \"this'");
-                because();
-                var properties = configuration.NewCommand.TemplateProperties;
+                Reset();
+                _unparsedArgs.Add("bob = 'new \"this'");
+                _because();
+                var properties = Configuration.NewCommand.TemplateProperties;
 
                 properties.Should().HaveCount(1);
                 var templateProperty = properties.FirstOrDefault();
@@ -272,10 +272,10 @@ namespace chocolatey.tests.infrastructure.app.commands
             [Fact]
             public void Should_set_template_properties_without_surrounding_apostrophes()
             {
-                reset();
-                unparsedArgs.Add("bob = 'new this'");
-                because();
-                var properties = configuration.NewCommand.TemplateProperties;
+                Reset();
+                _unparsedArgs.Add("bob = 'new this'");
+                _because();
+                var properties = Configuration.NewCommand.TemplateProperties;
 
                 properties.Should().HaveCount(1);
                 var templateProperty = properties.FirstOrDefault();
@@ -286,10 +286,10 @@ namespace chocolatey.tests.infrastructure.app.commands
             [Fact]
             public void Should_set_template_properties_without_removing_apostrophe()
             {
-                reset();
-                unparsedArgs.Add("bob = \"new 'this\"");
-                because();
-                var properties = configuration.NewCommand.TemplateProperties;
+                Reset();
+                _unparsedArgs.Add("bob = \"new 'this\"");
+                _because();
+                var properties = Configuration.NewCommand.TemplateProperties;
 
                 properties.Should().HaveCount(1);
                 var templateProperty = properties.FirstOrDefault();
@@ -307,13 +307,13 @@ namespace chocolatey.tests.infrastructure.app.commands
             [Fact]
             public void Should_throw_when_Name_is_not_set()
             {
-                configuration.NewCommand.Name = "";
+                Configuration.NewCommand.Name = "";
                 var errored = false;
                 Exception error = null;
 
                 try
                 {
-                    command.Validate(configuration);
+                    Command.Validate(Configuration);
                 }
                 catch (Exception ex)
                 {
@@ -329,8 +329,8 @@ namespace chocolatey.tests.infrastructure.app.commands
             [Fact]
             public void Should_continue_when_Name_is_set()
             {
-                configuration.NewCommand.Name = "bob";
-                command.Validate(configuration);
+                Configuration.NewCommand.Name = "bob";
+                Command.Validate(Configuration);
             }
         }
 
@@ -338,13 +338,13 @@ namespace chocolatey.tests.infrastructure.app.commands
         {
             public override void Because()
             {
-                command.DryRun(configuration);
+                Command.DryRun(Configuration);
             }
 
             [Fact]
             public void Should_call_service_noop()
             {
-                templateService.Verify(c => c.GenerateDryRun(configuration), Times.Once);
+                TemplateService.Verify(c => c.GenerateDryRun(Configuration), Times.Once);
             }
         }
 
@@ -352,67 +352,67 @@ namespace chocolatey.tests.infrastructure.app.commands
         {
             public override void Because()
             {
-                command.Run(configuration);
+                Command.Run(Configuration);
             }
 
             [Fact]
             public void Should_call_service_generate()
             {
-                templateService.Verify(c => c.Generate(configuration), Times.Once);
+                TemplateService.Verify(c => c.Generate(Configuration), Times.Once);
             }
         }
 
         public class When_handling_arguments_parsing : ChocolateyNewCommandSpecsBase
         {
-            private OptionSet optionSet;
+            private OptionSet _optionSet;
 
             public override void Context()
             {
                 base.Context();
-                optionSet = new OptionSet();
-                command.ConfigureArgumentParser(optionSet, configuration);
+                _optionSet = new OptionSet();
+                Command.ConfigureArgumentParser(_optionSet, Configuration);
             }
 
             public override void Because()
             {
-                optionSet.Parse(new[] { "--name", "Bob", "--automaticpackage", "--template-name", "custom", "--version", "0.42.0", "--maintainer", "Loyd", "--outputdirectory", "c:\\packages" });
+                _optionSet.Parse(new[] { "--name", "Bob", "--automaticpackage", "--template-name", "custom", "--version", "0.42.0", "--maintainer", "Loyd", "--outputdirectory", "c:\\packages" });
             }
 
             [Fact]
             public void Should_name_equal_to_Bob()
             {
-                configuration.NewCommand.Name.Should().Be("Bob");
-                configuration.NewCommand.TemplateProperties[TemplateValues.NamePropertyName].Should().Be("Bob");
+                Configuration.NewCommand.Name.Should().Be("Bob");
+                Configuration.NewCommand.TemplateProperties[TemplateValues.NamePropertyName].Should().Be("Bob");
             }
 
             [Fact]
             public void Should_automaticpackage_equal_to_true()
             {
-                configuration.NewCommand.AutomaticPackage.Should().BeTrue();
+                Configuration.NewCommand.AutomaticPackage.Should().BeTrue();
             }
 
             [Fact]
             public void Should_templatename_equal_to_custom()
             {
-                configuration.NewCommand.TemplateName.Should().Be("custom");
+                Configuration.NewCommand.TemplateName.Should().Be("custom");
             }
 
             [Fact]
             public void Should_version_equal_to_42()
             {
-                configuration.NewCommand.TemplateProperties[TemplateValues.VersionPropertyName].Should().Be("0.42.0");
+                Configuration.NewCommand.TemplateProperties[TemplateValues.VersionPropertyName].Should().Be("0.42.0");
             }
 
             [Fact]
             public void Should_maintainer_equal_to_Loyd()
             {
-                configuration.NewCommand.TemplateProperties[TemplateValues.MaintainerPropertyName].Should().Be("Loyd");
+                Configuration.NewCommand.TemplateProperties[TemplateValues.MaintainerPropertyName].Should().Be("Loyd");
             }
 
             [Fact]
             public void Should_outputdirectory_equal_packages()
             {
-                configuration.OutputDirectory.Should().Be("c:\\packages");
+                Configuration.OutputDirectory.Should().Be("c:\\packages");
             }
         }
     }

--- a/src/chocolatey.tests/infrastructure.app/commands/ChocolateyOutdatedCommandSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/commands/ChocolateyOutdatedCommandSpecs.cs
@@ -31,88 +31,88 @@ namespace chocolatey.tests.infrastructure.app.commands
         [ConcernFor("outdated")]
         public abstract class ChocolateyOutdatedCommandSpecsBase : TinySpec
         {
-            protected ChocolateyOutdatedCommand command;
-            protected Mock<IChocolateyPackageService> packageService = new Mock<IChocolateyPackageService>();
-            protected ChocolateyConfiguration configuration = new ChocolateyConfiguration();
+            protected ChocolateyOutdatedCommand Command;
+            protected Mock<IChocolateyPackageService> PackageService = new Mock<IChocolateyPackageService>();
+            protected ChocolateyConfiguration Configuration = new ChocolateyConfiguration();
 
             public override void Context()
             {
-                configuration.Sources = "bob";
-                command = new ChocolateyOutdatedCommand(packageService.Object);
+                Configuration.Sources = "bob";
+                Command = new ChocolateyOutdatedCommand(PackageService.Object);
             }
         }
 
         public class When_implementing_command_for : ChocolateyOutdatedCommandSpecsBase
         {
-            private List<string> results;
+            private List<string> _results;
 
             public override void Because()
             {
-                results = command.GetType().GetCustomAttributes(typeof(CommandForAttribute), false).Cast<CommandForAttribute>().Select(a => a.CommandName).ToList();
+                _results = Command.GetType().GetCustomAttributes(typeof(CommandForAttribute), false).Cast<CommandForAttribute>().Select(a => a.CommandName).ToList();
             }
 
             [Fact]
             public void Should_implement_outdated()
             {
-                results.Should().Contain("outdated");
+                _results.Should().Contain("outdated");
             }
         }
 
         public class When_configurating_the_argument_parser : ChocolateyOutdatedCommandSpecsBase
         {
-            private OptionSet optionSet;
+            private OptionSet _optionSet;
 
             public override void Context()
             {
                 base.Context();
-                optionSet = new OptionSet();
+                _optionSet = new OptionSet();
             }
 
             public override void Because()
             {
-                command.ConfigureArgumentParser(optionSet, configuration);
+                Command.ConfigureArgumentParser(_optionSet, Configuration);
             }
 
             [Fact]
             public void Should_add_source_to_the_option_set()
             {
-                optionSet.Contains("source").Should().BeTrue();
+                _optionSet.Contains("source").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_short_version_of_source_to_the_option_set()
             {
-                optionSet.Contains("s").Should().BeTrue();
+                _optionSet.Contains("s").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_user_to_the_option_set()
             {
-                optionSet.Contains("user").Should().BeTrue();
+                _optionSet.Contains("user").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_short_version_of_user_to_the_option_set()
             {
-                optionSet.Contains("u").Should().BeTrue();
+                _optionSet.Contains("u").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_password_to_the_option_set()
             {
-                optionSet.Contains("password").Should().BeTrue();
+                _optionSet.Contains("password").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_short_version_of_password_to_the_option_set()
             {
-                optionSet.Contains("p").Should().BeTrue();
+                _optionSet.Contains("p").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_ignore_pinned_to_the_option_set()
             {
-                optionSet.Contains("ignore-pinned").Should().BeTrue();
+                _optionSet.Contains("ignore-pinned").Should().BeTrue();
             }
         }
 
@@ -120,13 +120,13 @@ namespace chocolatey.tests.infrastructure.app.commands
         {
             public override void Because()
             {
-                command.DryRun(configuration);
+                Command.DryRun(Configuration);
             }
 
             [Fact]
             public void Should_call_service_outdated_noop()
             {
-                packageService.Verify(c => c.OutdatedDryRun(configuration), Times.Once);
+                PackageService.Verify(c => c.OutdatedDryRun(Configuration), Times.Once);
             }
         }
 
@@ -134,13 +134,13 @@ namespace chocolatey.tests.infrastructure.app.commands
         {
             public override void Because()
             {
-                command.Run(configuration);
+                Command.Run(Configuration);
             }
 
             [Fact]
             public void Should_call_service_outdated_run()
             {
-                packageService.Verify(c => c.Outdated(configuration), Times.Once);
+                PackageService.Verify(c => c.Outdated(Configuration), Times.Once);
             }
         }
     }

--- a/src/chocolatey.tests/infrastructure.app/commands/ChocolateyPackCommandSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/commands/ChocolateyPackCommandSpecs.cs
@@ -32,97 +32,97 @@ namespace chocolatey.tests.infrastructure.app.commands
         [ConcernFor("pack")]
         public abstract class ChocolateyPackCommandSpecsBase : TinySpec
         {
-            protected ChocolateyPackCommand command;
-            protected Mock<IChocolateyPackageService> packageService = new Mock<IChocolateyPackageService>();
-            protected ChocolateyConfiguration configuration = new ChocolateyConfiguration();
+            protected ChocolateyPackCommand Command;
+            protected Mock<IChocolateyPackageService> PackageService = new Mock<IChocolateyPackageService>();
+            protected ChocolateyConfiguration Configuration = new ChocolateyConfiguration();
 
             public override void Context()
             {
-                command = new ChocolateyPackCommand(packageService.Object);
+                Command = new ChocolateyPackCommand(PackageService.Object);
             }
         }
 
         public class When_implementing_command_for : ChocolateyPackCommandSpecsBase
         {
-            private List<string> results;
+            private List<string> _results;
 
             public override void Because()
             {
-                results = command.GetType().GetCustomAttributes(typeof(CommandForAttribute), false).Cast<CommandForAttribute>().Select(a => a.CommandName).ToList();
+                _results = Command.GetType().GetCustomAttributes(typeof(CommandForAttribute), false).Cast<CommandForAttribute>().Select(a => a.CommandName).ToList();
             }
 
             [Fact]
             public void Should_implement_pack()
             {
-                results.Should().Contain("pack");
+                _results.Should().Contain("pack");
             }
         }
 
         public class When_configurating_the_argument_parser : ChocolateyPackCommandSpecsBase
         {
-            private OptionSet optionSet;
+            private OptionSet _optionSet;
 
             public override void Context()
             {
                 base.Context();
-                optionSet = new OptionSet();
+                _optionSet = new OptionSet();
             }
 
             public override void Because()
             {
-                command.ConfigureArgumentParser(optionSet, configuration);
+                Command.ConfigureArgumentParser(_optionSet, Configuration);
             }
 
             [Fact]
             public void Should_add_version_to_the_option_set()
             {
-                optionSet.Contains("version").Should().BeTrue();
+                _optionSet.Contains("version").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_outputdirectory_to_the_option_set()
             {
-                optionSet.Contains("outputdirectory").Should().BeTrue();
+                _optionSet.Contains("outputdirectory").Should().BeTrue();
             }
         }
 
         public class When_handling_additional_argument_parsing : ChocolateyPackCommandSpecsBase
         {
-            private readonly IList<string> unparsedArgs = new List<string>();
-            private const string nuspecPath = "./some/path/to.nuspec";
+            private readonly IList<string> _unparsedArgs = new List<string>();
+            private const string NuspecPath = "./some/path/to.nuspec";
 
             public override void Context()
             {
                 base.Context();
-                unparsedArgs.Add(nuspecPath);
-                unparsedArgs.Add("foo=1");
-                unparsedArgs.Add("bar='baz'");
+                _unparsedArgs.Add(NuspecPath);
+                _unparsedArgs.Add("foo=1");
+                _unparsedArgs.Add("bar='baz'");
 
                 // Make sure we storing only the first property name specified regardless of case.
-                unparsedArgs.Add("Foo=2");
+                _unparsedArgs.Add("Foo=2");
             }
 
             public override void Because()
             {
-                command.ParseAdditionalArguments(unparsedArgs, configuration);
+                Command.ParseAdditionalArguments(_unparsedArgs, Configuration);
             }
 
             [Fact]
             public void Should_allow_a_path_to_the_nuspec_to_be_passed_in()
             {
-                configuration.Input.Should().Be(nuspecPath);
+                Configuration.Input.Should().Be(NuspecPath);
             }
 
             [Fact]
             public void Should_property_foo_equal_1()
             {
-                configuration.PackCommand.Properties["foo"].Should().Be("1");
+                Configuration.PackCommand.Properties["foo"].Should().Be("1");
             }
 
             [Fact]
             public void Should_property_bar_equal_baz()
             {
-                configuration.PackCommand.Properties["bar"].Should().Be("baz");
+                Configuration.PackCommand.Properties["bar"].Should().Be("baz");
             }
 
             [Fact]
@@ -138,13 +138,13 @@ namespace chocolatey.tests.infrastructure.app.commands
         {
             public override void Because()
             {
-                command.DryRun(configuration);
+                Command.DryRun(Configuration);
             }
 
             [Fact]
             public void Should_call_service_package_noop()
             {
-                packageService.Verify(c => c.PackDryRun(configuration), Times.Once);
+                PackageService.Verify(c => c.PackDryRun(Configuration), Times.Once);
             }
         }
 
@@ -152,42 +152,42 @@ namespace chocolatey.tests.infrastructure.app.commands
         {
             public override void Because()
             {
-                command.Run(configuration);
+                Command.Run(Configuration);
             }
 
             [Fact]
             public void Should_call_service_pack_run()
             {
-                packageService.Verify(c => c.Pack(configuration), Times.Once);
+                PackageService.Verify(c => c.Pack(Configuration), Times.Once);
             }
         }
 
         public class When_handling_arguments_parsing : ChocolateyPackCommandSpecsBase
         {
-            private OptionSet optionSet;
+            private OptionSet _optionSet;
 
             public override void Context()
             {
                 base.Context();
-                optionSet = new OptionSet();
-                command.ConfigureArgumentParser(optionSet, configuration);
+                _optionSet = new OptionSet();
+                Command.ConfigureArgumentParser(_optionSet, Configuration);
             }
 
             public override void Because()
             {
-                optionSet.Parse(new[] { "--version", "0.42.0", "--outputdirectory", "c:\\packages" });
+                _optionSet.Parse(new[] { "--version", "0.42.0", "--outputdirectory", "c:\\packages" });
             }
 
             [Fact]
             public void Should_version_equal_to_42()
             {
-                configuration.Version.Should().Be("0.42.0");
+                Configuration.Version.Should().Be("0.42.0");
             }
 
             [Fact]
             public void Should_outputdirectory_equal_packages()
             {
-                configuration.OutputDirectory.Should().Be("c:\\packages");
+                Configuration.OutputDirectory.Should().Be("c:\\packages");
             }
         }
     }

--- a/src/chocolatey.tests/infrastructure.app/commands/ChocolateyPinCommandSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/commands/ChocolateyPinCommandSpecs.cs
@@ -41,53 +41,53 @@ namespace chocolatey.tests.infrastructure.app.commands
         [ConcernFor("pin")]
         public abstract class ChocolateyPinCommandSpecsBase : TinySpec
         {
-            protected ChocolateyPinCommand command;
-            protected Mock<IChocolateyPackageInformationService> packageInfoService = new Mock<IChocolateyPackageInformationService>();
-            protected Mock<ILogger> nugetLogger = new Mock<ILogger>();
-            protected Mock<INugetService> nugetService = new Mock<INugetService>();
-            protected ChocolateyConfiguration configuration = new ChocolateyConfiguration();
-            protected Mock<IPackageMetadata> package = new Mock<IPackageMetadata>();
-            protected Mock<IPackageMetadata> pinnedPackage = new Mock<IPackageMetadata>();
-            protected Mock<IPackageMetadata> mingwPackage = new Mock<IPackageMetadata>();
-            protected Mock<IPackageMetadata> gstreamerMingwPackage = new Mock<IPackageMetadata>();
+            protected ChocolateyPinCommand Command;
+            protected Mock<IChocolateyPackageInformationService> PackageInfoService = new Mock<IChocolateyPackageInformationService>();
+            protected Mock<ILogger> NugetLogger = new Mock<ILogger>();
+            protected Mock<INugetService> NugetService = new Mock<INugetService>();
+            protected ChocolateyConfiguration Configuration = new ChocolateyConfiguration();
+            protected Mock<IPackageMetadata> Package = new Mock<IPackageMetadata>();
+            protected Mock<IPackageMetadata> PinnedPackage = new Mock<IPackageMetadata>();
+            protected Mock<IPackageMetadata> MingwPackage = new Mock<IPackageMetadata>();
+            protected Mock<IPackageMetadata> GstreamerMingwPackage = new Mock<IPackageMetadata>();
 
             public override void Context()
             {
                 //MockLogger = new MockLogger();
                 //Log.InitializeWith(MockLogger);
-                configuration.Sources = "https://localhost/somewhere/out/there";
-                command = new ChocolateyPinCommand(packageInfoService.Object, nugetLogger.Object, nugetService.Object);
+                Configuration.Sources = "https://localhost/somewhere/out/there";
+                Command = new ChocolateyPinCommand(PackageInfoService.Object, NugetLogger.Object, NugetService.Object);
 
-                package = new Mock<IPackageMetadata>();
-                package.Setup(p => p.Id).Returns("regular");
-                package.Setup(p => p.Version).Returns(new NuGetVersion("1.2.0"));
-                packageInfoService.Setup(s => s.Get(package.Object)).Returns(
-                    new ChocolateyPackageInformation(package.Object)
+                Package = new Mock<IPackageMetadata>();
+                Package.Setup(p => p.Id).Returns("regular");
+                Package.Setup(p => p.Version).Returns(new NuGetVersion("1.2.0"));
+                PackageInfoService.Setup(s => s.Get(Package.Object)).Returns(
+                    new ChocolateyPackageInformation(Package.Object)
                     {
                         IsPinned = false
                     });
-                pinnedPackage = new Mock<IPackageMetadata>();
-                pinnedPackage.Setup(p => p.Id).Returns("pinned");
-                pinnedPackage.Setup(p => p.Version).Returns(new NuGetVersion("1.1.0"));
-                packageInfoService.Setup(s => s.Get(pinnedPackage.Object)).Returns(
-                    new ChocolateyPackageInformation(pinnedPackage.Object)
+                PinnedPackage = new Mock<IPackageMetadata>();
+                PinnedPackage.Setup(p => p.Id).Returns("pinned");
+                PinnedPackage.Setup(p => p.Version).Returns(new NuGetVersion("1.1.0"));
+                PackageInfoService.Setup(s => s.Get(PinnedPackage.Object)).Returns(
+                    new ChocolateyPackageInformation(PinnedPackage.Object)
                     {
                         IsPinned = true
                     });
 
-                mingwPackage = new Mock<IPackageMetadata>();
-                mingwPackage.Setup(p => p.Id).Returns("mingw");
-                mingwPackage.Setup(p => p.Version).Returns(new NuGetVersion("1.0.0"));
-                packageInfoService.Setup(s => s.Get(mingwPackage.Object)).Returns(
-                    new ChocolateyPackageInformation(mingwPackage.Object)
+                MingwPackage = new Mock<IPackageMetadata>();
+                MingwPackage.Setup(p => p.Id).Returns("mingw");
+                MingwPackage.Setup(p => p.Version).Returns(new NuGetVersion("1.0.0"));
+                PackageInfoService.Setup(s => s.Get(MingwPackage.Object)).Returns(
+                    new ChocolateyPackageInformation(MingwPackage.Object)
                     {
                         IsPinned = true
                     });
-                gstreamerMingwPackage = new Mock<IPackageMetadata>();
-                gstreamerMingwPackage.Setup(p => p.Id).Returns("gstreamer-mingw");
-                gstreamerMingwPackage.Setup(p => p.Version).Returns(new NuGetVersion("1.0.0"));
-                packageInfoService.Setup(s => s.Get(gstreamerMingwPackage.Object)).Returns(
-                    new ChocolateyPackageInformation(gstreamerMingwPackage.Object)
+                GstreamerMingwPackage = new Mock<IPackageMetadata>();
+                GstreamerMingwPackage.Setup(p => p.Id).Returns("gstreamer-mingw");
+                GstreamerMingwPackage.Setup(p => p.Version).Returns(new NuGetVersion("1.0.0"));
+                PackageInfoService.Setup(s => s.Get(GstreamerMingwPackage.Object)).Returns(
+                    new ChocolateyPackageInformation(GstreamerMingwPackage.Object)
                     {
                         IsPinned = true
                     });
@@ -95,74 +95,74 @@ namespace chocolatey.tests.infrastructure.app.commands
 
             public void Reset()
             {
-                packageInfoService.ResetCalls();
-                nugetService.ResetCalls();
+                PackageInfoService.ResetCalls();
+                NugetService.ResetCalls();
             }
         }
 
         public class When_implementing_command_for : ChocolateyPinCommandSpecsBase
         {
-            private List<string> results;
+            private List<string> _results;
 
             public override void Because()
             {
-                results = command.GetType().GetCustomAttributes(typeof(CommandForAttribute), false).Cast<CommandForAttribute>().Select(a => a.CommandName).ToList();
+                _results = Command.GetType().GetCustomAttributes(typeof(CommandForAttribute), false).Cast<CommandForAttribute>().Select(a => a.CommandName).ToList();
             }
 
             [Fact]
             public void Should_implement_source()
             {
-                results.Should().Contain("pin");
+                _results.Should().Contain("pin");
             }
         }
 
         public class When_configurating_the_argument_parser : ChocolateyPinCommandSpecsBase
         {
-            private OptionSet optionSet;
+            private OptionSet _optionSet;
 
             public override void Context()
             {
                 base.Context();
-                optionSet = new OptionSet();
+                _optionSet = new OptionSet();
             }
 
             public override void Because()
             {
-                command.ConfigureArgumentParser(optionSet, configuration);
+                Command.ConfigureArgumentParser(_optionSet, Configuration);
             }
 
             [Fact]
             public void Should_add_name_to_the_option_set()
             {
-                optionSet.Contains("name").Should().BeTrue();
+                _optionSet.Contains("name").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_short_version_of_name_to_the_option_set()
             {
-                optionSet.Contains("n").Should().BeTrue();
+                _optionSet.Contains("n").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_version_to_the_option_set()
             {
-                optionSet.Contains("version").Should().BeTrue();
+                _optionSet.Contains("version").Should().BeTrue();
             }
         }
 
         public class When_handling_additional_argument_parsing : ChocolateyPinCommandSpecsBase
         {
-            private readonly IList<string> unparsedArgs = new List<string>();
-            private Action because;
+            private readonly IList<string> _unparsedArgs = new List<string>();
+            private Action _because;
 
             public override void Because()
             {
-                because = () => command.ParseAdditionalArguments(unparsedArgs, configuration);
+                _because = () => Command.ParseAdditionalArguments(_unparsedArgs, Configuration);
             }
 
             public new void Reset()
             {
-                unparsedArgs.Clear();
+                _unparsedArgs.Clear();
                 base.Reset();
             }
 
@@ -170,24 +170,24 @@ namespace chocolatey.tests.infrastructure.app.commands
             public void Should_use_the_first_unparsed_arg_as_the_subcommand()
             {
                 Reset();
-                unparsedArgs.Add("list");
-                because();
+                _unparsedArgs.Add("list");
+                _because();
 
-                configuration.PinCommand.Command.Should().Be(PinCommandType.List);
+                Configuration.PinCommand.Command.Should().Be(PinCommandType.List);
             }
 
             [Fact]
             public void Should_throw_when_more_than_one_unparsed_arg_is_passed()
             {
                 Reset();
-                unparsedArgs.Add("wtf");
-                unparsedArgs.Add("bbq");
+                _unparsedArgs.Add("wtf");
+                _unparsedArgs.Add("bbq");
                 var errored = false;
                 Exception error = null;
 
                 try
                 {
-                    because();
+                    _because();
                 }
                 catch (Exception ex)
                 {
@@ -205,109 +205,109 @@ namespace chocolatey.tests.infrastructure.app.commands
             public void Should_accept_add_as_the_subcommand()
             {
                 Reset();
-                unparsedArgs.Add("add");
-                because();
+                _unparsedArgs.Add("add");
+                _because();
 
-                configuration.PinCommand.Command.Should().Be(PinCommandType.Add);
+                Configuration.PinCommand.Command.Should().Be(PinCommandType.Add);
             }
 
             [Fact]
             public void Should_accept_uppercase_add_as_the_subcommand()
             {
                 Reset();
-                unparsedArgs.Add("ADD");
-                because();
+                _unparsedArgs.Add("ADD");
+                _because();
 
-                configuration.PinCommand.Command.Should().Be(PinCommandType.Add);
+                Configuration.PinCommand.Command.Should().Be(PinCommandType.Add);
             }
 
             [Fact]
             public void Should_remove_add_as_the_subcommand()
             {
                 Reset();
-                unparsedArgs.Add("remove");
-                because();
+                _unparsedArgs.Add("remove");
+                _because();
 
-                configuration.PinCommand.Command.Should().Be(PinCommandType.Remove);
+                Configuration.PinCommand.Command.Should().Be(PinCommandType.Remove);
             }
 
             [Fact]
             public void Should_set_unrecognized_values_to_list_as_the_subcommand()
             {
                 Reset();
-                unparsedArgs.Add("wtf");
-                because();
+                _unparsedArgs.Add("wtf");
+                _because();
 
-                configuration.PinCommand.Command.Should().Be(PinCommandType.List);
+                Configuration.PinCommand.Command.Should().Be(PinCommandType.List);
             }
 
             [Fact]
             public void Should_default_to_list_as_the_subcommand()
             {
                 Reset();
-                because();
+                _because();
 
-                configuration.PinCommand.Command.Should().Be(PinCommandType.List);
+                Configuration.PinCommand.Command.Should().Be(PinCommandType.List);
             }
 
             [Fact]
             public void Should_handle_passing_in_an_empty_string()
             {
                 Reset();
-                unparsedArgs.Add(" ");
-                because();
+                _unparsedArgs.Add(" ");
+                _because();
 
-                configuration.PinCommand.Command.Should().Be(PinCommandType.List);
+                Configuration.PinCommand.Command.Should().Be(PinCommandType.List);
             }
 
             [Fact]
             public void Should_set_config_sources_to_local_only()
             {
                 Reset();
-                because();
+                _because();
 
-                configuration.Sources.Should().Be(ApplicationParameters.PackagesLocation);
+                Configuration.Sources.Should().Be(ApplicationParameters.PackagesLocation);
             }
 
             [Fact]
             public void Should_set_config_local_only_to_true()
             {
                 Reset();
-                because();
+                _because();
 
-                configuration.ListCommand.LocalOnly.Should().BeTrue();
+                Configuration.ListCommand.LocalOnly.Should().BeTrue();
             }
 
             [Fact]
             public void Should_set_config_all_versions_to_true()
             {
                 Reset();
-                because();
+                _because();
 
-                configuration.AllVersions.Should().BeTrue();
+                Configuration.AllVersions.Should().BeTrue();
             }
         }
 
         public class When_validating : ChocolateyPinCommandSpecsBase
         {
-            private Action because;
+            private Action _because;
 
             public override void Because()
             {
-                because = () => command.Validate(configuration);
+                _because = () => Command.Validate(Configuration);
             }
 
             [Fact]
             public void Should_throw_when_command_is_not_list_and_name_is_not_set()
             {
-                configuration.PinCommand.Command = PinCommandType.Add;
-                configuration.PinCommand.Name = "";
+                Configuration.PinCommand.Command = PinCommandType.Add;
+                Configuration.PinCommand.Name = "";
                 var errored = false;
                 Exception error = null;
 
                 try
                 {
-                    because();
+                    _because();
                 }
                 catch (Exception ex)
                 {
@@ -318,23 +318,23 @@ namespace chocolatey.tests.infrastructure.app.commands
                 errored.Should().BeTrue();
                 error.Should().NotBeNull();
                 error.Should().BeOfType<ApplicationException>();
-                error.Message.Should().Be("When specifying the subcommand '{0}', you must also specify --name.".FormatWith(configuration.PinCommand.Command.ToStringSafe().ToLower()));
+                error.Message.Should().Be("When specifying the subcommand '{0}', you must also specify --name.".FormatWith(Configuration.PinCommand.Command.ToStringSafe().ToLower()));
             }
 
             [Fact]
             public void Should_continue_when_command_is_list_and_name_is_not_set()
             {
-                configuration.PinCommand.Command = PinCommandType.List;
-                configuration.PinCommand.Name = "";
-                because();
+                Configuration.PinCommand.Command = PinCommandType.List;
+                Configuration.PinCommand.Name = "";
+                _because();
             }
 
             [Fact]
             public void Should_continue_when_command_is_not_list_and_name_is_set()
             {
-                configuration.PinCommand.Command = PinCommandType.List;
-                configuration.PinCommand.Name = "bob";
-                because();
+                Configuration.PinCommand.Command = PinCommandType.List;
+                Configuration.PinCommand.Name = "bob";
+                _because();
             }
         }
 
@@ -342,7 +342,7 @@ namespace chocolatey.tests.infrastructure.app.commands
         {
             public override void Because()
             {
-                command.DryRun(configuration);
+                Command.DryRun(Configuration);
             }
 
             [Fact]
@@ -366,21 +366,21 @@ namespace chocolatey.tests.infrastructure.app.commands
             public override void Context()
             {
                 base.Context();
-                configuration.Sources = ApplicationParameters.PackagesLocation;
-                configuration.ListCommand.LocalOnly = true;
-                configuration.AllVersions = true;
+                Configuration.Sources = ApplicationParameters.PackagesLocation;
+                Configuration.ListCommand.LocalOnly = true;
+                Configuration.AllVersions = true;
                 var packageResults = new[]
                 {
-                    new PackageResult(package.Object, null),
-                    new PackageResult(pinnedPackage.Object, null)
+                    new PackageResult(Package.Object, null),
+                    new PackageResult(PinnedPackage.Object, null)
                 };
-                nugetService.Setup(n => n.List(It.IsAny<ChocolateyConfiguration>())).Returns(packageResults);
-                configuration.PinCommand.Command = PinCommandType.List;
+                NugetService.Setup(n => n.List(It.IsAny<ChocolateyConfiguration>())).Returns(packageResults);
+                Configuration.PinCommand.Command = PinCommandType.List;
             }
 
             public override void Because()
             {
-                command.Run(configuration);
+                Command.Run(Configuration);
             }
 
             [Fact]
@@ -415,16 +415,16 @@ namespace chocolatey.tests.infrastructure.app.commands
             public override void Context()
             {
                 base.Context();
-                configuration.Sources = ApplicationParameters.PackagesLocation;
-                configuration.ListCommand.LocalOnly = true;
-                configuration.AllVersions = true;
+                Configuration.Sources = ApplicationParameters.PackagesLocation;
+                Configuration.ListCommand.LocalOnly = true;
+                Configuration.AllVersions = true;
 
                 var packageResults = new[]
                 {
-                    new PackageResult(package.Object, null),
-                    new PackageResult(pinnedPackage.Object, null)
+                    new PackageResult(Package.Object, null),
+                    new PackageResult(PinnedPackage.Object, null)
                 };
-                nugetService.Setup(n => n.List(It.IsAny<ChocolateyConfiguration>())).Returns(packageResults);
+                NugetService.Setup(n => n.List(It.IsAny<ChocolateyConfiguration>())).Returns(packageResults);
             }
 
             public new void Reset()
@@ -448,10 +448,10 @@ namespace chocolatey.tests.infrastructure.app.commands
             public void Should_call_nuget_service_list_run_when_command_is_list()
             {
                 Reset();
-                configuration.PinCommand.Command = PinCommandType.List;
-                command.Run(configuration);
+                Configuration.PinCommand.Command = PinCommandType.List;
+                Command.Run(Configuration);
 
-                nugetService.Verify(n => n.List(It.IsAny<ChocolateyConfiguration>()), Times.Once);
+                NugetService.Verify(n => n.List(It.IsAny<ChocolateyConfiguration>()), Times.Once);
             }
 
             [Fact]
@@ -459,24 +459,24 @@ namespace chocolatey.tests.infrastructure.app.commands
             {
                 Reset();
 
-                configuration.PinCommand.Name = "regular";
-                configuration.PinCommand.Command = PinCommandType.Add;
+                Configuration.PinCommand.Name = "regular";
+                Configuration.PinCommand.Command = PinCommandType.Add;
 
-                command.SetPin(configuration);
+                Command.SetPin(Configuration);
 
-                packageInfoService.Verify(s => s.Save(It.IsAny<ChocolateyPackageInformation>()), Times.Once);
+                PackageInfoService.Verify(s => s.Save(It.IsAny<ChocolateyPackageInformation>()), Times.Once);
             }
 
             [Fact]
             public void Should_remove_pin_when_command_is_remove()
             {
                 Reset();
-                configuration.PinCommand.Name = "pinned";
-                configuration.PinCommand.Command = PinCommandType.Remove;
+                Configuration.PinCommand.Name = "pinned";
+                Configuration.PinCommand.Command = PinCommandType.Remove;
 
-                command.SetPin(configuration);
+                Command.SetPin(Configuration);
 
-                packageInfoService.Verify(s => s.Save(It.IsAny<ChocolateyPackageInformation>()), Times.Once);
+                PackageInfoService.Verify(s => s.Save(It.IsAny<ChocolateyPackageInformation>()), Times.Once);
             }
         }
 
@@ -485,16 +485,16 @@ namespace chocolatey.tests.infrastructure.app.commands
             public override void Context()
             {
                 base.Context();
-                configuration.Sources = ApplicationParameters.PackagesLocation;
-                configuration.ListCommand.LocalOnly = true;
-                configuration.AllVersions = true;
+                Configuration.Sources = ApplicationParameters.PackagesLocation;
+                Configuration.ListCommand.LocalOnly = true;
+                Configuration.AllVersions = true;
 
                 var packageResults = new[]
                 {
-                    new PackageResult(mingwPackage.Object, null),
-                    new PackageResult(gstreamerMingwPackage.Object, null)
+                    new PackageResult(MingwPackage.Object, null),
+                    new PackageResult(GstreamerMingwPackage.Object, null)
                 };
-                nugetService.Setup(n => n.List(It.IsAny<ChocolateyConfiguration>())).Returns(packageResults);
+                NugetService.Setup(n => n.List(It.IsAny<ChocolateyConfiguration>())).Returns(packageResults);
             }
 
             public new void Reset()
@@ -517,22 +517,22 @@ namespace chocolatey.tests.infrastructure.app.commands
             public void Should_call_nuget_service_list_run_when_command_is_list()
             {
                 Reset();
-                configuration.PinCommand.Command = PinCommandType.List;
-                command.Run(configuration);
+                Configuration.PinCommand.Command = PinCommandType.List;
+                Command.Run(Configuration);
 
-                nugetService.Verify(n => n.List(It.IsAny<ChocolateyConfiguration>()), Times.Once);
+                NugetService.Verify(n => n.List(It.IsAny<ChocolateyConfiguration>()), Times.Once);
             }
 
             [Fact]
             public void Should_remove_pin_from_correct_package()
             {
                 Reset();
-                configuration.PinCommand.Name = "mingw";
-                configuration.PinCommand.Command = PinCommandType.Remove;
+                Configuration.PinCommand.Name = "mingw";
+                Configuration.PinCommand.Command = PinCommandType.Remove;
 
-                command.SetPin(configuration);
+                Command.SetPin(Configuration);
 
-                packageInfoService.Verify(s =>
+                PackageInfoService.Verify(s =>
                     s.Save(It.Is<ChocolateyPackageInformation>(n =>
                         n.Package.Id.Equals("mingw"))), Times.Once);
             }

--- a/src/chocolatey.tests/infrastructure.app/commands/ChocolateySearchCommandSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/commands/ChocolateySearchCommandSpecs.cs
@@ -32,131 +32,131 @@ namespace chocolatey.tests.infrastructure.app.commands
         [ConcernFor("search")]
         public abstract class ChocolateySearchCommandSpecsBase : TinySpec
         {
-            protected ChocolateySearchCommand command;
-            protected Mock<IChocolateyPackageService> packageService = new Mock<IChocolateyPackageService>();
-            protected ChocolateyConfiguration configuration = new ChocolateyConfiguration();
+            protected ChocolateySearchCommand Command;
+            protected Mock<IChocolateyPackageService> PackageService = new Mock<IChocolateyPackageService>();
+            protected ChocolateyConfiguration Configuration = new ChocolateyConfiguration();
 
             public override void Context()
             {
-                configuration.Sources = "bob";
-                command = new ChocolateySearchCommand(packageService.Object);
+                Configuration.Sources = "bob";
+                Command = new ChocolateySearchCommand(PackageService.Object);
             }
         }
 
         public class When_implementing_command_for : ChocolateySearchCommandSpecsBase
         {
-            private List<string> results;
+            private List<string> _results;
 
             public override void Because()
             {
-                results = command.GetType().GetCustomAttributes(typeof(CommandForAttribute), false).Cast<CommandForAttribute>().Select(a => a.CommandName).ToList();
+                _results = Command.GetType().GetCustomAttributes(typeof(CommandForAttribute), false).Cast<CommandForAttribute>().Select(a => a.CommandName).ToList();
             }
 
             [Fact]
             public void Should_not_implement_list()
             {
-                results.Should().NotContain("list");
+                _results.Should().NotContain("list");
             }
 
             [Fact]
             public void Should_implement_search()
             {
-                results.Should().Contain("search");
+                _results.Should().Contain("search");
             }
 
             [Fact]
             public void Should_implement_find()
             {
-                results.Should().Contain("find");
+                _results.Should().Contain("find");
             }
         }
 
         public class When_configurating_the_argument_parser_for_search_command : ChocolateySearchCommandSpecsBase
         {
-            private OptionSet optionSet;
+            private OptionSet _optionSet;
 
             public override void Context()
             {
                 base.Context();
-                optionSet = new OptionSet();
-                configuration.CommandName = "search";
+                _optionSet = new OptionSet();
+                Configuration.CommandName = "search";
             }
 
             public override void Because()
             {
-                command.ConfigureArgumentParser(optionSet, configuration);
+                Command.ConfigureArgumentParser(_optionSet, Configuration);
             }
 
             [Fact]
             public void Should_add_source_to_the_option_set()
             {
-                optionSet.Contains("source").Should().BeTrue();
+                _optionSet.Contains("source").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_short_version_of_source_to_the_option_set()
             {
-                optionSet.Contains("s").Should().BeTrue();
+                _optionSet.Contains("s").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_prerelease_to_the_option_set()
             {
-                optionSet.Contains("prerelease").Should().BeTrue();
+                _optionSet.Contains("prerelease").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_short_version_of_prerelease_to_the_option_set()
             {
-                optionSet.Contains("pre").Should().BeTrue();
+                _optionSet.Contains("pre").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_includeprograms_to_the_option_set()
             {
-                optionSet.Contains("includeprograms").Should().BeTrue();
+                _optionSet.Contains("includeprograms").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_short_version_of_includeprograms_to_the_option_set()
             {
-                optionSet.Contains("i").Should().BeTrue();
+                _optionSet.Contains("i").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_allversions_to_the_option_set()
             {
-                optionSet.Contains("allversions").Should().BeTrue();
+                _optionSet.Contains("allversions").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_short_version_of_allversions_to_the_option_set()
             {
-                optionSet.Contains("a").Should().BeTrue();
+                _optionSet.Contains("a").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_user_to_the_option_set()
             {
-                optionSet.Contains("user").Should().BeTrue();
+                _optionSet.Contains("user").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_short_version_of_user_to_the_option_set()
             {
-                optionSet.Contains("u").Should().BeTrue();
+                _optionSet.Contains("u").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_password_to_the_option_set()
             {
-                optionSet.Contains("password").Should().BeTrue();
+                _optionSet.Contains("password").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_short_version_of_password_to_the_option_set()
             {
-                optionSet.Contains("p").Should().BeTrue();
+                _optionSet.Contains("p").Should().BeTrue();
             }
         }
 
@@ -164,129 +164,129 @@ namespace chocolatey.tests.infrastructure.app.commands
         [NUnit.Framework.TestFixture("find")]
         public class When_configurating_the_argument_parser : ChocolateySearchCommandSpecsBase
         {
-            private OptionSet optionSet;
+            private OptionSet _optionSet;
 
             public When_configurating_the_argument_parser(string commandName)
             {
-                configuration.CommandName = commandName;
+                Configuration.CommandName = commandName;
             }
 
             public override void Context()
             {
                 base.Context();
-                optionSet = new OptionSet();
+                _optionSet = new OptionSet();
             }
 
             public override void Because()
             {
-                command.ConfigureArgumentParser(optionSet, configuration);
+                Command.ConfigureArgumentParser(_optionSet, Configuration);
             }
 
             [Fact]
             public void Should_add_source_to_the_option_set()
             {
-                optionSet.Contains("source").Should().BeTrue();
+                _optionSet.Contains("source").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_short_version_of_source_to_the_option_set()
             {
-                optionSet.Contains("s").Should().BeTrue();
+                _optionSet.Contains("s").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_prerelease_to_the_option_set()
             {
-                optionSet.Contains("prerelease").Should().BeTrue();
+                _optionSet.Contains("prerelease").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_short_version_of_prerelease_to_the_option_set()
             {
-                optionSet.Contains("pre").Should().BeTrue();
+                _optionSet.Contains("pre").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_includeprograms_to_the_option_set()
             {
-                optionSet.Contains("includeprograms").Should().BeTrue();
+                _optionSet.Contains("includeprograms").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_short_version_of_includeprograms_to_the_option_set()
             {
-                optionSet.Contains("i").Should().BeTrue();
+                _optionSet.Contains("i").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_allversions_to_the_option_set()
             {
-                optionSet.Contains("allversions").Should().BeTrue();
+                _optionSet.Contains("allversions").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_short_version_of_allversions_to_the_option_set()
             {
-                optionSet.Contains("a").Should().BeTrue();
+                _optionSet.Contains("a").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_user_to_the_option_set()
             {
-                optionSet.Contains("user").Should().BeTrue();
+                _optionSet.Contains("user").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_short_version_of_user_to_the_option_set()
             {
-                optionSet.Contains("u").Should().BeTrue();
+                _optionSet.Contains("u").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_password_to_the_option_set()
             {
-                optionSet.Contains("password").Should().BeTrue();
+                _optionSet.Contains("password").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_short_version_of_password_to_the_option_set()
             {
-                optionSet.Contains("p").Should().BeTrue();
+                _optionSet.Contains("p").Should().BeTrue();
             }
         }
 
         public class When_handling_additional_argument_parsing : ChocolateySearchCommandSpecsBase
         {
-            private readonly IList<string> unparsedArgs = new List<string>();
-            private readonly string source = "https://somewhereoutthere";
-            private Action because;
+            private readonly IList<string> _unparsedArgs = new List<string>();
+            private readonly string _source = "https://somewhereoutthere";
+            private Action _because;
 
             public override void Context()
             {
                 base.Context();
-                unparsedArgs.Add("pkg1");
-                unparsedArgs.Add("pkg2");
-                configuration.Sources = source;
+                _unparsedArgs.Add("pkg1");
+                _unparsedArgs.Add("pkg2");
+                Configuration.Sources = _source;
             }
 
             public override void Because()
             {
-                because = () => command.ParseAdditionalArguments(unparsedArgs, configuration);
+                _because = () => Command.ParseAdditionalArguments(_unparsedArgs, Configuration);
             }
 
             [Fact]
             public void Should_set_unparsed_arguments_to_configuration_input()
             {
-                because();
-                configuration.Input.Should().Be("pkg1 pkg2");
+                _because();
+                Configuration.Input.Should().Be("pkg1 pkg2");
             }
 
             [Fact]
             public void Should_leave_source_as_set()
             {
-                configuration.ListCommand.LocalOnly = false;
-                because();
-                configuration.Sources.Should().Be(source);
+                Configuration.ListCommand.LocalOnly = false;
+                _because();
+                Configuration.Sources.Should().Be(_source);
             }
         }
 
@@ -295,18 +295,18 @@ namespace chocolatey.tests.infrastructure.app.commands
             public override void Context()
             {
                 base.Context();
-                configuration.CommandName = "search";
+                Configuration.CommandName = "search";
             }
 
             public override void Because()
             {
-                command.DryRun(configuration);
+                Command.DryRun(Configuration);
             }
 
             [Fact]
             public void Should_call_service_list_noop()
             {
-                packageService.Verify(c => c.ListDryRun(configuration), Times.Once);
+                PackageService.Verify(c => c.ListDryRun(Configuration), Times.Once);
             }
         }
 
@@ -314,13 +314,13 @@ namespace chocolatey.tests.infrastructure.app.commands
         {
             public override void Because()
             {
-                command.DryRun(configuration);
+                Command.DryRun(Configuration);
             }
 
             [Fact]
             public void Should_call_service_list_noop()
             {
-                packageService.Verify(c => c.ListDryRun(configuration), Times.Once);
+                PackageService.Verify(c => c.ListDryRun(Configuration), Times.Once);
             }
 
             [Fact]
@@ -335,18 +335,18 @@ namespace chocolatey.tests.infrastructure.app.commands
             public override void Context()
             {
                 base.Context();
-                configuration.CommandName = "search";
+                Configuration.CommandName = "search";
             }
 
             public override void Because()
             {
-                command.Run(configuration);
+                Command.Run(Configuration);
             }
 
             [Fact]
             public void Should_call_service_list_run()
             {
-                packageService.Verify(c => c.List(configuration), Times.Once);
+                PackageService.Verify(c => c.List(Configuration), Times.Once);
             }
         }
 
@@ -354,13 +354,13 @@ namespace chocolatey.tests.infrastructure.app.commands
         {
             public override void Because()
             {
-                command.Run(configuration);
+                Command.Run(Configuration);
             }
 
             [Fact]
             public void Should_call_service_list_run()
             {
-                packageService.Verify(c => c.List(configuration), Times.Once);
+                PackageService.Verify(c => c.List(Configuration), Times.Once);
             }
 
             [Fact]
@@ -376,12 +376,12 @@ namespace chocolatey.tests.infrastructure.app.commands
         {
             public When_outputting_help_message(string commandName)
             {
-                configuration.CommandName = commandName;
+                Configuration.CommandName = commandName;
             }
 
             public override void Because()
             {
-                command.HelpMessage(configuration);
+                Command.HelpMessage(Configuration);
             }
         }
     }

--- a/src/chocolatey.tests/infrastructure.app/commands/ChocolateySourceCommandSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/commands/ChocolateySourceCommandSpecs.cs
@@ -33,148 +33,148 @@ namespace chocolatey.tests.infrastructure.app.commands
         [ConcernFor("source")]
         public abstract class ChocolateySourceCommandSpecsBase : TinySpec
         {
-            protected ChocolateySourceCommand command;
-            protected Mock<IChocolateyConfigSettingsService> configSettingsService = new Mock<IChocolateyConfigSettingsService>();
-            protected ChocolateyConfiguration configuration = new ChocolateyConfiguration();
+            protected ChocolateySourceCommand Command;
+            protected Mock<IChocolateyConfigSettingsService> ConfigSettingsService = new Mock<IChocolateyConfigSettingsService>();
+            protected ChocolateyConfiguration Configuration = new ChocolateyConfiguration();
 
             public override void Context()
             {
-                configuration.Sources = "https://localhost/somewhere/out/there";
-                command = new ChocolateySourceCommand(configSettingsService.Object);
+                Configuration.Sources = "https://localhost/somewhere/out/there";
+                Command = new ChocolateySourceCommand(ConfigSettingsService.Object);
             }
         }
 
         public class When_implementing_command_for : ChocolateySourceCommandSpecsBase
         {
-            private List<string> results;
+            private List<string> _results;
 
             public override void Because()
             {
-                results = command.GetType().GetCustomAttributes(typeof(CommandForAttribute), false).Cast<CommandForAttribute>().Select(a => a.CommandName).ToList();
+                _results = Command.GetType().GetCustomAttributes(typeof(CommandForAttribute), false).Cast<CommandForAttribute>().Select(a => a.CommandName).ToList();
             }
 
             [Fact]
             public void Should_implement_source()
             {
-                results.Should().Contain("source");
+                _results.Should().Contain("source");
             }
 
             [Fact]
             public void Should_implement_sources()
             {
-                results.Should().Contain("sources");
+                _results.Should().Contain("sources");
             }
         }
 
         public class When_configurating_the_argument_parser : ChocolateySourceCommandSpecsBase
         {
-            private OptionSet optionSet;
+            private OptionSet _optionSet;
 
             public override void Context()
             {
                 base.Context();
-                optionSet = new OptionSet();
-                configuration.Sources = "https://localhost/somewhere/out/there";
+                _optionSet = new OptionSet();
+                Configuration.Sources = "https://localhost/somewhere/out/there";
             }
 
             public override void Because()
             {
-                command.ConfigureArgumentParser(optionSet, configuration);
+                Command.ConfigureArgumentParser(_optionSet, Configuration);
             }
 
             [Fact]
             public void Should_clear_previously_set_Source()
             {
-                configuration.Sources.Should().BeEmpty();
+                Configuration.Sources.Should().BeEmpty();
             }
 
             [Fact]
             public void Should_add_name_to_the_option_set()
             {
-                optionSet.Contains("name").Should().BeTrue();
+                _optionSet.Contains("name").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_short_version_of_name_to_the_option_set()
             {
-                optionSet.Contains("n").Should().BeTrue();
+                _optionSet.Contains("n").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_source_to_the_option_set()
             {
-                optionSet.Contains("source").Should().BeTrue();
+                _optionSet.Contains("source").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_short_version_of_source_to_the_option_set()
             {
-                optionSet.Contains("s").Should().BeTrue();
+                _optionSet.Contains("s").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_user_to_the_option_set()
             {
-                optionSet.Contains("user").Should().BeTrue();
+                _optionSet.Contains("user").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_short_version_of_user_to_the_option_set()
             {
-                optionSet.Contains("u").Should().BeTrue();
+                _optionSet.Contains("u").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_password_to_the_option_set()
             {
-                optionSet.Contains("password").Should().BeTrue();
+                _optionSet.Contains("password").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_short_version_of_password_to_the_option_set()
             {
-                optionSet.Contains("p").Should().BeTrue();
+                _optionSet.Contains("p").Should().BeTrue();
             }
         }
 
         public class When_handling_additional_argument_parsing : ChocolateySourceCommandSpecsBase
         {
-            private readonly IList<string> unparsedArgs = new List<string>();
-            private Action because;
+            private readonly IList<string> _unparsedArgs = new List<string>();
+            private Action _because;
 
             public override void Because()
             {
-                because = () => command.ParseAdditionalArguments(unparsedArgs, configuration);
+                _because = () => Command.ParseAdditionalArguments(_unparsedArgs, Configuration);
             }
 
             public void Reset()
             {
-                unparsedArgs.Clear();
-                configSettingsService.ResetCalls();
+                _unparsedArgs.Clear();
+                ConfigSettingsService.ResetCalls();
             }
 
             [Fact]
             public void Should_use_the_first_unparsed_arg_as_the_subcommand()
             {
                 Reset();
-                unparsedArgs.Add("list");
-                because();
+                _unparsedArgs.Add("list");
+                _because();
 
-                configuration.SourceCommand.Command.Should().Be(SourceCommandType.List);
+                Configuration.SourceCommand.Command.Should().Be(SourceCommandType.List);
             }
 
             [Fact]
             public void Should_throw_when_more_than_one_unparsed_arg_is_passed()
             {
                 Reset();
-                unparsedArgs.Add("wtf");
-                unparsedArgs.Add("bbq");
+                _unparsedArgs.Add("wtf");
+                _unparsedArgs.Add("bbq");
                 var errored = false;
                 Exception error = null;
 
                 try
                 {
-                    because();
+                    _because();
                 }
                 catch (Exception ex)
                 {
@@ -192,95 +192,95 @@ namespace chocolatey.tests.infrastructure.app.commands
             public void Should_accept_add_as_the_subcommand()
             {
                 Reset();
-                unparsedArgs.Add("add");
-                because();
+                _unparsedArgs.Add("add");
+                _because();
 
-                configuration.SourceCommand.Command.Should().Be(SourceCommandType.Add);
+                Configuration.SourceCommand.Command.Should().Be(SourceCommandType.Add);
             }
 
             [Fact]
             public void Should_accept_uppercase_add_as_the_subcommand()
             {
                 Reset();
-                unparsedArgs.Add("ADD");
-                because();
+                _unparsedArgs.Add("ADD");
+                _because();
 
-                configuration.SourceCommand.Command.Should().Be(SourceCommandType.Add);
+                Configuration.SourceCommand.Command.Should().Be(SourceCommandType.Add);
             }
 
             [Fact]
             public void Should_remove_add_as_the_subcommand()
             {
                 Reset();
-                unparsedArgs.Add("remove");
-                because();
+                _unparsedArgs.Add("remove");
+                _because();
 
-                configuration.SourceCommand.Command.Should().Be(SourceCommandType.Remove);
+                Configuration.SourceCommand.Command.Should().Be(SourceCommandType.Remove);
             }
 
             [Fact]
             public void Should_accept_enable_as_the_subcommand()
             {
                 Reset();
-                unparsedArgs.Add("enable");
-                because();
+                _unparsedArgs.Add("enable");
+                _because();
 
-                configuration.SourceCommand.Command.Should().Be(SourceCommandType.Enable);
+                Configuration.SourceCommand.Command.Should().Be(SourceCommandType.Enable);
             }
 
             [Fact]
             public void Should_accept_disable_as_the_subcommand()
             {
                 Reset();
-                unparsedArgs.Add("disable");
-                because();
+                _unparsedArgs.Add("disable");
+                _because();
 
-                configuration.SourceCommand.Command.Should().Be(SourceCommandType.Disable);
+                Configuration.SourceCommand.Command.Should().Be(SourceCommandType.Disable);
             }
 
             [Fact]
             public void Should_set_unrecognized_values_to_list_as_the_subcommand()
             {
                 Reset();
-                unparsedArgs.Add("wtf");
-                because();
+                _unparsedArgs.Add("wtf");
+                _because();
 
-                configuration.SourceCommand.Command.Should().Be(SourceCommandType.List);
+                Configuration.SourceCommand.Command.Should().Be(SourceCommandType.List);
             }
 
             [Fact]
             public void Should_default_to_list_as_the_subcommand()
             {
                 Reset();
-                because();
+                _because();
 
-                configuration.SourceCommand.Command.Should().Be(SourceCommandType.List);
+                Configuration.SourceCommand.Command.Should().Be(SourceCommandType.List);
             }
 
             [Fact]
             public void Should_handle_passing_in_an_empty_string()
             {
                 Reset();
-                unparsedArgs.Add(" ");
-                because();
+                _unparsedArgs.Add(" ");
+                _because();
 
-                configuration.SourceCommand.Command.Should().Be(SourceCommandType.List);
+                Configuration.SourceCommand.Command.Should().Be(SourceCommandType.List);
             }
         }
 
         public class When_validating : ChocolateySourceCommandSpecsBase
         {
-            private Action because;
+            private Action _because;
 
             public override void Because()
             {
-                because = () => command.Validate(configuration);
+                _because = () => Command.Validate(Configuration);
             }
 
             [Fact]
             public void Should_throw_when_command_is_not_list_and_name_is_not_set()
             {
-                configuration.SourceCommand.Name = "";
+                Configuration.SourceCommand.Name = "";
                 const string expectedMessage = "When specifying the subcommand '{0}', you must also specify --name.";
                 VerifyExceptionThrownOnCommand(expectedMessage);
             }
@@ -288,22 +288,22 @@ namespace chocolatey.tests.infrastructure.app.commands
             [Fact]
             public void Should_throw_when_command_is_add_and_source_is_not_set()
             {
-                configuration.SourceCommand.Name = "irrelevant";
-                configuration.Sources = string.Empty;
+                Configuration.SourceCommand.Name = "irrelevant";
+                Configuration.Sources = string.Empty;
                 const string expectedMessage = "When specifying the subcommand '{0}', you must also specify --source.";
                 VerifyExceptionThrownOnCommand(expectedMessage);
             }
 
             private void VerifyExceptionThrownOnCommand(string expectedMessage)
             {
-                configuration.SourceCommand.Command = SourceCommandType.Add;
+                Configuration.SourceCommand.Command = SourceCommandType.Add;
 
                 var errored = false;
                 Exception error = null;
 
                 try
                 {
-                    because();
+                    _because();
                 }
                 catch (Exception ex)
                 {
@@ -314,24 +314,24 @@ namespace chocolatey.tests.infrastructure.app.commands
                 errored.Should().BeTrue();
                 error.Should().NotBeNull();
                 error.Should().BeOfType<ApplicationException>();
-                var commandName = configuration.SourceCommand.Command.ToStringSafe().ToLower();
+                var commandName = Configuration.SourceCommand.Command.ToStringSafe().ToLower();
                 error.Message.Should().Be(expectedMessage.FormatWith(commandName));
             }
 
             [Fact]
             public void Should_continue_when_command_is_list_and_name_is_not_set()
             {
-                configuration.SourceCommand.Command = SourceCommandType.List;
-                configuration.SourceCommand.Name = "";
-                because();
+                Configuration.SourceCommand.Command = SourceCommandType.List;
+                Configuration.SourceCommand.Name = "";
+                _because();
             }
 
             [Fact]
             public void Should_continue_when_command_is_not_list_and_name_is_set()
             {
-                configuration.SourceCommand.Command = SourceCommandType.List;
-                configuration.SourceCommand.Name = "bob";
-                because();
+                Configuration.SourceCommand.Command = SourceCommandType.List;
+                Configuration.SourceCommand.Name = "bob";
+                _because();
             }
         }
 
@@ -339,81 +339,81 @@ namespace chocolatey.tests.infrastructure.app.commands
         {
             public override void Because()
             {
-                command.DryRun(configuration);
+                Command.DryRun(Configuration);
             }
 
             [Fact]
             public void Should_call_service_noop()
             {
-                configSettingsService.Verify(c => c.DryRun(configuration), Times.Once);
+                ConfigSettingsService.Verify(c => c.DryRun(Configuration), Times.Once);
             }
         }
 
         public class When_run_is_called : ChocolateySourceCommandSpecsBase
         {
-            private Action because;
+            private Action _because;
 
             public override void Because()
             {
-                because = () => command.Run(configuration);
+                _because = () => Command.Run(Configuration);
             }
 
             [Fact]
             public void Should_call_service_source_list_when_command_is_list()
             {
-                configuration.SourceCommand.Command = SourceCommandType.List;
-                because();
-                configSettingsService.Verify(c => c.ListSources(configuration), Times.Once);
+                Configuration.SourceCommand.Command = SourceCommandType.List;
+                _because();
+                ConfigSettingsService.Verify(c => c.ListSources(Configuration), Times.Once);
             }
 
             [Fact]
             public void Should_call_service_source_add_when_command_is_add()
             {
-                configuration.SourceCommand.Command = SourceCommandType.Add;
-                because();
-                configSettingsService.Verify(c => c.AddSource(configuration), Times.Once);
+                Configuration.SourceCommand.Command = SourceCommandType.Add;
+                _because();
+                ConfigSettingsService.Verify(c => c.AddSource(Configuration), Times.Once);
             }
 
             [Fact]
             public void Should_call_service_source_remove_when_command_is_remove()
             {
-                configuration.SourceCommand.Command = SourceCommandType.Remove;
-                because();
-                configSettingsService.Verify(c => c.RemoveSource(configuration), Times.Once);
+                Configuration.SourceCommand.Command = SourceCommandType.Remove;
+                _because();
+                ConfigSettingsService.Verify(c => c.RemoveSource(Configuration), Times.Once);
             }
 
             [Fact]
             public void Should_call_service_source_disable_when_command_is_disable()
             {
-                configuration.SourceCommand.Command = SourceCommandType.Disable;
-                because();
-                configSettingsService.Verify(c => c.DisableSource(configuration), Times.Once);
+                Configuration.SourceCommand.Command = SourceCommandType.Disable;
+                _because();
+                ConfigSettingsService.Verify(c => c.DisableSource(Configuration), Times.Once);
             }
 
             [Fact]
             public void Should_call_service_source_enable_when_command_is_enable()
             {
-                configuration.SourceCommand.Command = SourceCommandType.Enable;
-                because();
-                configSettingsService.Verify(c => c.EnableSource(configuration), Times.Once);
+                Configuration.SourceCommand.Command = SourceCommandType.Enable;
+                _because();
+                ConfigSettingsService.Verify(c => c.EnableSource(Configuration), Times.Once);
             }
         }
 
         public class When_list_is_called : ChocolateySourceCommandSpecsBase
         {
-            private Action because;
+            private Action _because;
 
             public override void Because()
             {
-                because = () => command.List(configuration);
+                _because = () => Command.List(Configuration);
             }
 
             [Fact]
             public void Should_call_service_source_list_when_command_is_list()
             {
-                configuration.SourceCommand.Command = SourceCommandType.List;
-                because();
-                configSettingsService.Verify(c => c.ListSources(configuration), Times.Once);
+                Configuration.SourceCommand.Command = SourceCommandType.List;
+                _because();
+                ConfigSettingsService.Verify(c => c.ListSources(Configuration), Times.Once);
             }
         }
     }

--- a/src/chocolatey.tests/infrastructure.app/commands/ChocolateyTemplateCommandSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/commands/ChocolateyTemplateCommandSpecs.cs
@@ -34,82 +34,82 @@ namespace chocolatey.tests.infrastructure.app.commands
         [ConcernFor("template")]
         public abstract class ChocolateyTemplateCommandSpecsBase : TinySpec
         {
-            protected ChocolateyTemplateCommand command;
-            protected Mock<ITemplateService> templateService = new Mock<ITemplateService>();
-            protected ChocolateyConfiguration configuration = new ChocolateyConfiguration();
+            protected ChocolateyTemplateCommand Command;
+            protected Mock<ITemplateService> TemplateService = new Mock<ITemplateService>();
+            protected ChocolateyConfiguration Configuration = new ChocolateyConfiguration();
 
             public override void Context()
             {
-                command = new ChocolateyTemplateCommand(templateService.Object);
+                Command = new ChocolateyTemplateCommand(TemplateService.Object);
             }
 
             public void Reset()
             {
-                templateService.ResetCalls();
+                TemplateService.ResetCalls();
             }
         }
 
         public class When_implementing_command_for : ChocolateyTemplateCommandSpecsBase
         {
-            private List<string> results;
+            private List<string> _results;
 
             public override void Because()
             {
-                results = command.GetType().GetCustomAttributes(typeof(CommandForAttribute), false).Cast<CommandForAttribute>().Select(a => a.CommandName).ToList();
+                _results = Command.GetType().GetCustomAttributes(typeof(CommandForAttribute), false).Cast<CommandForAttribute>().Select(a => a.CommandName).ToList();
             }
 
             [Fact]
             public void Should_implement_help()
             {
-                results.Should().Contain("template");
-                results.Should().Contain("templates");
+                _results.Should().Contain("template");
+                _results.Should().Contain("templates");
             }
         }
 
         public class When_configurating_the_argument_parser : ChocolateyTemplateCommandSpecsBase
         {
-            private OptionSet optionSet;
+            private OptionSet _optionSet;
 
             public override void Context()
             {
                 base.Context();
-                optionSet = new OptionSet();
+                _optionSet = new OptionSet();
             }
 
             public override void Because()
             {
-                command.ConfigureArgumentParser(optionSet, configuration);
+                Command.ConfigureArgumentParser(_optionSet, Configuration);
             }
 
             [Fact]
             public void Should_add_name_to_the_option_set()
             {
-                optionSet.Contains("name").Should().BeTrue();
+                _optionSet.Contains("name").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_short_version_of_name_to_the_option_set()
             {
-                optionSet.Contains("n").Should().BeTrue();
+                _optionSet.Contains("n").Should().BeTrue();
             }
         }
 
 
         public class When_handling_additional_argument_parsing : ChocolateyTemplateCommandSpecsBase
         {
-            private readonly IList<string> unparsedArgs = new List<string>();
-            private Action because;
+            private readonly IList<string> _unparsedArgs = new List<string>();
+            private Action _because;
 
             public override void Because()
             {
-                because = () => command.ParseAdditionalArguments(unparsedArgs, configuration);
+                _because = () => Command.ParseAdditionalArguments(_unparsedArgs, Configuration);
             }
 
             public new void Reset()
             {
-                configuration.TemplateCommand.Name = string.Empty;
-                configuration.TemplateCommand.Command = TemplateCommandType.Unknown;
-                unparsedArgs.Clear();
+                Configuration.TemplateCommand.Name = string.Empty;
+                Configuration.TemplateCommand.Command = TemplateCommandType.Unknown;
+                _unparsedArgs.Clear();
                 base.Reset();
             }
 
@@ -117,24 +117,24 @@ namespace chocolatey.tests.infrastructure.app.commands
             public void Should_use_the_first_unparsed_arg_as_the_subcommand()
             {
                 Reset();
-                unparsedArgs.Add("list");
-                because();
+                _unparsedArgs.Add("list");
+                _because();
 
-                configuration.TemplateCommand.Command.Should().Be(TemplateCommandType.List);
+                Configuration.TemplateCommand.Command.Should().Be(TemplateCommandType.List);
             }
 
             [Fact]
             public void Should_throw_when_more_than_one_unparsed_arg_is_passed()
             {
                 Reset();
-                unparsedArgs.Add("badcommand");
-                unparsedArgs.Add("bbq");
+                _unparsedArgs.Add("badcommand");
+                _unparsedArgs.Add("bbq");
                 var errorred = false;
                 Exception error = null;
 
                 try
                 {
-                    because();
+                    _because();
                 }
                 catch (Exception ex)
                 {
@@ -152,108 +152,108 @@ namespace chocolatey.tests.infrastructure.app.commands
             public void Should_accept_list_as_the_subcommand()
             {
                 Reset();
-                unparsedArgs.Add("list");
-                because();
+                _unparsedArgs.Add("list");
+                _because();
 
-                configuration.TemplateCommand.Command.Should().Be(TemplateCommandType.List);
+                Configuration.TemplateCommand.Command.Should().Be(TemplateCommandType.List);
             }
 
             [Fact]
             public void Should_accept_uppercase_list_as_the_subcommand()
             {
                 Reset();
-                unparsedArgs.Add("LIST");
-                because();
+                _unparsedArgs.Add("LIST");
+                _because();
 
-                configuration.TemplateCommand.Command.Should().Be(TemplateCommandType.List);
+                Configuration.TemplateCommand.Command.Should().Be(TemplateCommandType.List);
             }
 
             [Fact]
             public void Should_accept_info_as_the_subcommand()
             {
                 Reset();
-                unparsedArgs.Add("info");
-                because();
+                _unparsedArgs.Add("info");
+                _because();
 
-                configuration.TemplateCommand.Command.Should().Be(TemplateCommandType.Info);
+                Configuration.TemplateCommand.Command.Should().Be(TemplateCommandType.Info);
             }
 
             [Fact]
             public void Should_accept_uppercase_info_as_the_subcommand()
             {
                 Reset();
-                unparsedArgs.Add("INFO");
-                because();
+                _unparsedArgs.Add("INFO");
+                _because();
 
-                configuration.TemplateCommand.Command.Should().Be(TemplateCommandType.Info);
+                Configuration.TemplateCommand.Command.Should().Be(TemplateCommandType.Info);
             }
 
             [Fact]
             public void Should_set_unrecognized_values_to_list_as_the_subcommand()
             {
                 Reset();
-                unparsedArgs.Add("badcommand");
-                because();
+                _unparsedArgs.Add("badcommand");
+                _because();
 
-                configuration.TemplateCommand.Command.Should().Be(TemplateCommandType.List);
+                Configuration.TemplateCommand.Command.Should().Be(TemplateCommandType.List);
             }
 
             [Fact]
             public void Should_default_to_list_as_the_subcommand()
             {
                 Reset();
-                because();
+                _because();
 
-                configuration.TemplateCommand.Command.Should().Be(TemplateCommandType.List);
+                Configuration.TemplateCommand.Command.Should().Be(TemplateCommandType.List);
             }
 
             [Fact]
             public void Should_handle_passing_in_an_empty_string()
             {
                 Reset();
-                unparsedArgs.Add(" ");
-                because();
+                _unparsedArgs.Add(" ");
+                _because();
 
-                configuration.TemplateCommand.Command.Should().Be(TemplateCommandType.List);
+                Configuration.TemplateCommand.Command.Should().Be(TemplateCommandType.List);
             }
         }
 
         public class When_validating : ChocolateyTemplateCommandSpecsBase
         {
-            private Action because;
+            private Action _because;
 
             public override void Because()
             {
-                because = () => command.Validate(configuration);
+                _because = () => Command.Validate(Configuration);
             }
 
             [Fact]
             public void Should_continue_when_command_is_list_and_name_is_set()
             {
-                configuration.TemplateCommand.Command = TemplateCommandType.List;
-                configuration.TemplateCommand.Name = "bob";
-                because();
+                Configuration.TemplateCommand.Command = TemplateCommandType.List;
+                Configuration.TemplateCommand.Name = "bob";
+                _because();
             }
 
             [Fact]
             public void Should_continue_when_command_is_list_and_name_is_not_set()
             {
-                configuration.TemplateCommand.Command = TemplateCommandType.List;
-                configuration.TemplateCommand.Name = "";
-                because();
+                Configuration.TemplateCommand.Command = TemplateCommandType.List;
+                Configuration.TemplateCommand.Name = "";
+                _because();
             }
 
             [Fact]
             public void Should_throw_when_command_is_info_and_name_is_not_set()
             {
-                configuration.TemplateCommand.Command = TemplateCommandType.Info;
-                configuration.TemplateCommand.Name = "";
+                Configuration.TemplateCommand.Command = TemplateCommandType.Info;
+                Configuration.TemplateCommand.Name = "";
                 var errorred = false;
                 Exception error = null;
 
                 try
                 {
-                    because();
+                    _because();
                 }
                 catch (Exception ex)
                 {
@@ -264,15 +264,15 @@ namespace chocolatey.tests.infrastructure.app.commands
                 errorred.Should().BeTrue();
                 error.Should().NotBeNull();
                 error.Should().BeOfType<ApplicationException>();
-                error.Message.Should().Be("When specifying the subcommand '{0}', you must also specify --name.".FormatWith(configuration.TemplateCommand.Command.ToStringSafe().ToLower()));
+                error.Message.Should().Be("When specifying the subcommand '{0}', you must also specify --name.".FormatWith(Configuration.TemplateCommand.Command.ToStringSafe().ToLower()));
             }
 
             [Fact]
             public void Should_continue_when_command_info_and_name_is_set()
             {
-                configuration.TemplateCommand.Command = TemplateCommandType.Info;
-                configuration.TemplateCommand.Name = "bob";
-                because();
+                Configuration.TemplateCommand.Command = TemplateCommandType.Info;
+                Configuration.TemplateCommand.Name = "bob";
+                _because();
             }
         }
 
@@ -280,14 +280,14 @@ namespace chocolatey.tests.infrastructure.app.commands
         {
             public override void Because()
             {
-                configuration.TemplateCommand.Command = TemplateCommandType.List;
-                command.DryRun(configuration);
+                Configuration.TemplateCommand.Command = TemplateCommandType.List;
+                Command.DryRun(Configuration);
             }
 
             [Fact]
             public void Should_call_service_list_noop()
             {
-                templateService.Verify(c => c.ListDryRun(configuration), Times.Once);
+                TemplateService.Verify(c => c.ListDryRun(Configuration), Times.Once);
             }
         }
 
@@ -295,14 +295,14 @@ namespace chocolatey.tests.infrastructure.app.commands
         {
             public override void Because()
             {
-                configuration.TemplateCommand.Command = TemplateCommandType.List;
-                command.Run(configuration);
+                Configuration.TemplateCommand.Command = TemplateCommandType.List;
+                Command.Run(Configuration);
             }
 
             [Fact]
             public void Should_call_service_list()
             {
-                templateService.Verify(c => c.List(configuration), Times.Once);
+                TemplateService.Verify(c => c.List(Configuration), Times.Once);
             }
         }
     }

--- a/src/chocolatey.tests/infrastructure.app/commands/ChocolateyUninstallCommandSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/commands/ChocolateyUninstallCommandSpecs.cs
@@ -33,177 +33,177 @@ namespace chocolatey.tests.infrastructure.app.commands
         [ConcernFor("uninstall")]
         public abstract class ChocolateyUninstallCommandSpecsBase : TinySpec
         {
-            protected ChocolateyUninstallCommand command;
-            protected Mock<IChocolateyPackageService> packageService = new Mock<IChocolateyPackageService>();
-            protected ChocolateyConfiguration configuration = new ChocolateyConfiguration();
+            protected ChocolateyUninstallCommand Command;
+            protected Mock<IChocolateyPackageService> PackageService = new Mock<IChocolateyPackageService>();
+            protected ChocolateyConfiguration Configuration = new ChocolateyConfiguration();
 
             public override void Context()
             {
-                configuration.Sources = "bob";
-                command = new ChocolateyUninstallCommand(packageService.Object);
+                Configuration.Sources = "bob";
+                Command = new ChocolateyUninstallCommand(PackageService.Object);
             }
         }
 
         public class When_implementing_command_for : ChocolateyUninstallCommandSpecsBase
         {
-            private List<string> results;
+            private List<string> _results;
 
             public override void Because()
             {
-                results = command.GetType().GetCustomAttributes(typeof(CommandForAttribute), false).Cast<CommandForAttribute>().Select(a => a.CommandName).ToList();
+                _results = Command.GetType().GetCustomAttributes(typeof(CommandForAttribute), false).Cast<CommandForAttribute>().Select(a => a.CommandName).ToList();
             }
 
             [Fact]
             public void Should_implement_uninstall()
             {
-                results.Should().Contain("uninstall");
+                _results.Should().Contain("uninstall");
             }
         }
 
         public class When_configurating_the_argument_parser : ChocolateyUninstallCommandSpecsBase
         {
-            private OptionSet optionSet;
+            private OptionSet _optionSet;
 
             public override void Context()
             {
                 base.Context();
-                optionSet = new OptionSet();
+                _optionSet = new OptionSet();
             }
 
             public override void Because()
             {
-                command.ConfigureArgumentParser(optionSet, configuration);
+                Command.ConfigureArgumentParser(_optionSet, Configuration);
             }
 
             [Fact]
             public void Should_add_version_to_the_option_set()
             {
-                optionSet.Contains("version").Should().BeTrue();
+                _optionSet.Contains("version").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_allversions_to_the_option_set()
             {
-                optionSet.Contains("allversions").Should().BeTrue();
+                _optionSet.Contains("allversions").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_short_version_of_allversions_to_the_option_set()
             {
-                optionSet.Contains("a").Should().BeTrue();
+                _optionSet.Contains("a").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_uninstallargs_to_the_option_set()
             {
-                optionSet.Contains("uninstallarguments").Should().BeTrue();
+                _optionSet.Contains("uninstallarguments").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_short_version_of_uninstallargs_to_the_option_set()
             {
-                optionSet.Contains("ua").Should().BeTrue();
+                _optionSet.Contains("ua").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_overrideargs_to_the_option_set()
             {
-                optionSet.Contains("overridearguments").Should().BeTrue();
+                _optionSet.Contains("overridearguments").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_short_version_of_overrideargs_to_the_option_set()
             {
-                optionSet.Contains("o").Should().BeTrue();
+                _optionSet.Contains("o").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_notsilent_to_the_option_set()
             {
-                optionSet.Contains("notsilent").Should().BeTrue();
+                _optionSet.Contains("notsilent").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_packageparameters_to_the_option_set()
             {
-                optionSet.Contains("packageparameters").Should().BeTrue();
+                _optionSet.Contains("packageparameters").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_short_version_of_packageparameters_to_the_option_set()
             {
-                optionSet.Contains("params").Should().BeTrue();
+                _optionSet.Contains("params").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_applyPackageParametersToDependencies_to_the_option_set()
             {
-                optionSet.Contains("apply-package-parameters-to-dependencies").Should().BeTrue();
+                _optionSet.Contains("apply-package-parameters-to-dependencies").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_applyInstallArgumentsToDependencies_to_the_option_set()
             {
-                optionSet.Contains("apply-install-arguments-to-dependencies").Should().BeTrue();
+                _optionSet.Contains("apply-install-arguments-to-dependencies").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_forcedependencies_to_the_option_set()
             {
-                optionSet.Contains("forcedependencies").Should().BeTrue();
+                _optionSet.Contains("forcedependencies").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_short_version_of_forcedependencies_to_the_option_set()
             {
-                optionSet.Contains("x").Should().BeTrue();
+                _optionSet.Contains("x").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_skippowershell_to_the_option_set()
             {
-                optionSet.Contains("skippowershell").Should().BeTrue();
+                _optionSet.Contains("skippowershell").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_short_version_of_skippowershell_to_the_option_set()
             {
-                optionSet.Contains("n").Should().BeTrue();
+                _optionSet.Contains("n").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_skip_hooks_to_the_option_set()
             {
-                optionSet.Contains("skip-hooks").Should().BeTrue();
+                _optionSet.Contains("skip-hooks").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_short_version_of_skip_hooks_to_the_option_set()
             {
-                optionSet.Contains("skiphooks").Should().BeTrue();
+                _optionSet.Contains("skiphooks").Should().BeTrue();
             }
         }
 
         public class When_handling_additional_argument_parsing : ChocolateyUninstallCommandSpecsBase
         {
-            private readonly IList<string> unparsedArgs = new List<string>();
+            private readonly IList<string> _unparsedArgs = new List<string>();
 
             public override void Context()
             {
                 base.Context();
-                unparsedArgs.Add("pkg1");
-                unparsedArgs.Add("pkg2");
+                _unparsedArgs.Add("pkg1");
+                _unparsedArgs.Add("pkg2");
             }
 
             public override void Because()
             {
-                command.ParseAdditionalArguments(unparsedArgs, configuration);
+                Command.ParseAdditionalArguments(_unparsedArgs, Configuration);
             }
 
             [Fact]
             public void Should_set_unparsed_arguments_to_the_package_names()
             {
-                configuration.PackageNames.Should().Be("pkg1;pkg2");
+                Configuration.PackageNames.Should().Be("pkg1;pkg2");
             }
         }
 
@@ -216,13 +216,13 @@ namespace chocolatey.tests.infrastructure.app.commands
             [Fact]
             public void Should_throw_when_packagenames_is_not_set()
             {
-                configuration.PackageNames = "";
+                Configuration.PackageNames = "";
                 var errored = false;
                 Exception error = null;
 
                 try
                 {
-                    command.Validate(configuration);
+                    Command.Validate(Configuration);
                 }
                 catch (Exception ex)
                 {
@@ -238,8 +238,8 @@ namespace chocolatey.tests.infrastructure.app.commands
             [Fact]
             public void Should_continue_when_packagenames_is_set()
             {
-                configuration.PackageNames = "bob";
-                command.Validate(configuration);
+                Configuration.PackageNames = "bob";
+                Command.Validate(Configuration);
             }
         }
 
@@ -247,13 +247,13 @@ namespace chocolatey.tests.infrastructure.app.commands
         {
             public override void Because()
             {
-                command.DryRun(configuration);
+                Command.DryRun(Configuration);
             }
 
             [Fact]
             public void Should_call_service_uninstall_noop()
             {
-                packageService.Verify(c => c.UninstallDryRun(configuration), Times.Once);
+                PackageService.Verify(c => c.UninstallDryRun(Configuration), Times.Once);
             }
         }
 
@@ -261,13 +261,13 @@ namespace chocolatey.tests.infrastructure.app.commands
         {
             public override void Because()
             {
-                command.Run(configuration);
+                Command.Run(Configuration);
             }
 
             [Fact]
             public void Should_call_service_uninstall_run()
             {
-                packageService.Verify(c => c.Uninstall(configuration), Times.Once);
+                PackageService.Verify(c => c.Uninstall(Configuration), Times.Once);
             }
         }
     }

--- a/src/chocolatey.tests/infrastructure.app/commands/ChocolateyUnpackSelfCommandSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/commands/ChocolateyUnpackSelfCommandSpecs.cs
@@ -32,31 +32,31 @@ namespace chocolatey.tests.infrastructure.app.commands
         [ConcernFor("unpackself")]
         public abstract class ChocolateyUnpackSelfCommandSpecsBase : TinySpec
         {
-            protected ChocolateyUnpackSelfCommand command;
-            protected Mock<IFileSystem> fileSystem = new Mock<IFileSystem>();
-            protected Mock<IAssembly> assembly = new Mock<IAssembly>();
-            protected ChocolateyConfiguration configuration = new ChocolateyConfiguration();
+            protected ChocolateyUnpackSelfCommand Command;
+            protected Mock<IFileSystem> FileSystem = new Mock<IFileSystem>();
+            protected Mock<IAssembly> Assembly = new Mock<IAssembly>();
+            protected ChocolateyConfiguration Configuration = new ChocolateyConfiguration();
 
             public override void Context()
             {
-                command = new ChocolateyUnpackSelfCommand(fileSystem.Object);
-                command.InitializeWith(new Lazy<IAssembly>(() => assembly.Object));
+                Command = new ChocolateyUnpackSelfCommand(FileSystem.Object);
+                Command.InitializeWith(new Lazy<IAssembly>(() => Assembly.Object));
             }
         }
 
         public class When_implementing_command_for : ChocolateyUnpackSelfCommandSpecsBase
         {
-            private List<string> results;
+            private List<string> _results;
 
             public override void Because()
             {
-                results = command.GetType().GetCustomAttributes(typeof(CommandForAttribute), false).Cast<CommandForAttribute>().Select(a => a.CommandName).ToList();
+                _results = Command.GetType().GetCustomAttributes(typeof(CommandForAttribute), false).Cast<CommandForAttribute>().Select(a => a.CommandName).ToList();
             }
 
             [Fact]
             public void Should_implement_unpackself()
             {
-                results.Should().Contain("unpackself");
+                _results.Should().Contain("unpackself");
             }
         }
 
@@ -64,7 +64,7 @@ namespace chocolatey.tests.infrastructure.app.commands
         {
             public override void Because()
             {
-                command.DryRun(configuration);
+                Command.DryRun(Configuration);
             }
 
             [Fact]
@@ -90,13 +90,13 @@ namespace chocolatey.tests.infrastructure.app.commands
         {
             public override void Because()
             {
-                command.Run(configuration);
+                Command.Run(Configuration);
             }
 
             [Fact]
             public void Should_call_assembly_file_extractor()
             {
-                assembly.Verify(a => a.GetManifestResourceNames(), Times.Once);
+                Assembly.Verify(a => a.GetManifestResourceNames(), Times.Once);
             }
         }
     }

--- a/src/chocolatey.tests/infrastructure.app/commands/ChocolateyUpgradeCommandSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/commands/ChocolateyUpgradeCommandSpecs.cs
@@ -33,231 +33,231 @@ namespace chocolatey.tests.infrastructure.app.commands
         [ConcernFor("upgrade")]
         public abstract class ChocolateyUpgradeCommandSpecsBase : TinySpec
         {
-            protected ChocolateyUpgradeCommand command;
-            protected Mock<IChocolateyPackageService> packageService = new Mock<IChocolateyPackageService>();
-            protected ChocolateyConfiguration configuration = new ChocolateyConfiguration();
+            protected ChocolateyUpgradeCommand Command;
+            protected Mock<IChocolateyPackageService> PackageService = new Mock<IChocolateyPackageService>();
+            protected ChocolateyConfiguration Configuration = new ChocolateyConfiguration();
 
             public override void Context()
             {
-                configuration.Sources = "bob";
-                command = new ChocolateyUpgradeCommand(packageService.Object);
+                Configuration.Sources = "bob";
+                Command = new ChocolateyUpgradeCommand(PackageService.Object);
             }
         }
 
         public class When_implementing_command_for : ChocolateyUpgradeCommandSpecsBase
         {
-            private List<string> results;
+            private List<string> _results;
 
             public override void Because()
             {
-                results = command.GetType().GetCustomAttributes(typeof(CommandForAttribute), false).Cast<CommandForAttribute>().Select(a => a.CommandName).ToList();
+                _results = Command.GetType().GetCustomAttributes(typeof(CommandForAttribute), false).Cast<CommandForAttribute>().Select(a => a.CommandName).ToList();
             }
 
             [Fact]
             public void Should_implement_upgrade()
             {
-                results.Should().Contain("upgrade");
+                _results.Should().Contain("upgrade");
             }
         }
 
         public class When_configurating_the_argument_parser : ChocolateyUpgradeCommandSpecsBase
         {
-            private OptionSet optionSet;
+            private OptionSet _optionSet;
 
             public override void Context()
             {
                 base.Context();
-                optionSet = new OptionSet();
+                _optionSet = new OptionSet();
             }
 
             public override void Because()
             {
-                command.ConfigureArgumentParser(optionSet, configuration);
+                Command.ConfigureArgumentParser(_optionSet, Configuration);
             }
 
             [Fact]
             public void Should_add_source_to_the_option_set()
             {
-                optionSet.Contains("source").Should().BeTrue();
+                _optionSet.Contains("source").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_short_version_of_source_to_the_option_set()
             {
-                optionSet.Contains("s").Should().BeTrue();
+                _optionSet.Contains("s").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_version_to_the_option_set()
             {
-                optionSet.Contains("version").Should().BeTrue();
+                _optionSet.Contains("version").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_prerelease_to_the_option_set()
             {
-                optionSet.Contains("prerelease").Should().BeTrue();
+                _optionSet.Contains("prerelease").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_short_version_of_prerelease_to_the_option_set()
             {
-                optionSet.Contains("pre").Should().BeTrue();
+                _optionSet.Contains("pre").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_installargs_to_the_option_set()
             {
-                optionSet.Contains("installarguments").Should().BeTrue();
+                _optionSet.Contains("installarguments").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_short_version_of_installargs_to_the_option_set()
             {
-                optionSet.Contains("ia").Should().BeTrue();
+                _optionSet.Contains("ia").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_overrideargs_to_the_option_set()
             {
-                optionSet.Contains("overridearguments").Should().BeTrue();
+                _optionSet.Contains("overridearguments").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_short_version_of_overrideargs_to_the_option_set()
             {
-                optionSet.Contains("o").Should().BeTrue();
+                _optionSet.Contains("o").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_notsilent_to_the_option_set()
             {
-                optionSet.Contains("notsilent").Should().BeTrue();
+                _optionSet.Contains("notsilent").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_packageparameters_to_the_option_set()
             {
-                optionSet.Contains("packageparameters").Should().BeTrue();
+                _optionSet.Contains("packageparameters").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_short_version_of_packageparameters_to_the_option_set()
             {
-                optionSet.Contains("params").Should().BeTrue();
+                _optionSet.Contains("params").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_applyPackageParametersToDependencies_to_the_option_set()
             {
-                optionSet.Contains("apply-package-parameters-to-dependencies").Should().BeTrue();
+                _optionSet.Contains("apply-package-parameters-to-dependencies").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_applyInstallArgumentsToDependencies_to_the_option_set()
             {
-                optionSet.Contains("apply-install-arguments-to-dependencies").Should().BeTrue();
+                _optionSet.Contains("apply-install-arguments-to-dependencies").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_ignoredependencies_to_the_option_set()
             {
-                optionSet.Contains("ignoredependencies").Should().BeTrue();
+                _optionSet.Contains("ignoredependencies").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_short_version_of_ignoredependencies_to_the_option_set()
             {
-                optionSet.Contains("i").Should().BeTrue();
+                _optionSet.Contains("i").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_skippowershell_to_the_option_set()
             {
-                optionSet.Contains("skippowershell").Should().BeTrue();
+                _optionSet.Contains("skippowershell").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_short_version_of_skippowershell_to_the_option_set()
             {
-                optionSet.Contains("n").Should().BeTrue();
+                _optionSet.Contains("n").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_user_to_the_option_set()
             {
-                optionSet.Contains("user").Should().BeTrue();
+                _optionSet.Contains("user").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_short_version_of_user_to_the_option_set()
             {
-                optionSet.Contains("u").Should().BeTrue();
+                _optionSet.Contains("u").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_password_to_the_option_set()
             {
-                optionSet.Contains("password").Should().BeTrue();
+                _optionSet.Contains("password").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_short_version_of_password_to_the_option_set()
             {
-                optionSet.Contains("p").Should().BeTrue();
+                _optionSet.Contains("p").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_pin_to_the_option_set()
             {
-                optionSet.Contains("pinpackage").Should().BeTrue();
+                _optionSet.Contains("pinpackage").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_long_version_of_pin_to_the_option_set()
             {
-                optionSet.Contains("pin-package").Should().BeTrue();
+                _optionSet.Contains("pin-package").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_short_version_of_pin_to_the_option_set()
             {
-                optionSet.Contains("pin").Should().BeTrue();
+                _optionSet.Contains("pin").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_skip_hooks_to_the_option_set()
             {
-                optionSet.Contains("skip-hooks").Should().BeTrue();
+                _optionSet.Contains("skip-hooks").Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_short_version_of_skip_hooks_to_the_option_set()
             {
-                optionSet.Contains("skiphooks").Should().BeTrue();
+                _optionSet.Contains("skiphooks").Should().BeTrue();
             }
         }
 
         public class When_handling_additional_argument_parsing : ChocolateyUpgradeCommandSpecsBase
         {
-            private readonly IList<string> unparsedArgs = new List<string>();
+            private readonly IList<string> _unparsedArgs = new List<string>();
 
             public override void Context()
             {
                 base.Context();
-                unparsedArgs.Add("pkg1");
-                unparsedArgs.Add("pkg2");
+                _unparsedArgs.Add("pkg1");
+                _unparsedArgs.Add("pkg2");
             }
 
             public override void Because()
             {
-                command.ParseAdditionalArguments(unparsedArgs, configuration);
+                Command.ParseAdditionalArguments(_unparsedArgs, Configuration);
             }
 
             [Fact]
             public void Should_set_unparsed_arguments_to_the_package_names()
             {
-                configuration.PackageNames.Should().Be("pkg1;pkg2");
+                Configuration.PackageNames.Should().Be("pkg1;pkg2");
             }
         }
 
@@ -270,13 +270,13 @@ namespace chocolatey.tests.infrastructure.app.commands
             [Fact]
             public void Should_throw_when_packagenames_is_not_set()
             {
-                configuration.PackageNames = "";
+                Configuration.PackageNames = "";
                 var errored = false;
                 Exception error = null;
 
                 try
                 {
-                    command.Validate(configuration);
+                    Command.Validate(Configuration);
                 }
                 catch (Exception ex)
                 {
@@ -292,8 +292,8 @@ namespace chocolatey.tests.infrastructure.app.commands
             [Fact]
             public void Should_continue_when_packagenames_is_set()
             {
-                configuration.PackageNames = "bob";
-                command.Validate(configuration);
+                Configuration.PackageNames = "bob";
+                Command.Validate(Configuration);
             }
         }
 
@@ -301,13 +301,13 @@ namespace chocolatey.tests.infrastructure.app.commands
         {
             public override void Because()
             {
-                command.DryRun(configuration);
+                Command.DryRun(Configuration);
             }
 
             [Fact]
             public void Should_call_service_upgrade_noop()
             {
-                packageService.Verify(c => c.UpgradeDryRun(configuration), Times.Once);
+                PackageService.Verify(c => c.UpgradeDryRun(Configuration), Times.Once);
             }
         }
 
@@ -315,13 +315,13 @@ namespace chocolatey.tests.infrastructure.app.commands
         {
             public override void Because()
             {
-                command.Run(configuration);
+                Command.Run(Configuration);
             }
 
             [Fact]
             public void Should_call_service_upgrade_run()
             {
-                packageService.Verify(c => c.Upgrade(configuration), Times.Once);
+                PackageService.Verify(c => c.Upgrade(Configuration), Times.Once);
             }
         }
     }

--- a/src/chocolatey.tests/infrastructure.app/configuration/ConfigurationOptionsSpec.cs
+++ b/src/chocolatey.tests/infrastructure.app/configuration/ConfigurationOptionsSpec.cs
@@ -31,42 +31,42 @@ namespace chocolatey.tests.infrastructure.app.configuration
     {
         public abstract class ConfigurationOptionsSpecBase : TinySpec
         {
-            protected ICollection<string> args;
-            protected ChocolateyConfiguration config;
-            protected Action<OptionSet> setOptions;
-            protected Action<IList<string>> afterParse;
-            protected Action validateConfiguration;
-            protected Action helpMessage;
+            protected ICollection<string> Args;
+            protected ChocolateyConfiguration Config;
+            protected Action<OptionSet> SetOptions;
+            protected Action<IList<string>> AfterParse;
+            protected Action ValidateConfiguration;
+            protected Action HelpMessage;
 
-            protected Mock<IConsole> console = new Mock<IConsole>();
-            protected static StringBuilder helpMessageContents = new StringBuilder();
-            protected TextWriter errorWriter = new StringWriter(helpMessageContents);
-            protected TextWriter outputWriter = new StringWriter(helpMessageContents);
+            protected Mock<IConsole> Console = new Mock<IConsole>();
+            protected static StringBuilder HelpMessageContents = new StringBuilder();
+            protected TextWriter ErrorWriter = new StringWriter(HelpMessageContents);
+            protected TextWriter OutputWriter = new StringWriter(HelpMessageContents);
 
             public override void Context()
             {
-                ConfigurationOptions.InitializeWith(new Lazy<IConsole>(() => console.Object));
+                ConfigurationOptions.InitializeWith(new Lazy<IConsole>(() => Console.Object));
                 ConfigurationOptions.ClearOptions();
-                console.Setup((c) => c.Error).Returns(errorWriter);
-                console.Setup((c) => c.Out).Returns(outputWriter);
+                Console.Setup((c) => c.Error).Returns(ErrorWriter);
+                Console.Setup((c) => c.Out).Returns(OutputWriter);
             }
 
-            protected Action because;
+            protected Action BecauseAction;
 
             public override void Because()
             {
-                because = () => ConfigurationOptions.ParseArgumentsAndUpdateConfiguration(args, config, setOptions, afterParse, validateConfiguration, helpMessage);
+                BecauseAction = () => ConfigurationOptions.ParseArgumentsAndUpdateConfiguration(Args, Config, SetOptions, AfterParse, ValidateConfiguration, HelpMessage);
             }
 
             public override void BeforeEachSpec()
             {
-                args = new List<string>();
-                config = new ChocolateyConfiguration();
-                setOptions = set => { };
-                afterParse = list => { };
-                validateConfiguration = () => { };
-                helpMessage = () => { };
-                helpMessageContents.Clear();
+                Args = new List<string>();
+                Config = new ChocolateyConfiguration();
+                SetOptions = set => { };
+                AfterParse = list => { };
+                ValidateConfiguration = () => { };
+                HelpMessage = () => { };
+                HelpMessageContents.Clear();
                 ConfigurationOptions.ClearOptions();
             }
         }
@@ -76,71 +76,71 @@ namespace chocolatey.tests.infrastructure.app.configuration
             [Fact]
             public void Should_set_help_options_by_default()
             {
-                setOptions = set =>
+                SetOptions = set =>
                 {
                     set.Contains("h").Should().BeTrue();
                     set.Contains("help").Should().BeTrue();
                     set.Contains("?").Should().BeTrue();
                 };
-                because();
+                BecauseAction();
             }
 
             [Fact]
             public void Should_not_have_set_other_options_by_default()
             {
-                setOptions = set => { set.Contains("dude").Should().BeFalse(); };
-                because();
+                SetOptions = set => { set.Contains("dude").Should().BeFalse(); };
+                BecauseAction();
             }
 
             [Fact]
             public void Should_show_help_menu_when_help_is_requested()
             {
-                args.Add("-h");
+                Args.Add("-h");
 
-                because();
+                BecauseAction();
 
-                config.HelpRequested.Should().BeTrue();
-                config.ShowOnlineHelp.Should().BeFalse();
+                Config.HelpRequested.Should().BeTrue();
+                Config.ShowOnlineHelp.Should().BeFalse();
             }
 
             [Fact]
             public void Should_show_online_help_menu_when_help_is_requested()
             {
-                args.Add("-h");
-                args.Add("--online");
+                Args.Add("-h");
+                Args.Add("--online");
 
-                because();
+                BecauseAction();
 
-                config.HelpRequested.Should().BeTrue();
-                config.ShowOnlineHelp.Should().BeTrue();
+                Config.HelpRequested.Should().BeTrue();
+                Config.ShowOnlineHelp.Should().BeTrue();
             }
 
             [Fact]
             public void Should_have_a_helpMessage_with_contents_when_help_is_requested()
             {
-                args.Add("-h");
+                Args.Add("-h");
 
-                because();
+                BecauseAction();
 
-                helpMessageContents.ToString().Should().NotBeEmpty();
+                HelpMessageContents.ToString().Should().NotBeEmpty();
             }
 
             [Fact]
             public void Should_not_run_validate_configuration_when_help_is_requested()
             {
-                args.Add("-h");
-                validateConfiguration = () => { "should".Should().Be("not be reached"); };
+                Args.Add("-h");
+                ValidateConfiguration = () => { "should".Should().Be("not be reached"); };
 
-                because();
+                BecauseAction();
             }
 
             [Fact]
             public void Should_run_validate_configuration_unless_help_is_requested()
             {
                 var wasCalled = false;
-                validateConfiguration = () => { wasCalled = true; };
+                ValidateConfiguration = () => { wasCalled = true; };
 
-                because();
+                BecauseAction();
 
                 wasCalled.Should().BeTrue();
             }
@@ -149,13 +149,13 @@ namespace chocolatey.tests.infrastructure.app.configuration
             public void Should_give_an_empty_unparsed_args_to_after_parse()
             {
                 var wasCalled = false;
-                afterParse = list =>
+                AfterParse = list =>
                 {
                     wasCalled = true;
                     list.Should().BeEmpty();
                 };
 
-                because();
+                BecauseAction();
 
                 wasCalled.Should().BeTrue();
             }
@@ -163,15 +163,15 @@ namespace chocolatey.tests.infrastructure.app.configuration
             [Fact]
             public void Should_give_an_empty_unparsed_args_to_after_parse_when_all_specified_args_are_parsed()
             {
-                args.Add("-h");
+                Args.Add("-h");
                 var wasCalled = false;
-                afterParse = list =>
+                AfterParse = list =>
                 {
                     wasCalled = true;
                     list.Should().BeEmpty();
                 };
 
-                because();
+                BecauseAction();
 
                 wasCalled.Should().BeTrue();
             }
@@ -179,15 +179,15 @@ namespace chocolatey.tests.infrastructure.app.configuration
             [Fact]
             public void Should_give_unparsed_args_to_after_parse_when_not_picked_up_by_an_option()
             {
-                args.Add("--what-is=this");
+                Args.Add("--what-is=this");
                 var wasCalled = false;
-                afterParse = list =>
+                AfterParse = list =>
                 {
                     wasCalled = true;
-                    list.Should().Contain(args.First());
+                    list.Should().Contain(Args.First());
                 };
 
-                because();
+                BecauseAction();
 
                 wasCalled.Should().BeTrue();
             }
@@ -195,148 +195,148 @@ namespace chocolatey.tests.infrastructure.app.configuration
             [Fact]
             public void Should_find_command_name_in_unparsed_args_if_not_set_otherwise()
             {
-                args.Add("dude");
+                Args.Add("dude");
                 var wasCalled = false;
-                afterParse = list =>
+                AfterParse = list =>
                 {
                     wasCalled = true;
-                    list.Should().Contain(args.First());
+                    list.Should().Contain(Args.First());
                 };
 
-                because();
+                BecauseAction();
 
-                config.CommandName.Should().Be("dude");
+                Config.CommandName.Should().Be("dude");
                 wasCalled.Should().BeTrue();
             }
 
             [Fact]
             public void Should_set_help_requested_if_command_name_is_starts_with_a_prefix()
             {
-                args.Add("/dude");
+                Args.Add("/dude");
                 var wasCalled = false;
-                afterParse = list =>
+                AfterParse = list =>
                 {
                     wasCalled = true;
-                    list.Should().Contain(args.First());
+                    list.Should().Contain(Args.First());
                 };
 
-                because();
+                BecauseAction();
 
-                config.CommandName.Should().NotBe("dude");
-                config.HelpRequested.Should().BeTrue();
+                Config.CommandName.Should().NotBe("dude");
+                Config.HelpRequested.Should().BeTrue();
                 wasCalled.Should().BeTrue();
             }
 
             [Fact]
             public void Should_add_an_option_for_bob_when_specified()
             {
-                setOptions = set => { set.Add("bob", "sets the bob switch", option => config.Verbose = option != null); };
-                because();
+                SetOptions = set => { set.Add("bob", "sets the bob switch", option => Config.Verbose = option != null); };
+                BecauseAction();
 
-                config.Verbose.Should().BeFalse();
+                Config.Verbose.Should().BeFalse();
             }
 
             [Fact]
             public void Should_set_option_for_tim_to_true_when_specified_with_dash()
             {
-                setOptions = set => { set.Add("tim", "sets the tim switch", option => config.Verbose = option != null); };
-                args.Add("-tim");
+                SetOptions = set => { set.Add("tim", "sets the tim switch", option => Config.Verbose = option != null); };
+                Args.Add("-tim");
 
-                because();
+                BecauseAction();
 
-                config.Verbose.Should().BeTrue();
+                Config.Verbose.Should().BeTrue();
             }
 
             [Fact]
             public void Should_set_option_for_tina_to_true_when_specified_with_two_dashes()
             {
-                setOptions = set => { set.Add("tina", "sets the tina switch", option => config.Verbose = option != null); };
-                args.Add("--tina");
-                because();
+                SetOptions = set => { set.Add("tina", "sets the tina switch", option => Config.Verbose = option != null); };
+                Args.Add("--tina");
+                BecauseAction();
 
-                config.Verbose.Should().BeTrue();
+                Config.Verbose.Should().BeTrue();
             }
 
             [Fact]
             public void Should_set_option_for_gena_to_true_when_specified_with_forward_slash()
             {
-                setOptions = set => { set.Add("gena", "sets the gena switch", option => config.Verbose = option != null); };
-                args.Add("/gena");
+                SetOptions = set => { set.Add("gena", "sets the gena switch", option => Config.Verbose = option != null); };
+                Args.Add("/gena");
 
-                because();
+                BecauseAction();
 
-                config.Verbose.Should().BeTrue();
+                Config.Verbose.Should().BeTrue();
             }
 
             [Fact]
             public void Should_set_option_when_specified_as_single_dash_for_timmy_and_other_option_short_values_are_passed_the_same_way()
             {
-                setOptions = set =>
+                SetOptions = set =>
                 {
-                    set.Add("timmy", "sets the timmy switch", option => config.Verbose = option != null);
-                    set.Add("s|skip", "sets the skip switch", option => config.SkipPackageInstallProvider = option != null);
-                    set.Add("d|debug", "sets the debug switch", option => config.Debug = option != null);
+                    set.Add("timmy", "sets the timmy switch", option => Config.Verbose = option != null);
+                    set.Add("s|skip", "sets the skip switch", option => Config.SkipPackageInstallProvider = option != null);
+                    set.Add("d|debug", "sets the debug switch", option => Config.Debug = option != null);
                 };
-                args.Add("-timmy");
-                args.Add("-sd");
+                Args.Add("-timmy");
+                Args.Add("-sd");
 
-                because();
+                BecauseAction();
 
-                config.SkipPackageInstallProvider.Should().BeTrue();
-                config.Debug.Should().BeTrue();
-                config.Verbose.Should().BeTrue();
+                Config.SkipPackageInstallProvider.Should().BeTrue();
+                Config.Debug.Should().BeTrue();
+                Config.Verbose.Should().BeTrue();
             }
 
             [Fact]
             public void Should_set_option_when_specified_as_single_dash_for_lo_and_other_option_short_values_are_passed_the_same_way()
             {
-                setOptions = set =>
+                SetOptions = set =>
                 {
-                    set.Add("lo|local-only", "sets the lo switch", option => config.ListCommand.LocalOnly = option != null);
-                    set.Add("l|lskip", "sets the skip switch", option => config.SkipPackageInstallProvider = option != null);
-                    set.Add("m|mdebug", "sets the debug switch", option => config.Debug = option != null);
+                    set.Add("lo|local-only", "sets the lo switch", option => Config.ListCommand.LocalOnly = option != null);
+                    set.Add("l|lskip", "sets the skip switch", option => Config.SkipPackageInstallProvider = option != null);
+                    set.Add("m|mdebug", "sets the debug switch", option => Config.Debug = option != null);
                 };
-                args.Add("-lo");
-                args.Add("-ml");
+                Args.Add("-lo");
+                Args.Add("-ml");
 
-                because();
+                BecauseAction();
 
-                config.SkipPackageInstallProvider.Should().BeTrue();
-                config.Debug.Should().BeTrue();
-                config.ListCommand.LocalOnly.Should().BeTrue();
-                helpMessageContents.ToString().Should().BeEmpty();
+                Config.SkipPackageInstallProvider.Should().BeTrue();
+                Config.Debug.Should().BeTrue();
+                Config.ListCommand.LocalOnly.Should().BeTrue();
+                HelpMessageContents.ToString().Should().BeEmpty();
             }
 
             [Fact]
             public void Should_show_help_menu_when_passing_bundled_options_that_do_not_exist()
             {
-                setOptions = set => { set.Add("w|wdebug", "sets the debug switch", option => config.Debug = option != null); };
-                args.Add("-wz");
+                SetOptions = set => { set.Add("w|wdebug", "sets the debug switch", option => Config.Debug = option != null); };
+                Args.Add("-wz");
 
-                because();
+                BecauseAction();
 
-                config.Debug.Should().BeFalse();
-                helpMessageContents.ToString().Should().NotBeEmpty();
+                Config.Debug.Should().BeFalse();
+                HelpMessageContents.ToString().Should().NotBeEmpty();
             }
 
             [Fact]
             public void Should_successfully_parse_help_option()
             {
-                args.Add("-h");
+                Args.Add("-h");
 
-                because();
+                BecauseAction();
 
-                config.UnsuccessfulParsing.Should().BeFalse();
+                Config.UnsuccessfulParsing.Should().BeFalse();
             }
 
             [Fact]
             public void Should_not_parse_unknown_option()
             {
-                args.Add("-unknown");
+                Args.Add("-unknown");
 
-                because();
+                BecauseAction();
 
-                config.UnsuccessfulParsing.Should().BeTrue();
+                Config.UnsuccessfulParsing.Should().BeTrue();
             }
         }
     }

--- a/src/chocolatey.tests/infrastructure.app/nuget/NugetCommonSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/nuget/NugetCommonSpecs.cs
@@ -32,23 +32,23 @@ namespace chocolatey.tests.infrastructure.app.nuget
 
     public class NugetCommonSpecs
     {
-        private class when_gets_remote_repository : TinySpec
+        private class When_gets_remote_repository : TinySpec
         {
-            private Action because;
-            private readonly Mock<ILogger> nugetLogger = new Mock<ILogger>();
-            private readonly Mock<IPackageDownloader> packageDownloader = new Mock<IPackageDownloader>();
-            private readonly Mock<IFileSystem> filesystem = new Mock<IFileSystem>();
-            private ChocolateyConfiguration configuration;
-            private IEnumerable<SourceRepository> packageRepositories;
+            private Action _because;
+            private readonly Mock<ILogger> _nugetLogger = new Mock<ILogger>();
+            private readonly Mock<IPackageDownloader> _packageDownloader = new Mock<IPackageDownloader>();
+            private readonly Mock<IFileSystem> _filesystem = new Mock<IFileSystem>();
+            private ChocolateyConfiguration _configuration;
+            private IEnumerable<SourceRepository> _packageRepositories;
 
             public override void Context()
             {
-                configuration = new ChocolateyConfiguration();
-                nugetLogger.ResetCalls();
-                packageDownloader.ResetCalls();
-                filesystem.ResetCalls();
+                _configuration = new ChocolateyConfiguration();
+                _nugetLogger.ResetCalls();
+                _packageDownloader.ResetCalls();
+                _filesystem.ResetCalls();
 
-                filesystem.Setup(f => f.GetFullPath(It.IsAny<string>())).Returns((string a) =>
+                _filesystem.Setup(f => f.GetFullPath(It.IsAny<string>())).Returns((string a) =>
                 {
                     return "C:\\packages\\" + a;
                 });
@@ -56,18 +56,18 @@ namespace chocolatey.tests.infrastructure.app.nuget
 
             public override void Because()
             {
-                because = () => packageRepositories = NugetCommon.GetRemoteRepositories(configuration, nugetLogger.Object, filesystem.Object);
+                _because = () => _packageRepositories = NugetCommon.GetRemoteRepositories(_configuration, _nugetLogger.Object, _filesystem.Object);
             }
 
             [Fact]
             public void Should_create_repository_when_source_is_null()
             {
                 Context();
-                configuration.Sources = null;
+                _configuration.Sources = null;
 
-                because();
+                _because();
 
-                packageRepositories.Should().BeEmpty();
+                _packageRepositories.Should().BeEmpty();
             }
 
             [Fact]
@@ -75,14 +75,14 @@ namespace chocolatey.tests.infrastructure.app.nuget
             {
                 Context();
                 var source = "http://nexus.example.com:8081/repository/choco";
-                configuration.Sources = source;
-                configuration.CacheLocation = "C:\\temp";
+                _configuration.Sources = source;
+                _configuration.CacheLocation = "C:\\temp";
 
-                because();
+                _because();
 
-                packageRepositories.First().PackageSource.TrySourceAsUri.Should().NotBeNull();
-                packageRepositories.First().PackageSource.SourceUri.ToStringSafe().Should().Be(source);
-                packageRepositories.First().PackageSource.IsHttp.Should().BeTrue();
+                _packageRepositories.First().PackageSource.TrySourceAsUri.Should().NotBeNull();
+                _packageRepositories.First().PackageSource.SourceUri.ToStringSafe().Should().Be(source);
+                _packageRepositories.First().PackageSource.IsHttp.Should().BeTrue();
             }
 
             [Fact]
@@ -90,14 +90,14 @@ namespace chocolatey.tests.infrastructure.app.nuget
             {
                 Context();
                 var source = "https://nexus.example.com/repository/choco";
-                configuration.Sources = source;
-                configuration.CacheLocation = "C:\\temp";
+                _configuration.Sources = source;
+                _configuration.CacheLocation = "C:\\temp";
 
-                because();
+                _because();
 
-                packageRepositories.First().PackageSource.TrySourceAsUri.Should().NotBeNull();
-                packageRepositories.First().PackageSource.SourceUri.ToStringSafe().Should().Be(source);
-                packageRepositories.First().PackageSource.IsHttps.Should().BeTrue();
+                _packageRepositories.First().PackageSource.TrySourceAsUri.Should().NotBeNull();
+                _packageRepositories.First().PackageSource.SourceUri.ToStringSafe().Should().Be(source);
+                _packageRepositories.First().PackageSource.IsHttps.Should().BeTrue();
             }
 
             [Fact]
@@ -105,14 +105,14 @@ namespace chocolatey.tests.infrastructure.app.nuget
             {
                 Context();
                 var source = "C:\\packages";
-                configuration.Sources = source;
+                _configuration.Sources = source;
 
-                because();
+                _because();
 
-                packageRepositories.First().PackageSource.TrySourceAsUri.Should().NotBeNull();
-                packageRepositories.First().PackageSource.SourceUri.ToStringSafe()
-                    .Should().Be(("file:///" + source).Replace("\\","/"));
-                packageRepositories.First().PackageSource.IsLocal.Should().BeTrue();
+                _packageRepositories.First().PackageSource.TrySourceAsUri.Should().NotBeNull();
+                _packageRepositories.First().PackageSource.SourceUri.ToStringSafe()
+                    .Should().Be(("file:///" + source).Replace("\\", "/"));
+                _packageRepositories.First().PackageSource.IsLocal.Should().BeTrue();
             }
 
             [Fact]
@@ -121,14 +121,14 @@ namespace chocolatey.tests.infrastructure.app.nuget
                 Context();
                 var source = "choco";
                 var fullsource = "C:\\packages\\choco";
-                configuration.Sources = source;
+                _configuration.Sources = source;
 
-                because();
+                _because();
 
-                packageRepositories.First().PackageSource.TrySourceAsUri.Should().NotBeNull();
-                packageRepositories.First().PackageSource.SourceUri.ToStringSafe()
+                _packageRepositories.First().PackageSource.TrySourceAsUri.Should().NotBeNull();
+                _packageRepositories.First().PackageSource.SourceUri.ToStringSafe()
                     .Should().Be(("file:///" + fullsource).Replace("\\", "/"));
-                packageRepositories.First().PackageSource.IsLocal.Should().BeTrue();
+                _packageRepositories.First().PackageSource.IsLocal.Should().BeTrue();
             }
 
             [Fact]
@@ -137,14 +137,14 @@ namespace chocolatey.tests.infrastructure.app.nuget
                 Context();
                 var source = ".";
                 var fullsource = "C:\\packages";
-                configuration.Sources = source;
+                _configuration.Sources = source;
 
-                because();
+                _because();
 
-                packageRepositories.First().PackageSource.TrySourceAsUri.Should().NotBeNull();
-                packageRepositories.First().PackageSource.SourceUri.ToStringSafe()
+                _packageRepositories.First().PackageSource.TrySourceAsUri.Should().NotBeNull();
+                _packageRepositories.First().PackageSource.SourceUri.ToStringSafe()
                     .Should().Be(("file:///" + fullsource + "/").Replace("\\", "/"));
-                packageRepositories.First().PackageSource.IsLocal.Should().BeTrue();
+                _packageRepositories.First().PackageSource.IsLocal.Should().BeTrue();
             }
 
             [Fact]
@@ -152,15 +152,15 @@ namespace chocolatey.tests.infrastructure.app.nuget
             {
                 Context();
                 var source = "\\\\samba-server\\choco-share";
-                configuration.Sources = source;
+                _configuration.Sources = source;
 
-                because();
+                _because();
 
-                packageRepositories.First().PackageSource.TrySourceAsUri.Should().NotBeNull();
-                packageRepositories.First().PackageSource.SourceUri.ToStringSafe()
+                _packageRepositories.First().PackageSource.TrySourceAsUri.Should().NotBeNull();
+                _packageRepositories.First().PackageSource.SourceUri.ToStringSafe()
                     .Should().Be(("file:" + source).Replace("\\", "/"));
-                packageRepositories.First().PackageSource.IsLocal.Should().BeTrue();
-                packageRepositories.First().PackageSource.SourceUri.IsUnc.Should().BeTrue();
+                _packageRepositories.First().PackageSource.IsLocal.Should().BeTrue();
+                _packageRepositories.First().PackageSource.SourceUri.IsUnc.Should().BeTrue();
             }
 
             [Fact]
@@ -168,14 +168,14 @@ namespace chocolatey.tests.infrastructure.app.nuget
             {
                 Context();
                 var source = "https://community.chocolatey.org/api/v2/";
-                configuration.Sources = source;
-                configuration.Information.ChocolateyProductVersion = "vNext";
+                _configuration.Sources = source;
+                _configuration.Information.ChocolateyProductVersion = "vNext";
 
-                because();
+                _because();
 
                 // Change this when the NuGet version is updated.
                 string nugetClientVersion = "6.4.1";
-                string expectedUserAgentString = "{0}/{1} via NuGet Client/{2}".FormatWith(ApplicationParameters.UserAgent, configuration.Information.ChocolateyProductVersion, nugetClientVersion);
+                string expectedUserAgentString = "{0}/{1} via NuGet Client/{2}".FormatWith(ApplicationParameters.UserAgent, _configuration.Information.ChocolateyProductVersion, nugetClientVersion);
                 UserAgent.UserAgentString.Should().StartWith(expectedUserAgentString);
             }
         }

--- a/src/chocolatey.tests/infrastructure.app/services/ChocolateyPackageServiceSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/services/ChocolateyPackageServiceSpecs.cs
@@ -215,7 +215,7 @@ namespace chocolatey.tests.infrastructure.app.services
             [Fact, Categories.Unc]
             public void Should_throw_exception_when_UNC_path_is_passed_to_install_run()
             {
-                var directory = UNCHelper.convert_local_folder_path_to_ip_based_unc_path(Path.Combine(Path.GetPathRoot(Environment.CurrentDirectory), "testing"));
+                var directory = UNCHelper.ConvertLocalFolderPathToIpBasedUncPath(Path.Combine(Path.GetPathRoot(Environment.CurrentDirectory), "testing"));
                 var filePath = Path.Combine(directory, "my-package.nupkg");
                 Configuration.PackageNames = new Uri(filePath).AbsoluteUri;
                 FileSystem.Setup(f => f.GetFilenameWithoutExtension(filePath))

--- a/src/chocolatey.tests/infrastructure.app/services/FilesServiceSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/services/FilesServiceSpecs.cs
@@ -50,11 +50,11 @@ namespace chocolatey.tests.infrastructure.app.services
 
         public class When_FilesService_reads_from_files : FilesServiceSpecsBase
         {
-            private Func<PackageFiles> because;
+            private Func<PackageFiles> _because;
 
             public override void Because()
             {
-                because = () => Service.ReadPackageSnapshot("fake path");
+                _because = () => Service.ReadPackageSnapshot("fake path");
             }
 
             [Fact]
@@ -64,7 +64,7 @@ namespace chocolatey.tests.infrastructure.app.services
                 FileSystem.Setup(x => x.FileExists(It.IsAny<string>())).Returns(true);
                 XmlService.Setup(x => x.Deserialize<PackageFiles>(It.IsAny<string>())).Returns(new PackageFiles());
 
-                because();
+                _because();
             }
 
             [Fact]
@@ -73,7 +73,7 @@ namespace chocolatey.tests.infrastructure.app.services
                 Context();
                 FileSystem.Setup(x => x.FileExists(It.IsAny<string>())).Returns(false);
 
-                because();
+                _because();
 
                 XmlService.Verify(x => x.Deserialize<PackageFiles>(It.IsAny<string>()), Times.Never);
             }
@@ -81,52 +81,52 @@ namespace chocolatey.tests.infrastructure.app.services
 
         public class When_FilesService_saves_files : FilesServiceSpecsBase
         {
-            private Action because;
-            private PackageFiles files;
+            private Action _because;
+            private PackageFiles _files;
 
             public override void Because()
             {
-                because = () => Service.SavePackageSnapshot(files, "fake path");
+                _because = () => Service.SavePackageSnapshot(_files, "fake path");
             }
 
             [Fact]
             public void Should_save_if_the_snapshot_is_not_null()
             {
                 Context();
-                files = new PackageFiles();
+                _files = new PackageFiles();
 
-                because();
+                _because();
 
-                XmlService.Verify(x => x.Serialize(files, It.IsAny<string>()), Times.Once());
+                XmlService.Verify(x => x.Serialize(_files, It.IsAny<string>()), Times.Once());
             }
 
             [Fact]
             public void Should_not_do_anything_if_the_snapshot_is_null()
             {
                 Context();
-                files = null;
+                _files = null;
 
-                because();
+                _because();
 
-                XmlService.Verify(x => x.Serialize(files, It.IsAny<string>()), Times.Never);
+                XmlService.Verify(x => x.Serialize(_files, It.IsAny<string>()), Times.Never);
             }
         }
 
         public class When_FilesService_captures_files_and_install_directory_reports_choco_install_location : FilesServiceSpecsBase
         {
-            private PackageFiles result;
-            private PackageResult packageResult;
-            private readonly ChocolateyConfiguration config = new ChocolateyConfiguration();
+            private PackageFiles _result;
+            private PackageResult _packageResult;
+            private readonly ChocolateyConfiguration _config = new ChocolateyConfiguration();
 
             public override void Context()
             {
                 base.Context();
-                packageResult = new PackageResult("bob", "1.2.3", ApplicationParameters.InstallLocation);
+                _packageResult = new PackageResult("bob", "1.2.3", ApplicationParameters.InstallLocation);
             }
 
             public override void Because()
             {
-                result = Service.CaptureSnapshot(packageResult, config);
+                _result = Service.CaptureSnapshot(_packageResult, _config);
             }
 
             [Fact]
@@ -138,31 +138,31 @@ namespace chocolatey.tests.infrastructure.app.services
             [Fact]
             public void Should_return_a_warning_if_the_install_directory_matches_choco_install_location()
             {
-                packageResult.Warning.Should().BeTrue();
+                _packageResult.Warning.Should().BeTrue();
             }
 
             [Fact]
             public void Should_return_null()
             {
-                result.Should().BeNull();
+                _result.Should().BeNull();
             }
         }
 
         public class When_FilesService_captures_files_and_install_directory_reports_packages_location : FilesServiceSpecsBase
         {
-            private PackageFiles result;
-            private PackageResult packageResult;
-            private readonly ChocolateyConfiguration config = new ChocolateyConfiguration();
+            private PackageFiles _result;
+            private PackageResult _packageResult;
+            private readonly ChocolateyConfiguration _config = new ChocolateyConfiguration();
 
             public override void Context()
             {
                 base.Context();
-                packageResult = new PackageResult("bob", "1.2.3", ApplicationParameters.PackagesLocation);
+                _packageResult = new PackageResult("bob", "1.2.3", ApplicationParameters.PackagesLocation);
             }
 
             public override void Because()
             {
-                result = Service.CaptureSnapshot(packageResult, config);
+                _result = Service.CaptureSnapshot(_packageResult, _config);
             }
 
             [Fact]
@@ -174,31 +174,31 @@ namespace chocolatey.tests.infrastructure.app.services
             [Fact]
             public void Should_return_a_warning_if_the_install_directory_matches_choco_install_location()
             {
-                packageResult.Warning.Should().BeTrue();
+                _packageResult.Warning.Should().BeTrue();
             }
 
             [Fact]
             public void Should_return_null()
             {
-                result.Should().BeNull();
+                _result.Should().BeNull();
             }
         }
 
         public class When_FilesService_captures_files_and_package_result_is_null : FilesServiceSpecsBase
         {
-            private PackageFiles result;
-            private PackageResult packageResult;
-            private readonly ChocolateyConfiguration config = new ChocolateyConfiguration();
+            private PackageFiles _result;
+            private PackageResult _packageResult;
+            private readonly ChocolateyConfiguration _config = new ChocolateyConfiguration();
 
             public override void Context()
             {
                 base.Context();
-                packageResult = null;
+                _packageResult = null;
             }
 
             public override void Because()
             {
-                result = Service.CaptureSnapshot(packageResult, config);
+                _result = Service.CaptureSnapshot(_packageResult, _config);
             }
 
             [Fact]
@@ -210,23 +210,23 @@ namespace chocolatey.tests.infrastructure.app.services
             [Fact]
             public void Should_return_a_non_null_object()
             {
-                result.Should().NotBeNull();
+                _result.Should().NotBeNull();
             }
 
             [Fact]
             public void Should_return_empty_package_files()
             {
-                result.Files.Should().BeEmpty();
+                _result.Files.Should().BeEmpty();
             }
         }
 
         public class When_FilesService_captures_files_happy_path : FilesServiceSpecsBase
         {
-            private PackageFiles result;
-            private PackageResult packageResult;
-            private readonly ChocolateyConfiguration config = new ChocolateyConfiguration();
-            private readonly string installDirectory = ApplicationParameters.PackagesLocation + "\\bob";
-            private readonly IList<string> files = new List<string>
+            private PackageFiles _result;
+            private PackageResult _packageResult;
+            private readonly ChocolateyConfiguration _config = new ChocolateyConfiguration();
+            private readonly string _installDirectory = ApplicationParameters.PackagesLocation + "\\bob";
+            private readonly IList<string> _files = new List<string>
             {
                 "file1",
                 "file2"
@@ -235,39 +235,39 @@ namespace chocolatey.tests.infrastructure.app.services
             public override void Context()
             {
                 base.Context();
-                packageResult = new PackageResult("bob", "1.2.3", installDirectory);
+                _packageResult = new PackageResult("bob", "1.2.3", _installDirectory);
 
-                FileSystem.Setup(x => x.GetFiles(ApplicationParameters.PackagesLocation + "\\bob", It.IsAny<string>(), SearchOption.AllDirectories)).Returns(files);
+                FileSystem.Setup(x => x.GetFiles(ApplicationParameters.PackagesLocation + "\\bob", It.IsAny<string>(), SearchOption.AllDirectories)).Returns(_files);
                 HashProvider.Setup(x => x.ComputeFileHash(It.IsAny<string>())).Returns("yes");
             }
 
             public override void Because()
             {
-                result = Service.CaptureSnapshot(packageResult, config);
+                _result = Service.CaptureSnapshot(_packageResult, _config);
             }
 
             [Fact]
             public void Should_return_a_PackageFiles_object()
             {
-                result.Should().NotBeNull();
+                _result.Should().NotBeNull();
             }
 
             [Fact]
             public void Should_contain_package_files()
             {
-                result.Files.Should().NotBeEmpty();
+                _result.Files.Should().NotBeEmpty();
             }
 
             [Fact]
             public void Should_contain_the_correct_number_of_package_files()
             {
-                result.Files.Should().HaveCount(files.Count);
+                _result.Files.Should().HaveCount(_files.Count);
             }
 
             [Fact]
             public void Should_call_hash_provider_for_each_file()
             {
-                HashProvider.Verify(x => x.ComputeFileHash(It.IsAny<string>()), Times.Exactly(files.Count));
+                HashProvider.Verify(x => x.ComputeFileHash(It.IsAny<string>()), Times.Exactly(_files.Count));
             }
         }
     }

--- a/src/chocolatey.tests/infrastructure.app/services/NugetServiceSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/services/NugetServiceSpecs.cs
@@ -34,48 +34,48 @@ namespace chocolatey.tests.infrastructure.app.services
     {
         public abstract class NugetServiceSpecsBase : TinySpec
         {
-            protected NugetService service;
-            protected Mock<IChocolateyPackageInformationService> packageInfoService = new Mock<IChocolateyPackageInformationService>();
-            protected Mock<IFileSystem> fileSystem = new Mock<IFileSystem>();
-            protected Mock<ILogger> nugetLogger = new Mock<ILogger>();
-            protected Mock<IFilesService> filesService = new Mock<IFilesService>();
-            protected Mock<IPackageMetadata> package = new Mock<IPackageMetadata>();
-            protected Mock<IPackageDownloader> packageDownloader = new Mock<IPackageDownloader>();
-            protected Mock<IRuleService> ruleService = new Mock<IRuleService>();
+            protected NugetService Service;
+            protected Mock<IChocolateyPackageInformationService> PackageInfoService = new Mock<IChocolateyPackageInformationService>();
+            protected Mock<IFileSystem> FileSystem = new Mock<IFileSystem>();
+            protected Mock<ILogger> NugetLogger = new Mock<ILogger>();
+            protected Mock<IFilesService> FilesService = new Mock<IFilesService>();
+            protected Mock<IPackageMetadata> Package = new Mock<IPackageMetadata>();
+            protected Mock<IPackageDownloader> PackageDownloader = new Mock<IPackageDownloader>();
+            protected Mock<IRuleService> RuleService = new Mock<IRuleService>();
 
             public override void Context()
             {
-                fileSystem.ResetCalls();
-                nugetLogger.ResetCalls();
-                packageInfoService.ResetCalls();
-                filesService.ResetCalls();
-                package.ResetCalls();
+                FileSystem.ResetCalls();
+                NugetLogger.ResetCalls();
+                PackageInfoService.ResetCalls();
+                FilesService.ResetCalls();
+                Package.ResetCalls();
 
-                service = new NugetService(fileSystem.Object, nugetLogger.Object, packageInfoService.Object, filesService.Object, ruleService.Object);
+                Service = new NugetService(FileSystem.Object, NugetLogger.Object, PackageInfoService.Object, FilesService.Object, RuleService.Object);
             }
         }
 
         public class When_NugetService_backs_up_changed_files : NugetServiceSpecsBase
         {
-            private Action because;
-            private ChocolateyPackageInformation packageInfo;
-            private const string filePath = "c:\\tests";
-            private PackageFiles packageFiles;
-            private readonly ChocolateyConfiguration config = new ChocolateyConfiguration();
+            private Action _because;
+            private ChocolateyPackageInformation _packageInfo;
+            private const string FilePath = "c:\\tests";
+            private PackageFiles _packageFiles;
+            private readonly ChocolateyConfiguration _config = new ChocolateyConfiguration();
 
             public override void Context()
             {
                 base.Context();
-                package.Setup(x => x.Id).Returns("bob");
-                packageInfo = new ChocolateyPackageInformation(package.Object);
-                packageInfo.FilesSnapshot = new PackageFiles();
-                packageFiles = new PackageFiles();
-                fileSystem.Setup(x => x.DirectoryExists(It.IsAny<string>())).Returns(true);
+                Package.Setup(x => x.Id).Returns("bob");
+                _packageInfo = new ChocolateyPackageInformation(Package.Object);
+                _packageInfo.FilesSnapshot = new PackageFiles();
+                _packageFiles = new PackageFiles();
+                FileSystem.Setup(x => x.DirectoryExists(It.IsAny<string>())).Returns(true);
             }
 
             public override void Because()
             {
-                because = () => service.BackupChangedFiles(filePath, config, packageInfo);
+                _because = () => Service.BackupChangedFiles(FilePath, _config, _packageInfo);
             }
 
             [Fact]
@@ -85,22 +85,22 @@ namespace chocolatey.tests.infrastructure.app.services
 
                 var packageFile = new PackageFile
                 {
-                    Path = filePath,
+                    Path = FilePath,
                     Checksum = "1234"
                 };
-                packageFiles.Files.Add(packageFile);
-                packageInfo.FilesSnapshot = packageFiles;
+                _packageFiles.Files.Add(packageFile);
+                _packageInfo.FilesSnapshot = _packageFiles;
 
                 var fileSystemFiles = new List<string>()
                 {
-                    filePath
+                    FilePath
                 };
-                fileSystem.Setup(x => x.GetFiles(It.IsAny<string>(), It.IsAny<string>(), SearchOption.AllDirectories)).Returns(fileSystemFiles);
-                filesService.Setup(x => x.CaptureSnapshot(It.IsAny<string>(), config)).Returns(packageFiles);
+                FileSystem.Setup(x => x.GetFiles(It.IsAny<string>(), It.IsAny<string>(), SearchOption.AllDirectories)).Returns(fileSystemFiles);
+                FilesService.Setup(x => x.CaptureSnapshot(It.IsAny<string>(), _config)).Returns(_packageFiles);
 
-                because();
+                _because();
 
-                fileSystem.Verify(x => x.CopyFile(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>()), Times.Never);
+                FileSystem.Verify(x => x.CopyFile(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>()), Times.Never);
             }
 
             [Fact]
@@ -110,84 +110,84 @@ namespace chocolatey.tests.infrastructure.app.services
 
                 var packageFile = new PackageFile
                 {
-                    Path = filePath,
+                    Path = FilePath,
                     Checksum = "1234"
                 };
-                packageFiles.Files.Add(packageFile);
-                packageInfo.FilesSnapshot = packageFiles;
+                _packageFiles.Files.Add(packageFile);
+                _packageInfo.FilesSnapshot = _packageFiles;
 
                 var packageFileWithUpdatedChecksum = new PackageFile
                 {
-                    Path = filePath,
+                    Path = FilePath,
                     Checksum = "4321"
                 };
 
                 var fileSystemFiles = new List<string>()
                 {
-                    filePath
+                    FilePath
                 };
-                fileSystem.Setup(x => x.GetFiles(It.IsAny<string>(), It.IsAny<string>(), SearchOption.AllDirectories)).Returns(fileSystemFiles);
+                FileSystem.Setup(x => x.GetFiles(It.IsAny<string>(), It.IsAny<string>(), SearchOption.AllDirectories)).Returns(fileSystemFiles);
                 var updatedPackageFiles = new PackageFiles();
                 updatedPackageFiles.Files = new List<PackageFile>
                 {
                     packageFileWithUpdatedChecksum
                 };
-                filesService.Setup(x => x.CaptureSnapshot(It.IsAny<string>(), config)).Returns(updatedPackageFiles);
+                FilesService.Setup(x => x.CaptureSnapshot(It.IsAny<string>(), _config)).Returns(updatedPackageFiles);
 
-                because();
+                _because();
 
-                fileSystem.Verify(x => x.CopyFile(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>()), Times.Once);
+                FileSystem.Verify(x => x.CopyFile(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>()), Times.Once);
             }
         }
 
         public class When_NugetService_removes_installation_files_on_uninstall : NugetServiceSpecsBase
         {
-            private Action because;
-            private ChocolateyPackageInformation packageInfo;
-            private const string filePath = "c:\\tests";
-            private IList<PackageFile> packageFiles;
+            private Action _because;
+            private ChocolateyPackageInformation _packageInfo;
+            private const string FilePath = "c:\\tests";
+            private IList<PackageFile> _packageFiles;
 
             public override void Context()
             {
                 base.Context();
-                package.Setup(x => x.Id).Returns("bob");
-                packageInfo = new ChocolateyPackageInformation(package.Object);
-                packageInfo.FilesSnapshot = new PackageFiles();
-                packageFiles = new List<PackageFile>();
-                fileSystem.Setup(x => x.DirectoryExists(It.IsAny<string>())).Returns(true);
+                Package.Setup(x => x.Id).Returns("bob");
+                _packageInfo = new ChocolateyPackageInformation(Package.Object);
+                _packageInfo.FilesSnapshot = new PackageFiles();
+                _packageFiles = new List<PackageFile>();
+                FileSystem.Setup(x => x.DirectoryExists(It.IsAny<string>())).Returns(true);
             }
 
             public override void Because()
             {
-                because = () => service.RemoveInstallationFiles(package.Object, packageInfo);
+                _because = () => Service.RemoveInstallationFiles(Package.Object, _packageInfo);
             }
 
             [Fact]
             public void Should_do_nothing_if_the_directory_no_longer_exists()
             {
                 Context();
-                fileSystem.ResetCalls();
-                fileSystem.Setup(x => x.DirectoryExists(It.IsAny<string>())).Returns(false);
+                FileSystem.ResetCalls();
+                FileSystem.Setup(x => x.DirectoryExists(It.IsAny<string>())).Returns(false);
 
                 var packageFile = new PackageFile
                 {
-                    Path = filePath,
+                    Path = FilePath,
                     Checksum = "1234"
                 };
-                packageFiles.Add(packageFile);
-                packageInfo.FilesSnapshot.Files = packageFiles.ToList();
+                _packageFiles.Add(packageFile);
+                _packageInfo.FilesSnapshot.Files = _packageFiles.ToList();
 
                 var fileSystemFiles = new List<string>()
                 {
-                    filePath
+                    FilePath
                 };
-                fileSystem.Setup(x => x.GetFiles(It.IsAny<string>(), It.IsAny<string>(), SearchOption.AllDirectories)).Returns(fileSystemFiles);
-                filesService.Setup(x => x.GetPackageFile(It.IsAny<string>())).Returns(packageFile);
+                FileSystem.Setup(x => x.GetFiles(It.IsAny<string>(), It.IsAny<string>(), SearchOption.AllDirectories)).Returns(fileSystemFiles);
+                FilesService.Setup(x => x.GetPackageFile(It.IsAny<string>())).Returns(packageFile);
 
-                because();
+                _because();
 
-                filesService.Verify(x => x.GetPackageFile(It.IsAny<string>()), Times.Never);
-                fileSystem.Verify(x => x.DeleteFile(filePath), Times.Never);
+                FilesService.Verify(x => x.GetPackageFile(It.IsAny<string>()), Times.Never);
+                FileSystem.Verify(x => x.DeleteFile(FilePath), Times.Never);
             }
 
             [Fact]
@@ -197,23 +197,23 @@ namespace chocolatey.tests.infrastructure.app.services
 
                 var packageFile = new PackageFile
                 {
-                    Path = filePath,
+                    Path = FilePath,
                     Checksum = "1234"
                 };
-                packageFiles.Add(packageFile);
-                packageInfo.FilesSnapshot.Files = packageFiles.ToList();
+                _packageFiles.Add(packageFile);
+                _packageInfo.FilesSnapshot.Files = _packageFiles.ToList();
 
                 var fileSystemFiles = new List<string>()
                 {
-                    filePath
+                    FilePath
                 };
-                fileSystem.Setup(x => x.GetFiles(It.IsAny<string>(), It.IsAny<string>(), SearchOption.AllDirectories)).Returns(fileSystemFiles);
-                filesService.Setup(x => x.GetPackageFile(It.IsAny<string>())).Returns(packageFile);
-                fileSystem.Setup(x => x.FileExists(filePath)).Returns(true);
+                FileSystem.Setup(x => x.GetFiles(It.IsAny<string>(), It.IsAny<string>(), SearchOption.AllDirectories)).Returns(fileSystemFiles);
+                FilesService.Setup(x => x.GetPackageFile(It.IsAny<string>())).Returns(packageFile);
+                FileSystem.Setup(x => x.FileExists(FilePath)).Returns(true);
 
-                because();
+                _because();
 
-                fileSystem.Verify(x => x.DeleteFile(filePath));
+                FileSystem.Verify(x => x.DeleteFile(FilePath));
             }
 
             [Fact]
@@ -223,28 +223,28 @@ namespace chocolatey.tests.infrastructure.app.services
 
                 var packageFile = new PackageFile
                 {
-                    Path = filePath,
+                    Path = FilePath,
                     Checksum = "1234"
                 };
                 var packageFileWithUpdatedChecksum = new PackageFile
                 {
-                    Path = filePath,
+                    Path = FilePath,
                     Checksum = "4321"
                 };
-                packageFiles.Add(packageFile);
-                packageInfo.FilesSnapshot.Files = packageFiles.ToList();
+                _packageFiles.Add(packageFile);
+                _packageInfo.FilesSnapshot.Files = _packageFiles.ToList();
 
                 var fileSystemFiles = new List<string>()
                 {
-                    filePath
+                    FilePath
                 };
-                fileSystem.Setup(x => x.GetFiles(It.IsAny<string>(), It.IsAny<string>(), SearchOption.AllDirectories)).Returns(fileSystemFiles);
-                filesService.Setup(x => x.GetPackageFile(It.IsAny<string>())).Returns(packageFileWithUpdatedChecksum);
-                fileSystem.Setup(x => x.FileExists(filePath)).Returns(true);
+                FileSystem.Setup(x => x.GetFiles(It.IsAny<string>(), It.IsAny<string>(), SearchOption.AllDirectories)).Returns(fileSystemFiles);
+                FilesService.Setup(x => x.GetPackageFile(It.IsAny<string>())).Returns(packageFileWithUpdatedChecksum);
+                FileSystem.Setup(x => x.FileExists(FilePath)).Returns(true);
 
-                because();
+                _because();
 
-                fileSystem.Verify(x => x.DeleteFile(filePath), Times.Never);
+                FileSystem.Verify(x => x.DeleteFile(FilePath), Times.Never);
             }
 
             [Fact]
@@ -254,7 +254,7 @@ namespace chocolatey.tests.infrastructure.app.services
 
                 var packageFile = new PackageFile
                 {
-                    Path = filePath,
+                    Path = FilePath,
                     Checksum = "1234"
                 };
                 var packageFileNotInOriginal = new PackageFile
@@ -262,39 +262,39 @@ namespace chocolatey.tests.infrastructure.app.services
                     Path = "c:\\files",
                     Checksum = "4321"
                 };
-                packageFiles.Add(packageFile);
+                _packageFiles.Add(packageFile);
 
-                packageInfo.FilesSnapshot.Files = packageFiles.ToList();
+                _packageInfo.FilesSnapshot.Files = _packageFiles.ToList();
 
                 var fileSystemFiles = new List<string>()
                 {
-                    filePath
+                    FilePath
                 };
 
-                fileSystem.Setup(x => x.GetFiles(It.IsAny<string>(), It.IsAny<string>(), SearchOption.AllDirectories)).Returns(fileSystemFiles);
-                filesService.Setup(x => x.GetPackageFile(It.IsAny<string>())).Returns(packageFileNotInOriginal);
-                fileSystem.Setup(x => x.FileExists(filePath)).Returns(false);
+                FileSystem.Setup(x => x.GetFiles(It.IsAny<string>(), It.IsAny<string>(), SearchOption.AllDirectories)).Returns(fileSystemFiles);
+                FilesService.Setup(x => x.GetPackageFile(It.IsAny<string>())).Returns(packageFileNotInOriginal);
+                FileSystem.Setup(x => x.FileExists(FilePath)).Returns(false);
 
-                because();
+                _because();
 
-                fileSystem.Verify(x => x.DeleteFile(filePath), Times.Never);
+                FileSystem.Verify(x => x.DeleteFile(FilePath), Times.Never);
             }
         }
 
         public class When_NugetService_pack_noop : NugetServiceSpecsBase
         {
-            private Action because;
-            private readonly ChocolateyConfiguration config = new ChocolateyConfiguration();
+            private Action _because;
+            private readonly ChocolateyConfiguration _config = new ChocolateyConfiguration();
 
             public override void Context()
             {
                 base.Context();
-                fileSystem.Setup(x => x.GetCurrentDirectory()).Returns("c:\\projects\\chocolatey");
+                FileSystem.Setup(x => x.GetCurrentDirectory()).Returns("c:\\projects\\chocolatey");
             }
 
             public override void Because()
             {
-                because = () => service.PackDryRun(config);
+                _because = () => Service.PackDryRun(_config);
             }
 
             public override void AfterEachSpec()
@@ -307,7 +307,7 @@ namespace chocolatey.tests.infrastructure.app.services
             {
                 Context();
 
-                because();
+                _because();
 
                 var infos = MockLogger.MessagesFor(tests.LogLevel.Info);
                 infos.Should().ContainSingle();
@@ -319,9 +319,9 @@ namespace chocolatey.tests.infrastructure.app.services
             {
                 Context();
 
-                config.OutputDirectory = "c:\\packages";
+                _config.OutputDirectory = "c:\\packages";
 
-                because();
+                _because();
 
                 var infos = MockLogger.MessagesFor(tests.LogLevel.Info);
                 infos.Should().ContainSingle();

--- a/src/chocolatey.tests/infrastructure.app/services/TemplateServiceSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/services/TemplateServiceSpecs.cs
@@ -37,36 +37,36 @@ namespace chocolatey.tests.infrastructure.app.services
     {
         public abstract class TemplateServiceSpecsBase : TinySpec
         {
-            protected TemplateService service;
-            protected Mock<IFileSystem> fileSystem = new Mock<IFileSystem>();
-            protected Mock<IXmlService> xmlService = new Mock<IXmlService>();
-            protected Mock<ILogger> logger = new Mock<ILogger>();
+            protected TemplateService Service;
+            protected Mock<IFileSystem> FileSystem = new Mock<IFileSystem>();
+            protected Mock<IXmlService> XmlService = new Mock<IXmlService>();
+            protected Mock<ILogger> Logger = new Mock<ILogger>();
 
             public override void Context()
             {
-                fileSystem.ResetCalls();
-                xmlService.ResetCalls();
-                service = new TemplateService(fileSystem.Object, xmlService.Object, logger.Object);
+                FileSystem.ResetCalls();
+                XmlService.ResetCalls();
+                Service = new TemplateService(FileSystem.Object, XmlService.Object, Logger.Object);
             }
         }
 
         public class When_generate_noop_is_called : TemplateServiceSpecsBase
         {
-            private Action because;
-            private readonly ChocolateyConfiguration config = new ChocolateyConfiguration();
+            private Action _because;
+            private readonly ChocolateyConfiguration _config = new ChocolateyConfiguration();
 
             public override void Context()
             {
                 base.Context();
-                fileSystem.Setup(x => x.GetCurrentDirectory()).Returns("c:\\chocolatey");
-                fileSystem.Setup(x => x.CombinePaths(It.IsAny<string>(), It.IsAny<string>()))
+                FileSystem.Setup(x => x.GetCurrentDirectory()).Returns("c:\\chocolatey");
+                FileSystem.Setup(x => x.CombinePaths(It.IsAny<string>(), It.IsAny<string>()))
                     .Returns((string a, string[] b) => { return a + "\\" + b[0]; });
-                config.NewCommand.Name = "Bob";
+                _config.NewCommand.Name = "Bob";
             }
 
             public override void Because()
             {
-                because = () => service.GenerateDryRun(config);
+                _because = () => Service.GenerateDryRun(_config);
             }
 
             public override void BeforeEachSpec()
@@ -77,7 +77,7 @@ namespace chocolatey.tests.infrastructure.app.services
             [Fact]
             public void Should_log_current_directory_if_no_outputdirectory()
             {
-                because();
+                _because();
 
                 var infos = MockLogger.MessagesFor(LogLevel.Info);
                 infos.Should().ContainSingle();
@@ -87,9 +87,9 @@ namespace chocolatey.tests.infrastructure.app.services
             [Fact]
             public void Should_log_output_directory_if_outputdirectory_is_specified()
             {
-                config.OutputDirectory = "c:\\packages";
+                _config.OutputDirectory = "c:\\packages";
 
-                because();
+                _because();
 
                 var infos = MockLogger.MessagesFor(LogLevel.Info);
                 infos.Should().ContainSingle();
@@ -99,26 +99,26 @@ namespace chocolatey.tests.infrastructure.app.services
 
         public class When_generate_file_from_template_is_called : TemplateServiceSpecsBase
         {
-            private Action because;
-            private readonly ChocolateyConfiguration config = new ChocolateyConfiguration();
-            private readonly TemplateValues templateValues = new TemplateValues();
-            private readonly string template = "[[PackageName]]";
-            private const string fileLocation = "c:\\packages\\bob.nuspec";
-            private string fileContent;
+            private Action _because;
+            private readonly ChocolateyConfiguration _config = new ChocolateyConfiguration();
+            private readonly TemplateValues _templateValues = new TemplateValues();
+            private readonly string _template = "[[PackageName]]";
+            private const string FileLocation = "c:\\packages\\bob.nuspec";
+            private string _fileContent;
 
             public override void Context()
             {
                 base.Context();
 
-                fileSystem.Setup(x => x.WriteFile(It.Is((string fl) => fl == fileLocation), It.IsAny<string>(), Encoding.UTF8))
-                    .Callback((string filePath, string fileContent, Encoding encoding) => this.fileContent = fileContent);
+                FileSystem.Setup(x => x.WriteFile(It.Is((string fl) => fl == FileLocation), It.IsAny<string>(), Encoding.UTF8))
+                    .Callback((string filePath, string fileContent, Encoding encoding) => _fileContent = fileContent);
 
-                templateValues.PackageName = "Bob";
+                _templateValues.PackageName = "Bob";
             }
 
             public override void Because()
             {
-                because = () => service.GenerateFileFromTemplate(config, templateValues, template, fileLocation, Encoding.UTF8);
+                _because = () => Service.GenerateFileFromTemplate(_config, _templateValues, _template, FileLocation, Encoding.UTF8);
             }
 
             public override void BeforeEachSpec()
@@ -129,7 +129,7 @@ namespace chocolatey.tests.infrastructure.app.services
             [Fact]
             public void Should_write_file_withe_replaced_tokens()
             {
-                because();
+                _because();
 
                 var debugs = MockLogger.MessagesFor(LogLevel.Debug);
                 debugs.Should().ContainSingle();
@@ -139,9 +139,9 @@ namespace chocolatey.tests.infrastructure.app.services
             [Fact]
             public void Should_log_info_if_regular_output()
             {
-                config.RegularOutput = true;
+                _config.RegularOutput = true;
 
-                because();
+                _because();
 
                 var debugs = MockLogger.MessagesFor(LogLevel.Debug);
                 debugs.Should().ContainSingle();
@@ -155,30 +155,30 @@ namespace chocolatey.tests.infrastructure.app.services
 
         public class When_generate_is_called_with_existing_directory : TemplateServiceSpecsBase
         {
-            private Action because;
-            private readonly ChocolateyConfiguration config = new ChocolateyConfiguration();
-            private string verifiedDirectoryPath;
+            private Action _because;
+            private readonly ChocolateyConfiguration _config = new ChocolateyConfiguration();
+            private string _verifiedDirectoryPath;
 
             public override void Context()
             {
                 base.Context();
 
-                fileSystem.Setup(x => x.GetCurrentDirectory()).Returns("c:\\chocolatey");
-                fileSystem.Setup(x => x.CombinePaths(It.IsAny<string>(), It.IsAny<string>()))
+                FileSystem.Setup(x => x.GetCurrentDirectory()).Returns("c:\\chocolatey");
+                FileSystem.Setup(x => x.CombinePaths(It.IsAny<string>(), It.IsAny<string>()))
                     .Returns((string a, string[] b) => { return a + "\\" + b[0]; });
-                fileSystem.Setup(x => x.DirectoryExists(It.IsAny<string>())).Returns<string>(
+                FileSystem.Setup(x => x.DirectoryExists(It.IsAny<string>())).Returns<string>(
                     x =>
                     {
-                        verifiedDirectoryPath = x;
+                        _verifiedDirectoryPath = x;
                         return true;
                     });
 
-                config.NewCommand.Name = "Bob";
+                _config.NewCommand.Name = "Bob";
             }
 
             public override void Because()
             {
-                because = () => service.Generate(config);
+                _because = () => Service.Generate(_config);
             }
 
             public override void BeforeEachSpec()
@@ -194,7 +194,7 @@ namespace chocolatey.tests.infrastructure.app.services
 
                 try
                 {
-                    because();
+                    _because();
                 }
                 catch (ApplicationException ex)
                 {
@@ -204,20 +204,20 @@ namespace chocolatey.tests.infrastructure.app.services
 
                 errored.Should().BeTrue();
                 errorMessage.Should().Be(string.Format("The location for the template already exists. You can:{0} 1. Remove 'c:\\chocolatey\\Bob'{0} 2. Use --force{0} 3. Specify a different name", Environment.NewLine));
-                verifiedDirectoryPath.Should().Be("c:\\chocolatey\\Bob");
+                _verifiedDirectoryPath.Should().Be("c:\\chocolatey\\Bob");
             }
 
             [Fact]
             public void Should_throw_exception_even_with_outputdirectory()
             {
-                config.OutputDirectory = "c:\\packages";
+                _config.OutputDirectory = "c:\\packages";
 
                 bool errored = false;
                 string errorMessage = string.Empty;
 
                 try
                 {
-                    because();
+                    _because();
                 }
                 catch (ApplicationException ex)
                 {
@@ -227,24 +227,24 @@ namespace chocolatey.tests.infrastructure.app.services
 
                 errored.Should().BeTrue();
                 errorMessage.Should().Be(string.Format("The location for the template already exists. You can:{0} 1. Remove 'c:\\packages\\Bob'{0} 2. Use --force{0} 3. Specify a different name", Environment.NewLine));
-                verifiedDirectoryPath.Should().Be("c:\\packages\\Bob");
+                _verifiedDirectoryPath.Should().Be("c:\\packages\\Bob");
             }
         }
 
         public class When_generate_is_called : TemplateServiceSpecsBase
         {
-            private Action because;
-            private readonly ChocolateyConfiguration config = new ChocolateyConfiguration();
-            private readonly List<string> files = new List<string>();
-            private readonly HashSet<string> directoryCreated = new HashSet<string>(StringComparer.InvariantCultureIgnoreCase);
-            private readonly UTF8Encoding utf8WithoutBOM = new UTF8Encoding(false);
+            private Action _because;
+            private readonly ChocolateyConfiguration _config = new ChocolateyConfiguration();
+            private readonly List<string> _files = new List<string>();
+            private readonly HashSet<string> _directoryCreated = new HashSet<string>(StringComparer.InvariantCultureIgnoreCase);
+            private readonly UTF8Encoding _utf8WithoutBOM = new UTF8Encoding(false);
 
             public override void Context()
             {
                 base.Context();
 
-                fileSystem.Setup(x => x.GetCurrentDirectory()).Returns("c:\\chocolatey");
-                fileSystem.Setup(x => x.CombinePaths(It.IsAny<string>(), It.IsAny<string>()))
+                FileSystem.Setup(x => x.GetCurrentDirectory()).Returns("c:\\chocolatey");
+                FileSystem.Setup(x => x.CombinePaths(It.IsAny<string>(), It.IsAny<string>()))
                     .Returns(
                         (string a, string[] b) =>
                         {
@@ -254,53 +254,53 @@ namespace chocolatey.tests.infrastructure.app.services
                             }
                             return a + "\\" + b[0];
                         });
-                fileSystem.Setup(x => x.DirectoryExists(It.IsAny<string>())).Returns<string>(dirPath => dirPath.EndsWith("templates\\default"));
-                fileSystem.Setup(x => x.WriteFile(It.IsAny<string>(), It.IsAny<string>(), Encoding.UTF8))
-                    .Callback((string filePath, string fileContent, Encoding encoding) => files.Add(filePath));
-                fileSystem.Setup(x => x.WriteFile(It.IsAny<string>(), It.IsAny<string>(), utf8WithoutBOM))
-                    .Callback((string filePath, string fileContent, Encoding encoding) => files.Add(filePath));
-                fileSystem.Setup(x => x.DeleteDirectoryChecked(It.IsAny<string>(), true));
-                fileSystem.Setup(x => x.EnsureDirectoryExists(It.IsAny<string>())).Callback(
+                FileSystem.Setup(x => x.DirectoryExists(It.IsAny<string>())).Returns<string>(dirPath => dirPath.EndsWith("templates\\default"));
+                FileSystem.Setup(x => x.WriteFile(It.IsAny<string>(), It.IsAny<string>(), Encoding.UTF8))
+                    .Callback((string filePath, string fileContent, Encoding encoding) => _files.Add(filePath));
+                FileSystem.Setup(x => x.WriteFile(It.IsAny<string>(), It.IsAny<string>(), _utf8WithoutBOM))
+                    .Callback((string filePath, string fileContent, Encoding encoding) => _files.Add(filePath));
+                FileSystem.Setup(x => x.DeleteDirectoryChecked(It.IsAny<string>(), true));
+                FileSystem.Setup(x => x.EnsureDirectoryExists(It.IsAny<string>())).Callback(
                     (string directory) =>
                     {
                         if (!string.IsNullOrWhiteSpace(directory))
                         {
-                            directoryCreated.Add(directory);
+                            _directoryCreated.Add(directory);
                         }
                     });
-                fileSystem.Setup(x => x.GetFiles(It.IsAny<string>(), "*.*", SearchOption.AllDirectories)).Returns(new[] { "templates\\default\\template.nuspec", "templates\\default\\random.txt" });
-                fileSystem.Setup(x => x.GetDirectoryName(It.IsAny<string>())).Returns<string>(file => Path.GetDirectoryName(file));
-                fileSystem.Setup(x => x.GetFileExtension(It.IsAny<string>())).Returns<string>(file => Path.GetExtension(file));
-                fileSystem.Setup(x => x.ReadFile(It.IsAny<string>())).Returns(string.Empty);
+                FileSystem.Setup(x => x.GetFiles(It.IsAny<string>(), "*.*", SearchOption.AllDirectories)).Returns(new[] { "templates\\default\\template.nuspec", "templates\\default\\random.txt" });
+                FileSystem.Setup(x => x.GetDirectoryName(It.IsAny<string>())).Returns<string>(file => Path.GetDirectoryName(file));
+                FileSystem.Setup(x => x.GetFileExtension(It.IsAny<string>())).Returns<string>(file => Path.GetExtension(file));
+                FileSystem.Setup(x => x.ReadFile(It.IsAny<string>())).Returns(string.Empty);
 
-                config.NewCommand.Name = "Bob";
+                _config.NewCommand.Name = "Bob";
             }
 
             public override void Because()
             {
-                because = () => service.Generate(config);
+                _because = () => Service.Generate(_config);
             }
 
             public override void BeforeEachSpec()
             {
                 MockLogger.Reset();
-                files.Clear();
-                directoryCreated.Clear();
+                _files.Clear();
+                _directoryCreated.Clear();
             }
 
             [Fact]
             public void Should_generate_all_files_and_directories()
             {
-                because();
+                _because();
 
-                var directories = directoryCreated.ToList();
+                var directories = _directoryCreated.ToList();
                 directories.Should().HaveCount(2, "There should be 2 directories, but there was: " + string.Join(", ", directories));
                 directories.Should().HaveElementAt(0,"c:\\chocolatey\\Bob");
                 directories.Should().HaveElementAt(1,"c:\\chocolatey\\Bob\\tools");
 
-                files.Should().HaveCount(2, "There should be 2 files, but there was: " + string.Join(", ", files));
-                files.Should().HaveElementAt(0,"c:\\chocolatey\\Bob\\__name_replace__.nuspec");
-                files.Should().HaveElementAt(1,"c:\\chocolatey\\Bob\\random.txt");
+                _files.Should().HaveCount(2, "There should be 2 files, but there was: " + string.Join(", ", _files));
+                _files.Should().HaveElementAt(0, "c:\\chocolatey\\Bob\\__name_replace__.nuspec");
+                _files.Should().HaveElementAt(1, "c:\\chocolatey\\Bob\\random.txt");
 
                 MockLogger.MessagesFor(LogLevel.Info).Last().Should().Be(string.Format(@"Successfully generated Bob package specification files{0} at 'c:\chocolatey\Bob'", Environment.NewLine));
             }
@@ -308,18 +308,18 @@ namespace chocolatey.tests.infrastructure.app.services
             [Fact]
             public void Should_generate_all_files_and_directories_even_with_outputdirectory()
             {
-                config.OutputDirectory = "c:\\packages";
+                _config.OutputDirectory = "c:\\packages";
 
-                because();
+                _because();
 
-                var directories = directoryCreated.ToList();
+                var directories = _directoryCreated.ToList();
                 directories.Should().HaveCount(2, "There should be 2 directories, but there was: " + string.Join(", ", directories));
                 directories.Should().HaveElementAt(0,"c:\\packages\\Bob");
                 directories.Should().HaveElementAt(1,"c:\\packages\\Bob\\tools");
 
-                files.Should().HaveCount(2, "There should be 2 files, but there was: " + string.Join(", ", files));
-                files.Should().HaveElementAt(0,"c:\\packages\\Bob\\__name_replace__.nuspec");
-                files.Should().HaveElementAt(1,"c:\\packages\\Bob\\random.txt");
+                _files.Should().HaveCount(2, "There should be 2 files, but there was: " + string.Join(", ", _files));
+                _files.Should().HaveElementAt(0, "c:\\packages\\Bob\\__name_replace__.nuspec");
+                _files.Should().HaveElementAt(1, "c:\\packages\\Bob\\random.txt");
 
                 MockLogger.MessagesFor(LogLevel.Info).Last().Should().Be(string.Format(@"Successfully generated Bob package specification files{0} at 'c:\packages\Bob'", Environment.NewLine));
             }
@@ -327,18 +327,18 @@ namespace chocolatey.tests.infrastructure.app.services
 
         public class When_generate_is_called_with_nested_folders : TemplateServiceSpecsBase
         {
-            private Action because;
-            private readonly ChocolateyConfiguration config = new ChocolateyConfiguration();
-            private readonly List<string> files = new List<string>();
-            private readonly HashSet<string> directoryCreated = new HashSet<string>(StringComparer.InvariantCultureIgnoreCase);
-            private readonly UTF8Encoding utf8WithoutBOM = new UTF8Encoding(false);
+            private Action _because;
+            private readonly ChocolateyConfiguration _config = new ChocolateyConfiguration();
+            private readonly List<string> _files = new List<string>();
+            private readonly HashSet<string> _directoryCreated = new HashSet<string>(StringComparer.InvariantCultureIgnoreCase);
+            private readonly UTF8Encoding _utf8WithoutBOM = new UTF8Encoding(false);
 
             public override void Context()
             {
                 base.Context();
 
-                fileSystem.Setup(x => x.GetCurrentDirectory()).Returns("c:\\chocolatey");
-                fileSystem.Setup(x => x.CombinePaths(It.IsAny<string>(), It.IsAny<string>()))
+                FileSystem.Setup(x => x.GetCurrentDirectory()).Returns("c:\\chocolatey");
+                FileSystem.Setup(x => x.CombinePaths(It.IsAny<string>(), It.IsAny<string>()))
                     .Returns(
                         (string a, string[] b) =>
                         {
@@ -348,60 +348,60 @@ namespace chocolatey.tests.infrastructure.app.services
                             }
                             return a + "\\" + b[0];
                         });
-                fileSystem.Setup(x => x.DirectoryExists(It.IsAny<string>())).Returns<string>(dirPath => dirPath.EndsWith("templates\\test"));
-                fileSystem.Setup(x => x.WriteFile(It.IsAny<string>(), It.IsAny<string>(), Encoding.UTF8))
-                    .Callback((string filePath, string fileContent, Encoding encoding) => files.Add(filePath));
-                fileSystem.Setup(x => x.WriteFile(It.IsAny<string>(), It.IsAny<string>(), utf8WithoutBOM))
-                    .Callback((string filePath, string fileContent, Encoding encoding) => files.Add(filePath));
-                fileSystem.Setup(x => x.DeleteDirectoryChecked(It.IsAny<string>(), true));
-                fileSystem.Setup(x => x.GetFiles(It.IsAny<string>(), "*.*", SearchOption.AllDirectories))
+                FileSystem.Setup(x => x.DirectoryExists(It.IsAny<string>())).Returns<string>(dirPath => dirPath.EndsWith("templates\\test"));
+                FileSystem.Setup(x => x.WriteFile(It.IsAny<string>(), It.IsAny<string>(), Encoding.UTF8))
+                    .Callback((string filePath, string fileContent, Encoding encoding) => _files.Add(filePath));
+                FileSystem.Setup(x => x.WriteFile(It.IsAny<string>(), It.IsAny<string>(), _utf8WithoutBOM))
+                    .Callback((string filePath, string fileContent, Encoding encoding) => _files.Add(filePath));
+                FileSystem.Setup(x => x.DeleteDirectoryChecked(It.IsAny<string>(), true));
+                FileSystem.Setup(x => x.GetFiles(It.IsAny<string>(), "*.*", SearchOption.AllDirectories))
                     .Returns(new[] { "templates\\test\\template.nuspec", "templates\\test\\random.txt", "templates\\test\\tools\\chocolateyInstall.ps1", "templates\\test\\tools\\lower\\another.ps1" });
-                fileSystem.Setup(x => x.GetDirectories(It.IsAny<string>(), "*.*", SearchOption.AllDirectories))
+                FileSystem.Setup(x => x.GetDirectories(It.IsAny<string>(), "*.*", SearchOption.AllDirectories))
                     .Returns(new[] { "templates\\test", "templates\\test\\tools", "templates\\test\\tools\\lower" });
-                fileSystem.Setup(x => x.EnsureDirectoryExists(It.IsAny<string>())).Callback(
+                FileSystem.Setup(x => x.EnsureDirectoryExists(It.IsAny<string>())).Callback(
                     (string directory) =>
                     {
                         if (!string.IsNullOrWhiteSpace(directory))
                         {
-                            directoryCreated.Add(directory);
+                            _directoryCreated.Add(directory);
                         }
                     });
-                fileSystem.Setup(x => x.GetDirectoryName(It.IsAny<string>())).Returns<string>(file => Path.GetDirectoryName(file));
-                fileSystem.Setup(x => x.GetFileExtension(It.IsAny<string>())).Returns<string>(file => Path.GetExtension(file));
-                fileSystem.Setup(x => x.ReadFile(It.IsAny<string>())).Returns(string.Empty);
+                FileSystem.Setup(x => x.GetDirectoryName(It.IsAny<string>())).Returns<string>(file => Path.GetDirectoryName(file));
+                FileSystem.Setup(x => x.GetFileExtension(It.IsAny<string>())).Returns<string>(file => Path.GetExtension(file));
+                FileSystem.Setup(x => x.ReadFile(It.IsAny<string>())).Returns(string.Empty);
 
-                config.NewCommand.Name = "Bob";
-                config.NewCommand.TemplateName = "test";
+                _config.NewCommand.Name = "Bob";
+                _config.NewCommand.TemplateName = "test";
             }
 
             public override void Because()
             {
-                because = () => service.Generate(config);
+                _because = () => Service.Generate(_config);
             }
 
             public override void BeforeEachSpec()
             {
                 MockLogger.Reset();
-                files.Clear();
-                directoryCreated.Clear();
+                _files.Clear();
+                _directoryCreated.Clear();
             }
 
             [Fact]
             public void Should_generate_all_files_and_directories()
             {
-                because();
+                _because();
 
-                var directories = directoryCreated.ToList();
+                var directories = _directoryCreated.ToList();
                 directories.Should().HaveCount(3, "There should be 3 directories, but there was: " + string.Join(", ", directories));
                 directories.Should().HaveElementAt(0,"c:\\chocolatey\\Bob");
                 directories.Should().HaveElementAt(1,"c:\\chocolatey\\Bob\\tools");
                 directories.Should().HaveElementAt(2,"c:\\chocolatey\\Bob\\tools\\lower");
 
-                files.Should().HaveCount(4, "There should be 4 files, but there was: " + string.Join(", ", files));
-                files.Should().HaveElementAt(0,"c:\\chocolatey\\Bob\\__name_replace__.nuspec");
-                files.Should().HaveElementAt(1,"c:\\chocolatey\\Bob\\random.txt");
-                files.Should().HaveElementAt(2,"c:\\chocolatey\\Bob\\tools\\chocolateyInstall.ps1");
-                files.Should().HaveElementAt(3,"c:\\chocolatey\\Bob\\tools\\lower\\another.ps1");
+                _files.Should().HaveCount(4, "There should be 4 files, but there was: " + string.Join(", ", _files));
+                _files.Should().HaveElementAt(0, "c:\\chocolatey\\Bob\\__name_replace__.nuspec");
+                _files.Should().HaveElementAt(1, "c:\\chocolatey\\Bob\\random.txt");
+                _files.Should().HaveElementAt(2, "c:\\chocolatey\\Bob\\tools\\chocolateyInstall.ps1");
+                _files.Should().HaveElementAt(3, "c:\\chocolatey\\Bob\\tools\\lower\\another.ps1");
 
                 MockLogger.MessagesFor(LogLevel.Info).Last().Should().Be(string.Format(@"Successfully generated Bob package specification files{0} at 'c:\chocolatey\Bob'", Environment.NewLine));
             }
@@ -409,21 +409,21 @@ namespace chocolatey.tests.infrastructure.app.services
             [Fact]
             public void Should_generate_all_files_and_directories_even_with_outputdirectory()
             {
-                config.OutputDirectory = "c:\\packages";
+                _config.OutputDirectory = "c:\\packages";
 
-                because();
+                _because();
 
-                var directories = directoryCreated.ToList();
+                var directories = _directoryCreated.ToList();
                 directories.Should().HaveCount(3, "There should be 3 directories, but there was: " + string.Join(", ", directories));
                 directories.Should().HaveElementAt(0,"c:\\packages\\Bob");
                 directories.Should().HaveElementAt(1,"c:\\packages\\Bob\\tools");
                 directories.Should().HaveElementAt(2,"c:\\packages\\Bob\\tools\\lower");
 
-                files.Should().HaveCount(4, "There should be 4 files, but there was: " + string.Join(", ", files));
-                files.Should().HaveElementAt(0,"c:\\packages\\Bob\\__name_replace__.nuspec");
-                files.Should().HaveElementAt(1,"c:\\packages\\Bob\\random.txt");
-                files.Should().HaveElementAt(2,"c:\\packages\\Bob\\tools\\chocolateyInstall.ps1");
-                files.Should().HaveElementAt(3,"c:\\packages\\Bob\\tools\\lower\\another.ps1");
+                _files.Should().HaveCount(4, "There should be 4 files, but there was: " + string.Join(", ", _files));
+                _files.Should().HaveElementAt(0, "c:\\packages\\Bob\\__name_replace__.nuspec");
+                _files.Should().HaveElementAt(1, "c:\\packages\\Bob\\random.txt");
+                _files.Should().HaveElementAt(2, "c:\\packages\\Bob\\tools\\chocolateyInstall.ps1");
+                _files.Should().HaveElementAt(3, "c:\\packages\\Bob\\tools\\lower\\another.ps1");
 
                 MockLogger.MessagesFor(LogLevel.Info).Last().Should().Be(string.Format(@"Successfully generated Bob package specification files{0} at 'c:\packages\Bob'", Environment.NewLine));
             }
@@ -431,18 +431,18 @@ namespace chocolatey.tests.infrastructure.app.services
 
         public class When_generate_is_called_with_empty_nested_folders : TemplateServiceSpecsBase
         {
-            private Action because;
-            private readonly ChocolateyConfiguration config = new ChocolateyConfiguration();
-            private readonly List<string> files = new List<string>();
-            private readonly HashSet<string> directoryCreated = new HashSet<string>(StringComparer.InvariantCultureIgnoreCase);
-            private readonly UTF8Encoding utf8WithoutBOM = new UTF8Encoding(false);
+            private Action _because;
+            private readonly ChocolateyConfiguration _config = new ChocolateyConfiguration();
+            private readonly List<string> _files = new List<string>();
+            private readonly HashSet<string> _directoryCreated = new HashSet<string>(StringComparer.InvariantCultureIgnoreCase);
+            private readonly UTF8Encoding _utf8WithoutBOM = new UTF8Encoding(false);
 
             public override void Context()
             {
                 base.Context();
 
-                fileSystem.Setup(x => x.GetCurrentDirectory()).Returns("c:\\chocolatey");
-                fileSystem.Setup(x => x.CombinePaths(It.IsAny<string>(), It.IsAny<string>()))
+                FileSystem.Setup(x => x.GetCurrentDirectory()).Returns("c:\\chocolatey");
+                FileSystem.Setup(x => x.CombinePaths(It.IsAny<string>(), It.IsAny<string>()))
                     .Returns(
                         (string a, string[] b) =>
                         {
@@ -452,50 +452,50 @@ namespace chocolatey.tests.infrastructure.app.services
                             }
                             return a + "\\" + b[0];
                         });
-                fileSystem.Setup(x => x.DirectoryExists(It.IsAny<string>())).Returns<string>(dirPath => dirPath.EndsWith("templates\\test"));
-                fileSystem.Setup(x => x.WriteFile(It.IsAny<string>(), It.IsAny<string>(), Encoding.UTF8))
-                    .Callback((string filePath, string fileContent, Encoding encoding) => files.Add(filePath));
-                fileSystem.Setup(x => x.WriteFile(It.IsAny<string>(), It.IsAny<string>(), utf8WithoutBOM))
-                    .Callback((string filePath, string fileContent, Encoding encoding) => files.Add(filePath));
-                fileSystem.Setup(x => x.DeleteDirectoryChecked(It.IsAny<string>(), true));
-                fileSystem.Setup(x => x.GetFiles(It.IsAny<string>(), "*.*", SearchOption.AllDirectories))
+                FileSystem.Setup(x => x.DirectoryExists(It.IsAny<string>())).Returns<string>(dirPath => dirPath.EndsWith("templates\\test"));
+                FileSystem.Setup(x => x.WriteFile(It.IsAny<string>(), It.IsAny<string>(), Encoding.UTF8))
+                    .Callback((string filePath, string fileContent, Encoding encoding) => _files.Add(filePath));
+                FileSystem.Setup(x => x.WriteFile(It.IsAny<string>(), It.IsAny<string>(), _utf8WithoutBOM))
+                    .Callback((string filePath, string fileContent, Encoding encoding) => _files.Add(filePath));
+                FileSystem.Setup(x => x.DeleteDirectoryChecked(It.IsAny<string>(), true));
+                FileSystem.Setup(x => x.GetFiles(It.IsAny<string>(), "*.*", SearchOption.AllDirectories))
                     .Returns(new[] { "templates\\test\\template.nuspec", "templates\\test\\random.txt", "templates\\test\\tools\\chocolateyInstall.ps1", "templates\\test\\tools\\lower\\another.ps1" });
-                fileSystem.Setup(x => x.GetDirectories(It.IsAny<string>(), "*.*", SearchOption.AllDirectories))
+                FileSystem.Setup(x => x.GetDirectories(It.IsAny<string>(), "*.*", SearchOption.AllDirectories))
                     .Returns(new[] { "templates\\test", "templates\\test\\tools", "templates\\test\\tools\\lower", "templates\\test\\empty", "templates\\test\\empty\\nested" });
-                fileSystem.Setup(x => x.EnsureDirectoryExists(It.IsAny<string>())).Callback(
+                FileSystem.Setup(x => x.EnsureDirectoryExists(It.IsAny<string>())).Callback(
                     (string directory) =>
                     {
                         if (!string.IsNullOrWhiteSpace(directory))
                         {
-                            directoryCreated.Add(directory);
+                            _directoryCreated.Add(directory);
                         }
                     });
-                fileSystem.Setup(x => x.GetDirectoryName(It.IsAny<string>())).Returns<string>(file => Path.GetDirectoryName(file));
-                fileSystem.Setup(x => x.GetFileExtension(It.IsAny<string>())).Returns<string>(file => Path.GetExtension(file));
-                fileSystem.Setup(x => x.ReadFile(It.IsAny<string>())).Returns(string.Empty);
+                FileSystem.Setup(x => x.GetDirectoryName(It.IsAny<string>())).Returns<string>(file => Path.GetDirectoryName(file));
+                FileSystem.Setup(x => x.GetFileExtension(It.IsAny<string>())).Returns<string>(file => Path.GetExtension(file));
+                FileSystem.Setup(x => x.ReadFile(It.IsAny<string>())).Returns(string.Empty);
 
-                config.NewCommand.Name = "Bob";
-                config.NewCommand.TemplateName = "test";
+                _config.NewCommand.Name = "Bob";
+                _config.NewCommand.TemplateName = "test";
             }
 
             public override void Because()
             {
-                because = () => service.Generate(config);
+                _because = () => Service.Generate(_config);
             }
 
             public override void BeforeEachSpec()
             {
                 MockLogger.Reset();
-                files.Clear();
-                directoryCreated.Clear();
+                _files.Clear();
+                _directoryCreated.Clear();
             }
 
             [Fact]
             public void Should_generate_all_files_and_directories()
             {
-                because();
+                _because();
 
-                var directories = directoryCreated.ToList();
+                var directories = _directoryCreated.ToList();
                 directories.Should().HaveCount(5, "There should be 5 directories, but there was: " + string.Join(", ", directories));
                 directories.Should().HaveElementAt(0,"c:\\chocolatey\\Bob");
                 directories.Should().HaveElementAt(1,"c:\\chocolatey\\Bob\\tools");
@@ -503,11 +503,11 @@ namespace chocolatey.tests.infrastructure.app.services
                 directories.Should().HaveElementAt(3,"c:\\chocolatey\\Bob\\empty");
                 directories.Should().HaveElementAt(4,"c:\\chocolatey\\Bob\\empty\\nested");
 
-                files.Should().HaveCount(4, "There should be 4 files, but there was: " + string.Join(", ", files));
-                files.Should().HaveElementAt(0,"c:\\chocolatey\\Bob\\__name_replace__.nuspec");
-                files.Should().HaveElementAt(1,"c:\\chocolatey\\Bob\\random.txt");
-                files.Should().HaveElementAt(2,"c:\\chocolatey\\Bob\\tools\\chocolateyInstall.ps1");
-                files.Should().HaveElementAt(3,"c:\\chocolatey\\Bob\\tools\\lower\\another.ps1");
+                _files.Should().HaveCount(4, "There should be 4 files, but there was: " + string.Join(", ", _files));
+                _files.Should().HaveElementAt(0, "c:\\chocolatey\\Bob\\__name_replace__.nuspec");
+                _files.Should().HaveElementAt(1, "c:\\chocolatey\\Bob\\random.txt");
+                _files.Should().HaveElementAt(2, "c:\\chocolatey\\Bob\\tools\\chocolateyInstall.ps1");
+                _files.Should().HaveElementAt(3, "c:\\chocolatey\\Bob\\tools\\lower\\another.ps1");
 
                 MockLogger.MessagesFor(LogLevel.Info).Last().Should().Be(string.Format(@"Successfully generated Bob package specification files{0} at 'c:\chocolatey\Bob'", Environment.NewLine));
             }
@@ -515,11 +515,11 @@ namespace chocolatey.tests.infrastructure.app.services
             [Fact]
             public void Should_generate_all_files_and_directories_even_with_outputdirectory()
             {
-                config.OutputDirectory = "c:\\packages";
+                _config.OutputDirectory = "c:\\packages";
 
-                because();
+                _because();
 
-                var directories = directoryCreated.ToList();
+                var directories = _directoryCreated.ToList();
                 directories.Should().HaveCount(5, "There should be 5 directories, but there was: " + string.Join(", ", directories));
                 directories.Should().HaveElementAt(0,"c:\\packages\\Bob");
                 directories.Should().HaveElementAt(1,"c:\\packages\\Bob\\tools");
@@ -527,11 +527,11 @@ namespace chocolatey.tests.infrastructure.app.services
                 directories.Should().HaveElementAt(3,"c:\\packages\\Bob\\empty");
                 directories.Should().HaveElementAt(4,"c:\\packages\\Bob\\empty\\nested");
 
-                files.Should().HaveCount(4, "There should be 4 files, but there was: " + string.Join(", ", files));
-                files.Should().HaveElementAt(0,"c:\\packages\\Bob\\__name_replace__.nuspec");
-                files.Should().HaveElementAt(1,"c:\\packages\\Bob\\random.txt");
-                files.Should().HaveElementAt(2,"c:\\packages\\Bob\\tools\\chocolateyInstall.ps1");
-                files.Should().HaveElementAt(3,"c:\\packages\\Bob\\tools\\lower\\another.ps1");
+                _files.Should().HaveCount(4, "There should be 4 files, but there was: " + string.Join(", ", _files));
+                _files.Should().HaveElementAt(0, "c:\\packages\\Bob\\__name_replace__.nuspec");
+                _files.Should().HaveElementAt(1, "c:\\packages\\Bob\\random.txt");
+                _files.Should().HaveElementAt(2, "c:\\packages\\Bob\\tools\\chocolateyInstall.ps1");
+                _files.Should().HaveElementAt(3, "c:\\packages\\Bob\\tools\\lower\\another.ps1");
 
                 MockLogger.MessagesFor(LogLevel.Info).Last().Should().Be(string.Format(@"Successfully generated Bob package specification files{0} at 'c:\packages\Bob'", Environment.NewLine));
             }
@@ -539,24 +539,24 @@ namespace chocolatey.tests.infrastructure.app.services
 
         public class When_generate_is_called_with_defaulttemplatename_in_configuration_but_template_folder_doesnt_exist : TemplateServiceSpecsBase
         {
-            private Action because;
-            private readonly ChocolateyConfiguration config = new ChocolateyConfiguration();
+            private Action _because;
+            private readonly ChocolateyConfiguration _config = new ChocolateyConfiguration();
 
             public override void Context()
             {
                 base.Context();
 
-                fileSystem.Setup(x => x.GetCurrentDirectory()).Returns("c:\\chocolatey");
-                fileSystem.Setup(x => x.CombinePaths(It.IsAny<string>(), It.IsAny<string>()))
+                FileSystem.Setup(x => x.GetCurrentDirectory()).Returns("c:\\chocolatey");
+                FileSystem.Setup(x => x.CombinePaths(It.IsAny<string>(), It.IsAny<string>()))
                     .Returns((string a, string[] b) => { return a + "\\" + b[0]; });
 
-                config.NewCommand.Name = "Bob";
-                config.DefaultTemplateName = "msi";
+                _config.NewCommand.Name = "Bob";
+                _config.DefaultTemplateName = "msi";
             }
 
             public override void Because()
             {
-                because = () => service.Generate(config);
+                _because = () => Service.Generate(_config);
             }
 
             public override void BeforeEachSpec()
@@ -569,39 +569,39 @@ namespace chocolatey.tests.infrastructure.app.services
             [Platform(Exclude = "Mono")]
             public void Should_use_null_value_for_template()
             {
-                because();
+                _because();
 
-                config.NewCommand.TemplateName.Should().BeNull();
+                _config.NewCommand.TemplateName.Should().BeNull();
             }
         }
 
         public class When_generate_is_called_with_defaulttemplatename_in_configuration_and_template_folder_exists : TemplateServiceSpecsBase
         {
-            private Action because;
-            private readonly ChocolateyConfiguration config = new ChocolateyConfiguration();
-            private string verifiedDirectoryPath;
+            private Action _because;
+            private readonly ChocolateyConfiguration _config = new ChocolateyConfiguration();
+            private string _verifiedDirectoryPath;
 
             public override void Context()
             {
                 base.Context();
 
-                fileSystem.Setup(x => x.GetCurrentDirectory()).Returns("c:\\chocolatey");
-                fileSystem.Setup(x => x.CombinePaths(It.IsAny<string>(), It.IsAny<string>()))
+                FileSystem.Setup(x => x.GetCurrentDirectory()).Returns("c:\\chocolatey");
+                FileSystem.Setup(x => x.CombinePaths(It.IsAny<string>(), It.IsAny<string>()))
                     .Returns((string a, string[] b) => { return a + "\\" + b[0]; });
-                fileSystem.Setup(x => x.DirectoryExists(Path.Combine(ApplicationParameters.TemplatesLocation, "msi"))).Returns<string>(
+                FileSystem.Setup(x => x.DirectoryExists(Path.Combine(ApplicationParameters.TemplatesLocation, "msi"))).Returns<string>(
                     x =>
                     {
-                        verifiedDirectoryPath = x;
+                        _verifiedDirectoryPath = x;
                         return true;
                     });
 
-                config.NewCommand.Name = "Bob";
-                config.DefaultTemplateName = "msi";
+                _config.NewCommand.Name = "Bob";
+                _config.DefaultTemplateName = "msi";
             }
 
             public override void Because()
             {
-                because = () => service.Generate(config);
+                _because = () => Service.Generate(_config);
             }
 
             public override void BeforeEachSpec()
@@ -614,40 +614,40 @@ namespace chocolatey.tests.infrastructure.app.services
             [Platform(Exclude = "Mono")]
             public void Should_use_template_name_from_configuration()
             {
-                because();
+                _because();
 
-                config.NewCommand.TemplateName.Should().Be("msi");
+                _config.NewCommand.TemplateName.Should().Be("msi");
             }
         }
 
         public class When_generate_is_called_with_defaulttemplatename_in_configuration_and_template_name_option_set : TemplateServiceSpecsBase
         {
-            private Action because;
-            private readonly ChocolateyConfiguration config = new ChocolateyConfiguration();
-            private string verifiedDirectoryPath;
+            private Action _because;
+            private readonly ChocolateyConfiguration _config = new ChocolateyConfiguration();
+            private string _verifiedDirectoryPath;
 
             public override void Context()
             {
                 base.Context();
 
-                fileSystem.Setup(x => x.GetCurrentDirectory()).Returns("c:\\chocolatey");
-                fileSystem.Setup(x => x.CombinePaths(It.IsAny<string>(), It.IsAny<string>()))
+                FileSystem.Setup(x => x.GetCurrentDirectory()).Returns("c:\\chocolatey");
+                FileSystem.Setup(x => x.CombinePaths(It.IsAny<string>(), It.IsAny<string>()))
                     .Returns((string a, string[] b) => { return a + "\\" + b[0]; });
-                fileSystem.Setup(x => x.DirectoryExists(Path.Combine(ApplicationParameters.TemplatesLocation, "zip"))).Returns<string>(
+                FileSystem.Setup(x => x.DirectoryExists(Path.Combine(ApplicationParameters.TemplatesLocation, "zip"))).Returns<string>(
                     x =>
                     {
-                        verifiedDirectoryPath = x;
+                        _verifiedDirectoryPath = x;
                         return true;
                     });
 
-                config.NewCommand.Name = "Bob";
-                config.NewCommand.TemplateName = "zip";
-                config.DefaultTemplateName = "msi";
+                _config.NewCommand.Name = "Bob";
+                _config.NewCommand.TemplateName = "zip";
+                _config.DefaultTemplateName = "msi";
             }
 
             public override void Because()
             {
-                because = () => service.Generate(config);
+                _because = () => Service.Generate(_config);
             }
 
             public override void BeforeEachSpec()
@@ -660,28 +660,28 @@ namespace chocolatey.tests.infrastructure.app.services
             [Platform(Exclude = "Mono")]
             public void Should_use_template_name_from_command_line_option()
             {
-                because();
+                _because();
 
-                config.NewCommand.TemplateName.Should().Be("zip");
+                _config.NewCommand.TemplateName.Should().Be("zip");
             }
         }
 
         public class When_generate_is_called_with_built_in_option_set : TemplateServiceSpecsBase
         {
-            private Action because;
-            private readonly ChocolateyConfiguration config = new ChocolateyConfiguration();
+            private Action _because;
+            private readonly ChocolateyConfiguration _config = new ChocolateyConfiguration();
 
             public override void Context()
             {
                 base.Context();
 
-                config.NewCommand.Name = "Bob";
-                config.NewCommand.UseOriginalTemplate = true;
+                _config.NewCommand.Name = "Bob";
+                _config.NewCommand.UseOriginalTemplate = true;
             }
 
             public override void Because()
             {
-                because = () => service.Generate(config);
+                _because = () => Service.Generate(_config);
             }
 
             public override void BeforeEachSpec()
@@ -694,29 +694,29 @@ namespace chocolatey.tests.infrastructure.app.services
             [Platform(Exclude = "Mono")]
             public void Should_use_null_value_for_template()
             {
-                because();
+                _because();
 
-                config.NewCommand.TemplateName.Should().BeNull();
+                _config.NewCommand.TemplateName.Should().BeNull();
             }
         }
 
         public class When_generate_is_called_with_built_in_option_set_and_defaulttemplate_in_configuration : TemplateServiceSpecsBase
         {
-            private Action because;
-            private readonly ChocolateyConfiguration config = new ChocolateyConfiguration();
+            private Action _because;
+            private readonly ChocolateyConfiguration _config = new ChocolateyConfiguration();
 
             public override void Context()
             {
                 base.Context();
 
-                config.NewCommand.Name = "Bob";
-                config.NewCommand.UseOriginalTemplate = true;
-                config.DefaultTemplateName = "msi";
+                _config.NewCommand.Name = "Bob";
+                _config.NewCommand.UseOriginalTemplate = true;
+                _config.DefaultTemplateName = "msi";
             }
 
             public override void Because()
             {
-                because = () => service.Generate(config);
+                _because = () => Service.Generate(_config);
             }
 
             public override void BeforeEachSpec()
@@ -729,40 +729,40 @@ namespace chocolatey.tests.infrastructure.app.services
             [Platform(Exclude = "Mono")]
             public void Should_use_null_value_for_template()
             {
-                because();
+                _because();
 
-                config.NewCommand.TemplateName.Should().BeNull();
+                _config.NewCommand.TemplateName.Should().BeNull();
             }
         }
 
         public class When_generate_is_called_with_built_in_option_set_and_template_name_option_set_and_template_folder_exists : TemplateServiceSpecsBase
         {
-            private Action because;
-            private readonly ChocolateyConfiguration config = new ChocolateyConfiguration();
-            private string verifiedDirectoryPath;
+            private Action _because;
+            private readonly ChocolateyConfiguration _config = new ChocolateyConfiguration();
+            private string _verifiedDirectoryPath;
 
             public override void Context()
             {
                 base.Context();
 
-                fileSystem.Setup(x => x.GetCurrentDirectory()).Returns("c:\\chocolatey");
-                fileSystem.Setup(x => x.CombinePaths(It.IsAny<string>(), It.IsAny<string>()))
+                FileSystem.Setup(x => x.GetCurrentDirectory()).Returns("c:\\chocolatey");
+                FileSystem.Setup(x => x.CombinePaths(It.IsAny<string>(), It.IsAny<string>()))
                     .Returns((string a, string[] b) => { return a + "\\" + b[0]; });
-                fileSystem.Setup(x => x.DirectoryExists(Path.Combine(ApplicationParameters.TemplatesLocation, "zip"))).Returns<string>(
+                FileSystem.Setup(x => x.DirectoryExists(Path.Combine(ApplicationParameters.TemplatesLocation, "zip"))).Returns<string>(
                     x =>
                     {
-                        verifiedDirectoryPath = x;
+                        _verifiedDirectoryPath = x;
                         return true;
                     });
 
-                config.NewCommand.Name = "Bob";
-                config.NewCommand.TemplateName = "zip";
-                config.NewCommand.UseOriginalTemplate = true;
+                _config.NewCommand.Name = "Bob";
+                _config.NewCommand.TemplateName = "zip";
+                _config.NewCommand.UseOriginalTemplate = true;
             }
 
             public override void Because()
             {
-                because = () => service.Generate(config);
+                _because = () => Service.Generate(_config);
             }
 
             public override void BeforeEachSpec()
@@ -775,41 +775,41 @@ namespace chocolatey.tests.infrastructure.app.services
             [Platform(Exclude = "Mono")]
             public void Should_use_template_name_from_command_line_option()
             {
-                because();
+                _because();
 
-                config.NewCommand.TemplateName.Should().Be("zip");
+                _config.NewCommand.TemplateName.Should().Be("zip");
             }
         }
 
         public class When_generate_is_called_with_built_in_option_set_and_template_name_option_set_and_defaulttemplatename_set_and_template_folder_exists : TemplateServiceSpecsBase
         {
-            private Action because;
-            private readonly ChocolateyConfiguration config = new ChocolateyConfiguration();
-            private string verifiedDirectoryPath;
+            private Action _because;
+            private readonly ChocolateyConfiguration _config = new ChocolateyConfiguration();
+            private string _verifiedDirectoryPath;
 
             public override void Context()
             {
                 base.Context();
 
-                fileSystem.Setup(x => x.GetCurrentDirectory()).Returns("c:\\chocolatey");
-                fileSystem.Setup(x => x.CombinePaths(It.IsAny<string>(), It.IsAny<string>()))
+                FileSystem.Setup(x => x.GetCurrentDirectory()).Returns("c:\\chocolatey");
+                FileSystem.Setup(x => x.CombinePaths(It.IsAny<string>(), It.IsAny<string>()))
                     .Returns((string a, string[] b) => { return a + "\\" + b[0]; });
-                fileSystem.Setup(x => x.DirectoryExists(Path.Combine(ApplicationParameters.TemplatesLocation, "zip"))).Returns<string>(
+                FileSystem.Setup(x => x.DirectoryExists(Path.Combine(ApplicationParameters.TemplatesLocation, "zip"))).Returns<string>(
                     x =>
                     {
-                        verifiedDirectoryPath = x;
+                        _verifiedDirectoryPath = x;
                         return true;
                     });
 
-                config.NewCommand.Name = "Bob";
-                config.NewCommand.TemplateName = "zip";
-                config.DefaultTemplateName = "msi";
-                config.NewCommand.UseOriginalTemplate = true;
+                _config.NewCommand.Name = "Bob";
+                _config.NewCommand.TemplateName = "zip";
+                _config.DefaultTemplateName = "msi";
+                _config.NewCommand.UseOriginalTemplate = true;
             }
 
             public override void Because()
             {
-                because = () => service.Generate(config);
+                _because = () => Service.Generate(_config);
             }
 
             public override void BeforeEachSpec()
@@ -822,20 +822,20 @@ namespace chocolatey.tests.infrastructure.app.services
             [Platform(Exclude = "Mono")]
             public void Should_use_template_name_from_command_line_option()
             {
-                because();
+                _because();
 
-                config.NewCommand.TemplateName.Should().Be("zip");
+                _config.NewCommand.TemplateName.Should().Be("zip");
             }
         }
 
         public class When_list_noop_is_called : TemplateServiceSpecsBase
         {
-            private Action because;
-            private readonly ChocolateyConfiguration config = new ChocolateyConfiguration();
+            private Action _because;
+            private readonly ChocolateyConfiguration _config = new ChocolateyConfiguration();
 
             public override void Because()
             {
-                because = () => service.ListDryRun(config);
+                _because = () => Service.ListDryRun(_config);
             }
 
             public override void BeforeEachSpec()
@@ -846,7 +846,7 @@ namespace chocolatey.tests.infrastructure.app.services
             [Fact]
             public void Should_log_template_location_if_no_template_name()
             {
-                because();
+                _because();
 
                 var infos = MockLogger.MessagesFor(LogLevel.Info);
                 infos.Should().ContainSingle();
@@ -856,12 +856,12 @@ namespace chocolatey.tests.infrastructure.app.services
             [Fact]
             public void Should_log_template_name_if_template_name()
             {
-                config.TemplateCommand.Name = "msi";
-                because();
+                _config.TemplateCommand.Name = "msi";
+                _because();
 
                 var infos = MockLogger.MessagesFor(LogLevel.Info);
                 infos.Should().ContainSingle();
-                infos.Should().HaveElementAt(0,"Would have listed information about {0}".FormatWith(config.TemplateCommand.Name));
+                infos.Should().HaveElementAt(0, "Would have listed information about {0}".FormatWith(_config.TemplateCommand.Name));
             }
         }
     }

--- a/src/chocolatey.tests/infrastructure/commandline/InteractivePromptSpecs.cs
+++ b/src/chocolatey.tests/infrastructure/commandline/InteractivePromptSpecs.cs
@@ -27,46 +27,46 @@ namespace chocolatey.tests.infrastructure.commandline
     {
         public abstract class InteractivePromptSpecsBase : TinySpec
         {
-            protected Mock<IConsole> console = new Mock<IConsole>();
-            protected IList<string> choices = new List<string>();
-            protected string prompt_value;
+            protected Mock<IConsole> Console = new Mock<IConsole>();
+            protected IList<string> Choices = new List<string>();
+            protected string PromptValue;
 
             public override void Context()
             {
-                prompt_value = "hi";
+                PromptValue = "hi";
 
-                InteractivePrompt.InitializeWith(new Lazy<IConsole>(() => console.Object));
+                InteractivePrompt.InitializeWith(new Lazy<IConsole>(() => Console.Object));
 
-                choices.Add("yes");
-                choices.Add("no");
+                Choices.Add("yes");
+                Choices.Add("no");
             }
 
             public void Should_have_called_Console_ReadLine()
             {
-                console.Verify(c => c.ReadLine(), Times.AtLeastOnce);
+                Console.Verify(c => c.ReadLine(), Times.AtLeastOnce);
             }
         }
 
         public class When_prompting_with_interactivePrompt : InteractivePromptSpecsBase
         {
-            private string default_choice;
-            private Func<string> prompt;
+            private string _defaultChoice;
+            private Func<string> _prompt;
 
             public override void Because()
             {
-                console.Setup(c => c.ReadLine()).Returns(""); //Enter pressed
-                prompt = () => InteractivePrompt.PromptForConfirmation(prompt_value, choices, default_choice, requireAnswer: false);
+                Console.Setup(c => c.ReadLine()).Returns(""); //Enter pressed
+                _prompt = () => InteractivePrompt.PromptForConfirmation(PromptValue, Choices, _defaultChoice, requireAnswer: false);
             }
 
             [Fact]
             public void Should_error_when_the_choicelist_is_null()
             {
-                choices = null;
+                Choices = null;
                 bool errored = false;
-                console.Setup(c => c.ReadLine()).Returns(""); //Enter pressed
+                Console.Setup(c => c.ReadLine()).Returns(""); //Enter pressed
                 try
                 {
-                    prompt();
+                    _prompt();
                 }
                 catch (Exception)
                 {
@@ -74,19 +74,19 @@ namespace chocolatey.tests.infrastructure.commandline
                 }
 
                 errored.Should().BeTrue();
-                console.Verify(c => c.ReadLine(), Times.Never);
+                Console.Verify(c => c.ReadLine(), Times.Never);
             }
 
             [Fact]
             public void Should_error_when_the_choicelist_is_empty()
             {
-                choices = new List<string>();
+                Choices = new List<string>();
                 bool errored = false;
                 string errorMessage = string.Empty;
-                console.Setup(c => c.ReadLine()).Returns(""); //Enter pressed
+                Console.Setup(c => c.ReadLine()).Returns(""); //Enter pressed
                 try
                 {
-                    prompt();
+                    _prompt();
                 }
                 catch (Exception ex)
                 {
@@ -96,22 +96,22 @@ namespace chocolatey.tests.infrastructure.commandline
 
                 errored.Should().BeTrue();
                 errorMessage.Should().Contain("No choices passed in.");
-                console.Verify(c => c.ReadLine(), Times.Never);
+                Console.Verify(c => c.ReadLine(), Times.Never);
             }
 
             [Fact]
             public void Should_error_when_the_prompt_input_is_null()
             {
-                choices = new List<string>
+                Choices = new List<string>
                 {
                     "bob"
                 };
-                prompt_value = null;
+                PromptValue = null;
                 bool errored = false;
-                console.Setup(c => c.ReadLine()).Returns(""); //Enter pressed
+                Console.Setup(c => c.ReadLine()).Returns(""); //Enter pressed
                 try
                 {
-                    prompt();
+                    _prompt();
                 }
                 catch (Exception)
                 {
@@ -119,24 +119,24 @@ namespace chocolatey.tests.infrastructure.commandline
                 }
 
                 errored.Should().BeTrue();
-                console.Verify(c => c.ReadLine(), Times.Never);
+                Console.Verify(c => c.ReadLine(), Times.Never);
             }
 
             [Fact]
             public void Should_error_when_the_default_choice_is_not_in_list()
             {
-                choices = new List<string>
+                Choices = new List<string>
                 {
                     "bob"
                 };
-                default_choice = "maybe";
+                _defaultChoice = "maybe";
                 bool errored = false;
                 string errorMessage = string.Empty;
-                console.Setup(c => c.ReadLine()).Returns(""); //Enter pressed
+                Console.Setup(c => c.ReadLine()).Returns(""); //Enter pressed
                 string result = null;
                 try
                 {
-                    result = prompt();
+                    result = _prompt();
                 }
                 catch (Exception ex)
                 {
@@ -147,17 +147,17 @@ namespace chocolatey.tests.infrastructure.commandline
                 result.Should().NotBe("maybe");
                 errored.Should().BeTrue();
                 errorMessage.Should().Be("Default choice value must be one of the given choices.");
-                console.Verify(c => c.ReadLine(), Times.Never);
+                Console.Verify(c => c.ReadLine(), Times.Never);
             }
         }
 
         public class When_prompting_with_interactivePrompt_without_default_and_answer_is_not_required : InteractivePromptSpecsBase
         {
-            private Func<string> prompt;
+            private Func<string> _prompt;
 
             public override void Because()
             {
-                prompt = () => InteractivePrompt.PromptForConfirmation(prompt_value, choices, null, requireAnswer: false);
+                _prompt = () => InteractivePrompt.PromptForConfirmation(PromptValue, Choices, null, requireAnswer: false);
             }
 
             public override void AfterObservations()
@@ -169,83 +169,83 @@ namespace chocolatey.tests.infrastructure.commandline
             [Fact]
             public void Should_return_null_when_no_answer_given()
             {
-                console.Setup(c => c.ReadLine()).Returns(""); //Enter pressed
-                var result = prompt();
+                Console.Setup(c => c.ReadLine()).Returns(""); //Enter pressed
+                var result = _prompt();
                 result.Should().BeNull();
             }
 
             [Fact]
             public void Should_return_first_choice_when_1_is_given()
             {
-                console.Setup(c => c.ReadLine()).Returns("1");
-                var result = prompt();
-                result.Should().Be(choices[0]);
+                Console.Setup(c => c.ReadLine()).Returns("1");
+                var result = _prompt();
+                result.Should().Be(Choices[0]);
             }
 
             [Fact]
             public void Should_return_first_choice_when_value_of_choice_is_given()
             {
-                console.Setup(c => c.ReadLine()).Returns("yes");
-                var result = prompt();
-                result.Should().Be(choices[0]);
+                Console.Setup(c => c.ReadLine()).Returns("yes");
+                var result = _prompt();
+                result.Should().Be(Choices[0]);
             }
 
             [Fact]
             public void Should_return_second_choice_when_2_is_given()
             {
-                console.Setup(c => c.ReadLine()).Returns("2");
-                var result = prompt();
-                result.Should().Be(choices[1]);
+                Console.Setup(c => c.ReadLine()).Returns("2");
+                var result = _prompt();
+                result.Should().Be(Choices[1]);
             }
 
             [Fact]
             public void Should_return_null_choice_when_3_is_given()
             {
-                console.Setup(c => c.ReadLine()).Returns("3");
-                var result = prompt();
+                Console.Setup(c => c.ReadLine()).Returns("3");
+                var result = _prompt();
                 result.Should().BeNull();
             }
 
             [Fact]
             public void Should_return_null_choice_when_4_is_given()
             {
-                console.Setup(c => c.ReadLine()).Returns("4");
-                var result = prompt();
+                Console.Setup(c => c.ReadLine()).Returns("4");
+                var result = _prompt();
                 result.Should().BeNull();
             }
 
             [Fact]
             public void Should_return_null_choice_when_0_is_given()
             {
-                console.Setup(c => c.ReadLine()).Returns("0");
-                var result = prompt();
+                Console.Setup(c => c.ReadLine()).Returns("0");
+                var result = _prompt();
                 result.Should().BeNull();
             }
 
             [Fact]
             public void Should_return_null_choice_when_negative_1_is_given()
             {
-                console.Setup(c => c.ReadLine()).Returns("-1");
-                var result = prompt();
+                Console.Setup(c => c.ReadLine()).Returns("-1");
+                var result = _prompt();
                 result.Should().BeNull();
             }
 
             [Fact]
             public void Should_return_null_choice_when_alphabetical_characters_are_given()
             {
-                console.Setup(c => c.ReadLine()).Returns("abc");
-                var result = prompt();
+                Console.Setup(c => c.ReadLine()).Returns("abc");
+                var result = _prompt();
                 result.Should().BeNull();
             }
         }
 
         public class When_prompting_with_interactivePrompt_without_default_and_answer_is_required : InteractivePromptSpecsBase
         {
-            private Func<string> prompt;
+            private Func<string> _prompt;
 
             public override void Because()
             {
-                prompt = () => InteractivePrompt.PromptForConfirmation(prompt_value, choices, null, requireAnswer: true);
+                _prompt = () => InteractivePrompt.PromptForConfirmation(PromptValue, Choices, null, requireAnswer: true);
             }
 
             public override void AfterObservations()
@@ -259,33 +259,33 @@ namespace chocolatey.tests.infrastructure.commandline
             {
                 bool errored = false;
 
-                console.Setup(c => c.ReadLine()).Returns(""); //Enter pressed
+                Console.Setup(c => c.ReadLine()).Returns(""); //Enter pressed
                 try
                 {
-                    prompt();
+                    _prompt();
                 }
                 catch (Exception)
                 {
                     errored = true;
                 }
                 errored.Should().BeTrue();
-                console.Verify(c => c.ReadLine(), Times.AtLeast(8));
+                Console.Verify(c => c.ReadLine(), Times.AtLeast(8));
             }
 
             [Fact]
             public void Should_return_first_choice_when_1_is_given()
             {
-                console.Setup(c => c.ReadLine()).Returns("1");
-                var result = prompt();
-                result.Should().Be(choices[0]);
+                Console.Setup(c => c.ReadLine()).Returns("1");
+                var result = _prompt();
+                result.Should().Be(Choices[0]);
             }
 
             [Fact]
             public void Should_return_second_choice_when_2_is_given()
             {
-                console.Setup(c => c.ReadLine()).Returns("2");
-                var result = prompt();
-                result.Should().Be(choices[1]);
+                Console.Setup(c => c.ReadLine()).Returns("2");
+                var result = _prompt();
+                result.Should().Be(Choices[1]);
             }
 
             [Fact]
@@ -293,27 +293,27 @@ namespace chocolatey.tests.infrastructure.commandline
             {
                 bool errored = false;
 
-                console.Setup(c => c.ReadLine()).Returns("3"); //Enter pressed
+                Console.Setup(c => c.ReadLine()).Returns("3"); //Enter pressed
                 try
                 {
-                    prompt();
+                    _prompt();
                 }
                 catch (Exception)
                 {
                     errored = true;
                 }
                 errored.Should().BeTrue();
-                console.Verify(c => c.ReadLine(), Times.AtLeast(8));
+                Console.Verify(c => c.ReadLine(), Times.AtLeast(8));
             }
         }
 
         public class When_prompting_with_interactivePrompt_with_default_and_answer_is_not_required : InteractivePromptSpecsBase
         {
-            private Func<string> prompt;
+            private Func<string> _prompt;
 
             public override void Because()
             {
-                prompt = () => InteractivePrompt.PromptForConfirmation(prompt_value, choices, choices[1], requireAnswer: false);
+                _prompt = () => InteractivePrompt.PromptForConfirmation(PromptValue, Choices, Choices[1], requireAnswer: false);
             }
 
             public override void AfterObservations()
@@ -325,75 +325,75 @@ namespace chocolatey.tests.infrastructure.commandline
             [Fact]
             public void Should_return_default_when_no_answer_given()
             {
-                console.Setup(c => c.ReadLine()).Returns(""); //Enter pressed
-                var result = prompt();
-                result.Should().Be(choices[1]);
+                Console.Setup(c => c.ReadLine()).Returns(""); //Enter pressed
+                var result = _prompt();
+                result.Should().Be(Choices[1]);
             }
 
             [Fact]
             public void Should_return_first_choice_when_1_is_given()
             {
-                console.Setup(c => c.ReadLine()).Returns("1");
-                var result = prompt();
-                result.Should().Be(choices[0]);
+                Console.Setup(c => c.ReadLine()).Returns("1");
+                var result = _prompt();
+                result.Should().Be(Choices[0]);
             }
 
             [Fact]
             public void Should_return_second_choice_when_2_is_given()
             {
-                console.Setup(c => c.ReadLine()).Returns("2");
-                var result = prompt();
-                result.Should().Be(choices[1]);
+                Console.Setup(c => c.ReadLine()).Returns("2");
+                var result = _prompt();
+                result.Should().Be(Choices[1]);
             }
 
             [Fact]
             public void Should_return_null_choice_when_3_is_given()
             {
-                console.Setup(c => c.ReadLine()).Returns("3");
-                var result = prompt();
+                Console.Setup(c => c.ReadLine()).Returns("3");
+                var result = _prompt();
                 result.Should().BeNull();
             }
 
             [Fact]
             public void Should_return_null_choice_when_4_is_given()
             {
-                console.Setup(c => c.ReadLine()).Returns("4");
-                var result = prompt();
+                Console.Setup(c => c.ReadLine()).Returns("4");
+                var result = _prompt();
                 result.Should().BeNull();
             }
 
             [Fact]
             public void Should_return_null_choice_when_0_is_given()
             {
-                console.Setup(c => c.ReadLine()).Returns("0");
-                var result = prompt();
+                Console.Setup(c => c.ReadLine()).Returns("0");
+                var result = _prompt();
                 result.Should().BeNull();
             }
 
             [Fact]
             public void Should_return_null_choice_when_negative_1_is_given()
             {
-                console.Setup(c => c.ReadLine()).Returns("-1");
-                var result = prompt();
+                Console.Setup(c => c.ReadLine()).Returns("-1");
+                var result = _prompt();
                 result.Should().BeNull();
             }
 
             [Fact]
             public void Should_return_null_choice_when_alphabetical_characters_are_given()
             {
-                console.Setup(c => c.ReadLine()).Returns("abc");
-                var result = prompt();
+                Console.Setup(c => c.ReadLine()).Returns("abc");
+                var result = _prompt();
                 result.Should().BeNull();
             }
         }
 
         public class When_prompting_with_interactivePrompt_with_default_and_answer_is_required : InteractivePromptSpecsBase
         {
-            private Func<string> prompt;
+            private Func<string> _prompt;
 
             public override void Because()
             {
-                prompt = () => InteractivePrompt.PromptForConfirmation(prompt_value, choices, choices[0], requireAnswer: true);
+                _prompt = () => InteractivePrompt.PromptForConfirmation(PromptValue, Choices, Choices[0], requireAnswer: true);
             }
 
             public override void AfterObservations()
@@ -405,25 +405,25 @@ namespace chocolatey.tests.infrastructure.commandline
             [Fact]
             public void Should_error_when_no_answer_given()
             {
-                console.Setup(c => c.ReadLine()).Returns(""); //Enter pressed
-                var result = prompt();
-                result.Should().Be(choices[0]);
+                Console.Setup(c => c.ReadLine()).Returns(""); //Enter pressed
+                var result = _prompt();
+                result.Should().Be(Choices[0]);
             }
 
             [Fact]
             public void Should_return_first_choice_when_1_is_given()
             {
-                console.Setup(c => c.ReadLine()).Returns("1");
-                var result = prompt();
-                result.Should().Be(choices[0]);
+                Console.Setup(c => c.ReadLine()).Returns("1");
+                var result = _prompt();
+                result.Should().Be(Choices[0]);
             }
 
             [Fact]
             public void Should_return_second_choice_when_2_is_given()
             {
-                console.Setup(c => c.ReadLine()).Returns("2");
-                var result = prompt();
-                result.Should().Be(choices[1]);
+                Console.Setup(c => c.ReadLine()).Returns("2");
+                var result = _prompt();
+                result.Should().Be(Choices[1]);
             }
 
             [Fact]
@@ -431,39 +431,39 @@ namespace chocolatey.tests.infrastructure.commandline
             {
                 bool errored = false;
 
-                console.Setup(c => c.ReadLine()).Returns("3"); //Enter pressed
+                Console.Setup(c => c.ReadLine()).Returns("3"); //Enter pressed
                 try
                 {
-                    prompt();
+                    _prompt();
                 }
                 catch (Exception)
                 {
                     errored = true;
                 }
                 errored.Should().BeTrue();
-                console.Verify(c => c.ReadLine(), Times.AtLeast(8));
+                Console.Verify(c => c.ReadLine(), Times.AtLeast(8));
             }
         }
 
         public class When_prompting_short_with_interactivePrompt_guard_errors : InteractivePromptSpecsBase
         {
-            private Func<string> prompt;
+            private Func<string> _prompt;
 
             public override void Because()
             {
-                console.Setup(c => c.ReadLine()).Returns(""); //Enter pressed
-                prompt = () => InteractivePrompt.PromptForConfirmation(prompt_value, choices, defaultChoice: null, requireAnswer: true, shortPrompt: true);
+                Console.Setup(c => c.ReadLine()).Returns(""); //Enter pressed
+                _prompt = () => InteractivePrompt.PromptForConfirmation(PromptValue, Choices, defaultChoice: null, requireAnswer: true, shortPrompt: true);
             }
 
             [Fact]
             public void Should_error_when_the_choicelist_is_null()
             {
-                choices = null;
+                Choices = null;
                 bool errored = false;
-                console.Setup(c => c.ReadLine()).Returns(""); //Enter pressed
+                Console.Setup(c => c.ReadLine()).Returns(""); //Enter pressed
                 try
                 {
-                    prompt();
+                    _prompt();
                 }
                 catch (Exception)
                 {
@@ -471,19 +471,19 @@ namespace chocolatey.tests.infrastructure.commandline
                 }
 
                 errored.Should().BeTrue();
-                console.Verify(c => c.ReadLine(), Times.Never);
+                Console.Verify(c => c.ReadLine(), Times.Never);
             }
 
             [Fact]
             public void Should_error_when_the_choicelist_is_empty()
             {
-                choices = new List<string>();
+                Choices = new List<string>();
                 bool errored = false;
                 string errorMessage = string.Empty;
-                console.Setup(c => c.ReadLine()).Returns(""); //Enter pressed
+                Console.Setup(c => c.ReadLine()).Returns(""); //Enter pressed
                 try
                 {
-                    prompt();
+                    _prompt();
                 }
                 catch (Exception ex)
                 {
@@ -493,23 +493,23 @@ namespace chocolatey.tests.infrastructure.commandline
 
                 errored.Should().BeTrue();
                 errorMessage.Should().Contain("No choices passed in.");
-                console.Verify(c => c.ReadLine(), Times.Never);
+                Console.Verify(c => c.ReadLine(), Times.Never);
             }
 
             [Fact]
             public void Should_error_when_the_prompt_input_is_null()
             {
-                choices = new List<string>
+                Choices = new List<string>
                 {
                     "bob"
                 };
-                prompt_value = null;
+                PromptValue = null;
                 bool errored = false;
                 string errorMessage = string.Empty;
-                console.Setup(c => c.ReadLine()).Returns(""); //Enter pressed
+                Console.Setup(c => c.ReadLine()).Returns(""); //Enter pressed
                 try
                 {
-                    prompt();
+                    _prompt();
                 }
                 catch (Exception ex)
                 {
@@ -519,23 +519,23 @@ namespace chocolatey.tests.infrastructure.commandline
 
                 errored.Should().BeTrue();
                 errorMessage.Should().Contain("Value for prompt cannot be null.");
-                console.Verify(c => c.ReadLine(), Times.Never);
+                Console.Verify(c => c.ReadLine(), Times.Never);
             }
 
             [Fact]
             public void Should_error_when_the_choicelist_contains_empty_values()
             {
-                choices = new List<string>
+                Choices = new List<string>
                 {
                     "bob",
                     ""
                 };
                 bool errored = false;
                 string errorMessage = string.Empty;
-                console.Setup(c => c.ReadLine()).Returns(""); //Enter pressed
+                Console.Setup(c => c.ReadLine()).Returns(""); //Enter pressed
                 try
                 {
-                    prompt();
+                    _prompt();
                 }
                 catch (Exception ex)
                 {
@@ -545,23 +545,23 @@ namespace chocolatey.tests.infrastructure.commandline
 
                 errored.Should().BeTrue();
                 errorMessage.Should().Contain("Some choices are empty.");
-                console.Verify(c => c.ReadLine(), Times.Never);
+                Console.Verify(c => c.ReadLine(), Times.Never);
             }
 
             [Fact]
             public void Should_error_when_the_choicelist_has_multiple_items_with_same_first_letter()
             {
-                choices = new List<string>
+                Choices = new List<string>
                 {
                     "sally",
                     "suzy"
                 };
                 bool errored = false;
                 string errorMessage = string.Empty;
-                console.Setup(c => c.ReadLine()).Returns(""); //Enter pressed
+                Console.Setup(c => c.ReadLine()).Returns(""); //Enter pressed
                 try
                 {
-                    prompt();
+                    _prompt();
                 }
                 catch (Exception ex)
                 {
@@ -571,17 +571,17 @@ namespace chocolatey.tests.infrastructure.commandline
 
                 errored.Should().BeTrue();
                 errorMessage.Should().Contain("Multiple choices have the same first letter.");
-                console.Verify(c => c.ReadLine(), Times.Never);
+                Console.Verify(c => c.ReadLine(), Times.Never);
             }
         }
 
         public class When_prompting_short_with_interactivePrompt : InteractivePromptSpecsBase
         {
-            private Func<string> prompt;
+            private Func<string> _prompt;
 
             public override void Because()
             {
-                prompt = () => InteractivePrompt.PromptForConfirmation(prompt_value, choices, defaultChoice: null, requireAnswer: true, shortPrompt: true);
+                _prompt = () => InteractivePrompt.PromptForConfirmation(PromptValue, Choices, defaultChoice: null, requireAnswer: true, shortPrompt: true);
             }
 
             public override void AfterObservations()
@@ -595,48 +595,48 @@ namespace chocolatey.tests.infrastructure.commandline
             {
                 bool errored = false;
 
-                console.Setup(c => c.ReadLine()).Returns(""); //Enter pressed
+                Console.Setup(c => c.ReadLine()).Returns(""); //Enter pressed
                 try
                 {
-                    prompt();
+                    _prompt();
                 }
                 catch (Exception)
                 {
                     errored = true;
                 }
                 errored.Should().BeTrue();
-                console.Verify(c => c.ReadLine(), Times.AtLeast(8));
+                Console.Verify(c => c.ReadLine(), Times.AtLeast(8));
             }
 
             [Fact]
             public void Should_return_yes_when_yes_is_given()
             {
-                console.Setup(c => c.ReadLine()).Returns("yes");
-                var result = prompt();
+                Console.Setup(c => c.ReadLine()).Returns("yes");
+                var result = _prompt();
                 result.Should().Be("yes");
             }
 
             [Fact]
             public void Should_return_yes_when_y_is_given()
             {
-                console.Setup(c => c.ReadLine()).Returns("y");
-                var result = prompt();
+                Console.Setup(c => c.ReadLine()).Returns("y");
+                var result = _prompt();
                 result.Should().Be("yes");
             }
 
             [Fact]
             public void Should_return_no_choice_when_no_is_given()
             {
-                console.Setup(c => c.ReadLine()).Returns("no");
-                var result = prompt();
+                Console.Setup(c => c.ReadLine()).Returns("no");
+                var result = _prompt();
                 result.Should().Be("no");
             }
 
             [Fact]
             public void Should_return_no_choice_when_n_is_given()
             {
-                console.Setup(c => c.ReadLine()).Returns("n");
-                var result = prompt();
+                Console.Setup(c => c.ReadLine()).Returns("n");
+                var result = _prompt();
                 result.Should().Be("no");
             }
 
@@ -645,33 +645,33 @@ namespace chocolatey.tests.infrastructure.commandline
             {
                 bool errored = false;
 
-                console.Setup(c => c.ReadLine()).Returns("yup"); //Enter pressed
+                Console.Setup(c => c.ReadLine()).Returns("yup"); //Enter pressed
                 try
                 {
-                    prompt();
+                    _prompt();
                 }
                 catch (Exception)
                 {
                     errored = true;
                 }
                 errored.Should().BeTrue();
-                console.Verify(c => c.ReadLine(), Times.AtLeast(8));
+                Console.Verify(c => c.ReadLine(), Times.AtLeast(8));
             }
         }
 
         public class When_prompting_answer_with_dash_with_interactivePrompt : InteractivePromptSpecsBase
         {
-            private Func<string> prompt;
+            private Func<string> _prompt;
 
             public override void Context()
             {
                 base.Context();
-                choices.Add("all - yes to all");
+                Choices.Add("all - yes to all");
             }
 
             public override void Because()
             {
-                prompt = () => InteractivePrompt.PromptForConfirmation(prompt_value, choices, defaultChoice: null, requireAnswer: true, shortPrompt: true);
+                _prompt = () => InteractivePrompt.PromptForConfirmation(PromptValue, Choices, defaultChoice: null, requireAnswer: true, shortPrompt: true);
             }
 
             public override void AfterObservations()
@@ -683,16 +683,16 @@ namespace chocolatey.tests.infrastructure.commandline
             [Fact]
             public void Should_return_all_when_full_all_answer_is_given()
             {
-                console.Setup(c => c.ReadLine()).Returns("all - yes to all");
-                var result = prompt();
+                Console.Setup(c => c.ReadLine()).Returns("all - yes to all");
+                var result = _prompt();
                 result.Should().Be("all - yes to all");
             }
 
             [Fact]
             public void Should_return_all_when_only_all_is_given()
             {
-                console.Setup(c => c.ReadLine()).Returns("all");
-                var result = prompt();
+                Console.Setup(c => c.ReadLine()).Returns("all");
+                var result = _prompt();
                 result.Should().Be("all - yes to all");
             }
         }

--- a/src/chocolatey.tests/infrastructure/commands/CommandExecutorSpecs.cs
+++ b/src/chocolatey.tests/infrastructure/commands/CommandExecutorSpecs.cs
@@ -28,130 +28,130 @@ namespace chocolatey.tests.infrastructure.commands
     {
         public abstract class CommandExecutorSpecsBase : TinySpec
         {
-            protected Mock<IFileSystem> fileSystem = new Mock<IFileSystem>();
-            protected Mock<IProcess> process = new Mock<IProcess>();
-            protected CommandExecutor commandExecutor;
+            protected Mock<IFileSystem> FileSystem = new Mock<IFileSystem>();
+            protected Mock<IProcess> Process = new Mock<IProcess>();
+            protected CommandExecutor CommandExecutor;
 
             public override void Context()
             {
-                commandExecutor = new CommandExecutor(fileSystem.Object);
-                CommandExecutor.InitializeWith(new Lazy<IFileSystem>(() => fileSystem.Object), () => process.Object);
+                CommandExecutor = new CommandExecutor(FileSystem.Object);
+                CommandExecutor.InitializeWith(new Lazy<IFileSystem>(() => FileSystem.Object), () => Process.Object);
             }
         }
 
         public class When_CommandExecutor_is_executed_normally : CommandExecutorSpecsBase
         {
-            private int result;
+            private int _result;
 
             public override void Context()
             {
                 base.Context();
-                process.Setup(p => p.ExitCode).Returns(0);
-                process.Setup(p => p.WaitForExit(It.IsAny<int>())).Returns(true);
+                Process.Setup(p => p.ExitCode).Returns(0);
+                Process.Setup(p => p.WaitForExit(It.IsAny<int>())).Returns(true);
             }
 
             public override void Because()
             {
-                result = commandExecutor.Execute("bob", "args", ApplicationParameters.DefaultWaitForExitInSeconds);
+                _result = CommandExecutor.Execute("bob", "args", ApplicationParameters.DefaultWaitForExitInSeconds);
             }
 
             [Fact]
             public void Should_call_Start()
             {
-                process.Verify(p => p.Start(), Times.Once);
+                Process.Verify(p => p.Start(), Times.Once);
             }
 
             [Fact]
             public void Should_have_EnableRaisingEvents_set_to_true()
             {
-                process.VerifySet(p => p.EnableRaisingEvents = true);
+                Process.VerifySet(p => p.EnableRaisingEvents = true);
             }
 
             [Fact]
             public void Should_call_WaitForExit()
             {
-                process.Verify(p => p.WaitForExit(It.IsAny<int>()), Times.Once);
+                Process.Verify(p => p.WaitForExit(It.IsAny<int>()), Times.Once);
             }
 
             [Fact]
             public void Should_call_BeginErrorReadLine()
             {
-                process.Verify(p => p.BeginErrorReadLine(), Times.Once);
+                Process.Verify(p => p.BeginErrorReadLine(), Times.Once);
             }
 
             [Fact]
             public void Should_call_BeginOutputReadLine()
             {
-                process.Verify(p => p.BeginOutputReadLine(), Times.Once);
+                Process.Verify(p => p.BeginOutputReadLine(), Times.Once);
             }
 
             [Fact]
             public void Should_call_ExitCode()
             {
-                process.Verify(p => p.ExitCode, Times.Once);
+                Process.Verify(p => p.ExitCode, Times.Once);
             }
 
             [Fact]
             public void Should_return_an_exit_code_of_zero_when_finished()
             {
-                result.Should().Be(0);
+                _result.Should().Be(0);
             }
         }
 
         public class When_CommandExecutor_has_a_long_running_process_that_takes_longer_than_wait_time : CommandExecutorSpecsBase
         {
-            private int result;
+            private int _result;
 
             public override void Context()
             {
                 base.Context();
-                process.Setup(p => p.WaitForExit(It.IsAny<int>())).Returns(false);
-                process.Setup(p => p.ExitCode).Returns(0);
+                Process.Setup(p => p.WaitForExit(It.IsAny<int>())).Returns(false);
+                Process.Setup(p => p.ExitCode).Returns(0);
             }
 
             public override void Because()
             {
-                result = commandExecutor.Execute("bob", "args", ApplicationParameters.DefaultWaitForExitInSeconds);
+                _result = CommandExecutor.Execute("bob", "args", ApplicationParameters.DefaultWaitForExitInSeconds);
             }
 
             [Fact]
             public void Should_call_WaitForExit()
             {
-                process.Verify(p => p.WaitForExit(It.IsAny<int>()), Times.Once);
+                Process.Verify(p => p.WaitForExit(It.IsAny<int>()), Times.Once);
             }
 
             [Fact]
             public void Should_return_an_exit_code_of_negative_one_since_it_timed_out()
             {
-                result.Should().Be(-1);
+                _result.Should().Be(-1);
             }
 
             [Fact]
             public void Should_not_call_ExitCode()
             {
-                process.Verify(p => p.ExitCode, Times.Never);
+                Process.Verify(p => p.ExitCode, Times.Never);
             }
         }
 
         public class When_CommandExecutor_does_not_wait_for_exit : CommandExecutorSpecsBase
         {
-            private int result;
+            private int _result;
 
             public override void Because()
             {
-                result = commandExecutor.Execute("bob", "args", waitForExitInSeconds: 0, workingDirectory: null, stdOutAction: null, stdErrAction: null, updateProcessPath: false, allowUseWindow: true, waitForExit: false);
+                _result = CommandExecutor.Execute("bob", "args", waitForExitInSeconds: 0, workingDirectory: null, stdOutAction: null, stdErrAction: null, updateProcessPath: false, allowUseWindow: true, waitForExit: false);
             }
 
             [Fact]
             public void Should_have_an_exit_code_of_negative_one_as_it_didnt_wait_for_finish()
             {
-                result.Should().Be(-1);
+                _result.Should().Be(-1);
             }
 
             [Fact]
             public void Should_not_call_WaitForExit()
             {
-                process.Verify(p => p.WaitForExit(It.IsAny<int>()), Times.Never);
+                Process.Verify(p => p.WaitForExit(It.IsAny<int>()), Times.Never);
             }
         }
     }

--- a/src/chocolatey.tests/infrastructure/commands/ExternalCommandArgsBuilderSpecs.cs
+++ b/src/chocolatey.tests/infrastructure/commands/ExternalCommandArgsBuilderSpecs.cs
@@ -26,60 +26,60 @@ namespace chocolatey.tests.infrastructure.commands
     {
         public class When_using_ExternalCommandArgsBuilder : TinySpec
         {
-            private Func<string> buildConfigs;
-            protected IDictionary<string, ExternalCommandArgument> argsDictionary = new Dictionary<string, ExternalCommandArgument>();
-            protected ChocolateyConfiguration configuration = new ChocolateyConfiguration();
+            private Func<string> _buildConfigs;
+            protected IDictionary<string, ExternalCommandArgument> ArgsDictionary = new Dictionary<string, ExternalCommandArgument>();
+            protected ChocolateyConfiguration Configuration = new ChocolateyConfiguration();
 
             public override void Context()
             {
-                configuration.Sources = "yo";
-                configuration.Verbose = true;
-                configuration.ApiKeyCommand.Key = "dude";
-                configuration.CommandName = "with a space";
+                Configuration.Sources = "yo";
+                Configuration.Verbose = true;
+                Configuration.ApiKeyCommand.Key = "dude";
+                Configuration.CommandName = "with a space";
             }
 
             public override void Because()
             {
-                buildConfigs = () => ExternalCommandArgsBuilder.BuildArguments(configuration, argsDictionary);
+                _buildConfigs = () => ExternalCommandArgsBuilder.BuildArguments(Configuration, ArgsDictionary);
             }
 
             [Fact]
             public void Should_add_a_parameter_if_property_value_is_set()
             {
-                argsDictionary.Clear();
-                argsDictionary.Add(
+                ArgsDictionary.Clear();
+                ArgsDictionary.Add(
                     "Sources",
                     new ExternalCommandArgument
                     {
                         ArgumentOption = "-source "
                     });
-                buildConfigs().Should().Be("-source " + configuration.Sources);
+                _buildConfigs().Should().Be("-source " + Configuration.Sources);
             }
 
             [Fact]
             public void Should_add_a_parameter_if_property_value_is_sub_property()
             {
-                argsDictionary.Clear();
-                argsDictionary.Add(
+                ArgsDictionary.Clear();
+                ArgsDictionary.Add(
                     "ApiKeyCommand.Key",
                     new ExternalCommandArgument
                     {
                         ArgumentOption = "-apikey "
                     });
-                buildConfigs().Should().Be("-apikey " + configuration.ApiKeyCommand.Key);
+                _buildConfigs().Should().Be("-apikey " + Configuration.ApiKeyCommand.Key);
             }
 
             [Fact]
             public void Should_skip_a_parameter_that_does_not_match_the_case_of_the_property_name_exactly()
             {
-                argsDictionary.Clear();
-                argsDictionary.Add(
+                ArgsDictionary.Clear();
+                ArgsDictionary.Add(
                     "sources",
                     new ExternalCommandArgument
                     {
                         ArgumentOption = "-source "
                     });
-                buildConfigs().Should().Be("");
+                _buildConfigs().Should().Be("");
             }
 
             [Fact]
@@ -92,163 +92,163 @@ namespace chocolatey.tests.infrastructure.commands
                     {
                         ArgumentOption = "-source "
                     });
-                ExternalCommandArgsBuilder.BuildArguments(configuration, ignoreCaseDictionary).Should().Be("-source yo");
+                ExternalCommandArgsBuilder.BuildArguments(Configuration, ignoreCaseDictionary).Should().Be("-source yo");
             }
 
             [Fact]
             public void Should_not_override_ArgumentValue_with_the_property_value_for_a_parameter()
             {
-                argsDictionary.Clear();
-                argsDictionary.Add(
+                ArgsDictionary.Clear();
+                ArgsDictionary.Add(
                     "Sources",
                     new ExternalCommandArgument
                     {
                         ArgumentOption = "-source ",
                         ArgumentValue = "bob"
                     });
-                buildConfigs().Should().Be("-source bob");
+                _buildConfigs().Should().Be("-source bob");
             }
 
             [Fact]
             public void Should_skip_a_parameter_if_property_value_has_no_value()
             {
-                argsDictionary.Clear();
-                argsDictionary.Add(
+                ArgsDictionary.Clear();
+                ArgsDictionary.Add(
                     "Version",
                     new ExternalCommandArgument
                     {
                         ArgumentOption = "-version "
                     });
-                buildConfigs().Should().Be("");
+                _buildConfigs().Should().Be("");
             }
 
             [Fact]
             public void Should_add_a_parameter_when_Required_set_true_even_if_property_has_no_value()
             {
-                argsDictionary.Clear();
-                argsDictionary.Add(
+                ArgsDictionary.Clear();
+                ArgsDictionary.Add(
                     "Version",
                     new ExternalCommandArgument
                     {
                         ArgumentOption = "install",
                         Required = true
                     });
-                buildConfigs().Should().Be("install");
+                _buildConfigs().Should().Be("install");
             }
 
             [Fact]
             public void Should_skip_a_parameter_not_found_in_the_properties_object()
             {
-                argsDictionary.Clear();
-                argsDictionary.Add(
+                ArgsDictionary.Clear();
+                ArgsDictionary.Add(
                     "_install_",
                     new ExternalCommandArgument
                     {
                         ArgumentOption = "install"
                     });
-                buildConfigs().Should().Be("");
+                _buildConfigs().Should().Be("");
             }
 
             [Fact]
             public void Should_add_a_parameter_not_found_in_the_properties_object_when_Required_set_to_true()
             {
-                argsDictionary.Clear();
-                argsDictionary.Add(
+                ArgsDictionary.Clear();
+                ArgsDictionary.Add(
                     "_install_",
                     new ExternalCommandArgument
                     {
                         ArgumentOption = "install",
                         Required = true
                     });
-                buildConfigs().Should().Be("install");
+                _buildConfigs().Should().Be("install");
             }
 
             [Fact]
             public void Should_add_a_boolean_as_a_switch_when_true()
             {
-                argsDictionary.Clear();
-                argsDictionary.Add(
+                ArgsDictionary.Clear();
+                ArgsDictionary.Add(
                     "Verbose",
                     new ExternalCommandArgument
                     {
                         ArgumentOption = "-verbose"
                     });
-                buildConfigs().Should().Be("-verbose");
+                _buildConfigs().Should().Be("-verbose");
             }
 
             [Fact]
             public void Should_skip_a_boolean_as_a_switch_when_false()
             {
-                argsDictionary.Clear();
-                argsDictionary.Add(
+                ArgsDictionary.Clear();
+                ArgsDictionary.Add(
                     "Prerelease",
                     new ExternalCommandArgument
                     {
                         ArgumentOption = "-pre"
                     });
-                buildConfigs().Should().Be("");
+                _buildConfigs().Should().Be("");
             }
 
             [Fact]
             public void Should_quote_a_value_when_QuoteValue_is_set_to_true()
             {
-                argsDictionary.Clear();
-                argsDictionary.Add(
+                ArgsDictionary.Clear();
+                ArgsDictionary.Add(
                     "Sources",
                     new ExternalCommandArgument
                     {
                         ArgumentOption = "-source ",
                         QuoteValue = true
                     });
-                buildConfigs().Should().Be("-source \"yo\"");
+                _buildConfigs().Should().Be("-source \"yo\"");
             }
 
             [Fact]
             public void Should_auto_quote_an_argument_value_with_spaces()
             {
-                argsDictionary.Clear();
-                argsDictionary.Add(
+                ArgsDictionary.Clear();
+                ArgsDictionary.Add(
                     "CommandName",
                     new ExternalCommandArgument
                     {
                         ArgumentOption = "-command "
                     });
-                buildConfigs().Should().Be("-command \"{0}\"".FormatWith(configuration.CommandName));
+                _buildConfigs().Should().Be("-command \"{0}\"".FormatWith(Configuration.CommandName));
             }
 
             [Fact]
             public void Should_not_quote_an_argument_option_with_spaces()
             {
-                argsDictionary.Clear();
-                argsDictionary.Add(
+                ArgsDictionary.Clear();
+                ArgsDictionary.Add(
                     "Sources",
                     new ExternalCommandArgument
                     {
                         ArgumentOption = "-source you know = ",
                         QuoteValue = true
                     });
-                buildConfigs().Should().Be("-source you know = \"yo\"");
+                _buildConfigs().Should().Be("-source you know = \"yo\"");
             }
 
             [Fact]
             public void Should_use_only_the_value_when_UseValueOnly_is_set_to_true()
             {
-                argsDictionary.Clear();
-                argsDictionary.Add(
+                ArgsDictionary.Clear();
+                ArgsDictionary.Add(
                     "Sources",
                     new ExternalCommandArgument
                     {
                         ArgumentOption = "-source ",
                         UseValueOnly = true
                     });
-                buildConfigs().Should().Be("yo");
+                _buildConfigs().Should().Be("yo");
             }
 
             [Fact]
             public void Should_use_only_the_value_when_UseValueOnly_and_Required_is_set_to_true()
             {
-                argsDictionary.Clear();
-                argsDictionary.Add(
+                ArgsDictionary.Clear();
+                ArgsDictionary.Add(
                     "_source_",
                     new ExternalCommandArgument
                     {
@@ -257,55 +257,55 @@ namespace chocolatey.tests.infrastructure.commands
                         UseValueOnly = true,
                         Required = true
                     });
-                buildConfigs().Should().Be("bob");
+                _buildConfigs().Should().Be("bob");
             }
 
             [Fact]
             public void Should_not_add_a_value_when_UseValueOnly_is_set_to_true_and_no_value_is_set()
             {
-                argsDictionary.Clear();
-                argsDictionary.Add(
+                ArgsDictionary.Clear();
+                ArgsDictionary.Add(
                     "Version",
                     new ExternalCommandArgument
                     {
                         ArgumentOption = "-version ",
                         UseValueOnly = true
                     });
-                buildConfigs().Should().Be("");
+                _buildConfigs().Should().Be("");
             }
 
             [Fact]
             public void Should_separate_arguments_by_one_space()
             {
-                argsDictionary.Clear();
-                argsDictionary.Add(
+                ArgsDictionary.Clear();
+                ArgsDictionary.Add(
                     "_install_",
                     new ExternalCommandArgument
                     {
                         ArgumentOption = "install",
                         Required = true
                     });
-                argsDictionary.Add(
+                ArgsDictionary.Add(
                     "Sources",
                     new ExternalCommandArgument
                     {
                         ArgumentOption = "-source "
                     });
-                buildConfigs().Should().Be("install -source yo");
+                _buildConfigs().Should().Be("install -source yo");
             }
 
             [Fact]
             public void Should_add_items_in_order_based_on_the_dictionary()
             {
-                argsDictionary.Clear();
-                argsDictionary.Add(
+                ArgsDictionary.Clear();
+                ArgsDictionary.Add(
                     "_install_",
                     new ExternalCommandArgument
                     {
                         ArgumentOption = "install",
                         Required = true
                     });
-                argsDictionary.Add(
+                ArgsDictionary.Add(
                     "_output_directory_",
                     new ExternalCommandArgument
                     {
@@ -314,21 +314,21 @@ namespace chocolatey.tests.infrastructure.commands
                         QuoteValue = true,
                         Required = true
                     });
-                argsDictionary.Add(
+                ArgsDictionary.Add(
                     "Sources",
                     new ExternalCommandArgument
                     {
                         ArgumentOption = "-source ",
                         QuoteValue = true
                     });
-                argsDictionary.Add(
+                ArgsDictionary.Add(
                     "_non_interactive_",
                     new ExternalCommandArgument
                     {
                         ArgumentOption = "-noninteractive",
                         Required = true
                     });
-                argsDictionary.Add(
+                ArgsDictionary.Add(
                     "_no_cache_",
                     new ExternalCommandArgument
                     {
@@ -336,7 +336,7 @@ namespace chocolatey.tests.infrastructure.commands
                         Required = true
                     });
 
-                buildConfigs().Should().Be("install -outputdirectory \"bob\" -source \"{0}\" -noninteractive -nocache".FormatWith(configuration.Sources));
+                _buildConfigs().Should().Be("install -outputdirectory \"bob\" -source \"{0}\" -noninteractive -nocache".FormatWith(Configuration.Sources));
             }
         }
     }

--- a/src/chocolatey.tests/infrastructure/commands/PowershellExecutorSpecs.cs
+++ b/src/chocolatey.tests/infrastructure/commands/PowershellExecutorSpecs.cs
@@ -38,8 +38,8 @@ namespace chocolatey.tests.infrastructure.commands
 
         public class When_powershellExecutor_is_searching_for_powershell_locations_and_all_locations_exist : PowerShellExecutorSpecsBase
         {
-            private string result = string.Empty;
-            private readonly string expected = Environment.ExpandEnvironmentVariables("%systemroot%\\SysNative\\WindowsPowerShell\\v1.0\\powershell.exe");
+            private string _result = string.Empty;
+            private readonly string _expected = Environment.ExpandEnvironmentVariables("%systemroot%\\SysNative\\WindowsPowerShell\\v1.0\\powershell.exe");
 
             public override void Context()
             {
@@ -49,50 +49,50 @@ namespace chocolatey.tests.infrastructure.commands
 
             public override void Because()
             {
-                result = PowershellExecutor.GetPowerShellLocation(FileSystem.Object);
+                _result = PowershellExecutor.GetPowerShellLocation(FileSystem.Object);
             }
 
             [Fact]
             public void Should_not_return_null()
             {
-                result.Should().NotBeNull();
+                _result.Should().NotBeNull();
             }
 
             [Fact]
             public void Should_find_powershell()
             {
-                result.Should().NotBeEmpty();
+                _result.Should().NotBeEmpty();
             }
 
             [Fact]
             public void Should_return_the_sysnative_path()
             {
-                result.Should().Be(expected);
+                _result.Should().Be(_expected);
             }
         }
 
         public class When_powershellExecutor_is_searching_for_powershell_locations_there_is_no_sysnative : PowerShellExecutorSpecsBase
         {
-            private string result = string.Empty;
-            private readonly string expected = Environment.ExpandEnvironmentVariables("%systemroot%\\System32\\WindowsPowerShell\\v1.0\\powershell.exe");
+            private string _result = string.Empty;
+            private readonly string _expected = Environment.ExpandEnvironmentVariables("%systemroot%\\System32\\WindowsPowerShell\\v1.0\\powershell.exe");
 
             public override void Context()
             {
                 base.Context();
 
-                FileSystem.Setup(fs => fs.FileExists(expected)).Returns(true);
-                FileSystem.Setup(fs => fs.FileExists(It.Is<string>(v => v != expected))).Returns(false);
+                FileSystem.Setup(fs => fs.FileExists(_expected)).Returns(true);
+                FileSystem.Setup(fs => fs.FileExists(It.Is<string>(v => v != _expected))).Returns(false);
             }
 
             public override void Because()
             {
-                result = PowershellExecutor.GetPowerShellLocation(FileSystem.Object);
+                _result = PowershellExecutor.GetPowerShellLocation(FileSystem.Object);
             }
 
             [Fact]
             public void Should_return_system32_path()
             {
-                result.Should().Be(expected);
+                _result.Should().Be(_expected);
             }
         }
 

--- a/src/chocolatey.tests/infrastructure/cryptography/CryptoHashProviderSpecs.cs
+++ b/src/chocolatey.tests/infrastructure/cryptography/CryptoHashProviderSpecs.cs
@@ -41,36 +41,36 @@ namespace chocolatey.tests.infrastructure.cryptography
 
         public class When_HashProvider_provides_a_hash : CryptoHashProviderSpecsBase
         {
-            private string result;
-            private readonly string filePath = "c:\\path\\does\\not\\matter.txt";
-            private readonly byte[] byteArray = new byte[] { 23, 25, 27 };
+            private string _result;
+            private readonly string _filePath = "c:\\path\\does\\not\\matter.txt";
+            private readonly byte[] _byteArray = new byte[] { 23, 25, 27 };
 
             public override void Context()
             {
                 base.Context();
                 FileSystem.Setup(x => x.FileExists(It.IsAny<string>())).Returns(true);
-                FileSystem.Setup(x => x.ReadFileBytes(filePath)).Returns(byteArray);
+                FileSystem.Setup(x => x.ReadFileBytes(_filePath)).Returns(_byteArray);
             }
 
             public override void Because()
             {
-                result = Provider.ComputeFileHash(filePath);
+                _result = Provider.ComputeFileHash(_filePath);
             }
 
             [Fact]
             public void Should_provide_the_correct_hash_based_on_a_checksum()
             {
-                var expected = BitConverter.ToString(SHA256.Create().ComputeHash(byteArray)).Replace("-", string.Empty);
+                var expected = BitConverter.ToString(SHA256.Create().ComputeHash(_byteArray)).Replace("-", string.Empty);
 
-                result.Should().Be(expected);
+                _result.Should().Be(expected);
             }
         }
 
         public class When_HashProvider_attempts_to_provide_a_hash_for_a_file_over_2GB : CryptoHashProviderSpecsBase
         {
-            private string result;
-            private readonly string filePath = "c:\\path\\does\\not\\matter.txt";
-            private readonly byte[] byteArray = new byte[] { 23, 25, 27 };
+            private string _result;
+            private readonly string _filePath = "c:\\path\\does\\not\\matter.txt";
+            private readonly byte[] _byteArray = new byte[] { 23, 25, 27 };
             private readonly Mock<IHashAlgorithm> _hashAlgorithm = new Mock<IHashAlgorithm>();
 
             public override void Context()
@@ -79,13 +79,13 @@ namespace chocolatey.tests.infrastructure.cryptography
                 Provider = new CryptoHashProvider(FileSystem.Object, _hashAlgorithm.Object);
 
                 FileSystem.Setup(x => x.FileExists(It.IsAny<string>())).Returns(true);
-                FileSystem.Setup(x => x.ReadFileBytes(filePath)).Returns(byteArray);
-                _hashAlgorithm.Setup(x => x.ComputeHash(byteArray)).Throws<IOException>(); //IO.IO_FileTooLong2GB (over Int32.MaxValue)
+                FileSystem.Setup(x => x.ReadFileBytes(_filePath)).Returns(_byteArray);
+                _hashAlgorithm.Setup(x => x.ComputeHash(_byteArray)).Throws<IOException>(); //IO.IO_FileTooLong2GB (over Int32.MaxValue)
             }
 
             public override void Because()
             {
-                result = Provider.ComputeFileHash(filePath);
+                _result = Provider.ComputeFileHash(_filePath);
             }
 
             [Fact]
@@ -103,7 +103,7 @@ namespace chocolatey.tests.infrastructure.cryptography
             [Fact]
             public void Should_provide_an_unchanging_hash_for_a_file_too_big_to_hash()
             {
-                result.Should().Be(ApplicationParameters.HashProviderFileTooBig);
+                _result.Should().Be(ApplicationParameters.HashProviderFileTooBig);
             }
         }
     }

--- a/src/chocolatey.tests/infrastructure/filesystem/DotNetFileSystemSpecs.cs
+++ b/src/chocolatey.tests/infrastructure/filesystem/DotNetFileSystemSpecs.cs
@@ -130,26 +130,21 @@ namespace chocolatey.tests.infrastructure.filesystem
 
         public class When_finding_paths_to_executables_with_dotNetFileSystem : DotNetFileSystemSpecsBase
         {
-            public Mock<IEnvironment> _environment = new Mock<IEnvironment>();
+            public Mock<IEnvironment> Environment = new Mock<IEnvironment>();
 
             public override void Context()
             {
                 base.Context();
-                _environment.Setup(x => x.GetEnvironmentVariable(ApplicationParameters.Environment.PathExtensions)).Returns(".COM;.EXE;.BAT;.CMD;.VBS;.VBE;.JS;.JSE;.WSF;.WSH;.MSC;.CPL");
-                _environment.Setup(x => x.GetEnvironmentVariable(ApplicationParameters.Environment.Path)).Returns(
+                Environment.Setup(x => x.GetEnvironmentVariable(ApplicationParameters.Environment.PathExtensions)).Returns(".COM;.EXE;.BAT;.CMD;.VBS;.VBE;.JS;.JSE;.WSF;.WSH;.MSC;.CPL");
+                Environment.Setup(x => x.GetEnvironmentVariable(ApplicationParameters.Environment.Path)).Returns(
                     @"C:\ProgramData\Chocolatey\bin{0}C:\Program Files\Microsoft\Web Platform Installer\{0}C:\Users\yes\AppData\Roaming\Boxstarter{0}C:\tools\ChocolateyPackageUpdater{0}C:\Windows\system32{0}C:\Windows{0}C:\Windows\System32\Wbem{0}C:\Windows\System32\WindowsPowerShell\v1.0\{0}"
                         .FormatWith(Path.PathSeparator)
                 );
-                FileSystem.InitializeWith(new Lazy<IEnvironment>(() => _environment.Object));
+                FileSystem.InitializeWith(new Lazy<IEnvironment>(() => Environment.Object));
             }
 
             public override void Because()
             {
-            }
-
-            private void reset()
-            {
-                _environment.ResetCalls();
             }
 
             [Fact]
@@ -192,17 +187,17 @@ namespace chocolatey.tests.infrastructure.filesystem
 
         public class When_finding_paths_to_executables_with_dotNetFileSystem_with_empty_path_extensions : DotNetFileSystemSpecsBase
         {
-            public Mock<IEnvironment> _environment = new Mock<IEnvironment>();
+            public Mock<IEnvironment> Environment = new Mock<IEnvironment>();
 
             public override void Context()
             {
                 base.Context();
-                _environment.Setup(x => x.GetEnvironmentVariable(ApplicationParameters.Environment.PathExtensions)).Returns(string.Empty);
-                _environment.Setup(x => x.GetEnvironmentVariable(ApplicationParameters.Environment.Path)).Returns(
+                Environment.Setup(x => x.GetEnvironmentVariable(ApplicationParameters.Environment.PathExtensions)).Returns(string.Empty);
+                Environment.Setup(x => x.GetEnvironmentVariable(ApplicationParameters.Environment.Path)).Returns(
                     "/usr/local/bin{0}/usr/bin/{0}/bin{0}/usr/sbin{0}/sbin"
                         .FormatWith(Path.PathSeparator)
                 );
-                FileSystem.InitializeWith(new Lazy<IEnvironment>(() => _environment.Object));
+                FileSystem.InitializeWith(new Lazy<IEnvironment>(() => Environment.Object));
             }
 
             public override void Because()

--- a/src/chocolatey.tests/infrastructure/guards/EnsureSpecs.cs
+++ b/src/chocolatey.tests/infrastructure/guards/EnsureSpecs.cs
@@ -33,49 +33,49 @@ namespace chocolatey.tests.infrastructure.guards
 
         public class When_Ensure_is_being_set_to_a_type : EnsureSpecsBase
         {
-            private object result;
-            private readonly object bob = "something";
+            private object _result;
+            private readonly object _bob = "something";
 
             public override void Because()
             {
-                result = Ensure.That(() => bob);
+                _result = Ensure.That(() => _bob);
             }
 
             [Fact]
             public void Should_return_a_type_of_object_for_ensuring()
             {
-                result.Should().BeOfType<Ensure<object>>();
+                _result.Should().BeOfType<Ensure<object>>();
             }
 
             [Fact]
             public void Should_have_the_value_specified()
             {
-                var bobEnsure = result as Ensure<object>;
-                bobEnsure.Value.Should().Be(bob);
+                var bobEnsure = _result as Ensure<object>;
+                bobEnsure.Value.Should().Be(_bob);
             }
         }
 
         public class When_Ensure_is_a_string_type : EnsureSpecsBase
         {
-            private object result;
-            private readonly string bob = "something";
+            private object _result;
+            private readonly string _bob = "something";
 
             public override void Because()
             {
-                result = Ensure.That(() => bob);
+                _result = Ensure.That(() => _bob);
             }
 
             [Fact]
             public void Should_return_a_ensure_string_type()
             {
-                result.Should().BeOfType<EnsureString>();
+                _result.Should().BeOfType<EnsureString>();
             }
 
             [Fact]
             public void Should_have_the_value_specified()
             {
-                var bobEnsure = result as EnsureString;
-                bobEnsure.Value.Should().Be(bob);
+                var bobEnsure = _result as EnsureString;
+                bobEnsure.Value.Should().Be(_bob);
             }
         }
 
@@ -367,9 +367,9 @@ namespace chocolatey.tests.infrastructure.guards
 
         public class When_testing_Ensure_meets_against_a_string_value_that_passes : EnsureSpecsBase
         {
-            private object exceptionType;
-            private string exceptionMessage = string.Empty;
-            private bool exceptionActionInvoked;
+            private object _exceptionType;
+            private string _exceptionMessage = string.Empty;
+            private bool _exceptionActionInvoked;
 
             public override void Because()
             {
@@ -381,33 +381,33 @@ namespace chocolatey.tests.infrastructure.guards
                         s => s == s.ToLower(),
                         (name, value) =>
                         {
-                            exceptionActionInvoked = true;
+                            _exceptionActionInvoked = true;
                             throw new ApplicationException("this is what we throw.");
                         });
                 }
                 catch (Exception ex)
                 {
-                    exceptionType = ex;
-                    exceptionMessage = ex.Message;
+                    _exceptionType = ex;
+                    _exceptionMessage = ex.Message;
                 }
             }
 
             [Fact]
             public void Should_not_invoke_the_exceptionAction()
             {
-                exceptionActionInvoked.Should().BeFalse();
+                _exceptionActionInvoked.Should().BeFalse();
             }
 
             [Fact]
             public void Should_not_return_a_specified_exception_since_there_was_no_failure()
             {
-                exceptionType.Should().BeNull();
+                _exceptionType.Should().BeNull();
             }
 
             [Fact]
             public void Should_not_return_the_specified_error_message()
             {
-                exceptionMessage.Should().NotContain("this is what we throw.");
+                _exceptionMessage.Should().NotContain("this is what we throw.");
             }
 
             [Fact]
@@ -419,9 +419,9 @@ namespace chocolatey.tests.infrastructure.guards
 
         public class When_testing_Ensure_meets_against_a_string_value_that_fails : EnsureSpecsBase
         {
-            private object exceptionType;
-            private string exceptionMessage = string.Empty;
-            private bool exceptionActionInvoked;
+            private object _exceptionType;
+            private string _exceptionMessage = string.Empty;
+            private bool _exceptionActionInvoked;
 
             public override void Because()
             {
@@ -433,33 +433,33 @@ namespace chocolatey.tests.infrastructure.guards
                         s => s == s.ToLower(),
                         (name, value) =>
                         {
-                            exceptionActionInvoked = true;
+                            _exceptionActionInvoked = true;
                             throw new ApplicationException("this is what we throw.");
                         });
                 }
                 catch (Exception ex)
                 {
-                    exceptionType = ex;
-                    exceptionMessage = ex.Message;
+                    _exceptionType = ex;
+                    _exceptionMessage = ex.Message;
                 }
             }
 
             [Fact]
             public void Should_invoke_the_exceptionAction()
             {
-                exceptionActionInvoked.Should().BeTrue();
+                _exceptionActionInvoked.Should().BeTrue();
             }
 
             [Fact]
             public void Should_return_the_specified_exception_of_type_ApplicationException()
             {
-                exceptionType.Should().BeOfType<ApplicationException>();
+                _exceptionType.Should().BeOfType<ApplicationException>();
             }
 
             [Fact]
             public void Should_return_the_specified_error_message()
             {
-                exceptionMessage.Should().Contain("this is what we throw.");
+                _exceptionMessage.Should().Contain("this is what we throw.");
             }
 
             [Fact]
@@ -471,9 +471,9 @@ namespace chocolatey.tests.infrastructure.guards
 
         public class When_testing_Ensure_meets_against_a_null_value_without_guarding_the_value : EnsureSpecsBase
         {
-            private object exceptionType;
-            private string exceptionMessage = string.Empty;
-            private bool exceptionActionInvoked;
+            private object _exceptionType;
+            private string _exceptionMessage = string.Empty;
+            private bool _exceptionActionInvoked;
 
             public override void Because()
             {
@@ -485,39 +485,39 @@ namespace chocolatey.tests.infrastructure.guards
                         s => s == s.ToLower(),
                         (name, value) =>
                         {
-                            exceptionActionInvoked = true;
+                            _exceptionActionInvoked = true;
                             throw new ApplicationException("this is what we throw.");
                         });
                 }
                 catch (Exception ex)
                 {
-                    exceptionType = ex;
-                    exceptionMessage = ex.Message;
+                    _exceptionType = ex;
+                    _exceptionMessage = ex.Message;
                 }
             }
 
             [Fact]
             public void Should_not_invoke_the_exceptionAction()
             {
-                exceptionActionInvoked.Should().BeFalse();
+                _exceptionActionInvoked.Should().BeFalse();
             }
 
             [Fact]
             public void Should_throw_an_error()
             {
-                exceptionType.Should().NotBeNull();
+                _exceptionType.Should().NotBeNull();
             }
 
             [Fact]
             public void Should_not_return_the_specified_exception_of_type_ApplicationException()
             {
-                exceptionType.Should().NotBeOfType<ApplicationException>();
+                _exceptionType.Should().NotBeOfType<ApplicationException>();
             }
 
             [Fact]
             public void Should_not_return_the_specified_error_message()
             {
-                exceptionMessage.Should().NotContain("this is what we throw.");
+                _exceptionMessage.Should().NotContain("this is what we throw.");
             }
 
             //[Fact]

--- a/src/chocolatey.tests/infrastructure/information/VersionInformationSpecs.cs
+++ b/src/chocolatey.tests/infrastructure/information/VersionInformationSpecs.cs
@@ -31,35 +31,35 @@ namespace chocolatey.tests.infrastructure.information
 
         public class When_calling_VersionInformation_to_get_current_assembly_version : VersionInformationSpecsBase
         {
-            public string result = null;
+            public string Result = null;
 
             public override void Because()
             {
-                result = VersionInformation.GetCurrentAssemblyVersion();
+                Result = VersionInformation.GetCurrentAssemblyVersion();
             }
 
             [Fact]
             public void Should_not_be_null()
             {
-                result.Should().NotBeNull();
+                Result.Should().NotBeNull();
             }
 
             [Fact]
             public void Should_not_be_empty()
             {
-                result.Should().NotBeEmpty();
+                Result.Should().NotBeEmpty();
             }
 
             [Fact]
             public void Should_be_transferable_to_Version()
             {
-                new Version(result).Should().NotBeNull();
+                new Version(Result).Should().NotBeNull();
             }
 
             [Fact]
             public void Should_not_equal_zero_dot_zero_dot_zero_dot_zero()
             {
-                result.Should().NotBe("0.0.0.0");
+                Result.Should().NotBe("0.0.0.0");
             }
         }
     }

--- a/src/chocolatey.tests/infrastructure/platforms/PlatformSpecs.cs
+++ b/src/chocolatey.tests/infrastructure/platforms/PlatformSpecs.cs
@@ -40,23 +40,23 @@ namespace chocolatey.tests.infrastructure.platforms
 
         public class When_calling_Platform_get_platform : PlatformSpecsBase
         {
-            private PlatformType result;
+            private PlatformType _result;
 
             public override void Because()
             {
-                result = Platform.GetPlatform();
+                _result = Platform.GetPlatform();
             }
 
             [Fact]
             public void Should_not_be_Unknown()
             {
-                result.Should().NotBe(PlatformType.Unknown);
+                _result.Should().NotBe(PlatformType.Unknown);
             }
         }
 
         public class When_calling_Platform_get_platform_on_Windows : PlatformSpecsBase
         {
-            private PlatformType result;
+            private PlatformType _result;
 
             public override void Context()
             {
@@ -66,19 +66,19 @@ namespace chocolatey.tests.infrastructure.platforms
 
             public override void Because()
             {
-                result = Platform.GetPlatform();
+                _result = Platform.GetPlatform();
             }
 
             [Fact]
             public void Should_return_Windows()
             {
-                result.Should().Be(PlatformType.Windows);
+                _result.Should().Be(PlatformType.Windows);
             }
         }
 
         public class When_calling_Platform_get_platform_on_MacOSX : PlatformSpecsBase
         {
-            private PlatformType result;
+            private PlatformType _result;
 
             public override void Context()
             {
@@ -88,19 +88,19 @@ namespace chocolatey.tests.infrastructure.platforms
 
             public override void Because()
             {
-                result = Platform.GetPlatform();
+                _result = Platform.GetPlatform();
             }
 
             [Fact]
             public void Should_return_Mac()
             {
-                result.Should().Be(PlatformType.Mac);
+                _result.Should().Be(PlatformType.Mac);
             }
         }
 
         public class When_calling_Platform_get_platform_on_Linux : PlatformSpecsBase
         {
-            private PlatformType result;
+            private PlatformType _result;
 
             public override void Context()
             {
@@ -111,19 +111,19 @@ namespace chocolatey.tests.infrastructure.platforms
 
             public override void Because()
             {
-                result = Platform.GetPlatform();
+                _result = Platform.GetPlatform();
             }
 
             [Fact]
             public void Should_return_Linux()
             {
-                result.Should().Be(PlatformType.Linux);
+                _result.Should().Be(PlatformType.Linux);
             }
         }
 
         public class When_calling_Platform_get_platform_on_PlatformId_Linux_with_MacOSX_folder_structure : PlatformSpecsBase
         {
-            private PlatformType result;
+            private PlatformType _result;
 
             public override void Context()
             {
@@ -134,13 +134,13 @@ namespace chocolatey.tests.infrastructure.platforms
 
             public override void Because()
             {
-                result = Platform.GetPlatform();
+                _result = Platform.GetPlatform();
             }
 
             [Fact]
             public void Should_return_Mac()
             {
-                result.Should().Be(PlatformType.Mac);
+                _result.Should().Be(PlatformType.Mac);
             }
         }
     }

--- a/src/chocolatey.tests/infrastructure/tokens/TokenReplacerSpecs.cs
+++ b/src/chocolatey.tests/infrastructure/tokens/TokenReplacerSpecs.cs
@@ -32,95 +32,95 @@ namespace chocolatey.tests.infrastructure.tokens
 
         public class When_using_TokenReplacer : TokenReplacerSpecsBase
         {
-            public ChocolateyConfiguration configuration = new ChocolateyConfiguration();
-            public string name = "bob";
+            public ChocolateyConfiguration Configuration = new ChocolateyConfiguration();
+            public string Name = "bob";
 
             public override void Because()
             {
-                configuration.CommandName = name;
+                Configuration.CommandName = Name;
             }
 
             [Fact]
             public void When_given_brace_brace_CommandName_brace_brace_should_replace_with_the_Name_from_the_configuration()
             {
-                TokenReplacer.ReplaceTokens(configuration, "Hi! My name is [[CommandName]]").Should().Be("Hi! My name is " + name);
+                TokenReplacer.ReplaceTokens(Configuration, "Hi! My name is [[CommandName]]").Should().Be("Hi! My name is " + Name);
             }
 
             [Fact]
             public void When_given_brace_CommandName_brace_should_NOT_replace_the_value()
             {
-                TokenReplacer.ReplaceTokens(configuration, "Hi! My name is [CommandName]").Should().Be("Hi! My name is [CommandName]");
+                TokenReplacer.ReplaceTokens(Configuration, "Hi! My name is [CommandName]").Should().Be("Hi! My name is [CommandName]");
             }
 
             [Fact]
             public void When_given_a_value_that_is_the_name_of_a_configuration_item_but_is_not_properly_tokenized_it_should_NOT_replace_the_value()
             {
-                TokenReplacer.ReplaceTokens(configuration, "Hi! My name is CommandName").Should().Be("Hi! My name is CommandName");
+                TokenReplacer.ReplaceTokens(Configuration, "Hi! My name is CommandName").Should().Be("Hi! My name is CommandName");
             }
 
             [Fact]
             public void When_given_brace_brace_commandname_brace_brace_should_replace_with_the_Name_from_the_configuration()
             {
-                TokenReplacer.ReplaceTokens(configuration, "Hi! My name is [[commandname]]").Should().Be("Hi! My name is " + name);
+                TokenReplacer.ReplaceTokens(Configuration, "Hi! My name is [[commandname]]").Should().Be("Hi! My name is " + Name);
             }
 
             [Fact]
             public void When_given_brace_brace_COMMANDNAME_brace_brace_should_replace_with_the_Name_from_the_configuration()
             {
-                TokenReplacer.ReplaceTokens(configuration, "Hi! My name is [[COMMANDNAME]]").Should().Be("Hi! My name is " + name);
+                TokenReplacer.ReplaceTokens(Configuration, "Hi! My name is [[COMMANDNAME]]").Should().Be("Hi! My name is " + Name);
             }
 
             [Fact]
             public void When_given_brace_brace_cOMmAnDnAMe_brace_brace_should_replace_with_the_Name_from_the_configuration()
             {
-                TokenReplacer.ReplaceTokens(configuration, "Hi! My name is [[cOMmAnDnAMe]]").Should().Be("Hi! My name is " + name);
+                TokenReplacer.ReplaceTokens(Configuration, "Hi! My name is [[cOMmAnDnAMe]]").Should().Be("Hi! My name is " + Name);
             }
 
             [Fact]
             public void If_given_brace_brace_Version_brace_brace_should_NOT_replace_with_the_Name_from_the_configuration()
             {
-                TokenReplacer.ReplaceTokens(configuration, "Go to [[Version]]").Should().NotContain(name);
+                TokenReplacer.ReplaceTokens(Configuration, "Go to [[Version]]").Should().NotContain(Name);
             }
 
             [Fact]
             public void If_given_a_value_that_is_not_set_should_return_that_value_as_string_Empty()
             {
-                TokenReplacer.ReplaceTokens(configuration, "Go to [[Version]]").Should().Be("Go to " + string.Empty);
+                TokenReplacer.ReplaceTokens(Configuration, "Go to [[Version]]").Should().Be("Go to " + string.Empty);
             }
 
             [Fact]
             public void If_given_a_value_that_does_not_exist_should_return_the_original_value_unchanged()
             {
-                TokenReplacer.ReplaceTokens(configuration, "Hi! My name is [[DataBase]]").Should().Be("Hi! My name is [[DataBase]]");
+                TokenReplacer.ReplaceTokens(Configuration, "Hi! My name is [[DataBase]]").Should().Be("Hi! My name is [[DataBase]]");
             }
 
             [Fact]
             public void If_given_an_empty_value_should_return_the_empty_value()
             {
-                TokenReplacer.ReplaceTokens(configuration, "").Should().Be("");
+                TokenReplacer.ReplaceTokens(Configuration, "").Should().Be("");
             }
 
             [Fact]
             public void If_given_an_null_value_should_return_the_ll_value()
             {
-                TokenReplacer.ReplaceTokens(configuration, null).Should().Be("");
+                TokenReplacer.ReplaceTokens(Configuration, null).Should().Be("");
             }
         }
 
         public class When_using_TokenReplacer_with_a_Dictionary : TokenReplacerSpecsBase
         {
-            public Dictionary<string, string> tokens = new Dictionary<string, string>();
-            private readonly string value = "sweet";
+            public Dictionary<string, string> Tokens = new Dictionary<string, string>();
+            private readonly string _value = "sweet";
 
             public override void Because()
             {
-                tokens.Add("dude", value);
+                Tokens.Add("dude", _value);
             }
 
             [Fact]
             public void When_given_a_proper_token_it_should_replace_with_the_dictionary_value()
             {
-                TokenReplacer.ReplaceTokens(tokens, "Hi! My name is [[dude]]").Should().Be("Hi! My name is " + value);
+                TokenReplacer.ReplaceTokens(Tokens, "Hi! My name is [[dude]]").Should().Be("Hi! My name is " + _value);
             }
         }
     }

--- a/src/chocolatey.tests/infrastructure/tolerance/FaultToleranceSpecs.cs
+++ b/src/chocolatey.tests/infrastructure/tolerance/FaultToleranceSpecs.cs
@@ -29,7 +29,7 @@ namespace chocolatey.tests.infrastructure.tolerance
             {
             }
 
-            protected void reset()
+            protected void Reset()
             {
                 MockLogger.Reset();
             }
@@ -44,7 +44,7 @@ namespace chocolatey.tests.infrastructure.tolerance
             [Fact]
             public void Should_not_allow_the_number_of_retries_to_be_zero()
             {
-                reset();
+                Reset();
 
                 Action m = () => FaultTolerance.Retry(
                     0,
@@ -58,7 +58,7 @@ namespace chocolatey.tests.infrastructure.tolerance
             [Fact]
             public void Should_throw_an_error_if_retries_are_reached()
             {
-                reset();
+                Reset();
 
                 Action m = () => FaultTolerance.Retry(2, () => { throw new Exception("YIKES"); }, waitDurationMilliseconds: 0);
 
@@ -68,7 +68,7 @@ namespace chocolatey.tests.infrastructure.tolerance
             [Fact]
             public void Should_log_warning_each_time()
             {
-                reset();
+                Reset();
 
                 try
                 {
@@ -85,7 +85,7 @@ namespace chocolatey.tests.infrastructure.tolerance
             [Fact]
             public void Should_retry_the_number_of_times_specified()
             {
-                reset();
+                Reset();
 
                 var i = 0;
                 try
@@ -110,7 +110,7 @@ namespace chocolatey.tests.infrastructure.tolerance
             [Fact]
             public void Should_return_immediately_when_successful()
             {
-                reset();
+                Reset();
 
                 var i = 0;
                 FaultTolerance.Retry(3, () => { i += 1; }, waitDurationMilliseconds: 0);
@@ -130,7 +130,7 @@ namespace chocolatey.tests.infrastructure.tolerance
             [Fact]
             public void Should_log_an_error_message()
             {
-                reset();
+                Reset();
 
                 FaultTolerance.TryCatchWithLoggingException(
                     () => { throw new Exception("This is the message"); },
@@ -143,7 +143,7 @@ namespace chocolatey.tests.infrastructure.tolerance
             [Fact]
             public void Should_log_the_expected_error_message()
             {
-                reset();
+                Reset();
 
                 FaultTolerance.TryCatchWithLoggingException(
                     () => { throw new Exception("This is the message"); },
@@ -156,7 +156,7 @@ namespace chocolatey.tests.infrastructure.tolerance
             [Fact]
             public void Should_log_a_warning_message_when_set_to_warn()
             {
-                reset();
+                Reset();
 
                 FaultTolerance.TryCatchWithLoggingException(
                     () => { throw new Exception("This is the message"); },
@@ -170,7 +170,7 @@ namespace chocolatey.tests.infrastructure.tolerance
             [Fact]
             public void Should_throw_an_error_if_throwError_set_to_true()
             {
-                reset();
+                Reset();
 
                 Action m = () => FaultTolerance.TryCatchWithLoggingException(
                     () => { throw new Exception("This is the message"); },
@@ -184,7 +184,7 @@ namespace chocolatey.tests.infrastructure.tolerance
             [Fact]
             public void Should_still_throw_an_error_when_warn_is_set_if_throwError_set_to_true()
             {
-                reset();
+                Reset();
 
                 Action m = () => FaultTolerance.TryCatchWithLoggingException(
                     () => { throw new Exception("This is the message"); },

--- a/src/chocolatey/infrastructure/commandline/Options.cs
+++ b/src/chocolatey/infrastructure/commandline/Options.cs
@@ -284,12 +284,13 @@ namespace chocolatey.infrastructure.commandline
 		Required,
 	}
 
-	public abstract class Option {
-		string prototype, description;
-		string[] names;
-		OptionValueType type;
-		int count;
-		string[] separators;
+    public abstract class Option
+    {
+        string _prototype, _description;
+        string[] _names;
+        OptionValueType _type;
+        int _count;
+        string[] _separators;
 
 		protected Option (string prototype, string description)
 			: this (prototype, description, 1)
@@ -305,45 +306,45 @@ namespace chocolatey.infrastructure.commandline
 			if (maxValueCount < 0)
 				throw new ArgumentOutOfRangeException ("maxValueCount");
 
-			this.prototype   = prototype;
-			this.names       = prototype.Split ('|');
-			this.description = description;
-			this.count       = maxValueCount;
-			this.type        = ParsePrototype ();
+            this._prototype = prototype;
+            this._names = prototype.Split('|');
+            this._description = description;
+            this._count = maxValueCount;
+            this._type = ParsePrototype();
 
-			if (this.count == 0 && type != OptionValueType.None)
-				throw new ArgumentException (
-						"Cannot provide maxValueCount of 0 for OptionValueType.Required or " +
-							"OptionValueType.Optional.",
-						"maxValueCount");
-			if (this.type == OptionValueType.None && maxValueCount > 1)
-				throw new ArgumentException (
-						string.Format ("Cannot provide maxValueCount of {0} for OptionValueType.None.", maxValueCount),
-						"maxValueCount");
-			if (Array.IndexOf (names, "<>") >= 0 &&
-					((names.Length == 1 && this.type != OptionValueType.None) ||
-					 (names.Length > 1 && this.MaxValueCount > 1)))
-				throw new ArgumentException (
-						"The default option handler '<>' cannot require values.",
-						"prototype");
-		}
+            if (this._count == 0 && _type != OptionValueType.None)
+                throw new ArgumentException(
+                        "Cannot provide maxValueCount of 0 for OptionValueType.Required or " +
+                            "OptionValueType.Optional.",
+                        "maxValueCount");
+            if (this._type == OptionValueType.None && maxValueCount > 1)
+                throw new ArgumentException(
+                        string.Format("Cannot provide maxValueCount of {0} for OptionValueType.None.", maxValueCount),
+                        "maxValueCount");
+            if (Array.IndexOf(_names, "<>") >= 0 &&
+                    ((_names.Length == 1 && this._type != OptionValueType.None) ||
+                     (_names.Length > 1 && this.MaxValueCount > 1)))
+                throw new ArgumentException(
+                        "The default option handler '<>' cannot require values.",
+                        "prototype");
+        }
 
-		public string           Prototype       {get {return prototype;}}
-		public string           Description     {get {return description;}}
-		public OptionValueType  OptionValueType {get {return type;}}
-		public int              MaxValueCount   {get {return count;}}
+        public string Prototype { get { return _prototype; } }
+        public string Description { get { return _description; } }
+        public OptionValueType OptionValueType { get { return _type; } }
+        public int MaxValueCount { get { return _count; } }
 
-		public string[] GetNames ()
-		{
-			return (string[]) names.Clone ();
-		}
+        public string[] GetNames()
+        {
+            return (string[])_names.Clone();
+        }
 
-		public string[] GetValueSeparators ()
-		{
-			if (separators == null)
-				return new string [0];
-			return (string[]) separators.Clone ();
-		}
+        public string[] GetValueSeparators()
+        {
+            if (_separators == null)
+                return new string[0];
+            return (string[])_separators.Clone();
+        }
 
 		protected static T Parse<T> (string value, OptionContext c)
 		{
@@ -363,48 +364,50 @@ namespace chocolatey.infrastructure.commandline
 			return t;
 		}
 
-		internal string[] Names           {get {return names;}}
-		internal string[] ValueSeparators {get {return separators;}}
+        internal string[] Names { get { return _names; } }
+        internal string[] ValueSeparators { get { return _separators; } }
 
-		static readonly char[] NameTerminator = new char[]{'=', ':'};
+        static readonly char[] _nameTerminator = new char[] { '=', ':' };
 
-		private OptionValueType ParsePrototype ()
-		{
-			char type = '\0';
-			List<string> seps = new List<string> ();
-			for (int i = 0; i < names.Length; ++i) {
-				string name = names [i];
-				if (name.Length == 0)
-					throw new ArgumentException ("Empty option names are not supported.", "prototype");
+        private OptionValueType ParsePrototype()
+        {
+            char type = '\0';
+            List<string> seps = new List<string>();
+            for (int i = 0; i < _names.Length; ++i)
+            {
+                string name = _names[i];
+                if (name.Length == 0)
+                    throw new ArgumentException("Empty option names are not supported.", "prototype");
 
-				int end = name.IndexOfAny (NameTerminator);
-				if (end == -1)
-					continue;
-				names [i] = name.Substring (0, end);
-				if (type == '\0' || type == name [end])
-					type = name [end];
-				else
-					throw new ArgumentException (
-							string.Format ("Conflicting option types: '{0}' vs. '{1}'.", type, name [end]),
-							"prototype");
-				AddSeparators (name, end, seps);
-			}
+                int end = name.IndexOfAny(_nameTerminator);
+                if (end == -1)
+                    continue;
+                _names[i] = name.Substring(0, end);
+                if (type == '\0' || type == name[end])
+                    type = name[end];
+                else
+                    throw new ArgumentException(
+                            string.Format("Conflicting option types: '{0}' vs. '{1}'.", type, name[end]),
+                            "prototype");
+                AddSeparators(name, end, seps);
+            }
 
 			if (type == '\0')
 				return OptionValueType.None;
 
-			if (count <= 1 && seps.Count != 0)
-				throw new ArgumentException (
-						string.Format ("Cannot provide key/value separators for Options taking {0} value(s).", count),
-						"prototype");
-			if (count > 1) {
-				if (seps.Count == 0)
-					this.separators = new string[]{":", "="};
-				else if (seps.Count == 1 && seps [0].Length == 0)
-					this.separators = null;
-				else
-					this.separators = seps.ToArray ();
-			}
+            if (_count <= 1 && seps.Count != 0)
+                throw new ArgumentException(
+                        string.Format("Cannot provide key/value separators for Options taking {0} value(s).", _count),
+                        "prototype");
+            if (_count > 1)
+            {
+                if (seps.Count == 0)
+                    this._separators = new string[] { ":", "=" };
+                else if (seps.Count == 1 && seps[0].Length == 0)
+                    this._separators = null;
+                else
+                    this._separators = seps.ToArray();
+            }
 
 			return type == '=' ? OptionValueType.Required : OptionValueType.Optional;
 		}
@@ -506,15 +509,16 @@ namespace chocolatey.infrastructure.commandline
 
         public OptionSet(Converter<string, string> localizer)
             : base(StringComparer.OrdinalIgnoreCase)
-		{
-			this.localizer = localizer;
-		}
+        {
+            this._localizer = localizer;
+        }
 
-		Converter<string, string> localizer;
+        Converter<string, string> _localizer;
 
-		public Converter<string, string> MessageLocalizer {
-			get {return localizer;}
-		}
+        public Converter<string, string> MessageLocalizer
+        {
+            get { return _localizer; }
+        }
 
 		protected override string GetKeyForItem (Option item)
 		{
@@ -588,22 +592,23 @@ namespace chocolatey.infrastructure.commandline
 			return this;
 		}
 
-		sealed class ActionOption : Option {
-			Action<OptionValueCollection> action;
+        sealed class ActionOption : Option
+        {
+            Action<OptionValueCollection> _action;
 
-			public ActionOption (string prototype, string description, int count, Action<OptionValueCollection> action)
-				: base (prototype, description, count)
-			{
-				if (action == null)
-					throw new ArgumentNullException ("action");
-				this.action = action;
-			}
+            public ActionOption(string prototype, string description, int count, Action<OptionValueCollection> action)
+                : base(prototype, description, count)
+            {
+                if (action == null)
+                    throw new ArgumentNullException("action");
+                this._action = action;
+            }
 
-			protected override void OnParseComplete (OptionContext c)
-			{
-				action (c.OptionValues);
-			}
-		}
+            protected override void OnParseComplete(OptionContext c)
+            {
+                _action(c.OptionValues);
+            }
+        }
 
 		public OptionSet Add (string prototype, Action<string> action)
 		{
@@ -635,41 +640,43 @@ namespace chocolatey.infrastructure.commandline
 			return this;
 		}
 
-		sealed class ActionOption<T> : Option {
-			Action<T> action;
+        sealed class ActionOption<T> : Option
+        {
+            Action<T> _action;
 
-			public ActionOption (string prototype, string description, Action<T> action)
-				: base (prototype, description, 1)
-			{
-				if (action == null)
-					throw new ArgumentNullException ("action");
-				this.action = action;
-			}
+            public ActionOption(string prototype, string description, Action<T> action)
+                : base(prototype, description, 1)
+            {
+                if (action == null)
+                    throw new ArgumentNullException("action");
+                this._action = action;
+            }
 
-			protected override void OnParseComplete (OptionContext c)
-			{
-				action (Parse<T> (c.OptionValues [0], c));
-			}
-		}
+            protected override void OnParseComplete(OptionContext c)
+            {
+                _action(Parse<T>(c.OptionValues[0], c));
+            }
+        }
 
-		sealed class ActionOption<TKey, TValue> : Option {
-			OptionAction<TKey, TValue> action;
+        sealed class ActionOption<TKey, TValue> : Option
+        {
+            OptionAction<TKey, TValue> _action;
 
-			public ActionOption (string prototype, string description, OptionAction<TKey, TValue> action)
-				: base (prototype, description, 2)
-			{
-				if (action == null)
-					throw new ArgumentNullException ("action");
-				this.action = action;
-			}
+            public ActionOption(string prototype, string description, OptionAction<TKey, TValue> action)
+                : base(prototype, description, 2)
+            {
+                if (action == null)
+                    throw new ArgumentNullException("action");
+                this._action = action;
+            }
 
-			protected override void OnParseComplete (OptionContext c)
-			{
-				action (
-						Parse<TKey> (c.OptionValues [0], c),
-						Parse<TValue> (c.OptionValues [1], c));
-			}
-		}
+            protected override void OnParseComplete(OptionContext c)
+            {
+                _action(
+                        Parse<TKey>(c.OptionValues[0], c),
+                        Parse<TValue>(c.OptionValues[1], c));
+            }
+        }
 
 		public OptionSet Add<T> (string prototype, Action<T> action)
 		{
@@ -763,27 +770,29 @@ namespace chocolatey.infrastructure.commandline
 			return false;
 		}
 
-		private readonly Regex ValueOption = new Regex (
-			@"^(?<flag>--|-|/)(?<name>[^:=]+)((?<sep>[:=])(?<value>.*))?$");
+        private readonly Regex _valueOption = new Regex(
+            @"^(?<flag>--|-|/)(?<name>[^:=]+)((?<sep>[:=])(?<value>.*))?$");
 
 		protected bool GetOptionParts (string argument, out string flag, out string name, out string sep, out string value)
 		{
 			if (argument == null)
 				throw new ArgumentNullException ("argument");
 
-			flag = name = sep = value = null;
-			Match m = ValueOption.Match (argument);
-			if (!m.Success) {
-				return false;
-			}
-			flag  = m.Groups ["flag"].Value;
-			name  = m.Groups ["name"].Value;
-			if (m.Groups ["sep"].Success && m.Groups ["value"].Success) {
-				sep   = m.Groups ["sep"].Value;
-				value = m.Groups ["value"].Value;
-			}
-			return true;
-		}
+            flag = name = sep = value = null;
+            Match m = _valueOption.Match(argument);
+            if (!m.Success)
+            {
+                return false;
+            }
+            flag = m.Groups["flag"].Value;
+            name = m.Groups["name"].Value;
+            if (m.Groups["sep"].Success && m.Groups["value"].Success)
+            {
+                sep = m.Groups["sep"].Value;
+                value = m.Groups["value"].Value;
+            }
+            return true;
+        }
 
 		protected virtual bool Parse (string argument, OptionContext c)
 		{
@@ -830,24 +839,26 @@ namespace chocolatey.infrastructure.commandline
 			return false;
 		}
 
-		private void ParseValue (string option, OptionContext c)
-		{
-			if (option != null)
-				foreach (string o in c.Option.ValueSeparators != null
-						? option.Split (c.Option.ValueSeparators, StringSplitOptions.None)
-						: new string[]{option}) {
-					c.OptionValues.Add (o);
-				}
-			if (c.OptionValues.Count == c.Option.MaxValueCount ||
-					c.Option.OptionValueType == OptionValueType.Optional)
-				c.Option.Invoke (c);
-			else if (c.OptionValues.Count > c.Option.MaxValueCount) {
-				throw new OptionException (localizer (string.Format (
-								"Error: Found {0} option values when expecting {1}.",
-								c.OptionValues.Count, c.Option.MaxValueCount)),
-						c.OptionName);
-			}
-		}
+        private void ParseValue(string option, OptionContext c)
+        {
+            if (option != null)
+                foreach (string o in c.Option.ValueSeparators != null
+                        ? option.Split(c.Option.ValueSeparators, StringSplitOptions.None)
+                        : new string[] { option })
+                {
+                    c.OptionValues.Add(o);
+                }
+            if (c.OptionValues.Count == c.Option.MaxValueCount ||
+                    c.Option.OptionValueType == OptionValueType.Optional)
+                c.Option.Invoke(c);
+            else if (c.OptionValues.Count > c.Option.MaxValueCount)
+            {
+                throw new OptionException(_localizer(string.Format(
+                                "Error: Found {0} option values when expecting {1}.",
+                                c.OptionValues.Count, c.Option.MaxValueCount)),
+                        c.OptionName);
+            }
+        }
 
 		private bool ParseBool (string option, string n, OptionContext c)
 		{
@@ -866,22 +877,24 @@ namespace chocolatey.infrastructure.commandline
 			return false;
 		}
 
-		private bool ParseBundledValue (string f, string n, OptionContext c)
-		{
-            IDictionary<Option,string> normalOptions = new Dictionary<Option, string>();
-			if (f != "-")
-				return false;
-			for (int i = 0; i < n.Length; ++i) {
-				Option p;
-				string opt = f + n [i].ToString ();
-				string rn = n [i].ToString ();
-				if (!Contains (rn)) {
-					if (i == 0)
-						return false;
-					throw new OptionException (string.Format (localizer (
-									"Cannot bundle unregistered option '{0}'."), opt), opt);
-				}
-				p = this [rn];
+        private bool ParseBundledValue(string f, string n, OptionContext c)
+        {
+            IDictionary<Option, string> normalOptions = new Dictionary<Option, string>();
+            if (f != "-")
+                return false;
+            for (int i = 0; i < n.Length; ++i)
+            {
+                Option p;
+                string opt = f + n[i].ToString();
+                string rn = n[i].ToString();
+                if (!Contains(rn))
+                {
+                    if (i == 0)
+                        return false;
+                    throw new OptionException(string.Format(_localizer(
+                                    "Cannot bundle unregistered option '{0}'."), opt), opt);
+                }
+                p = this[rn];
 
                 switch (p.OptionValueType)
                 {
@@ -936,15 +949,16 @@ namespace chocolatey.infrastructure.commandline
 					o.Write (new string (' ', OptionWidth));
 				}
 
-				List<string> lines = GetLines (localizer (GetDescription (p.Description)));
-				o.WriteLine (lines [0]);
-				string prefix = new string (' ', OptionWidth+2);
-				for (int i = 1; i < lines.Count; ++i) {
-					o.Write (prefix);
-					o.WriteLine (lines [i]);
-				}
-			}
-		}
+                List<string> lines = GetLines(_localizer(GetDescription(p.Description)));
+                o.WriteLine(lines[0]);
+                string prefix = new string(' ', OptionWidth + 2);
+                for (int i = 1; i < lines.Count; ++i)
+                {
+                    o.Write(prefix);
+                    o.WriteLine(lines[i]);
+                }
+            }
+        }
 
 		bool WriteOptionPrototype (TextWriter o, Option p, ref int written)
 		{
@@ -970,24 +984,28 @@ namespace chocolatey.infrastructure.commandline
 				Write (o, ref written, names [i]);
 			}
 
-			if (p.OptionValueType == OptionValueType.Optional ||
-					p.OptionValueType == OptionValueType.Required) {
-				if (p.OptionValueType == OptionValueType.Optional) {
-					Write (o, ref written, localizer ("["));
-				}
-				Write (o, ref written, localizer ("=" + GetArgumentName (0, p.MaxValueCount, p.Description)));
-				string sep = p.ValueSeparators != null && p.ValueSeparators.Length > 0
-					? p.ValueSeparators [0]
-					: " ";
-				for (int c = 1; c < p.MaxValueCount; ++c) {
-					Write (o, ref written, localizer (sep + GetArgumentName (c, p.MaxValueCount, p.Description)));
-				}
-				if (p.OptionValueType == OptionValueType.Optional) {
-					Write (o, ref written, localizer ("]"));
-				}
-			}
-			return true;
-		}
+            if (p.OptionValueType == OptionValueType.Optional ||
+                    p.OptionValueType == OptionValueType.Required)
+            {
+                if (p.OptionValueType == OptionValueType.Optional)
+                {
+                    Write(o, ref written, _localizer("["));
+                }
+                Write(o, ref written, _localizer("=" + GetArgumentName(0, p.MaxValueCount, p.Description)));
+                string sep = p.ValueSeparators != null && p.ValueSeparators.Length > 0
+                    ? p.ValueSeparators[0]
+                    : " ";
+                for (int c = 1; c < p.MaxValueCount; ++c)
+                {
+                    Write(o, ref written, _localizer(sep + GetArgumentName(c, p.MaxValueCount, p.Description)));
+                }
+                if (p.OptionValueType == OptionValueType.Optional)
+                {
+                    Write(o, ref written, _localizer("]"));
+                }
+            }
+            return true;
+        }
 
 		static int GetNextOptionIndex (string[] names, int i)
 		{

--- a/src/chocolatey/infrastructure/platforms/Platform.cs
+++ b/src/chocolatey/infrastructure/platforms/Platform.cs
@@ -164,6 +164,7 @@ namespace chocolatey.infrastructure.platforms
         // ReSharper disable MemberCanBePrivate.Local
         // ReSharper disable FieldCanBeMadeReadOnly.Local
 
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE1006:Naming Styles", Justification = "Part of the Windows API calls, and should not be changed.")]
         [StructLayout(LayoutKind.Sequential)]
         private struct OSVERSIONINFOEX
         {

--- a/src/chocolatey/infrastructure/powershell/PoshHostUserInterface.cs
+++ b/src/chocolatey/infrastructure/powershell/PoshHostUserInterface.cs
@@ -131,14 +131,14 @@ namespace chocolatey.infrastructure.powershell
             this.Log().Debug(message.EscapeCurlyBraces());
         }
 
-        private bool hasLoggedStartProgress = false;
+        private bool _hasLoggedStartProgress = false;
         public override void WriteProgress(long sourceId, ProgressRecord record)
         {
             if (record.PercentComplete == -1) return;
 
-            if (!hasLoggedStartProgress)
+            if (!_hasLoggedStartProgress)
             {
-                hasLoggedStartProgress = true;
+                _hasLoggedStartProgress = true;
                 this.Log().Debug(record.Activity.EscapeCurlyBraces());
             }
 

--- a/src/chocolatey/infrastructure/results/PackageResult.cs
+++ b/src/chocolatey/infrastructure/results/PackageResult.cs
@@ -33,12 +33,12 @@ namespace chocolatey.infrastructure.results
     {
         public bool Inconclusive
         {
-            get { return _messages.Value.Any(x => x.MessageType == ResultType.Inconclusive); }
+            get { return Messages.Any(x => x.MessageType == ResultType.Inconclusive); }
         }
 
         public bool Warning
         {
-            get { return _messages.Value.Any(x => x.MessageType == ResultType.Warn); }
+            get { return Messages.Any(x => x.MessageType == ResultType.Warn); }
         }
 
         public string Name { get; private set; }

--- a/src/chocolatey/infrastructure/results/Result.cs
+++ b/src/chocolatey/infrastructure/results/Result.cs
@@ -25,16 +25,30 @@ namespace chocolatey.infrastructure.results
     /// </summary>
     public class Result : IResult
     {
-        protected readonly Lazy<List<ResultMessage>> _messages = new Lazy<List<ResultMessage>>();
+        // Should this just be private, instead of a protected field?
+        protected readonly Lazy<List<ResultMessage>> LazyMessages;
+
+        public Result()
+        {
+            LazyMessages = new Lazy<List<ResultMessage>>();
+#pragma warning disable CS0618 // Type or member is obsolete
+            _messages = LazyMessages;
+#pragma warning restore CS0618 // Type or member is obsolete
+        }
 
         public bool Success
         {
-            get { return !_messages.Value.Any(x => x.MessageType == ResultType.Error); }
+            get { return !LazyMessages.Value.Any(x => x.MessageType == ResultType.Error); }
         }
 
         public ICollection<ResultMessage> Messages
         {
-            get { return _messages.Value; }
+            get { return LazyMessages.Value; }
         }
+
+#pragma warning disable IDE1006 // Naming Styles
+        [Obsolete("This field is deprecated and will be removed in v3. Use LazyMessages or Messages instead.")]
+        protected readonly Lazy<List<ResultMessage>> _messages;
+#pragma warning restore IDE1006 // Naming Styles
     }
 }


### PR DESCRIPTION
## Description Of Changes

A while back we started implementing a standard of the naming style
that is meant to be followed in the repository.
At that time not everything was renamed to follow this new naming style,
and this change attempts to update all remaining items that hadn't been
renamed.

## Motivation and Context

To be consistent across the entire codebase.

## Testing

1. Other than running `.\build.ps1` the changes has not been tested as there are no functional changes.

With the above said, it may be a good idea to run test kitchen for CLI for this PR before merging.

### Operating Systems Testing

- Windows 10

## Change Types Made
<!-- Tick the boxes for the type of changes that have been made -->

* [ ] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.
* [x] Maintenance changes

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [x] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue

N/A