### PR TITLE
(tests) Clear HTTP Cache before getting packages

### DIFF
--- a/tests/chocolatey-tests/commands/choco-push.Tests.ps1
+++ b/tests/chocolatey-tests/commands/choco-push.Tests.ps1
@@ -160,7 +160,7 @@ Describe 'choco push nuget <_> repository' -Tag Chocolatey, PushCommand -Skip:($
             }
 
             $Output = Invoke-Choco push $PackagePath --source $RepositoryToUse$RepositoryEndpoint @KeyParameter
-
+            Invoke-Choco cache remove
             $VerifyPackagesSplat = @(
                 "--pre"
                 "--source"
@@ -172,15 +172,7 @@ Describe 'choco push nuget <_> repository' -Tag Chocolatey, PushCommand -Skip:($
                 "--version"
                 "$VersionUnderTest-$AddedVersion"
             )
-
-            # Nexus can take a moment to index the package, but we want to validate that it was successfully pushed
-            $Timer =  [System.Diagnostics.Stopwatch]::StartNew()
-            while ($Timer.Elapsed.TotalSeconds -lt 300 -and -not (
-                $Packages = (Invoke-Choco find $PackageUnderTest @VerifyPackagesSplat --Limit-Output).Lines | ConvertFrom-ChocolateyOutput -Command List
-            )) {
-                Write-Verbose "$($PackageUnderTest) was not found on $($RepositoryToUse)$($RepositoryEndpoint). Waiting for 5 seconds before trying again."
-                Start-Sleep -Seconds 5
-            }
+            $Packages = (Invoke-Choco find $PackageUnderTest @VerifyPackagesSplat --Limit-Output).Lines | ConvertFrom-ChocolateyOutput -Command List
         }
 
         AfterAll {


### PR DESCRIPTION
## Description Of Changes

Clear the HTTP caches before trying to get the pushed package.

## Motivation and Context

We are seeing sporadic failures of this test when the package is in fact there. This should help resolve that.

## Testing

Running in Test Kitchen (about the only place we see these failures)

### Operating Systems Testing

- Windows Server 2019
- Windows Server 2016

## Change Types Made

* [ ] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.
* [x] Pester Test change

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [x] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue

N/A