### PR TITLE
(#3258) Expand logging for nuget resources errors

### DIFF
--- a/src/chocolatey/ExceptionExtensions.cs
+++ b/src/chocolatey/ExceptionExtensions.cs
@@ -1,0 +1,21 @@
+﻿namespace chocolatey
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Text;
+    using System.Threading.Tasks;
+
+    public static class ExceptionExtensions
+    {
+        public static IEnumerable<Exception> Enumerate(this Exception error)
+        {
+            while (error != null)
+            {
+                yield return error;
+
+                error = error.InnerException;
+            }
+        }
+    }
+}

--- a/src/chocolatey/chocolatey.csproj
+++ b/src/chocolatey/chocolatey.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\packages\Microsoft.CodeAnalysis.BannedApiAnalyzers.3.3.3\build\Microsoft.CodeAnalysis.BannedApiAnalyzers.props" Condition="Exists('..\packages\Microsoft.CodeAnalysis.BannedApiAnalyzers.3.3.3\build\Microsoft.CodeAnalysis.BannedApiAnalyzers.props')" />
   <PropertyGroup>

--- a/src/chocolatey/chocolatey.csproj
+++ b/src/chocolatey/chocolatey.csproj
@@ -200,6 +200,7 @@
       <Link>Properties\SolutionVersion.cs</Link>
     </Compile>
     <Compile Include="AssemblyExtensions.cs" />
+    <Compile Include="ExceptionExtensions.cs" />
     <Compile Include="infrastructure.app\attributes\MultiServiceAttribute.cs" />
     <Compile Include="infrastructure.app\commands\ChocolateyCacheCommand.cs" />
     <Compile Include="infrastructure.app\commands\ChocolateyListCommand.cs" />


### PR DESCRIPTION
## Description Of Changes

- When resolving resources for a repository, take the initial warning we have and then inspect its inner exceptions.
- Log _all_ exception messages found this way to Debug, except for the last one which is logged as a warning again.

The reason the outermost and innermost exceptions are logged as warnings and the rest are relegated to debug is so that we have the best chance of giving users the most actionable information -- often the surface or the deepest exception contain the real problem, while the ones in the middle are often not as useful. However, should we encounter cases where the others are needed, users can inspect the log file for the additional messages, or use `--debug` to see them on a re-run.

## Motivation and Context

Previously all that was logged was the surface exception, which in quite a few cases we've seen not yielding any useful information.

Instead, log the entire exception chain, surfacing just the outermost and innermost exceptions, which we generally expect to contain the most relevant information for users.

## Testing

Reproducing the exact cases we've seen this thus far seemed non-trivial and needing quite a bit of setup to me, so I found this trivial case that illustrates the same behaviour:

1. Run `choco search chocolatey --source https://www.google.com/ --proxy www.google.com`
2. You should get two warnings; one that says `unable to load the service index`, and another that says `the remote server returned an error (405)`
3. Rerun the command with `--debug` and note there is an additional (in this case, not useful) exception logged between the two warnings that simply says `an error occurred while sending the request`

### Operating Systems Testing

Win11

## Change Types Made
<!-- Tick the boxes for the type of changes that have been made -->

* [ ] Bug fix (non-breaking change).
* [x] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [x] Requires a change to the documentation. - the shortlink links to a doc page that is to-be-written
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [x] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue
<!-- Make sure you have raised an issue for this pull request before
continuing. -->

Fixes #3258 

<!-- PLEASE REMOVE ALL COMMENTS BEFORE SUBMITTING -->
