### PR TITLE
(#1485) Display package source during install/upgrade

### DIFF
--- a/src/chocolatey.tests.integration/scenarios/InstallScenarios.cs
+++ b/src/chocolatey.tests.integration/scenarios/InstallScenarios.cs
@@ -331,6 +331,26 @@ namespace chocolatey.tests.integration.scenarios
             }
 
             [Fact]
+            public void Should_contain_message_with_source()
+            {
+                var message = "Downloading package from source '{0}'".FormatWith(Configuration.Sources);
+
+                MockLogger.Messages.Should().ContainKey(LogLevel.Info.ToString()).WhoseValue.Should()
+                    .Contain(message);
+            }
+
+            [Fact]
+            public void Should_contain_message_with_download_uri()
+            {
+                var packagePath = "file:///{0}/{1}.{2}{3}".FormatWith(Configuration.Sources.Replace("\\","/"), Configuration.PackageNames,
+                    TestVersion(), NuGetConstants.PackageExtension);
+               var message = "Package download location '{0}'".FormatWith(packagePath);
+
+                MockLogger.Messages.Should().ContainKey(LogLevel.Debug.ToString()).WhoseValue.Should()
+                    .Contain(message);
+            }
+
+            [Fact]
             [WindowsOnly]
             [Platform(Exclude = "Mono")]
             public void Should_have_executed_chocolateyInstall_script()

--- a/src/chocolatey.tests.integration/scenarios/UpgradeScenarios.cs
+++ b/src/chocolatey.tests.integration/scenarios/UpgradeScenarios.cs
@@ -266,6 +266,26 @@ namespace chocolatey.tests.integration.scenarios
             }
 
             [Fact]
+            public void Should_contain_message_with_source()
+            {
+                var message = "Downloading package from source '{0}'".FormatWith(Configuration.Sources);
+
+                MockLogger.Messages.Should().ContainKey(LogLevel.Info.ToString()).WhoseValue.Should()
+                    .Contain(message);
+            }
+
+            [Fact]
+            public void Should_contain_message_with_download_uri()
+            {
+                var packagePath = "file:///{0}/{1}.{2}{3}".FormatWith(Configuration.Sources.Replace("\\", "/"), Configuration.PackageNames,
+                    "1.1.0", NuGetConstants.PackageExtension);
+                var message = "Package download location '{0}'".FormatWith(packagePath);
+
+                MockLogger.Messages.Should().ContainKey(LogLevel.Debug.ToString()).WhoseValue.Should()
+                    .Contain(message);
+            }
+
+            [Fact]
             [WindowsOnly]
             [Platform(Exclude = "Mono")]
             public void Should_have_executed_chocolateyBeforeModify_script_for_original_package()

--- a/src/chocolatey/infrastructure.app/services/NugetService.cs
+++ b/src/chocolatey/infrastructure.app/services/NugetService.cs
@@ -828,6 +828,9 @@ Please see https://docs.chocolatey.org/en-us/troubleshooting for more
 
                         _fileSystem.DeleteFile(pathResolver.GetInstalledPackageFilePath(packageDependencyInfo));
 
+                        this.Log().Info("Downloading package from source '{0}'".FormatWith(packageDependencyInfo.Source));
+                        this.Log().Debug("Package download location '{0}'".FormatWith(packageDependencyInfo.DownloadUri));
+
                         ChocolateyProgressInfo.ShouldDisplayDownloadProgress = config.Features.ShowDownloadProgress;
 
                         using (var downloadResult = downloadResource.GetDownloadResourceResultAsync(
@@ -1559,6 +1562,9 @@ Please see https://docs.chocolatey.org/en-us/troubleshooting for more
                                 var downloadResource = endpoint.DownloadResource;
 
                                 _fileSystem.DeleteFile(pathResolver.GetInstalledPackageFilePath(packageDependencyInfo));
+
+                                this.Log().Info("Downloading package from source '{0}'".FormatWith(packageDependencyInfo.Source));
+                                this.Log().Debug("Package download location '{0}'".FormatWith(packageDependencyInfo.DownloadUri));
 
                                 ChocolateyProgressInfo.ShouldDisplayDownloadProgress = config.Features.ShowDownloadProgress;
 


### PR DESCRIPTION
## Description Of Changes

This logs the package source uri to info before downloading nupkgs
during both install and upgrade. Additionally, it debug logs the
download URI that the nupkg available at. 

The information outputs for both individual package installs/upgrades,
and for dependencies that get installed/upgraded by their parent 
package. This information is especially useful when multiple sources
are in play, so the user can determine where individual packages 
are coming from.

## Motivation and Context

See #1485

Now that Chocolatey CLI is using NuGet.Client libraries, this was trivial to implement.

## Testing

See added NUnit tests for installing/upgrading from a local source.

For remote sources:
1. Run `.\choco.exe install wget --force --skip-powershell --debug`
1. Validate that the previous command logged the source and download url
1. Run `.\choco.exe upgrade wget --force --skip-powershell --debug`
1. Validate that the previous command logged the source and download url
1. Run `.\choco.exe install dotnet-all --force --skip-powershell --debug`
1. Validate that the previous command logged the source and download url for each downloaded package

### Operating Systems Testing
- Windows 10 22H2

## Change Types Made

* [ ] Bug fix (non-breaking change).
* [x] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [x] Tests to cover my changes, have been added.
* [x] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue

Fixes #1485