### PR TITLE
(#3281) Add validation for cache folder permissions

### DIFF
--- a/src/chocolatey/chocolatey.csproj
+++ b/src/chocolatey/chocolatey.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\packages\Microsoft.CodeAnalysis.BannedApiAnalyzers.3.3.3\build\Microsoft.CodeAnalysis.BannedApiAnalyzers.props" Condition="Exists('..\packages\Microsoft.CodeAnalysis.BannedApiAnalyzers.3.3.3\build\Microsoft.CodeAnalysis.BannedApiAnalyzers.props')" />
   <PropertyGroup>
@@ -241,6 +241,7 @@
     <Compile Include="infrastructure.app\rules\ServicableMetadataRule.cs" />
     <Compile Include="infrastructure.app\rules\VersionMetadataRule.cs" />
     <Compile Include="infrastructure.app\services\RuleService.cs" />
+    <Compile Include="infrastructure.app\validations\CacheFolderValidationLockdown.cs" />
     <Compile Include="infrastructure\commands\ExitCodeDescription.cs" />
     <Compile Include="infrastructure\cryptography\DefaultEncryptionUtility.cs" />
     <Compile Include="infrastructure\adapters\IEncryptionUtility.cs" />

--- a/src/chocolatey/infrastructure.app/ApplicationParameters.cs
+++ b/src/chocolatey/infrastructure.app/ApplicationParameters.cs
@@ -74,6 +74,9 @@ namespace chocolatey.infrastructure.app
               System.Environment.GetFolderPath(System.Environment.SpecialFolder.UserProfile, System.Environment.SpecialFolderOption.DoNotVerify)
             : CommonAppDataChocolatey;
         public static readonly string HttpCacheUserLocation = _fileSystem.CombinePaths(UserProfilePath, ".chocolatey", "http-cache");
+        // CommonAppDataChocolatey is always set to ProgramData\Chocolatey.
+        // So we append HttpCache to that name if it is possible.
+        public static readonly string HttpCacheSystemLocation = CommonAppDataChocolatey + "HttpCache";
         public static readonly string HttpCacheLocation = GetHttpCacheLocation();
 
         public static readonly string UserLicenseFileLocation = _fileSystem.CombinePaths(UserProfilePath, "chocolatey.license.xml");
@@ -112,9 +115,7 @@ namespace chocolatey.infrastructure.app
         {
             if (ProcessInformation.IsElevated() || string.IsNullOrEmpty(System.Environment.GetFolderPath(System.Environment.SpecialFolder.UserProfile, System.Environment.SpecialFolderOption.DoNotVerify)))
             {
-                // CommonAppDataChocolatey is always set to ProgramData\Chocolatey.
-                // So we append HttpCache to that name if it is possible.
-                return CommonAppDataChocolatey + "HttpCache";
+                return HttpCacheSystemLocation;
             }
             else
             {

--- a/src/chocolatey/infrastructure.app/registration/ChocolateyRegistrationModule.cs
+++ b/src/chocolatey/infrastructure.app/registration/ChocolateyRegistrationModule.cs
@@ -82,7 +82,8 @@ namespace chocolatey.infrastructure.app.registration
 
             registrator.RegisterService<IValidation>(
                 typeof(GlobalConfigurationValidation),
-                typeof(SystemStateValidation));
+                typeof(SystemStateValidation),
+                typeof(CacheFolderLockdownValidation));
 
             // Rule registrations
             registrator.RegisterService<IRuleService, RuleService>();

--- a/src/chocolatey/infrastructure.app/validations/CacheFolderValidationLockdown.cs
+++ b/src/chocolatey/infrastructure.app/validations/CacheFolderValidationLockdown.cs
@@ -78,7 +78,7 @@ namespace chocolatey.infrastructure.app.validations
                     result.Add(new ValidationResult
                     {
                         ExitCode = 0,
-                        Message = "System Cache directory is not locked down to administrators. Remove the directory '{0}' to have Chocolatey CLI create it with the proper permissions.".FormatWith(cacheFolderPath),
+                        Message = "System Cache directory is not locked down to administrators.\nRemove the directory '{0}' to have Chocolatey CLI create it with the proper permissions.".FormatWith(cacheFolderPath).SplitOnSpace(linePrefix: "   "),
                         Status = ValidationStatus.Warning
                     });
                 }
@@ -106,7 +106,7 @@ namespace chocolatey.infrastructure.app.validations
                 result.Add(new ValidationResult
                 {
                     ExitCode = 1, // Should we error?
-                    Message = "System Cache directory was not created, or could not be locked down to administrators.",
+                    Message = "System Cache directory was not created, or could not be locked down to administrators.".SplitOnSpace(linePrefix: "   "),
                     Status = ValidationStatus.Error
                 });
             }

--- a/src/chocolatey/infrastructure.app/validations/CacheFolderValidationLockdown.cs
+++ b/src/chocolatey/infrastructure.app/validations/CacheFolderValidationLockdown.cs
@@ -1,0 +1,127 @@
+﻿// Copyright © 2017 - 2023 Chocolatey Software, Inc
+// Copyright © 2011 - 2017 RealDimensions Software, LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace chocolatey.infrastructure.app.validations
+{
+    using System;
+    using System.Collections.Generic;
+    using chocolatey.infrastructure.app.configuration;
+    using chocolatey.infrastructure.filesystem;
+    using chocolatey.infrastructure.information;
+    using chocolatey.infrastructure.validations;
+
+    public sealed class CacheFolderLockdownValidation : IValidation
+    {
+        private readonly IFileSystem _fileSystem;
+
+        public CacheFolderLockdownValidation(IFileSystem fileSystem)
+        {
+            _fileSystem = fileSystem;
+        }
+
+        public ICollection<ValidationResult> Validate(ChocolateyConfiguration config)
+        {
+            this.Log().Debug("Cache Folder Lockdown Checks:");
+
+            var result = new List<ValidationResult>();
+
+            if (!ProcessInformation.IsElevated() && !string.IsNullOrEmpty(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile, Environment.SpecialFolderOption.DoNotVerify)))
+            {
+                this.Log().Debug(" - Elevated State = Failed");
+
+                result.Add(new ValidationResult
+                {
+                    ExitCode = 0,
+                    Message = "User Cache directory is valid.",
+                    Status = ValidationStatus.Success
+                });
+
+                return result;
+            }
+
+            this.Log().Debug(" - Elevated State = Checked");
+
+            var cacheFolderPath = ApplicationParameters.HttpCacheLocation;
+
+            if (_fileSystem.DirectoryExists(cacheFolderPath))
+            {
+                this.Log().Debug(" - Folder Exists = Checked");
+
+                if (_fileSystem.IsLockedDirectory(cacheFolderPath))
+                {
+                    this.Log().Debug(" - Folder lockdown = Checked");
+
+                    result.Add(new ValidationResult
+                    {
+                        ExitCode = 0,
+                        Message = "System Cache directory is locked down to administrators.",
+                        Status = ValidationStatus.Success
+                    });
+                }
+                else
+                {
+                    this.Log().Debug(" - Folder lockdown = Failed");
+
+                    result.Add(new ValidationResult
+                    {
+                        ExitCode = 0,
+                        Message = "System Cache directory is not locked down to administrators. Remove the directory '{0}' to have Chocolatey CLI create it with the proper permissions.".FormatWith(cacheFolderPath),
+                        Status = ValidationStatus.Warning
+                    });
+                }
+
+                return result;
+            }
+
+            this.Log().Debug(" - Folder Exists = Failed");
+
+            if (_fileSystem.LockDirectory(cacheFolderPath))
+            {
+                this.Log().Debug(" - Folder lockdown update = Success");
+
+                result.Add(new ValidationResult
+                {
+                    ExitCode = 0,
+                    Message = "System Cache directory successfullly created and locked down to administrators.",
+                    Status = ValidationStatus.Success,
+                });
+            }
+            else
+            {
+                this.Log().Debug(" - Folder lockdown update = Failed");
+
+                result.Add(new ValidationResult
+                {
+                    ExitCode = 1, // Should we error?
+                    Message = "System Cache directory was not created, or could not be locked down to administrators.",
+                    Status = ValidationStatus.Error
+                });
+            }
+
+            return result;
+        }
+
+#pragma warning disable IDE1006
+
+        [Obsolete("This overload is deprecated and will be removed in v3.")]
+        public ICollection<ValidationResult> validate(ChocolateyConfiguration config)
+        {
+            return Validate(config);
+        }
+
+#pragma warning restore IDE1006
+    }
+}

--- a/src/chocolatey/infrastructure/filesystem/IFileSystem.cs
+++ b/src/chocolatey/infrastructure/filesystem/IFileSystem.cs
@@ -444,6 +444,10 @@ namespace chocolatey.infrastructure.filesystem
         /// <param name="isSilent">Should this method be silent? false by default</param>
         void DeleteDirectoryChecked(string directoryPath, bool recursive, bool overrideAttributes, bool isSilent);
 
+        bool IsLockedDirectory(string directoryPath);
+
+        bool LockDirectory(string directoryPath);
+
         #endregion
 
         /// <summary>


### PR DESCRIPTION
## Description Of Changes

These changes introduces a new validation check to ensure that
the system cache folder that is used for storing NuGet responses
have been properly locked down to administrators.

When the directory exists, and allows modifications or creations of
files by normal user this will output a validation warning about steps
that can be taken to lock down the directory.

When the directory does not exist, this same validation check ensure
that the directory is created while only allowing Administrators to
modify, create or delete anything in the folder.

## Motivation and Context

We should do what we can to prevent malicious users to make modifications to something that can have reporcussions for the user that is installing a package.

## Testing

### Elevated tests

1. Create directory `C:\ProgramData\ChocolateyHttpCache` and delete any log files
2. Run the command `choco search vcredist140`
3. Validate the following warning is 
   ![image](https://github.com/chocolatey/choco/assets/1474648/37da9975-62ae-48cc-8727-70ed0d38ddf6)
4. Validate log file contains
   ![image](https://github.com/chocolatey/choco/assets/1474648/dbee5ee1-faa6-45d3-ae0e-4e7a02c8c8b8)
5. Delete folder `C:\ProgramData\ChocolateyHttpCache` and log file
6. Run `choco search vcredist140`
7. Validate no warning is shown in console
8. Validate log file contains
   ![image](https://github.com/chocolatey/choco/assets/1474648/9cf0a0f4-6092-4ea4-8dda-06a642926f9f)
9. Delete log file again (Do not remove cache folder)
10. Run `choco search vcredist140` again
11. Validate no warning is shown in console
12. Validate log file contains image
    ![image](https://github.com/chocolatey/choco/assets/1474648/a05064ad-1e20-41be-976e-914035c00466)

### Non-Elevated tests

1. Create directory `C:\Users\<USERNAME>\.chocolatey\http-cache` and recreate folder `C:\ProgramData\ChocolateyHttpCache`
2. Run the command `choco search vcredist140 —debug`
3. Validate no warning is shown
4. Validate console output contains image
   ![image](https://github.com/chocolatey/choco/assets/1474648/b307715a-a8f6-4c03-a2ab-10f617ba1a2b)
5. Delete Folder `C:\Users\<USERNAME>\.chocolatey\http-cache`
6. Replay steps 2-4
7. Replay again steps 2-4

### Operating Systems Testing

- Windows Server 2022

## Change Types Made

* [ ] Bug fix (non-breaking change).
* [x] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [x] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue

Fixes #3281

