### PR TITLE
(#1021) Use credentials for downloads

### DIFF
--- a/src/chocolatey.resources/helpers/functions/Get-WebFile.ps1
+++ b/src/chocolatey.resources/helpers/functions/Get-WebFile.ps1
@@ -66,6 +66,9 @@ Silences the progress output.
 .PARAMETER Options
 OPTIONAL - Specify custom headers.
 
+.PARAMETER Credentials
+OPTIONAL A System.Net.ICredentials-Object that can be used for downloading files from a server which requires user authentication.
+
 .PARAMETER IgnoredArguments
 Allows splatting with arguments that do not apply. Do not use directly.
 
@@ -88,6 +91,7 @@ Get-WebFileName
         [parameter(Mandatory = $false)][switch] $Passthru,
         [parameter(Mandatory = $false)][switch] $quiet,
         [parameter(Mandatory = $false)][hashtable] $options = @{Headers = @{} },
+        [parameter(Mandatory = $false)][System.Net.ICredentials] $credentials = $null,
         [parameter(ValueFromRemainingArguments = $true)][Object[]] $ignoredArguments
     )
 
@@ -110,7 +114,10 @@ Get-WebFileName
 
     $req = [System.Net.HttpWebRequest]::Create($url);
     $defaultCreds = [System.Net.CredentialCache]::DefaultCredentials
-    if ($defaultCreds -ne $null) {
+    if ($null -ne $credentials) {
+        $req.Credentials = $credentials
+    }
+    elseif ($defaultCreds -ne $null) {
         $req.Credentials = $defaultCreds
     }
 

--- a/src/chocolatey.resources/helpers/functions/Get-WebFileName.ps1
+++ b/src/chocolatey.resources/helpers/functions/Get-WebFileName.ps1
@@ -53,6 +53,9 @@ from the url response.
 The user agent to use as part of the request. Defaults to 'chocolatey
 command line'.
 
+.PARAMETER Credentials
+OPTIONAL A System.Net.ICredentials-Object that can be used for downloading files from a server which requires user authentication.
+
 .PARAMETER IgnoredArguments
 Allows splatting with arguments that do not apply. Do not use directly.
 
@@ -69,6 +72,7 @@ Get-ChocolateyWebFile
         [parameter(Mandatory = $false, Position = 0)][string] $url = '',
         [parameter(Mandatory = $true, Position = 1)][string] $defaultName,
         [parameter(Mandatory = $false)][string] $userAgent = 'chocolatey command line',
+        [parameter(Mandatory = $false)][System.Net.ICredentials] $credentials = $null,
         [parameter(ValueFromRemainingArguments = $true)][Object[]] $ignoredArguments
     )
 
@@ -107,7 +111,10 @@ Get-ChocolateyWebFile
     }
 
     $defaultCreds = [System.Net.CredentialCache]::DefaultCredentials
-    if ($defaultCreds -ne $null) {
+    if ($null -ne $credentials) {
+        $request.Credentials = $credentials
+    }
+    elseif ($defaultCreds -ne $null) {
         $request.Credentials = $defaultCreds
     }
 

--- a/src/chocolatey.resources/helpers/functions/Get-WebHeaders.ps1
+++ b/src/chocolatey.resources/helpers/functions/Get-WebHeaders.ps1
@@ -37,6 +37,9 @@ This is the url to get a request/response from.
 The user agent to use as part of the request. Defaults to 'chocolatey
 command line'.
 
+.PARAMETER Credentials
+OPTIONAL A System.Net.ICredentials-Object that can be used for downloading files from a server which requires user authentication.
+
 .PARAMETER IgnoredArguments
 Allows splatting with arguments that do not apply. Do not use directly.
 
@@ -52,6 +55,7 @@ Get-WebFile
     param(
         [parameter(Mandatory = $false, Position = 0)][string] $url = '',
         [parameter(Mandatory = $false, Position = 1)][string] $userAgent = 'chocolatey command line',
+        [parameter(Mandatory = $false)][System.Net.ICredentials] $credentials = $null,
         [parameter(ValueFromRemainingArguments = $true)][Object[]] $ignoredArguments
     )
 
@@ -63,7 +67,10 @@ Get-WebFile
 
     $request = [System.Net.HttpWebRequest]::Create($url);
     $defaultCreds = [System.Net.CredentialCache]::DefaultCredentials
-    if ($defaultCreds -ne $null) {
+    if ($null -ne $credentials) {
+        $request.Credentials = $credentials
+    }
+    elseif ($defaultCreds -ne $null) {
         $request.Credentials = $defaultCreds
     }
 

--- a/src/chocolatey.resources/helpers/functions/Install-ChocolateyPackage.ps1
+++ b/src/chocolatey.resources/helpers/functions/Install-ChocolateyPackage.ps1
@@ -217,6 +217,9 @@ be used in place.
 NOTE: You can also use `Install-ChocolateyInstallPackage` for the same
 functionality (see links).
 
+.PARAMETER Credentials
+OPTIONAL A System.Net.ICredentials-Object that can be used for downloading files from a server which requires user authentication.
+
 .PARAMETER IgnoredArguments
 Allows splatting with arguments that do not apply. Do not use directly.
 
@@ -364,6 +367,7 @@ Install-ChocolateyZipPackage
         [alias("useOnlyPackageSilentArgs")][switch] $useOnlyPackageSilentArguments = $false,
         [parameter(Mandatory = $false)][switch]$useOriginalLocation,
         [parameter(Mandatory = $false)][scriptblock] $beforeInstall,
+        [parameter(Mandatory = $false)][System.Net.ICredentials] $credentials = $null,
         [parameter(ValueFromRemainingArguments = $true)][Object[]] $ignoredArguments
     )
     [string]$silentArgs = $silentArgs -join ' '
@@ -413,6 +417,7 @@ Install-ChocolateyZipPackage
             -Checksum64 $checksum64 `
             -ChecksumType64 $checksumType64 `
             -Options $options `
+            -Credentials $credentials `
             -GetOriginalFileName
     }
 

--- a/src/chocolatey.resources/helpers/functions/Install-ChocolateyPowershellCommand.ps1
+++ b/src/chocolatey.resources/helpers/functions/Install-ChocolateyPowershellCommand.ps1
@@ -136,6 +136,9 @@ The recommendation is to use at least SHA256.
 .PARAMETER Options
 OPTIONAL - Specify custom headers.
 
+.PARAMETER Credentials
+OPTIONAL A System.Net.ICredentials-Object that can be used for downloading files from a server which requires user authentication.
+
 .PARAMETER IgnoredArguments
 Allows splatting with arguments that do not apply. Do not use directly.
 
@@ -187,13 +190,14 @@ Install-ChocolateyZipPackage
         [parameter(Mandatory = $false)][string] $checksum64 = '',
         [parameter(Mandatory = $false)][string] $checksumType64 = '',
         [parameter(Mandatory = $false)][hashtable] $options = @{Headers = @{} },
+        [parameter(Mandatory = $false)][System.Net.ICredentials] $credentials = $null,
         [parameter(ValueFromRemainingArguments = $true)][Object[]] $ignoredArguments
     )
 
     Write-FunctionCallLogMessage -Invocation $MyInvocation -Parameters $PSBoundParameters
 
     if ($url -ne '') {
-        Get-ChocolateyWebFile $packageName $psFileFullPath $url $url64bit -checksum $checksum -checksumType $checksumType -checksum64 $checksum64 -checksumType64 $checksumType64 -Options $options
+        Get-ChocolateyWebFile $packageName $psFileFullPath $url $url64bit -checksum $checksum -checksumType $checksumType -checksum64 $checksum64 -checksumType64 $checksumType64 -Options $options -Credentials $credentials
     }
 
     if ($env:chocolateyPackageName -ne $null -and $env:chocolateyPackageName -eq $env:ChocolateyInstallDirectoryPackage) {

--- a/src/chocolatey.resources/helpers/functions/Install-ChocolateyVsixPackage.ps1
+++ b/src/chocolatey.resources/helpers/functions/Install-ChocolateyVsixPackage.ps1
@@ -107,6 +107,9 @@ Will be used for VsixUrl if VsixUrl is empty.
 This parameter provides compatibility, but should not be used directly
 and not with the community package repository until January 2018.
 
+.PARAMETER Credentials
+OPTIONAL A System.Net.ICredentials-Object that can be used for downloading files from a server which requires user authentication.
+
 .PARAMETER IgnoredArguments
 Allows splatting with arguments that do not apply. Do not use directly.
 
@@ -144,6 +147,7 @@ Install-ChocolateyZipPackage
         [parameter(Mandatory = $false)][string] $checksumType = '',
         [parameter(Mandatory = $false)][hashtable] $options = @{Headers = @{} },
         [alias("fileFullPath")][parameter(Mandatory = $false)][string] $file = '',
+        [parameter(Mandatory = $false)][System.Net.ICredentials] $credentials = $null,
         [parameter(ValueFromRemainingArguments = $true)][Object[]] $ignoredArguments
     )
 
@@ -193,7 +197,7 @@ Install-ChocolateyZipPackage
     if ($installer) {
         $download = "$env:TEMP\$($packageName.Replace(' ','')).vsix"
         try {
-            Get-ChocolateyWebFile $packageName $download $vsixUrl -checksum $checksum -checksumType $checksumType -Options $options
+            Get-ChocolateyWebFile $packageName $download $vsixUrl -checksum $checksum -checksumType $checksumType -Options $options -Credentials $credentials
         }
         catch {
             throw "There were errors attempting to retrieve the vsix from $vsixUrl. The error message was '$_'."

--- a/src/chocolatey.resources/helpers/functions/Install-ChocolateyZipPackage.ps1
+++ b/src/chocolatey.resources/helpers/functions/Install-ChocolateyZipPackage.ps1
@@ -159,6 +159,9 @@ Usage of this parameter will prevent Uninstall-ChocolateyZipPackage
 from working, extracted files will have to be cleaned up with
 Remove-Item or a similar command instead.
 
+.PARAMETER Credentials
+OPTIONAL A System.Net.ICredentials-Object that can be used for downloading files from a server which requires user authentication.
+
 .PARAMETER IgnoredArguments
 Allows splatting with arguments that do not apply. Do not use directly.
 
@@ -200,6 +203,7 @@ Get-ChocolateyUnzip
         [alias("fileFullPath")][parameter(Mandatory = $false)][string] $file = '',
         [alias("fileFullPath64")][parameter(Mandatory = $false)][string] $file64 = '',
         [parameter(Mandatory = $false)][switch] $disableLogging,
+        [parameter(Mandatory = $false)][System.Net.ICredentials] $credentials = $null,
         [parameter(ValueFromRemainingArguments = $true)][Object[]] $ignoredArguments
     )
 
@@ -225,6 +229,6 @@ Get-ChocolateyUnzip
         $url64bit = $file64
     }
 
-    $filePath = Get-ChocolateyWebFile $packageName $downloadFilePath $url $url64bit -checkSum $checkSum -checksumType $checksumType -checkSum64 $checkSum64 -checksumType64 $checksumType64 -options $options -getOriginalFileName
+    $filePath = Get-ChocolateyWebFile $packageName $downloadFilePath $url $url64bit -checkSum $checkSum -checksumType $checksumType -checkSum64 $checkSum64 -checksumType64 $checksumType64 -options $options -getOriginalFileName -Credentials $credentials
     Get-ChocolateyUnzip "$filePath" $unzipLocation $specificFolder $packageName -disableLogging:$disableLogging
 }


### PR DESCRIPTION
## Description Of Changes
This is a fairly simple change, which adds an optional `credentials`-parameter to some of the powershell-helper-functions for downloading files from web-servers which require authentication.

The changed helper-functions are:

- Get-WebFile
- Get-WebFileName
- Get-WebHeaders
- Get-ChocolateyWebFile
- Install-ChocolateyPackage
- Install-ChocolateyPowershellCommand
- Install-ChocolateyVsixPackage
- Install-ChocolateyZipPackage

`Install-ChocolateyPackage`, `Install-ChocolateyPowershellCommand`, `Install-ChocolateyVsixPackage` and `Install-ChocolateyZipPackage` all pass the `credentials`-parameter to `Get-ChocolateyWebFile` which in turn passes the parameter to `Get-WebFile`, `Get-WebFileName` and `Get-WebHeaders`.  

The `Get-Web*`- functions utilize the `System.Net.HttpWebRequest`-Object and attach the `credentials`-Parameter to it, if it was specified at all.

The new parameter is completly optional. If you do not specify it, `$null` is passed down the functions and no credentials are used for downloading files.

## Motivation and Context
It is currently not possible to pass credentials to the helper-functions to download files from servers which require authentication.

An almost identical pull-request was made some years ago (#1031) by @Apteryx but was closed some days ago due to inactivity, hence this new pull-request for this feature.

I'm not sure if the documentation for the helper functions are updated automatically from the powershell-code, so I made no changes to any documentation so far. Please let me know if this is required/desired.

## Testing
I replaced the powershell helper-functions in a test environment directly in `C:\ProgramData\chocolatey\helpers\functions`, created a custom package and passed credentials to `Get-ChocolateyWebFile`, `Install-ChocolateyPackage` and `Install-ChocolateyZipPackage`.
The files were downloaded from a nextcloud-instance.

The credentials were created like this:

``` powershell
$password = ConvertTo-SecureString "password" -AsPlainText -Force
$credential = New-Object System.Management.Automation.PSCredential ("user", $password)
```

### Operating Systems Testing
- Windows 10 22H2
- Windows 11 22H2

## Change Types Made

* [ ] Bug fix (non-breaking change).
* [x] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [x] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [ ] All new and existing tests passed?
* [x] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue

Fixes #1021

<!-- PLEASE REMOVE ALL COMMENTS BEFORE SUBMITTING -->
