### PR TITLE
(#3291) Update Chocolatey.NuGet.Client libraries to 3.4.2

### DIFF
--- a/docs/legal/CREDITS.md
+++ b/docs/legal/CREDITS.md
@@ -707,7 +707,7 @@ Chocolatey uses [Microsoft.Web.Xdt](https://www.nuget.org/packages/Microsoft.Web
   It also applies even if Microsoft knew or should have known about the possibility of the damages. The above limitation or exclusion may not apply to you because your country may not allow the exclusion or limitation of incidental, consequential or other damages.
 ```
 
-### Chocolatey.NuGet.Client @ 3.4.0
+### Chocolatey.NuGet.Client @ 3.4.2
 
 Chocolatey uses [NuGet.Client](https://github.com/NuGet/NuGet.Client) [(modified)](https://github.com/chocolatey/NuGet.Client) to work with packaging.
 [License terms](https://github.com/NuGet/NuGet.Client/blob/72f9f2b2eab28c9d91a22065c55aa7702abf7e01/LICENSE.txt):

--- a/src/chocolatey.tests.integration/chocolatey.tests.integration.csproj
+++ b/src/chocolatey.tests.integration/chocolatey.tests.integration.csproj
@@ -80,22 +80,22 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Chocolatey.NuGet.Common">
-      <HintPath>..\packages\Chocolatey.NuGet.Common.3.4.0\lib\net472\Chocolatey.NuGet.Common.dll</HintPath>
+      <HintPath>..\packages\Chocolatey.NuGet.Common.3.4.2\lib\net472\Chocolatey.NuGet.Common.dll</HintPath>
     </Reference>
     <Reference Include="Chocolatey.NuGet.Configuration">
-      <HintPath>..\packages\Chocolatey.NuGet.Configuration.3.4.0\lib\net472\Chocolatey.NuGet.Configuration.dll</HintPath>
+      <HintPath>..\packages\Chocolatey.NuGet.Configuration.3.4.2\lib\net472\Chocolatey.NuGet.Configuration.dll</HintPath>
     </Reference>
     <Reference Include="Chocolatey.NuGet.Frameworks">
-      <HintPath>..\packages\Chocolatey.NuGet.Frameworks.3.4.0\lib\net472\Chocolatey.NuGet.Frameworks.dll</HintPath>
+      <HintPath>..\packages\Chocolatey.NuGet.Frameworks.3.4.2\lib\net472\Chocolatey.NuGet.Frameworks.dll</HintPath>
     </Reference>
     <Reference Include="Chocolatey.NuGet.Packaging">
-      <HintPath>..\packages\Chocolatey.NuGet.Packaging.3.4.0\lib\net472\Chocolatey.NuGet.Packaging.dll</HintPath>
+      <HintPath>..\packages\Chocolatey.NuGet.Packaging.3.4.2\lib\net472\Chocolatey.NuGet.Packaging.dll</HintPath>
     </Reference>
     <Reference Include="Chocolatey.NuGet.Protocol">
-      <HintPath>..\packages\Chocolatey.NuGet.Protocol.3.4.0\lib\net472\Chocolatey.NuGet.Protocol.dll</HintPath>
+      <HintPath>..\packages\Chocolatey.NuGet.Protocol.3.4.2\lib\net472\Chocolatey.NuGet.Protocol.dll</HintPath>
     </Reference>
     <Reference Include="Chocolatey.NuGet.Versioning">
-      <HintPath>..\packages\Chocolatey.NuGet.Versioning.3.4.0\lib\net472\Chocolatey.NuGet.Versioning.dll</HintPath>
+      <HintPath>..\packages\Chocolatey.NuGet.Versioning.3.4.2\lib\net472\Chocolatey.NuGet.Versioning.dll</HintPath>
     </Reference>
     <Reference Include="FluentAssertions, Version=6.11.0.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
       <HintPath>..\packages\FluentAssertions.6.11.0\lib\net47\FluentAssertions.dll</HintPath>

--- a/src/chocolatey.tests.integration/packages.config
+++ b/src/chocolatey.tests.integration/packages.config
@@ -1,11 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Chocolatey.NuGet.Common" version="3.4.0" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.Configuration" version="3.4.0" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.Frameworks" version="3.4.0" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.Packaging" version="3.4.0" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.Protocol" version="3.4.0" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.Versioning" version="3.4.0" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.Common" version="3.4.2" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.Configuration" version="3.4.2" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.Frameworks" version="3.4.2" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.Packaging" version="3.4.2" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.Protocol" version="3.4.2" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.Versioning" version="3.4.2" targetFramework="net48" />
   <package id="FluentAssertions" version="6.11.0" targetFramework="net48" />
   <package id="FluentAssertions.Analyzers" version="0.19.1" targetFramework="net48" developmentDependency="true" />
   <package id="log4net" version="2.0.12" targetFramework="net48" />

--- a/src/chocolatey.tests/chocolatey.tests.csproj
+++ b/src/chocolatey.tests/chocolatey.tests.csproj
@@ -79,43 +79,43 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Chocolatey.NuGet.Commands">
-      <HintPath>..\packages\Chocolatey.NuGet.Commands.3.4.0\lib\net472\Chocolatey.NuGet.Commands.dll</HintPath>
+      <HintPath>..\packages\Chocolatey.NuGet.Commands.3.4.2\lib\net472\Chocolatey.NuGet.Commands.dll</HintPath>
     </Reference>
     <Reference Include="Chocolatey.NuGet.Common">
-      <HintPath>..\packages\Chocolatey.NuGet.Common.3.4.0\lib\net472\Chocolatey.NuGet.Common.dll</HintPath>
+      <HintPath>..\packages\Chocolatey.NuGet.Common.3.4.2\lib\net472\Chocolatey.NuGet.Common.dll</HintPath>
     </Reference>
     <Reference Include="Chocolatey.NuGet.Configuration">
-      <HintPath>..\packages\Chocolatey.NuGet.Configuration.3.4.0\lib\net472\Chocolatey.NuGet.Configuration.dll</HintPath>
+      <HintPath>..\packages\Chocolatey.NuGet.Configuration.3.4.2\lib\net472\Chocolatey.NuGet.Configuration.dll</HintPath>
     </Reference>
     <Reference Include="Chocolatey.NuGet.Credentials">
-      <HintPath>..\packages\Chocolatey.NuGet.Credentials.3.4.0\lib\net472\Chocolatey.NuGet.Credentials.dll</HintPath>
+      <HintPath>..\packages\Chocolatey.NuGet.Credentials.3.4.2\lib\net472\Chocolatey.NuGet.Credentials.dll</HintPath>
     </Reference>
     <Reference Include="Chocolatey.NuGet.DependencyResolver.Core">
-      <HintPath>..\packages\Chocolatey.NuGet.DependencyResolver.Core.3.4.0\lib\net472\Chocolatey.NuGet.DependencyResolver.Core.dll</HintPath>
+      <HintPath>..\packages\Chocolatey.NuGet.DependencyResolver.Core.3.4.2\lib\net472\Chocolatey.NuGet.DependencyResolver.Core.dll</HintPath>
     </Reference>
     <Reference Include="Chocolatey.NuGet.Frameworks">
-      <HintPath>..\packages\Chocolatey.NuGet.Frameworks.3.4.0\lib\net472\Chocolatey.NuGet.Frameworks.dll</HintPath>
+      <HintPath>..\packages\Chocolatey.NuGet.Frameworks.3.4.2\lib\net472\Chocolatey.NuGet.Frameworks.dll</HintPath>
     </Reference>
     <Reference Include="Chocolatey.NuGet.LibraryModel">
-      <HintPath>..\packages\Chocolatey.NuGet.LibraryModel.3.4.0\lib\net472\Chocolatey.NuGet.LibraryModel.dll</HintPath>
+      <HintPath>..\packages\Chocolatey.NuGet.LibraryModel.3.4.2\lib\net472\Chocolatey.NuGet.LibraryModel.dll</HintPath>
     </Reference>
     <Reference Include="Chocolatey.NuGet.PackageManagement">
-      <HintPath>..\packages\Chocolatey.NuGet.PackageManagement.3.4.0\lib\net472\Chocolatey.NuGet.PackageManagement.dll</HintPath>
+      <HintPath>..\packages\Chocolatey.NuGet.PackageManagement.3.4.2\lib\net472\Chocolatey.NuGet.PackageManagement.dll</HintPath>
     </Reference>
     <Reference Include="Chocolatey.NuGet.Packaging">
-      <HintPath>..\packages\Chocolatey.NuGet.Packaging.3.4.0\lib\net472\Chocolatey.NuGet.Packaging.dll</HintPath>
+      <HintPath>..\packages\Chocolatey.NuGet.Packaging.3.4.2\lib\net472\Chocolatey.NuGet.Packaging.dll</HintPath>
     </Reference>
     <Reference Include="Chocolatey.NuGet.ProjectModel">
-      <HintPath>..\packages\Chocolatey.NuGet.ProjectModel.3.4.0\lib\net472\Chocolatey.NuGet.ProjectModel.dll</HintPath>
+      <HintPath>..\packages\Chocolatey.NuGet.ProjectModel.3.4.2\lib\net472\Chocolatey.NuGet.ProjectModel.dll</HintPath>
     </Reference>
     <Reference Include="Chocolatey.NuGet.Protocol">
-      <HintPath>..\packages\Chocolatey.NuGet.Protocol.3.4.0\lib\net472\Chocolatey.NuGet.Protocol.dll</HintPath>
+      <HintPath>..\packages\Chocolatey.NuGet.Protocol.3.4.2\lib\net472\Chocolatey.NuGet.Protocol.dll</HintPath>
     </Reference>
     <Reference Include="Chocolatey.NuGet.Resolver">
-      <HintPath>..\packages\Chocolatey.NuGet.Resolver.3.4.0\lib\net472\Chocolatey.NuGet.Resolver.dll</HintPath>
+      <HintPath>..\packages\Chocolatey.NuGet.Resolver.3.4.2\lib\net472\Chocolatey.NuGet.Resolver.dll</HintPath>
     </Reference>
     <Reference Include="Chocolatey.NuGet.Versioning">
-      <HintPath>..\packages\Chocolatey.NuGet.Versioning.3.4.0\lib\net472\Chocolatey.NuGet.Versioning.dll</HintPath>
+      <HintPath>..\packages\Chocolatey.NuGet.Versioning.3.4.2\lib\net472\Chocolatey.NuGet.Versioning.dll</HintPath>
     </Reference>
     <Reference Include="FluentAssertions, Version=6.11.0.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
       <HintPath>..\packages\FluentAssertions.6.11.0\lib\net47\FluentAssertions.dll</HintPath>

--- a/src/chocolatey.tests/packages.config
+++ b/src/chocolatey.tests/packages.config
@@ -1,18 +1,18 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Chocolatey.NuGet.Commands" version="3.4.0" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.Common" version="3.4.0" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.Configuration" version="3.4.0" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.Credentials" version="3.4.0" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.DependencyResolver.Core" version="3.4.0" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.Frameworks" version="3.4.0" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.LibraryModel" version="3.4.0" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.PackageManagement" version="3.4.0" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.Packaging" version="3.4.0" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.ProjectModel" version="3.4.0" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.Protocol" version="3.4.0" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.Resolver" version="3.4.0" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.Versioning" version="3.4.0" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.Commands" version="3.4.2" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.Common" version="3.4.2" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.Configuration" version="3.4.2" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.Credentials" version="3.4.2" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.DependencyResolver.Core" version="3.4.2" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.Frameworks" version="3.4.2" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.LibraryModel" version="3.4.2" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.PackageManagement" version="3.4.2" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.Packaging" version="3.4.2" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.ProjectModel" version="3.4.2" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.Protocol" version="3.4.2" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.Resolver" version="3.4.2" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.Versioning" version="3.4.2" targetFramework="net48" />
   <package id="FluentAssertions" version="6.11.0" targetFramework="net48" />
   <package id="FluentAssertions.Analyzers" version="0.19.1" targetFramework="net48" developmentDependency="true" />
   <package id="log4net" version="2.0.12" targetFramework="net48" />

--- a/src/chocolatey/chocolatey.csproj
+++ b/src/chocolatey/chocolatey.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\packages\Microsoft.CodeAnalysis.BannedApiAnalyzers.3.3.3\build\Microsoft.CodeAnalysis.BannedApiAnalyzers.props" Condition="Exists('..\packages\Microsoft.CodeAnalysis.BannedApiAnalyzers.3.3.3\build\Microsoft.CodeAnalysis.BannedApiAnalyzers.props')" />
   <PropertyGroup>
@@ -103,43 +103,43 @@
       <HintPath>..\packages\AlphaFS.2.1.3\lib\net40\AlphaFS.dll</HintPath>
     </Reference>
     <Reference Include="Chocolatey.NuGet.Commands">
-      <HintPath>..\packages\Chocolatey.NuGet.Commands.3.4.0\lib\net472\Chocolatey.NuGet.Commands.dll</HintPath>
+      <HintPath>..\packages\Chocolatey.NuGet.Commands.3.4.2\lib\net472\Chocolatey.NuGet.Commands.dll</HintPath>
     </Reference>
     <Reference Include="Chocolatey.NuGet.Common">
-      <HintPath>..\packages\Chocolatey.NuGet.Common.3.4.0\lib\net472\Chocolatey.NuGet.Common.dll</HintPath>
+      <HintPath>..\packages\Chocolatey.NuGet.Common.3.4.2\lib\net472\Chocolatey.NuGet.Common.dll</HintPath>
     </Reference>
     <Reference Include="Chocolatey.NuGet.Configuration">
-      <HintPath>..\packages\Chocolatey.NuGet.Configuration.3.4.0\lib\net472\Chocolatey.NuGet.Configuration.dll</HintPath>
+      <HintPath>..\packages\Chocolatey.NuGet.Configuration.3.4.2\lib\net472\Chocolatey.NuGet.Configuration.dll</HintPath>
     </Reference>
     <Reference Include="Chocolatey.NuGet.Credentials">
-      <HintPath>..\packages\Chocolatey.NuGet.Credentials.3.4.0\lib\net472\Chocolatey.NuGet.Credentials.dll</HintPath>
+      <HintPath>..\packages\Chocolatey.NuGet.Credentials.3.4.2\lib\net472\Chocolatey.NuGet.Credentials.dll</HintPath>
     </Reference>
     <Reference Include="Chocolatey.NuGet.DependencyResolver.Core">
-      <HintPath>..\packages\Chocolatey.NuGet.DependencyResolver.Core.3.4.0\lib\net472\Chocolatey.NuGet.DependencyResolver.Core.dll</HintPath>
+      <HintPath>..\packages\Chocolatey.NuGet.DependencyResolver.Core.3.4.2\lib\net472\Chocolatey.NuGet.DependencyResolver.Core.dll</HintPath>
     </Reference>
     <Reference Include="Chocolatey.NuGet.Frameworks">
-      <HintPath>..\packages\Chocolatey.NuGet.Frameworks.3.4.0\lib\net472\Chocolatey.NuGet.Frameworks.dll</HintPath>
+      <HintPath>..\packages\Chocolatey.NuGet.Frameworks.3.4.2\lib\net472\Chocolatey.NuGet.Frameworks.dll</HintPath>
     </Reference>
     <Reference Include="Chocolatey.NuGet.LibraryModel">
-      <HintPath>..\packages\Chocolatey.NuGet.LibraryModel.3.4.0\lib\net472\Chocolatey.NuGet.LibraryModel.dll</HintPath>
+      <HintPath>..\packages\Chocolatey.NuGet.LibraryModel.3.4.2\lib\net472\Chocolatey.NuGet.LibraryModel.dll</HintPath>
     </Reference>
     <Reference Include="Chocolatey.NuGet.PackageManagement">
-      <HintPath>..\packages\Chocolatey.NuGet.PackageManagement.3.4.0\lib\net472\Chocolatey.NuGet.PackageManagement.dll</HintPath>
+      <HintPath>..\packages\Chocolatey.NuGet.PackageManagement.3.4.2\lib\net472\Chocolatey.NuGet.PackageManagement.dll</HintPath>
     </Reference>
     <Reference Include="Chocolatey.NuGet.Packaging">
-      <HintPath>..\packages\Chocolatey.NuGet.Packaging.3.4.0\lib\net472\Chocolatey.NuGet.Packaging.dll</HintPath>
+      <HintPath>..\packages\Chocolatey.NuGet.Packaging.3.4.2\lib\net472\Chocolatey.NuGet.Packaging.dll</HintPath>
     </Reference>
     <Reference Include="Chocolatey.NuGet.ProjectModel">
-      <HintPath>..\packages\Chocolatey.NuGet.ProjectModel.3.4.0\lib\net472\Chocolatey.NuGet.ProjectModel.dll</HintPath>
+      <HintPath>..\packages\Chocolatey.NuGet.ProjectModel.3.4.2\lib\net472\Chocolatey.NuGet.ProjectModel.dll</HintPath>
     </Reference>
     <Reference Include="Chocolatey.NuGet.Protocol">
-      <HintPath>..\packages\Chocolatey.NuGet.Protocol.3.4.0\lib\net472\Chocolatey.NuGet.Protocol.dll</HintPath>
+      <HintPath>..\packages\Chocolatey.NuGet.Protocol.3.4.2\lib\net472\Chocolatey.NuGet.Protocol.dll</HintPath>
     </Reference>
     <Reference Include="Chocolatey.NuGet.Resolver">
-      <HintPath>..\packages\Chocolatey.NuGet.Resolver.3.4.0\lib\net472\Chocolatey.NuGet.Resolver.dll</HintPath>
+      <HintPath>..\packages\Chocolatey.NuGet.Resolver.3.4.2\lib\net472\Chocolatey.NuGet.Resolver.dll</HintPath>
     </Reference>
     <Reference Include="Chocolatey.NuGet.Versioning">
-      <HintPath>..\packages\Chocolatey.NuGet.Versioning.3.4.0\lib\net472\Chocolatey.NuGet.Versioning.dll</HintPath>
+      <HintPath>..\packages\Chocolatey.NuGet.Versioning.3.4.2\lib\net472\Chocolatey.NuGet.Versioning.dll</HintPath>
     </Reference>
     <Reference Include="log4net, Version=2.0.12.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
       <HintPath>..\packages\log4net.2.0.12\lib\net45\log4net.dll</HintPath>

--- a/src/chocolatey/packages.config
+++ b/src/chocolatey/packages.config
@@ -1,19 +1,19 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="AlphaFS" version="2.1.3" targetFramework="net40-Client" />
-  <package id="Chocolatey.NuGet.Commands" version="3.4.0" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.Common" version="3.4.0" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.Configuration" version="3.4.0" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.Credentials" version="3.4.0" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.DependencyResolver.Core" version="3.4.0" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.Frameworks" version="3.4.0" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.LibraryModel" version="3.4.0" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.PackageManagement" version="3.4.0" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.Packaging" version="3.4.0" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.ProjectModel" version="3.4.0" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.Protocol" version="3.4.0" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.Resolver" version="3.4.0" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.Versioning" version="3.4.0" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.Commands" version="3.4.2" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.Common" version="3.4.2" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.Configuration" version="3.4.2" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.Credentials" version="3.4.2" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.DependencyResolver.Core" version="3.4.2" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.Frameworks" version="3.4.2" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.LibraryModel" version="3.4.2" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.PackageManagement" version="3.4.2" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.Packaging" version="3.4.2" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.ProjectModel" version="3.4.2" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.Protocol" version="3.4.2" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.Resolver" version="3.4.2" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.Versioning" version="3.4.2" targetFramework="net48" />
   <package id="log4net" version="2.0.12" targetFramework="net48" />
   <package id="Microsoft.Bcl.HashCode" version="1.1.1" targetFramework="net48" />
   <package id="Microsoft.CodeAnalysis.BannedApiAnalyzers" version="3.3.3" targetFramework="net48" developmentDependency="true" />


### PR DESCRIPTION
## Description Of Changes

To fix a bug in licensed extension when downloading packages and the cache location is set to a restricted folder, there was a need to update Chocolatey.NuGet.Client and pull in the changes to Chocolatey CLI. This PR makes the necessary changes for this.

## Motivation and Context

See description

## Testing

See the testing step in the NuGet.Client PR: https://github.com/chocolatey/NuGet.Client/pull/47

### Operating Systems Testing

- Windows 10
- Windows Server 2022

## Change Types Made

* [ ] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.
* [ ] Version Update

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [x] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue

Fixes #3291 
