### PR TITLE
(#3315) Save software installation location

### DIFF
--- a/src/chocolatey/infrastructure.app/domain/ChocolateyPackageInformation.cs
+++ b/src/chocolatey/infrastructure.app/domain/ChocolateyPackageInformation.cs
@@ -36,5 +36,6 @@ namespace chocolatey.infrastructure.app.domain
         public bool HasSilentUninstall { get; set; }
         public bool IsPinned { get; set; }
         public string ExtraInformation { get; set; }
+        public string DeploymentLocation { get; set; }
     }
 }

--- a/src/chocolatey/infrastructure.app/services/ChocolateyPackageService.cs
+++ b/src/chocolatey/infrastructure.app/services/ChocolateyPackageService.cs
@@ -566,6 +566,8 @@ Did you know Pro / Business automatically syncs with Programs and
                 }
             }
 
+            pkgInfo.DeploymentLocation = Environment.GetEnvironmentVariable(ApplicationParameters.Environment.ChocolateyPackageInstallLocation);
+
             UpdatePackageInformation(pkgInfo);
             EnsureBadPackagesPathIsClean(packageResult);
             EventManager.Publish(new HandlePackageResultCompletedMessage(packageResult, config, commandName));
@@ -601,11 +603,10 @@ package '{0}' - stopping further execution".FormatWith(packageResult.Name));
 
             this.Log().Info(ChocolateyLoggers.Important, " The {0} of {1} was successful.".FormatWith(commandName.ToStringSafe(), packageResult.Name));
 
-            var installLocation = Environment.GetEnvironmentVariable(ApplicationParameters.Environment.ChocolateyPackageInstallLocation);
             var installerDetected = Environment.GetEnvironmentVariable(ApplicationParameters.Environment.ChocolateyPackageInstallerType);
-            if (!string.IsNullOrWhiteSpace(installLocation))
+            if (!string.IsNullOrWhiteSpace(pkgInfo.DeploymentLocation))
             {
-                this.Log().Info(ChocolateyLoggers.Important, "  Software installed to '{0}'".FormatWith(installLocation.EscapeCurlyBraces()));
+                this.Log().Info(ChocolateyLoggers.Important, "  Deployed to '{0}'".FormatWith(pkgInfo.DeploymentLocation.EscapeCurlyBraces()));
             }
             else if (!string.IsNullOrWhiteSpace(installerDetected))
             {


### PR DESCRIPTION
## Description Of Changes

Saves the location of where the contents of the Chocolatey package
(whether that is a native installer, or an extraction of a zip file, or
whatever else is in the package) is deployed to into a
".deploymentLocation" file inside the package info directory.

This allows Chocolatey CLI or GUI to later retrieve it and display it to
the user when listing the details of locally installed package(s).

## Motivation and Context

See #3315

## Testing

1. `.\choco.exe install wget --force`
1. Ensure that the software location is logged and a `.softwareLocation` file containing the path is created in the folder under `.chocolatey`
1. `.\choco.exe install wget --skip-powershell --force`
1. Ensure that there is no software location logged and there is no `.softwareLocation` file 
1. `.\choco.exe install balcon`
1. Ensure that the software location is logged and a `.softwareLocation` file containing the path is created in the folder under `.chocolatey`


### Operating Systems Testing
- Windows 10 22H2

## Change Types Made

* [ ] Bug fix (non-breaking change).
* [x] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [x] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue

Fixes #3315
