### PR TITLE
(#1901) Display software installation location

### DIFF
--- a/src/chocolatey/infrastructure.app/services/NugetService.cs
+++ b/src/chocolatey/infrastructure.app/services/NugetService.cs
@@ -194,7 +194,7 @@ that uses these options.");
 
                 ChocolateyPackageMetadata packageLocalMetadata;
                 string packageInstallLocation = null;
-                string softwareInstallLocation = null;
+                string deploymentLocation = null;
                 if (package.PackagePath != null && !string.IsNullOrWhiteSpace(package.PackagePath))
                 {
                     packageLocalMetadata = new ChocolateyPackageMetadata(package.PackagePath, _fileSystem);
@@ -216,7 +216,7 @@ that uses these options.");
                         }
                     }
 
-                    softwareInstallLocation = packageInfo.SoftwareInstallLocation;
+                    deploymentLocation = packageInfo.DeploymentLocation;
                 }
 
                 if (!config.QuietOutput)
@@ -278,7 +278,7 @@ that uses these options.");
                                 package.Summary != null && !string.IsNullOrWhiteSpace(package.Summary.ToStringSafe()) ? "\r\n Summary: {0}".FormatWith(package.Summary.EscapeCurlyBraces().ToStringSafe()) : string.Empty,
                                 package.Description.EscapeCurlyBraces().Replace("\n    ", "\n").Replace("\n", "\n  "),
                                 !string.IsNullOrWhiteSpace(package.ReleaseNotes.ToStringSafe()) ? "{0} Release Notes: {1}".FormatWith(Environment.NewLine, package.ReleaseNotes.EscapeCurlyBraces().Replace("\n    ", "\n").Replace("\n", "\n  ")) : string.Empty,
-                                !string.IsNullOrWhiteSpace(softwareInstallLocation) ? "{0} Software installed to: '{1}'".FormatWith(Environment.NewLine, softwareInstallLocation) : string.Empty
+                                !string.IsNullOrWhiteSpace(deploymentLocation) ? "{0} Deployed to: '{1}'".FormatWith(Environment.NewLine, deploymentLocation) : string.Empty
                             ));
                         }
                     }

--- a/src/chocolatey/infrastructure.app/services/NugetService.cs
+++ b/src/chocolatey/infrastructure.app/services/NugetService.cs
@@ -194,6 +194,7 @@ that uses these options.");
 
                 ChocolateyPackageMetadata packageLocalMetadata;
                 string packageInstallLocation = null;
+                string softwareInstallLocation = null;
                 if (package.PackagePath != null && !string.IsNullOrWhiteSpace(package.PackagePath))
                 {
                     packageLocalMetadata = new ChocolateyPackageMetadata(package.PackagePath, _fileSystem);
@@ -215,6 +216,7 @@ that uses these options.");
                         }
                     }
 
+                    softwareInstallLocation = packageInfo.SoftwareInstallLocation;
                 }
 
                 if (!config.QuietOutput)
@@ -241,7 +243,7 @@ that uses these options.");
  Tags: {9}
  Software Site: {10}
  Software License: {11}{12}{13}{14}{15}{16}
- Description: {17}{18}
+ Description: {17}{18}{19}
 ".FormatWith(
                                 package.Title.EscapeCurlyBraces(),
                                 package.Published.GetValueOrDefault().UtcDateTime.ToShortDateString(),
@@ -275,7 +277,8 @@ that uses these options.");
                                 !string.IsNullOrWhiteSpace(package.BugTrackerUrl.ToStringSafe()) ? "{0} Issues: {1}".FormatWith(Environment.NewLine, package.BugTrackerUrl.ToStringSafe()) : string.Empty,
                                 package.Summary != null && !string.IsNullOrWhiteSpace(package.Summary.ToStringSafe()) ? "\r\n Summary: {0}".FormatWith(package.Summary.EscapeCurlyBraces().ToStringSafe()) : string.Empty,
                                 package.Description.EscapeCurlyBraces().Replace("\n    ", "\n").Replace("\n", "\n  "),
-                                !string.IsNullOrWhiteSpace(package.ReleaseNotes.ToStringSafe()) ? "{0} Release Notes: {1}".FormatWith(Environment.NewLine, package.ReleaseNotes.EscapeCurlyBraces().Replace("\n    ", "\n").Replace("\n", "\n  ")) : string.Empty
+                                !string.IsNullOrWhiteSpace(package.ReleaseNotes.ToStringSafe()) ? "{0} Release Notes: {1}".FormatWith(Environment.NewLine, package.ReleaseNotes.EscapeCurlyBraces().Replace("\n    ", "\n").Replace("\n", "\n  ")) : string.Empty,
+                                !string.IsNullOrWhiteSpace(softwareInstallLocation) ? "{0} Software installed to: '{1}'".FormatWith(Environment.NewLine, softwareInstallLocation) : string.Empty
                             ));
                         }
                     }


### PR DESCRIPTION
## Description Of Changes

Displays the saved software installation location for info and list
commands. If the package has no software install location, it displays
nothing, and if the package was installed/upgraded before the saving
feature was added, again, it does not show that line.

## Motivation and Context

See #1901

## Testing

1. `.\choco.exe install balcon wget`
1. `.\choco.exe info balcon --local-only`
1. Ensure the software install location is listed
1. `.\choco.exe list --verbose`
1. Ensure the software install location is listed for both packages


### Operating Systems Testing
- Windows 10 22H2

## Change Types Made

* [ ] Bug fix (non-breaking change).
* [x] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [ ] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue

Fixes #1901
Depends on #3316 (merged)
