### PR TITLE
Fix Install-ChocolateyPath: exact check if path is present

### DIFF
--- a/src/chocolatey.resources/helpers/functions/Install-ChocolateyPath.ps1
+++ b/src/chocolatey.resources/helpers/functions/Install-ChocolateyPath.ps1
@@ -80,7 +80,8 @@ Get-ToolsLocation
     #get the PATH variable
     Update-SessionEnvironment
     $envPath = $env:PATH
-    if (!$envPath.ToLower().Contains($pathToInstall.ToLower())) {
+    $statementTerminator = ";"
+    if ($envPath -inotmatch ("(^|$statementTerminator)" + [regex]::escape($pathToInstall) + "\\?($statementTerminator|`$)")) {
         try {
             Write-Host "PATH environment variable does not have $pathToInstall in it. Adding..."
         }
@@ -90,7 +91,6 @@ Get-ToolsLocation
 
         $actualPath = Get-EnvironmentVariable -Name 'Path' -Scope $pathType -PreserveVariables
 
-        $statementTerminator = ";"
         #does the path end in ';'?
         $hasStatementTerminator = $actualPath -ne $null -and $actualPath.EndsWith($statementTerminator)
         # if the last digit is not ;, then we are adding it


### PR DESCRIPTION
## Description Of Changes
Accurately check if path exists by checking the separator before and after path. In addition, a following folder separator is ignored.

## Motivation and Context
Install-ChocolateyPath has a bug which does not accurately check if the path already exists in the PATH variable. If a subpath already exists, any parent path is no longer added. See #3318 

## Testing
By calling the patched `Install-ChocolateyPath` in the reproduction steps described in #3318. 

### Operating Systems Testing
- Windows 10


## Change Types Made

* [X] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [X] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [ ] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

I am not sure about the compatibility with PowerShell v2 - please check again first

## Related Issue
#3318 

