### PR TITLE
(maint) Fix typos and punctuation in Feature command messages

### DIFF
--- a/src/chocolatey.tests/infrastructure.app/commands/ChocolateyFeatureCommandSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/commands/ChocolateyFeatureCommandSpecs.cs
@@ -143,7 +143,7 @@ namespace chocolatey.tests.infrastructure.app.commands
                 errored.Should().BeTrue();
                 error.Should().NotBeNull();
                 error.Should().BeOfType<ApplicationException>();
-                error.Message.Should().Contain("A single features command must be listed");
+                error.Message.Should().Contain("A single feature command must be listed.");
             }
 
             [Fact]

--- a/src/chocolatey/infrastructure.app/commands/ChocolateyConfigCommand.cs
+++ b/src/chocolatey/infrastructure.app/commands/ChocolateyConfigCommand.cs
@@ -77,7 +77,7 @@ namespace chocolatey.infrastructure.app.commands
                 )
                 && unparsedArguments.Count > 1)
             {
-                throw new ApplicationException("A single features command must be listed. Please see the help menu for those commands");
+                throw new ApplicationException("A single config command must be listed. Please see the help menu for those commands.");
             }
 
             if (string.IsNullOrWhiteSpace(configuration.ConfigCommand.Name) && unparsedArguments.Count >= 2)

--- a/src/chocolatey/infrastructure.app/commands/ChocolateyFeatureCommand.cs
+++ b/src/chocolatey/infrastructure.app/commands/ChocolateyFeatureCommand.cs
@@ -74,7 +74,7 @@ namespace chocolatey.infrastructure.app.commands
                 )
                 && unparsedArguments.Count > 1)
             {
-                throw new ApplicationException("A single features command must be listed. Please see the help menu for those commands");
+                throw new ApplicationException("A single feature command must be listed. Please see the help menu for those commands.");
             }
 
             if (string.IsNullOrWhiteSpace(configuration.FeatureCommand.Name) && unparsedArguments.Count >= 2)


### PR DESCRIPTION
## Description Of Changes
Fixing typos and punctuation for the feature command messages.

## Motivation and Context
Typos and punctuation.

## Testing
N/A

### Operating Systems Testing
N/A

## Change Types Made

* [ ] Bug fix (non-breaking change).
* [x] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [ ] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue
As this was just a maint fix to typos and punctuation in strings, no issue was created.