### PR TITLE
(#3327) Improves UX of Chocolatey Install without 4.8

### DIFF
--- a/nuspec/chocolatey/chocolatey/tools/chocolateysetup.psm1
+++ b/nuspec/chocolatey/chocolatey/tools/chocolateysetup.psm1
@@ -834,17 +834,27 @@ function Install-DotNet48IfMissing {
 }
 
 function Invoke-Chocolatey-Initial {
+    if ($PSVersionTable.Major -le 3 -and $script:DotNetInstallRequiredReboot) {
+        Write-Debug "Skipping initialization due to known issues before rebooting."
+        return
+    }
+
     Write-Debug "Initializing Chocolatey files, etc by running Chocolatey CLI..."
 
     try {
         $chocoInstallationFolder = Get-ChocolateyInstallFolder
         $chocoExe = Join-Path -Path $chocoInstallationFolder -ChildPath "choco.exe"
-        $runResult = & $chocoExe -v
-        Write-Debug "Chocolatey CLI execution completed successfully."
+        $runResult = & $chocoExe -v *>&1
+        if ($LASTEXITCODE -eq 0) {
+            Write-Debug "Chocolatey CLI execution completed successfully."
+        }
+        else {
+            throw
+        }
     }
     catch {
         Write-ChocolateyWarning "Unable to run Chocolatey CLI at this time:`n$($runResult)"
     }
 }
 
-Export-ModuleMember -Function Initialize-Chocolatey;
+Export-ModuleMember -Function Initialize-Chocolatey

--- a/nuspec/chocolatey/chocolatey/tools/chocolateysetup.psm1
+++ b/nuspec/chocolatey/chocolatey/tools/chocolateysetup.psm1
@@ -167,7 +167,7 @@ The packages themselves go to `'$chocolateyLibPath`'
 A shim file for the command line goes to `'$chocolateyExePath`'
   and points to an executable in `'$yourPkgPath`'.
 
-Creating Chocolatey folders if they do not already exist.
+Creating Chocolatey CLI folders if they do not already exist.
 
 "@ | Write-Output
 
@@ -206,12 +206,12 @@ Creating Chocolatey folders if they do not already exist.
 
     if ($script:DotNetInstallRequiredReboot) {
         @"
-Chocolatey (choco.exe) is nearly ready.
+Chocolatey CLI (choco.exe) is nearly ready.
 You need to restart this machine prior to using choco.
 "@ | Write-Output
     } else {
         @"
-Chocolatey (choco.exe) is now ready.
+Chocolatey CLI (choco.exe) is now ready.
 You can call choco from anywhere, command line or powershell by typing choco.
 Run choco /? for a list of functions.
 You may need to shut down and restart powershell and/or consoles
@@ -819,7 +819,7 @@ function Install-DotNet48IfMissing {
         $s = [System.Diagnostics.Process]::Start($psi);
         $s.WaitForExit();
         if ($s.ExitCode -eq 1641 -or $s.ExitCode -eq 3010) {
-          Write-Warning ".NET Framework 4.8 was installed, but a reboot is required before using Chocolatey."
+          Write-Warning ".NET Framework 4.8 was installed, but a reboot is required before using Chocolatey CLI."
           $script:DotNetInstallRequiredReboot = $true
         } elseif ($s.ExitCode -ne 0) {
             if ($netFx48InstallTries -ge 2) {
@@ -834,16 +834,16 @@ function Install-DotNet48IfMissing {
 }
 
 function Invoke-Chocolatey-Initial {
-    Write-Debug "Initializing Chocolatey files, etc by running Chocolatey..."
+    Write-Debug "Initializing Chocolatey files, etc by running Chocolatey CLI..."
 
     try {
         $chocoInstallationFolder = Get-ChocolateyInstallFolder
         $chocoExe = Join-Path -Path $chocoInstallationFolder -ChildPath "choco.exe"
         $runResult = & $chocoExe -v
-        Write-Debug "Chocolatey execution completed successfully."
+        Write-Debug "Chocolatey CLI execution completed successfully."
     }
     catch {
-        Write-ChocolateyWarning "Unable to run Chocolatey at this time:`n$($runResult)"
+        Write-ChocolateyWarning "Unable to run Chocolatey CLI at this time:`n$($runResult)"
     }
 }
 

--- a/nuspec/chocolatey/chocolatey/tools/chocolateysetup.psm1
+++ b/nuspec/chocolatey/chocolatey/tools/chocolateysetup.psm1
@@ -126,7 +126,7 @@ function Initialize-Chocolatey {
     $installModule = Join-Path $thisScriptFolder 'chocolateyInstall\helpers\chocolateyInstaller.psm1'
     Import-Module $installModule -Force
 
-  Install-DotNet48IfMissing
+    Install-DotNet48IfMissing
 
     if ($chocolateyPath -eq '') {
         $programData = [Environment]::GetFolderPath("CommonApplicationData")
@@ -204,13 +204,20 @@ Creating Chocolatey folders if they do not already exist.
         $env:ChocolateyExitCode = 0
     }
 
-    @"
+    if ($script:DotNetInstallRequiredReboot) {
+        @"
+Chocolatey (choco.exe) is nearly ready.
+You need to restart this machine prior to using choco.
+"@ | Write-Output
+    } else {
+        @"
 Chocolatey (choco.exe) is now ready.
 You can call choco from anywhere, command line or powershell by typing choco.
 Run choco /? for a list of functions.
 You may need to shut down and restart powershell and/or consoles
  first prior to using choco.
 "@ | Write-Output
+    }
 
     if (-not $allowInsecureRootInstall) {
         Remove-OldChocolateyInstall $defaultChocolateyPathOld
@@ -812,9 +819,9 @@ function Install-DotNet48IfMissing {
         $s = [System.Diagnostics.Process]::Start($psi);
         $s.WaitForExit();
         if ($s.ExitCode -eq 1641 -or $s.ExitCode -eq 3010) {
-          throw ".NET Framework 4.8 was installed, but a reboot is required. `n Please reboot the system and try to install/upgrade Chocolatey again."
-        }
-        if ($s.ExitCode -ne 0) {
+          Write-Warning ".NET Framework 4.8 was installed, but a reboot is required before using Chocolatey."
+          $script:DotNetInstallRequiredReboot = $true
+        } elseif ($s.ExitCode -ne 0) {
             if ($netFx48InstallTries -ge 2) {
                 Write-ChocolateyError ".NET Framework install failed with exit code `'$($s.ExitCode)`'. `n This will cause the rest of the install to fail."
                 throw "Error installing .NET Framework 4.8 (exit code $($s.ExitCode)). `n Please install the .NET Framework 4.8 manually and reboot the system `n and then try to install/upgrade Chocolatey again. `n Download at `'$NetFx48Url`'"
@@ -832,11 +839,11 @@ function Invoke-Chocolatey-Initial {
     try {
         $chocoInstallationFolder = Get-ChocolateyInstallFolder
         $chocoExe = Join-Path -Path $chocoInstallationFolder -ChildPath "choco.exe"
-        & $chocoExe -v | Out-Null
+        $runResult = & $chocoExe -v
         Write-Debug "Chocolatey execution completed successfully."
     }
     catch {
-        Write-ChocolateyWarning "Unable to run Chocolatey at this time.  It is likely that .Net Framework installation requires a system reboot"
+        Write-ChocolateyWarning "Unable to run Chocolatey at this time:`n$($runResult)"
     }
 }
 


### PR DESCRIPTION
## Description Of Changes
This commit introduces the idea that the dotnet installation needing a reboot should not immediately halt the Chocolatey installation, but instead proceed as far as possible - then prompt for a reboot without throwing.

## Motivation and Context
The install script currently throws after dotnet 4.8 is installed, which requires the user reboot and then re-run the install script. This, at least, reduces the need for an additional step post-reboot.

## Testing
1. Build or finagle Chocolatey package with updated setup functions
    I downloaded the [Chocolatey 2.2.2 package](https://community.chocolatey.org/api/v2/package/chocolatey/2.2.2) and used 7zip to overwrite `chocolateysetup.psm1` with my changes.
2. Download [Install.ps1](https://community.chocolatey.org/install.ps1)
3. Run `Install.ps1 -ChocolateyDownloadUrl ~\Path\to\Choco.nupkg` (after execution policy / unblocking files)

### Operating Systems Testing
- Windows 2019 (without dotnet 4.8 installed)  
    ![image](https://github.com/chocolatey/choco/assets/1975761/e0bc0aa1-a3e5-4c95-a4d6-04c028d13e68)
- Windows 10 sandbox (with dotnet 4.8 available)
    ![image](https://github.com/chocolatey/choco/assets/1975761/03ac323c-a7da-4be6-a06a-a41c775c6447)
    (no change to output)
- Windows Server 2012 (with dotnet 4.8 available, and PowerShell v3)
    ![image](https://github.com/chocolatey/choco/assets/1975761/25d321d5-b459-40a2-b37f-13c16a579491)
- Windows Server 2012 (without dotnet 4.8, and PowerShell v3)
    ![image](https://github.com/chocolatey/choco/assets/1975761/160c9d18-9a2e-4cc2-88f5-85938f2ed85b)

## Change Types Made

* ~[ ] Bug fix (non-breaking change).~
* [x] Feature / Enhancement (non-breaking change).
* ~[ ] Breaking change (fix or feature that could cause existing functionality to change).~
* ~[ ] Documentation changes.~
* [x] PowerShell code changes.

## Change Checklist

* [?] Requires a change to the documentation.
    I am unsure if there is any reference to this behaviour in our documentation.
* [ ] Documentation has been updated.
* ~[ ] Tests to cover my changes, have been added.~
* ~[ ] All new and existing tests passed?~
* [x] PowerShell code changes: PowerShell v2 compatibility checked visually but not by running it on an actual PSv2 system

## Related Issue

Fixes #3327
