### PR TITLE
(#3342) Separate TeamCity Builds: Unit test, Scheduled integration test, QA

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,6 +49,7 @@ jobs:
         path: tools
         key: ${{ runner.os }}-tools-${{ hashFiles('recipe.cake') }}
     - name: Build with .Net Framework
+      shell: powershell
       run: ./build.ps1 --verbosity=diagnostic --target=CI --testExecutionType=unit --shouldRunOpenCover=false
     - name: Upload Windows build results
       uses: actions/upload-artifact@v3

--- a/recipe.cake
+++ b/recipe.cake
@@ -1,4 +1,4 @@
-#load nuget:?package=Chocolatey.Cake.Recipe&version=0.25.0
+#load nuget:?package=Chocolatey.Cake.Recipe&version=0.26.3
 
 ///////////////////////////////////////////////////////////////////////////////
 // TOOLS


### PR DESCRIPTION
## Description Of Changes

This PR splits the current general TeamCity build which runs unit tests on a version control trigger and unit + integration tests on a schedule into two separate builds:

* Chocolatey CLI (Built with Unit Tests) `ID: Chocolatey`
* Chocolatey CLI (Scheduled Integration Testing) `ID: ChocolateySchd `

It also introduces an additional build specifically for running Code Analysis and Dependency Checking:

* Chocolatey CLI (SonarQube) `ID: ChocolateyQA`

Note: Please advise if these names are appropriate, and recommend alternatives as needed.

## Motivation and Context

This change enables TeamCity to accurately track how long each build configuration should take to run and how many tests each should run.

## Testing

This has been tested on a non-Production TeamCity instance, the KTS file imported successfully and the three builds ran as expected.

![image](https://github.com/chocolatey/choco/assets/6955786/a11d4c6d-357e-471c-9769-24ac140eb425)

### Operating Systems Testing

N/A

## Change Types Made

N/A? Build change

* [ ] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [ ] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue

Fixes #3342
