### PR TITLE
(#2712) Normalize ExitCode pester test on Support Branch

### DIFF
--- a/tests/pester-tests/chocolatey.Tests.ps1
+++ b/tests/pester-tests/chocolatey.Tests.ps1
@@ -77,7 +77,7 @@ Describe "Ensuring Chocolatey is correctly installed" -Tag Environment, Chocolat
         It "Outputs the version when run with --version" {
             $Output = Invoke-Choco --version
             $script:CurrentVersion = $Output.String
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
             $LastExitCode | Should -Be 0
             ($Output.String -split '-' | Select-Object -First 1) -as [version] | Should -BeTrue
         }
@@ -333,7 +333,7 @@ exit $error.count
         }
 
         It 'should exit Success (0)' {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It 'should <removal> shim <_> on upgrade' -ForEach $RemovedShims {
@@ -356,7 +356,7 @@ exit $error.count
         }
 
         It 'Exits with Success (0)' {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It 'Should remove the invalid configuration file' {

--- a/tests/pester-tests/commands/choco-apikey.Tests.ps1
+++ b/tests/pester-tests/commands/choco-apikey.Tests.ps1
@@ -27,7 +27,7 @@ Describe "choco <_>" -ForEach $Command -Tag Chocolatey, ApiKeyCommand {
         }
 
         It "Exits with Success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Only displays chocolatey name with version" {
@@ -44,7 +44,7 @@ Describe "choco <_>" -ForEach $Command -Tag Chocolatey, ApiKeyCommand {
         }
 
         It "Exits with Success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Only displays chocolatey name with version" {
@@ -59,7 +59,7 @@ Describe "choco <_>" -ForEach $Command -Tag Chocolatey, ApiKeyCommand {
         }
 
         It "Exits with Success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Only displays chocolatey name with version" {
@@ -75,7 +75,7 @@ Describe "choco <_>" -ForEach $Command -Tag Chocolatey, ApiKeyCommand {
         }
 
         It "Exits with Success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Only displays chocolatey name with version" {
@@ -108,7 +108,7 @@ Describe "choco <_>" -ForEach $Command -Tag Chocolatey, ApiKeyCommand {
         }
 
         It "Exits with Success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Displays chocolatey name with version" {
@@ -155,7 +155,7 @@ Describe "choco <_>" -ForEach $Command -Tag Chocolatey, ApiKeyCommand {
         }
 
         It "Exits with Success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Displays chocolatey name with version" {
@@ -190,7 +190,7 @@ Describe "choco <_>" -ForEach $Command -Tag Chocolatey, ApiKeyCommand {
         }
 
         It "Exits with Success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Displays chocolatey name with version" {
@@ -219,7 +219,7 @@ Describe "choco <_>" -ForEach $Command -Tag Chocolatey, ApiKeyCommand {
         }
 
         It "Exits with Success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Displays chocolatey name with version" {
@@ -237,7 +237,7 @@ Describe "choco <_>" -ForEach $Command -Tag Chocolatey, ApiKeyCommand {
         }
 
         It "Exits with Failure (1)" {
-            $Output.ExitCode | Should -Be 1
+            $Output.ExitCode | Should -Be 1 -Because $Output.String
         }
 
         It "Displays chocolatey name with version" {
@@ -257,7 +257,7 @@ Describe "choco <_>" -ForEach $Command -Tag Chocolatey, ApiKeyCommand {
         }
 
         It "Exits with Success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Displays chocolatey name with version" {
@@ -280,7 +280,7 @@ Describe "choco <_>" -ForEach $Command -Tag Chocolatey, ApiKeyCommand {
         }
 
         It "Exits with Success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Displays chocolatey name with version" {

--- a/tests/pester-tests/commands/choco-config.Tests.ps1
+++ b/tests/pester-tests/commands/choco-config.Tests.ps1
@@ -91,7 +91,7 @@ Describe "choco config" -Tag Chocolatey, ConfigCommand {
         }
 
         It "Exits with Success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Displays chocolatey name with version" {
@@ -173,7 +173,7 @@ Describe "choco config" -Tag Chocolatey, ConfigCommand {
         }
 
         It "Exits with Success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Displays chocolatey name with version" {
@@ -191,7 +191,7 @@ Describe "choco config" -Tag Chocolatey, ConfigCommand {
         }
 
         It "Exits with Success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Displays chocolatey name with version" {
@@ -209,7 +209,7 @@ Describe "choco config" -Tag Chocolatey, ConfigCommand {
         }
 
         It "Exits with failure (1)" {
-            $Output.ExitCode | Should -Be 1
+            $Output.ExitCode | Should -Be 1 -Because $Output.String
         }
 
         It "Outputs an error indicating that there's no config by that name" {
@@ -226,7 +226,7 @@ Describe "choco config" -Tag Chocolatey, ConfigCommand {
         }
 
         It "Exits with Success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Displays chocolatey name with version" {
@@ -253,7 +253,7 @@ Describe "choco config" -Tag Chocolatey, ConfigCommand {
         }
 
         It "Exits with Success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Displays chocolatey name with version" {
@@ -280,7 +280,7 @@ Describe "choco config" -Tag Chocolatey, ConfigCommand {
         }
 
         It "Exits with Success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Displays chocolatey name with version" {
@@ -310,7 +310,7 @@ Describe "choco config" -Tag Chocolatey, ConfigCommand {
         }
 
         It "Exits with Success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Displays chocolatey name with version" {
@@ -337,7 +337,7 @@ Describe "choco config" -Tag Chocolatey, ConfigCommand {
         }
 
         It "Exits with Success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Displays chocolatey name with version" {

--- a/tests/pester-tests/commands/choco-deprecated.Tests.ps1
+++ b/tests/pester-tests/commands/choco-deprecated.Tests.ps1
@@ -76,7 +76,7 @@ Describe "Deprecated Chocolatey Helper Commands" -Skip:(-not (Test-ChocolateyVer
     }
 
     It 'should exit success (0)' {
-        $Output.ExitCode | Should -Be 0
+        $Output.ExitCode | Should -Be 0 -Because $Output.String
     }
 
     It 'should warn that Get-BinRoot is deprecated' {

--- a/tests/pester-tests/commands/choco-export.Tests.ps1
+++ b/tests/pester-tests/commands/choco-export.Tests.ps1
@@ -76,7 +76,7 @@ Describe "choco export" -Tag Chocolatey, ExportCommand {
         }
 
         It "Exits with Success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Displays description of command" {
@@ -133,7 +133,7 @@ Describe "choco export" -Tag Chocolatey, ExportCommand {
         }
 
         It "Exits with success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         # NOTE: There is no output other than the header, and possibly the unofficial statement
@@ -184,7 +184,7 @@ Describe "choco export" -Tag Chocolatey, ExportCommand {
         }
 
         It "Exits with success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         # NOTE: There is no output other than the header, and possibly the unofficial statement
@@ -226,7 +226,7 @@ Describe "choco export" -Tag Chocolatey, ExportCommand {
         }
 
         It "Exits with success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         # NOTE: There is no output other than the header, and possibly the unofficial statement
@@ -277,7 +277,7 @@ Describe "choco export" -Tag Chocolatey, ExportCommand {
         }
 
         It "Exits with success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         # NOTE: There is no output other than the header, and possibly the unofficial statement
@@ -319,7 +319,7 @@ Describe "choco export" -Tag Chocolatey, ExportCommand {
         }
 
         It "Exits with success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         # NOTE: There is no output other than the header, and possibly the unofficial statement
@@ -387,7 +387,7 @@ Describe "choco export" -Tag Chocolatey, ExportCommand {
         }
 
         It "Exits with success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         # NOTE: There is no output other than the header, and possibly the unofficial statement
@@ -415,7 +415,7 @@ Describe "choco export" -Tag Chocolatey, ExportCommand {
         }
 
         It "Exits with Failure (1)" {
-            $Output.ExitCode | Should -Be 1
+            $Output.ExitCode | Should -Be 1 -Because $Output.String
         }
 
         It "Reports unable to export packages" {
@@ -439,7 +439,7 @@ Describe "choco export" -Tag Chocolatey, ExportCommand {
         }
 
         It "Exits with Failure (1)" {
-            $Output.ExitCode | Should -Be 1
+            $Output.ExitCode | Should -Be 1 -Because $Output.String
         }
 
         It "Reports unable to export packages" {
@@ -459,7 +459,7 @@ Describe "choco export" -Tag Chocolatey, ExportCommand {
         }
 
         It "Exits with Failure (1)" {
-            $Output.ExitCode | Should -Be 1
+            $Output.ExitCode | Should -Be 1 -Because $Output.String
         }
 
         It "Displays help page" {

--- a/tests/pester-tests/commands/choco-feature.Tests.ps1
+++ b/tests/pester-tests/commands/choco-feature.Tests.ps1
@@ -34,7 +34,7 @@ Describe "choco <_>" -ForEach $Command -Tag Chocolatey, FeatureCommand {
         }
 
         It "Exits with Success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Lists available features" {
@@ -121,7 +121,7 @@ Describe "choco <_>" -ForEach $Command -Tag Chocolatey, FeatureCommand {
         }
 
         It "Exits with Success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Outputs a message indicating that it disabled the feature" {
@@ -145,7 +145,7 @@ Describe "choco <_>" -ForEach $Command -Tag Chocolatey, FeatureCommand {
         }
 
         It "Exits with Success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Outputs a message indicating that it enabled the feature" {
@@ -169,7 +169,7 @@ Describe "choco <_>" -ForEach $Command -Tag Chocolatey, FeatureCommand {
         }
 
         It "Exits with Success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Outputs a message indicating that it disabled the feature" {
@@ -189,7 +189,7 @@ Describe "choco <_>" -ForEach $Command -Tag Chocolatey, FeatureCommand {
         }
 
         It "Exits with Failure (1)" {
-            $Output.ExitCode | Should -Be 1
+            $Output.ExitCode | Should -Be 1 -Because $Output.String
         }
 
         It "Outputs a message indicating it didn't find the feature in question" {
@@ -206,7 +206,7 @@ Describe "choco <_>" -ForEach $Command -Tag Chocolatey, FeatureCommand {
         }
 
         It "Exits with Failure (1)" {
-            $Output.ExitCode | Should -Be 1
+            $Output.ExitCode | Should -Be 1 -Because $Output.String
         }
 
         It "Outputs a message indicating it didn't find the feature in question" {

--- a/tests/pester-tests/commands/choco-help.Tests.ps1
+++ b/tests/pester-tests/commands/choco-help.Tests.ps1
@@ -45,7 +45,7 @@ Describe "choco help sections with option <_>" -ForEach $HelpOptions -Tag Chocol
         }
 
         It "Exits with Success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Outputs the Top-Level Help" {
@@ -70,7 +70,7 @@ Describe "choco help sections with option <_>" -ForEach $HelpOptions -Tag Chocol
         }
 
         It "'choco <_> $helpArgument' exits with Success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Outputs help for <_>" {

--- a/tests/pester-tests/commands/choco-info.Tests.ps1
+++ b/tests/pester-tests/commands/choco-info.Tests.ps1
@@ -29,7 +29,7 @@ Describe "choco info" -Tag Chocolatey, InfoCommand {
         }
 
         It "Exits with Success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Displays <Title> with value <Value>" -ForEach $infoItems {
@@ -101,7 +101,7 @@ Describe "choco info" -Tag Chocolatey, InfoCommand {
         }
 
         It "Exits with Success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Displays the package mvcmusicstore-db 1.2.0" {
@@ -134,7 +134,7 @@ Describe "choco info" -Tag Chocolatey, InfoCommand {
         }
 
         It "Exits with Success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Displays the package mvcmusicstore-db 1.2.0" {
@@ -155,7 +155,7 @@ Describe "choco info" -Tag Chocolatey, InfoCommand {
         }
 
         It "Exits with Success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Outputs a warning message that installed side by side package is deprecated" {
@@ -174,7 +174,7 @@ Describe "choco info" -Tag Chocolatey, InfoCommand {
         }
 
         It 'Exits with Success (0)' {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It 'Outputs warning about unable to retrieve packages from source' {

--- a/tests/pester-tests/commands/choco-install.Tests.ps1
+++ b/tests/pester-tests/commands/choco-install.Tests.ps1
@@ -1645,6 +1645,7 @@ Describe "choco install" -Tag Chocolatey, InstallCommand {
     Context "Installing package while specifying a cache location (Arg: <_>)" -ForEach '-c', '--cache', '--cachelocation', '--cache-location' -Tag Internal, LongPaths, CacheLocation {
         BeforeAll {
             $paths = Restore-ChocolateyInstallSnapshot
+            $features = Get-chocolateyFeature
 
             $Output = Invoke-Choco install install-chocolateyzip --version 3.21.2 --confirm "$_" "$($paths.CachePath)" --no-progress
         }

--- a/tests/pester-tests/commands/choco-install.Tests.ps1
+++ b/tests/pester-tests/commands/choco-install.Tests.ps1
@@ -34,7 +34,7 @@ Describe "choco install" -Tag Chocolatey, InstallCommand {
         }
 
         It "Exits with Success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Doesn't install the package to the lib directory" {
@@ -64,7 +64,7 @@ Describe "choco install" -Tag Chocolatey, InstallCommand {
         }
 
         It "Exits with Success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Doesn't install the package to the lib directory" {
@@ -90,7 +90,7 @@ Describe "choco install" -Tag Chocolatey, InstallCommand {
         }
 
         It "Exits with Success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Installed a package to the lib directory" {
@@ -172,7 +172,7 @@ Describe "choco install" -Tag Chocolatey, InstallCommand {
         }
 
         It "Exits with Failure (1), due to the missing 'missingpackage'" {
-            $Output.ExitCode | Should -Be 1
+            $Output.ExitCode | Should -Be 1 -Because $Output.String
         }
 
         It "Installs the package '<_>' in the Lib directory" -ForEach @("InstallPackage"; "HasDependency"; "IsDependency"; "UpgradePackage") {
@@ -333,7 +333,7 @@ Describe "choco install" -Tag Chocolatey, InstallCommand {
         }
 
         It "Exits with Success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Should still have a package in the lib directory" {
@@ -370,7 +370,7 @@ Describe "choco install" -Tag Chocolatey, InstallCommand {
         }
 
         It "Exits with Success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Should install the package in the lib directory" {
@@ -409,7 +409,7 @@ Describe "choco install" -Tag Chocolatey, InstallCommand {
         }
 
         It "Exits with Success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Should install the package in the lib directory" {
@@ -458,7 +458,7 @@ Describe "choco install" -Tag Chocolatey, InstallCommand {
         }
 
         It "Exits with Success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Has successfully retained an install of the original package" {
@@ -504,11 +504,11 @@ Describe "choco install" -Tag Chocolatey, InstallCommand {
         }
 
         It "Exits with Success (0)" -Tag FossOnly {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Exits with Failure (1)" -Tag Licensed {
-            $Output.ExitCode | Should -Be 1
+            $Output.ExitCode | Should -Be 1 -Because $Output.String
         }
 
         It "Has successfully retained an install of the original package" {
@@ -544,7 +544,7 @@ Describe "choco install" -Tag Chocolatey, InstallCommand {
         }
 
         It "Exits with Failure (1)" {
-            $Output.ExitCode | Should -Be 1
+            $Output.ExitCode | Should -Be 1 -Because $Output.String
         }
 
         It "Doesn't install the package to the lib directory" {
@@ -566,7 +566,7 @@ Describe "choco install" -Tag Chocolatey, InstallCommand {
         }
 
         It "Exits with Failure (1)" {
-            $Output.ExitCode | Should -Be 1
+            $Output.ExitCode | Should -Be 1 -Because $Output.String
         }
 
         It "Doesn't install the package to the lib directory" {
@@ -616,7 +616,7 @@ Describe "choco install" -Tag Chocolatey, InstallCommand {
         }
 
         It "Exits with Success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Installed a package to the lib directory" {
@@ -646,7 +646,7 @@ Describe "choco install" -Tag Chocolatey, InstallCommand {
         }
 
         It "Exits with Failure (1)" {
-            $Output.ExitCode | Should -Be 1
+            $Output.ExitCode | Should -Be 1 -Because $Output.String
         }
 
         It "Doesn't install the package to the lib directory" {
@@ -672,7 +672,7 @@ Describe "choco install" -Tag Chocolatey, InstallCommand {
         }
 
         It "Exits with Success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Installed a package to the lib directory" {
@@ -706,7 +706,7 @@ Describe "choco install" -Tag Chocolatey, InstallCommand {
         }
 
         It "Exits with Success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Installed the package to the lib directory" {
@@ -744,7 +744,7 @@ Describe "choco install" -Tag Chocolatey, InstallCommand {
         }
 
         It "Exits with Success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Installed the package to the lib directory" {
@@ -781,7 +781,7 @@ Describe "choco install" -Tag Chocolatey, InstallCommand {
         }
 
         It "Exits with Success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Installed the package to the lib directory" {
@@ -815,7 +815,7 @@ Describe "choco install" -Tag Chocolatey, InstallCommand {
         }
 
         It "Exits with Success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Installed the package to the lib directory" {
@@ -854,7 +854,7 @@ Describe "choco install" -Tag Chocolatey, InstallCommand {
         }
 
         It "Exits with Success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Installed the package to the lib directory" {
@@ -904,7 +904,7 @@ Describe "choco install" -Tag Chocolatey, InstallCommand {
         }
 
         It "Exits with Success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Installed the package to the lib directory" {
@@ -953,7 +953,7 @@ Describe "choco install" -Tag Chocolatey, InstallCommand {
         }
 
         It "Exits with Success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Installed the package to the lib directory" {
@@ -991,7 +991,7 @@ Describe "choco install" -Tag Chocolatey, InstallCommand {
         }
 
         It "Exits with Failure (1)" {
-            $Output.ExitCode | Should -Be 1
+            $Output.ExitCode | Should -Be 1 -Because $Output.String
         }
 
         It "Doesn't install the package to the lib directory" {
@@ -1017,7 +1017,7 @@ Describe "choco install" -Tag Chocolatey, InstallCommand {
         }
 
         It "Exits with Success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Has installed a package to the lib directory" {
@@ -1051,7 +1051,7 @@ Describe "choco install" -Tag Chocolatey, InstallCommand {
         }
 
         It "Exits with Success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Installed the package to the lib directory" {
@@ -1090,7 +1090,7 @@ Describe "choco install" -Tag Chocolatey, InstallCommand {
         }
 
         It "Exits with Failure (1)" {
-            $Output.ExitCode | Should -Be 1
+            $Output.ExitCode | Should -Be 1 -Because $Output.String
         }
 
         It "Has not installed the package to the lib directory" {
@@ -1113,7 +1113,7 @@ Describe "choco install" -Tag Chocolatey, InstallCommand {
         }
 
         It "Exits with Success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Has installed the package to the lib directory" {
@@ -1142,7 +1142,7 @@ Describe "choco install" -Tag Chocolatey, InstallCommand {
         }
 
         It "Exits with Failure (1)" {
-            $Output.ExitCode | Should -Be 1
+            $Output.ExitCode | Should -Be 1 -Because $Output.String
         }
 
         It "Has not installed the package to the lib directory" {
@@ -1181,7 +1181,7 @@ Describe "choco install" -Tag Chocolatey, InstallCommand {
         }
 
         It "Exits with Success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Has installed the package to the lib directory" {
@@ -1216,7 +1216,7 @@ Describe "choco install" -Tag Chocolatey, InstallCommand {
         }
 
         It "Exits with Success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Warns that this functionality is deprecated" {
@@ -1299,7 +1299,7 @@ Describe "choco install" -Tag Chocolatey, InstallCommand {
         }
 
         It "Exits with Success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Outputs a message showing that installation was successful" {
@@ -1329,7 +1329,7 @@ Describe "choco install" -Tag Chocolatey, InstallCommand {
         }
 
         It "Exits with Failure (1)" {
-            $Output.ExitCode | Should -Be 1
+            $Output.ExitCode | Should -Be 1 -Because $Output.String
         }
 
         It "Outputs a message indicating that there were no sources enabled" {
@@ -1353,7 +1353,7 @@ Describe "choco install" -Tag Chocolatey, InstallCommand {
         }
 
         It "Exits with Success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Displays package files install completed" {
@@ -1372,7 +1372,7 @@ Describe "choco install" -Tag Chocolatey, InstallCommand {
         }
 
         It "Exits with Success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Displays package files install completed" {
@@ -1399,7 +1399,7 @@ Describe "choco install" -Tag Chocolatey, InstallCommand {
         }
 
         It "Exits with Success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         # TODO: Background service only works with Chocolatey Licensed Extension. Assess moving this test to CLE test suite
@@ -1435,7 +1435,7 @@ Describe "choco install" -Tag Chocolatey, InstallCommand {
         }
 
         It "Exits with Success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         # TODO: Background service only works with Chocolatey Licensed Extension. Assess moving this test to CLE test suite
@@ -1495,7 +1495,7 @@ Describe "choco install" -Tag Chocolatey, InstallCommand {
         }
 
         It "Exits with Success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Outputs string defined in before installation block" {
@@ -1516,8 +1516,8 @@ Describe "choco install" -Tag Chocolatey, InstallCommand {
         }
 
         It "Exits with Failure (1)" {
-            $result1.ExitCode | Should -Be 1
-            $result2.ExitCode | Should -Be 1
+            $result1.ExitCode | Should -Be 1 -Because $result1.String
+            $result2.ExitCode | Should -Be 1 -Because $result2.String
         }
 
         It "should identify a circular dependency" {
@@ -1565,7 +1565,7 @@ Describe "choco install" -Tag Chocolatey, InstallCommand {
         }
 
         It "Exits with Success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Does not output extracted file path '<_>'" -ForEach @('tools\'; 'tools\chocolateybeforemodify.ps1'; 'tools\chocolateyinstall.ps1'; 'tools\chocolateyuninstall.ps1'; 'zip-log-disable-test.nuspec') {
@@ -1581,7 +1581,7 @@ Describe "choco install" -Tag Chocolatey, InstallCommand {
         }
 
         It "Exits with Success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Does not output extracted file path '<_>'" -ForEach @('tools\'; 'tools\chocolateybeforemodify.ps1'; 'tools\chocolateyinstall.ps1'; 'tools\chocolateyuninstall.ps1'; 'zip-log-disable-test.nuspec') {
@@ -1622,7 +1622,7 @@ Describe "choco install" -Tag Chocolatey, InstallCommand {
         }
 
         It "Installs successfully and exits with success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Installed the packages to the lib directory" {
@@ -1714,7 +1714,7 @@ Describe "choco install" -Tag Chocolatey, InstallCommand {
         }
 
         It 'Exits with Success (0)' {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It 'Installs package to expected directory' {
@@ -1740,7 +1740,7 @@ Describe "choco install" -Tag Chocolatey, InstallCommand {
         }
 
         It 'Exits with Success (0)' {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It 'Installs package to expected directory' {
@@ -1766,7 +1766,7 @@ Describe "choco install" -Tag Chocolatey, InstallCommand {
         }
 
         It 'Exits with Success (0)' {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It 'Installs package to expected directory' {
@@ -1792,7 +1792,7 @@ Describe "choco install" -Tag Chocolatey, InstallCommand {
         }
 
         It 'Exits with Success (0)' {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It 'Installs package to expected directory' {
@@ -1820,7 +1820,7 @@ Describe "choco install" -Tag Chocolatey, InstallCommand {
         }
 
         It 'Exits with Success (0)' {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It 'Outputs warning about unable to load service index' {

--- a/tests/pester-tests/commands/choco-list.Tests.ps1
+++ b/tests/pester-tests/commands/choco-list.Tests.ps1
@@ -41,7 +41,7 @@ Describe "choco <_>" -ForEach $Command -Tag Chocolatey, ListCommand, SearchComma
         }
 
         It "Exits with Success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Lists available packages once" {
@@ -68,7 +68,7 @@ Describe "choco <_>" -ForEach $Command -Tag Chocolatey, ListCommand, SearchComma
         }
 
         It "Exits with Success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Contains packages and versions with a space between them" {
@@ -90,7 +90,7 @@ Describe "choco <_>" -ForEach $Command -Tag Chocolatey, ListCommand, SearchComma
         }
 
         It "Exits with Success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Shows each instance of an available package" {
@@ -116,7 +116,7 @@ Describe "choco <_>" -ForEach $Command -Tag Chocolatey, ListCommand, SearchComma
         }
 
         It "Exits with Success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Shows each instance of an available package" {
@@ -146,7 +146,7 @@ Describe "choco <_>" -ForEach $Command -Tag Chocolatey, ListCommand, SearchComma
         }
 
         It "Exits with Success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Shows version <_> of the package" -ForEach @("1.1.0"; "1.0.0") {
@@ -164,7 +164,7 @@ Describe "choco <_>" -ForEach $Command -Tag Chocolatey, ListCommand, SearchComma
         }
 
         It "Exits with Success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Shows version <_> of local package" -ForEach @("2.0.0"; "1.1.0") {
@@ -183,7 +183,7 @@ Describe "choco <_>" -ForEach $Command -Tag Chocolatey, ListCommand, SearchComma
         }
 
         It "Exits with Success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Should contain packages and version with a space between them" {
@@ -213,7 +213,7 @@ Describe "choco <_>" -ForEach $Command -Tag Chocolatey, ListCommand, SearchComma
         }
 
         It "Exits with Success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Should contain packages and version with a space between them" {
@@ -235,7 +235,7 @@ Describe "choco <_>" -ForEach $Command -Tag Chocolatey, ListCommand, SearchComma
         }
 
         It "Exits with Success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Should not contain packages and version with a space between them" {
@@ -257,7 +257,7 @@ Describe "choco <_>" -ForEach $Command -Tag Chocolatey, ListCommand, SearchComma
         }
 
         It "Exits with Success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Should contain package name(s)" {
@@ -282,7 +282,7 @@ Describe "choco <_>" -ForEach $Command -Tag Chocolatey, ListCommand, SearchComma
         }
 
         It "Exits with Failure (1)" {
-            $Output.ExitCode | Should -Be 1
+            $Output.ExitCode | Should -Be 1 -Because $Output.String
         }
 
         It "Outputs an appropriate message to indicate the failure to search no sources, and nothing else" {
@@ -296,7 +296,7 @@ Describe "choco <_>" -ForEach $Command -Tag Chocolatey, ListCommand, SearchComma
         }
 
         It "Exits with Success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Should contain packages and version with a space between them" {
@@ -346,7 +346,7 @@ Describe "choco <_>" -ForEach $Command -Tag Chocolatey, ListCommand, SearchComma
         }
 
         It "Exits with Success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Displays the package <_>" -ForEach @("mvcmusicstore-db 1.2.0"; "mvcmusicstore-web 1.2.0") {
@@ -369,7 +369,7 @@ Describe "choco <_>" -ForEach $Command -Tag Chocolatey, ListCommand, SearchComma
         }
 
         It "Exits with Success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Displays the package <_>" -ForEach @("mvcmusicstore-db 1.2.0"; "mvcmusicstore-web 1.2.0") {
@@ -390,7 +390,7 @@ Describe "choco <_>" -ForEach $Command -Tag Chocolatey, ListCommand, SearchComma
         }
 
         It "Exits with Success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Should list package isexactversiondependency v<_>" -ForEach @("1.0.1"; "1.0.0"; "2.0.0"; "1.1.0") {
@@ -410,7 +410,7 @@ Describe "choco <_>" -ForEach $Command -Tag Chocolatey, ListCommand, SearchComma
         }
 
         It "Exits with Success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Should list package isexactversiondependency v<_>" -ForEach @("1.0.1"; "1.0.0"; "2.0.0"; "1.1.0"; "1.0.0-beta") {
@@ -440,7 +440,7 @@ Describe "choco <_>" -ForEach $Command -Tag Chocolatey, ListCommand, SearchComma
         }
 
         It 'Exits with Success (0)' {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It 'Outputs warning about unable to contact source' {

--- a/tests/pester-tests/commands/choco-new.Tests.ps1
+++ b/tests/pester-tests/commands/choco-new.Tests.ps1
@@ -35,7 +35,7 @@ Describe "choco new" -Tag Chocolatey, NewCommand {
         }
 
         It "Exits with Success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Displays chocolatey name with version" {
@@ -83,7 +83,7 @@ Describe "choco new" -Tag Chocolatey, NewCommand {
         }
 
         It "Exits with Success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Displays chocolatey name with version" {
@@ -117,7 +117,7 @@ Describe "choco new" -Tag Chocolatey, NewCommand {
             }
 
             It "Exits with Success (0)" {
-                $Output.ExitCode | Should -Be 0
+                $Output.ExitCode | Should -Be 0 -Because $Output.String
             }
 
             It "Displays chocolatey name with version" {
@@ -151,7 +151,7 @@ Describe "choco new" -Tag Chocolatey, NewCommand {
         }
 
         It "Exits with Success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Creates the empty folders expected (<_>)" -ForEach $EmptyFolders {

--- a/tests/pester-tests/commands/choco-pack.Tests.ps1
+++ b/tests/pester-tests/commands/choco-pack.Tests.ps1
@@ -56,7 +56,7 @@ Describe "choco pack" -Tag Chocolatey, PackCommand {
         }
 
         It "'choco pack' exits with Failure (1)" {
-            $Output.ExitCode | Should -Be 1
+            $Output.ExitCode | Should -Be 1 -Because $Output.String
         }
 
         It "Outputs Error Message" {
@@ -72,7 +72,7 @@ Describe "choco pack" -Tag Chocolatey, PackCommand {
         }
 
         It "'choco pack' exits with Success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Displays Chocolatey name with version" {
@@ -94,7 +94,7 @@ Describe "choco pack" -Tag Chocolatey, PackCommand {
         }
 
         It "'choco pack' exits with Success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Displays Chocolatey name with version" {
@@ -116,7 +116,7 @@ Describe "choco pack" -Tag Chocolatey, PackCommand {
         }
 
         It "'choco pack' exits with Failure (1)" {
-            $Output.ExitCode | Should -Be 1
+            $Output.ExitCode | Should -Be 1 -Because $Output.String
         }
 
         It "Displays Chocolatey name with version" {
@@ -138,7 +138,7 @@ Describe "choco pack" -Tag Chocolatey, PackCommand {
         }
 
         It "'choco pack' exits with Failure (1)" {
-            $Output.ExitCode | Should -Be 1
+            $Output.ExitCode | Should -Be 1 -Because $Output.String
         }
 
         It "Displays Chocolatey name with version" {
@@ -161,7 +161,7 @@ Describe "choco pack" -Tag Chocolatey, PackCommand {
         }
 
         It "'choco pack' exits with Failure (1)" {
-            $Output.ExitCode | Should -Be 1
+            $Output.ExitCode | Should -Be 1 -Because $Output.String
         }
 
         It "Displays serialize error" {
@@ -179,7 +179,7 @@ Describe "choco pack" -Tag Chocolatey, PackCommand {
         }
 
         It "'choco pack' exits with Failure (1)" {
-            $Output.ExitCode | Should -Be 1
+            $Output.ExitCode | Should -Be 1 -Because $Output.String
         }
 
         It "Displays Chocolatey name with version" {
@@ -201,7 +201,7 @@ Describe "choco pack" -Tag Chocolatey, PackCommand {
         }
 
         It "'choco pack' exits with Failure (1)" {
-            $Output.ExitCode | Should -Be 1
+            $Output.ExitCode | Should -Be 1 -Because $Output.String
         }
 
         It "Displays Chocolatey name with version" {
@@ -223,7 +223,7 @@ Describe "choco pack" -Tag Chocolatey, PackCommand {
         }
 
         It "'choco pack' exits with Failure (1)" {
-            $Output.ExitCode | Should -Be 1
+            $Output.ExitCode | Should -Be 1 -Because $Output.String
         }
 
         It "Displays Chocolatey name with version" {
@@ -245,7 +245,7 @@ Describe "choco pack" -Tag Chocolatey, PackCommand {
         }
 
         It "'choco pack' exits with Failure (1)" {
-            $Output.ExitCode | Should -Be 1
+            $Output.ExitCode | Should -Be 1 -Because $Output.String
         }
 
         It "Displays Chocolatey name with version" {
@@ -267,7 +267,7 @@ Describe "choco pack" -Tag Chocolatey, PackCommand {
         }
 
         It "'choco pack' exits with Success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Displays Chocolatey name with version" {
@@ -299,7 +299,7 @@ Describe "choco pack" -Tag Chocolatey, PackCommand {
         }
 
         It "'choco pack' exits with Success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Displays Chocolatey name with version" {
@@ -328,7 +328,7 @@ Describe "choco pack" -Tag Chocolatey, PackCommand {
         }
 
         It "'choco pack' exits with Success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Displays Chocolatey name with version" {

--- a/tests/pester-tests/commands/choco-pin.Tests.ps1
+++ b/tests/pester-tests/commands/choco-pin.Tests.ps1
@@ -30,7 +30,7 @@ Describe "choco pin" -Tag Chocolatey, PinCommand {
         }
 
         It "Exits with ExitCode 0" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Has no Pins listed" {
@@ -48,7 +48,7 @@ Describe "choco pin" -Tag Chocolatey, PinCommand {
         }
 
         It "Exits with ExitCode 0" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Lists the new Pin" {
@@ -67,7 +67,7 @@ Describe "choco pin" -Tag Chocolatey, PinCommand {
         }
 
         It "Exits with ExitCode 0" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Lists the Pins" {
@@ -85,7 +85,7 @@ Describe "choco pin" -Tag Chocolatey, PinCommand {
         }
 
         It "Exits with ExitCode 0" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Sets the Pin" {
@@ -105,7 +105,7 @@ Describe "choco pin" -Tag Chocolatey, PinCommand {
         }
 
         It "Exits with ExitCode 0" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Changes Nothing" {
@@ -123,7 +123,7 @@ Describe "choco pin" -Tag Chocolatey, PinCommand {
         }
 
         It "Exits with ExitCode 1" {
-            $Output.ExitCode | Should -Be 1
+            $Output.ExitCode | Should -Be 1 -Because $Output.String
         }
 
         It "Outputs a message indicating the failure" {
@@ -146,7 +146,7 @@ Describe "choco pin" -Tag Chocolatey, PinCommand {
         }
 
         It "Exits with ExitCode 0" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Removed the Pin" {
@@ -163,7 +163,7 @@ Describe "choco pin" -Tag Chocolatey, PinCommand {
         }
 
         It "Exits with ExitCode 0" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Changes Nothing" {
@@ -179,7 +179,7 @@ Describe "choco pin" -Tag Chocolatey, PinCommand {
         }
 
         It "Exits with ExitCode 1" {
-            $Output.ExitCode | Should -Be 1
+            $Output.ExitCode | Should -Be 1 -Because $Output.String
         }
 
         It "Outputs a message indicating the failure" {

--- a/tests/pester-tests/commands/choco-push.Tests.ps1
+++ b/tests/pester-tests/commands/choco-push.Tests.ps1
@@ -52,7 +52,7 @@ Describe "choco push" -Tag Chocolatey, PushCommand, ProxySkip -Skip:($null -eq $
         }
 
         It "Exits with Failure (1)" {
-            $Output.ExitCode | Should -Be 1
+            $Output.ExitCode | Should -Be 1 -Because $Output.String
         }
 
         It "Should Report the actual cause of the error" {
@@ -83,7 +83,7 @@ Describe "choco push" -Tag Chocolatey, PushCommand, ProxySkip -Skip:($null -eq $
         }
 
         It "Exits with Failure (1)" {
-            $Output.ExitCode | Should -Be 1
+            $Output.ExitCode | Should -Be 1 -Because $Output.String
         }
 
         It "Should Report the actual cause of the error" {
@@ -114,7 +114,7 @@ Describe "choco push" -Tag Chocolatey, PushCommand, ProxySkip -Skip:($null -eq $
         }
 
         It "Exits with Failure (1)" {
-            $Output.ExitCode | Should -Be 1
+            $Output.ExitCode | Should -Be 1 -Because $Output.String
         }
 
         It "Should Report the actual cause of the error" {

--- a/tests/pester-tests/commands/choco-removed.Tests.ps1
+++ b/tests/pester-tests/commands/choco-removed.Tests.ps1
@@ -36,7 +36,7 @@ exit $command.Count
         }
 
         It 'Exits with Success (0)' {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It 'Reports the correct command name' {
@@ -67,7 +67,7 @@ exit $command.Count
         }
 
         It 'Exits with Failure (1)' {
-            $Output.ExitCode | Should -Be 1
+            $Output.ExitCode | Should -Be 1 -Because $Output.String
         }
 
         It 'Reports missing API key' {
@@ -84,7 +84,7 @@ exit $command.Count
         }
 
         It 'Exits with Failure (1)' {
-            $Output.ExitCode | Should -Be 1
+            $Output.ExitCode | Should -Be 1 -Because $Output.String
         }
 
         It "Reports that the command doesn't exist" {

--- a/tests/pester-tests/commands/choco-source.Tests.ps1
+++ b/tests/pester-tests/commands/choco-source.Tests.ps1
@@ -42,7 +42,7 @@ Describe "choco <_>" -ForEach $Command -Tag Chocolatey, SourceCommand {
         }
 
         It "Exits with Success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Displays chocolatey name with version" {
@@ -76,7 +76,7 @@ Describe "choco <_>" -ForEach $Command -Tag Chocolatey, SourceCommand {
         }
 
         It "Exits with Success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Displays chocolatey name with version" {
@@ -120,7 +120,7 @@ Describe "choco <_>" -ForEach $Command -Tag Chocolatey, SourceCommand {
         }
 
         It "Exits with Success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Displays chocolatey name with version" {
@@ -167,7 +167,7 @@ Describe "choco <_>" -ForEach $Command -Tag Chocolatey, SourceCommand {
         }
 
         It "Exits with Success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Displays chocolatey name with version" {
@@ -206,7 +206,7 @@ Describe "choco <_>" -ForEach $Command -Tag Chocolatey, SourceCommand {
         }
 
         It "Exits with Success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Displays chocolatey name with version" {
@@ -232,7 +232,7 @@ Describe "choco <_>" -ForEach $Command -Tag Chocolatey, SourceCommand {
         }
 
         It "Exits with Success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Displays chocolatey name with version" {
@@ -263,7 +263,7 @@ Describe "choco <_>" -ForEach $Command -Tag Chocolatey, SourceCommand {
         }
 
         It "Exits with Success (0)" {
-            $Output.ExitCode | Should -Be 1
+            $Output.ExitCode | Should -Be 1 -Because $Output.String
         }
 
         It "Displays chocolatey name with version" {
@@ -287,7 +287,7 @@ Describe "choco <_>" -ForEach $Command -Tag Chocolatey, SourceCommand {
         }
 
         It "Exits with Success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Displays chocolatey name with version" {
@@ -311,7 +311,7 @@ Describe "choco <_>" -ForEach $Command -Tag Chocolatey, SourceCommand {
         }
 
         It "Exits with Success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Displays chocolatey name with version" {
@@ -335,7 +335,7 @@ Describe "choco <_>" -ForEach $Command -Tag Chocolatey, SourceCommand {
         }
 
         It "Exits with Success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Displays chocolatey name with version" {
@@ -366,7 +366,7 @@ Describe "choco <_>" -ForEach $Command -Tag Chocolatey, SourceCommand {
         }
 
         It "Exits with Success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Displays chocolatey name with version" {
@@ -394,7 +394,7 @@ Describe "choco <_>" -ForEach $Command -Tag Chocolatey, SourceCommand {
         }
 
         It "Exits with Success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Displays chocolatey name with version" {
@@ -415,7 +415,7 @@ Describe "choco <_>" -ForEach $Command -Tag Chocolatey, SourceCommand {
         }
 
         It "Exits with Success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Displays chocolatey name with version" {

--- a/tests/pester-tests/commands/choco-template.Tests.ps1
+++ b/tests/pester-tests/commands/choco-template.Tests.ps1
@@ -29,7 +29,7 @@ Describe "choco <_>" -ForEach @(
         }
 
         It "Exits with Success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Displays the templates expected" {
@@ -52,7 +52,7 @@ Describe "choco <_>" -ForEach @(
         }
 
         It "Exits with Success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Displays the templates expected" {
@@ -75,7 +75,7 @@ Describe "choco <_>" -ForEach @(
         }
 
         It "Exits with Failure (1)" {
-            $Output.ExitCode | Should -Be 1
+            $Output.ExitCode | Should -Be 1 -Because $Output.String
         }
 
         It "Displays error with correct format" {
@@ -93,7 +93,7 @@ Describe "choco <_>" -ForEach @(
         }
 
         It "Exits with Success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Displays template information" {
@@ -140,7 +140,7 @@ Describe "choco <_>" -ForEach @(
         }
 
         It "Exits with Success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Displays template name and version" {
@@ -160,7 +160,7 @@ Describe "choco <_>" -ForEach @(
         }
 
         It "Exits with Success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Displays the templates marking the default as expected" {
@@ -185,7 +185,7 @@ Describe "choco <_>" -ForEach @(
         }
 
         It "Exits with Success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Displays the templates marking the default as expected" {
@@ -208,7 +208,7 @@ Describe "choco <_>" -ForEach @(
         }
 
         It "Exits with Success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Displays <Name> template information" -ForEach @(

--- a/tests/pester-tests/commands/choco-uninstall.Tests.ps1
+++ b/tests/pester-tests/commands/choco-uninstall.Tests.ps1
@@ -24,7 +24,7 @@ Describe "choco uninstall" -Tag Chocolatey, UninstallCommand {
         }
 
         It "Exits with Success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Removed a package to the lib directory" {

--- a/tests/pester-tests/commands/choco-upgrade.Tests.ps1
+++ b/tests/pester-tests/commands/choco-upgrade.Tests.ps1
@@ -264,6 +264,7 @@ Describe "choco upgrade" -Tag Chocolatey, UpgradeCommand {
     Context "Upgrading non-existing package while specifying a cache location (Arg: <_>)" -ForEach '-c', '--cache', '--cachelocation', '--cache-location' -Tag Internal, LongPaths, CacheLocation {
         BeforeAll {
             $paths = Restore-ChocolateyInstallSnapshot
+            $features = Get-chocolateyFeature
 
             $Output = Invoke-Choco upgrade install-chocolateyzip --version 3.21.2 --confirm "$_" "$($paths.CachePath)" --no-progress
         }
@@ -331,6 +332,7 @@ Describe "choco upgrade" -Tag Chocolatey, UpgradeCommand {
     Context "Upgrading non-existing package while specifying a cache location (Arg: <_>)" -ForEach '-c', '--cache', '--cachelocation', '--cache-location' -Tag Internal, LongPaths, CacheLocation {
         BeforeAll {
             $paths = Restore-ChocolateyInstallSnapshot
+            $features = Get-chocolateyFeature
 
             $Output = Invoke-Choco upgrade install-chocolateyzip --version 3.21.2 --confirm "$_" "$($paths.CachePath)" --no-progress
         }

--- a/tests/pester-tests/commands/choco-upgrade.Tests.ps1
+++ b/tests/pester-tests/commands/choco-upgrade.Tests.ps1
@@ -22,7 +22,7 @@ Describe "choco upgrade" -Tag Chocolatey, UpgradeCommand {
         }
 
         It "Exits with Success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Installed a package to the lib directory" {
@@ -56,7 +56,7 @@ Describe "choco upgrade" -Tag Chocolatey, UpgradeCommand {
         }
 
         It "Exits with Success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Installed the package to the lib directory" {
@@ -94,7 +94,7 @@ Describe "choco upgrade" -Tag Chocolatey, UpgradeCommand {
         }
 
         It "Exits with Success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Installed the package to the lib directory" {
@@ -135,7 +135,7 @@ Describe "choco upgrade" -Tag Chocolatey, UpgradeCommand {
         }
 
         It "Exits with Success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Output should include pinned package" {
@@ -160,7 +160,7 @@ Describe "choco upgrade" -Tag Chocolatey, UpgradeCommand {
         }
 
         It 'Exits with Success (0)' {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It 'Outputs running curl script with correct arguments' {
@@ -201,7 +201,7 @@ Describe "choco upgrade" -Tag Chocolatey, UpgradeCommand {
         }
 
         It 'Exits with Success (0)' {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It 'Outputs running curl script with correct arguments' {
@@ -248,7 +248,7 @@ Describe "choco upgrade" -Tag Chocolatey, UpgradeCommand {
         }
 
         It "Installs successfully and exits with success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Installed the packages to the lib directory" {
@@ -474,7 +474,7 @@ Describe "choco upgrade" -Tag Chocolatey, UpgradeCommand {
             $PackageUnderTest = "hasinnoinstaller"
             $PackageVersion   = '6.2.0.3'
 
-            # We are purposely using the --reduce-nupkg-only option (both here and in the next call to Invoke-Choco), to make the 
+            # We are purposely using the --reduce-nupkg-only option (both here and in the next call to Invoke-Choco), to make the
             # test as close to default operation, when running both in the context of OSS and CLE. It was found during testing, that
             # the Package Optimizer would remove the application installer, which is the file that is being locked during the test,
             # which means then that the test doesn't actually test what we want it to. We are locking the exe here instead of say a
@@ -613,7 +613,7 @@ Describe "choco upgrade" -Tag Chocolatey, UpgradeCommand {
 
         # This was broken in v1.0.0
         It "Exits with Success (0)" -Tag Broken {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Outputs a message showing that installation was successful" {

--- a/tests/pester-tests/commands/choco-version.Tests.ps1
+++ b/tests/pester-tests/commands/choco-version.Tests.ps1
@@ -17,7 +17,7 @@ Describe "choco version" -Tag Chocolatey, VersionCommand -Skip:(Test-ChocolateyV
         }
 
         It "Exits successfully (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Reports that the command is deprecated" {
@@ -36,7 +36,7 @@ Describe "choco version" -Tag Chocolatey, VersionCommand -Skip:(Test-ChocolateyV
         }
 
         It "Exits successfully (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Outputs Help for Version" {


### PR DESCRIPTION
## Description Of Changes

Normalize the exit code checking of the Pester tests. Add proper Chocolatey License check where needed.

## Motivation and Context

This normalizes the exit code checking of the pester tests so that if they don't return as expected we have the output of the command. Also to bring some of the install/upgrade tests in line with the develop branch.

## Testing

Ran through Test Kitchen in Team City (see link to gep13 in Slack)

### Operating Systems Testing

Windows Server 2016/2019

## Change Types Made

* [ ] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.
* [x] Pester test changes

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [x] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue

* Related to #2712 
