### PR TITLE
(#2712) Normalize ExitCode pester tests

### DIFF
--- a/tests/pester-tests/chocolatey.Tests.ps1
+++ b/tests/pester-tests/chocolatey.Tests.ps1
@@ -83,7 +83,7 @@ Describe "Ensuring Chocolatey is correctly installed" -Tag Environment, Chocolat
         It "Outputs the version when run with --version" {
             $Output = Invoke-Choco --version
             $script:CurrentVersion = $Output.String
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
             $LastExitCode | Should -Be 0
             ($Output.String -split '-' | Select-Object -First 1) -as [version] | Should -BeTrue
         }
@@ -345,7 +345,7 @@ exit $error.count
         }
 
         It 'should exit Success (0)' {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It 'should <removal> shim <_> on upgrade' -ForEach $RemovedShims {
@@ -369,7 +369,7 @@ exit $error.count
         }
 
         It 'Exits with Success (0)' {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It 'Should remove the invalid configuration file' {

--- a/tests/pester-tests/commands/choco-apikey.Tests.ps1
+++ b/tests/pester-tests/commands/choco-apikey.Tests.ps1
@@ -27,7 +27,7 @@ Describe "choco <_>" -ForEach $Command -Tag Chocolatey, ApiKeyCommand {
         }
 
         It "Exits with Success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Only displays chocolatey name with version" {
@@ -42,7 +42,7 @@ Describe "choco <_>" -ForEach $Command -Tag Chocolatey, ApiKeyCommand {
         }
 
         It "Exits with Success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Only displays chocolatey name with version" {
@@ -57,7 +57,7 @@ Describe "choco <_>" -ForEach $Command -Tag Chocolatey, ApiKeyCommand {
         }
 
         It "Exits with Success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Only displays chocolatey name with version" {
@@ -71,7 +71,7 @@ Describe "choco <_>" -ForEach $Command -Tag Chocolatey, ApiKeyCommand {
         }
 
         It "Exits with Success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Only displays chocolatey name with version" {
@@ -104,7 +104,7 @@ Describe "choco <_>" -ForEach $Command -Tag Chocolatey, ApiKeyCommand {
         }
 
         It "Exits with Success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Displays chocolatey name with version" {
@@ -148,7 +148,7 @@ Describe "choco <_>" -ForEach $Command -Tag Chocolatey, ApiKeyCommand {
         }
 
         It "Exits with Success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Displays chocolatey name with version" {
@@ -195,7 +195,7 @@ Describe "choco <_>" -ForEach $Command -Tag Chocolatey, ApiKeyCommand {
         }
 
         It "Exits with Success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Displays chocolatey name with version" {
@@ -243,7 +243,7 @@ Describe "choco <_>" -ForEach $Command -Tag Chocolatey, ApiKeyCommand {
         }
 
         It "Exits with Success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Displays chocolatey name with version" {
@@ -275,7 +275,7 @@ Describe "choco <_>" -ForEach $Command -Tag Chocolatey, ApiKeyCommand {
         }
 
         It "Exits with Success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Displays chocolatey name with version" {
@@ -299,7 +299,7 @@ Describe "choco <_>" -ForEach $Command -Tag Chocolatey, ApiKeyCommand {
         }
 
         It "Exits with Success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Displays chocolatey name with version" {
@@ -317,7 +317,7 @@ Describe "choco <_>" -ForEach $Command -Tag Chocolatey, ApiKeyCommand {
         }
 
         It "Exits with Failure (1)" {
-            $Output.ExitCode | Should -Be 1
+            $Output.ExitCode | Should -Be 1 -Because $Output.String
         }
 
         It "Displays chocolatey name with version" {
@@ -337,7 +337,7 @@ Describe "choco <_>" -ForEach $Command -Tag Chocolatey, ApiKeyCommand {
         }
 
         It "Exits with Success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Displays chocolatey name with version" {
@@ -358,7 +358,7 @@ Describe "choco <_>" -ForEach $Command -Tag Chocolatey, ApiKeyCommand {
         }
 
         It "Exits with Success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Displays chocolatey name with version" {

--- a/tests/pester-tests/commands/choco-config.Tests.ps1
+++ b/tests/pester-tests/commands/choco-config.Tests.ps1
@@ -62,7 +62,7 @@ Describe "choco config" -Tag Chocolatey, ConfigCommand {
         }
 
         It "Exits with Success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Displays chocolatey name with version" {
@@ -104,7 +104,7 @@ Describe "choco config" -Tag Chocolatey, ConfigCommand {
         }
 
         It "Exits with Success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Displays chocolatey name with version" {
@@ -122,7 +122,7 @@ Describe "choco config" -Tag Chocolatey, ConfigCommand {
         }
 
         It "Exits with Success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Displays chocolatey name with version" {
@@ -140,7 +140,7 @@ Describe "choco config" -Tag Chocolatey, ConfigCommand {
         }
 
         It "Exits with failure (1)" {
-            $Output.ExitCode | Should -Be 1
+            $Output.ExitCode | Should -Be 1 -Because $Output.String
         }
 
         It "Outputs an error indicating that there's no config by that name" {
@@ -157,7 +157,7 @@ Describe "choco config" -Tag Chocolatey, ConfigCommand {
         }
 
         It "Exits with Success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Displays chocolatey name with version" {
@@ -184,7 +184,7 @@ Describe "choco config" -Tag Chocolatey, ConfigCommand {
         }
 
         It "Exits with Success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Displays chocolatey name with version" {
@@ -211,7 +211,7 @@ Describe "choco config" -Tag Chocolatey, ConfigCommand {
         }
 
         It "Exits with Success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Displays chocolatey name with version" {
@@ -241,7 +241,7 @@ Describe "choco config" -Tag Chocolatey, ConfigCommand {
         }
 
         It "Exits with Success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Displays chocolatey name with version" {
@@ -268,7 +268,7 @@ Describe "choco config" -Tag Chocolatey, ConfigCommand {
         }
 
         It "Exits with Success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Displays chocolatey name with version" {

--- a/tests/pester-tests/commands/choco-export.Tests.ps1
+++ b/tests/pester-tests/commands/choco-export.Tests.ps1
@@ -76,7 +76,7 @@ Describe "choco export" -Tag Chocolatey, ExportCommand {
         }
 
         It "Exits with Success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Displays description of command" {
@@ -133,7 +133,7 @@ Describe "choco export" -Tag Chocolatey, ExportCommand {
         }
 
         It "Exits with success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         # NOTE: There is no output other than the header, and possibly the unofficial statement
@@ -184,7 +184,7 @@ Describe "choco export" -Tag Chocolatey, ExportCommand {
         }
 
         It "Exits with success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         # NOTE: There is no output other than the header, and possibly the unofficial statement
@@ -226,7 +226,7 @@ Describe "choco export" -Tag Chocolatey, ExportCommand {
         }
 
         It "Exits with success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         # NOTE: There is no output other than the header, and possibly the unofficial statement
@@ -277,7 +277,7 @@ Describe "choco export" -Tag Chocolatey, ExportCommand {
         }
 
         It "Exits with success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         # NOTE: There is no output other than the header, and possibly the unofficial statement
@@ -319,7 +319,7 @@ Describe "choco export" -Tag Chocolatey, ExportCommand {
         }
 
         It "Exits with success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         # NOTE: There is no output other than the header, and possibly the unofficial statement
@@ -387,7 +387,7 @@ Describe "choco export" -Tag Chocolatey, ExportCommand {
         }
 
         It "Exits with success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         # NOTE: There is no output other than the header, and possibly the unofficial statement
@@ -415,7 +415,7 @@ Describe "choco export" -Tag Chocolatey, ExportCommand {
         }
 
         It "Exits with Failure (1)" {
-            $Output.ExitCode | Should -Be 1
+            $Output.ExitCode | Should -Be 1 -Because $Output.String
         }
 
         It "Reports unable to export packages" {
@@ -439,7 +439,7 @@ Describe "choco export" -Tag Chocolatey, ExportCommand {
         }
 
         It "Exits with Failure (1)" {
-            $Output.ExitCode | Should -Be 1
+            $Output.ExitCode | Should -Be 1 -Because $Output.String
         }
 
         It "Reports unable to export packages" {
@@ -459,7 +459,7 @@ Describe "choco export" -Tag Chocolatey, ExportCommand {
         }
 
         It "Exits with Failure (1)" {
-            $Output.ExitCode | Should -Be 1
+            $Output.ExitCode | Should -Be 1 -Because $Output.String
         }
 
         It "Displays help page" {

--- a/tests/pester-tests/commands/choco-feature.Tests.ps1
+++ b/tests/pester-tests/commands/choco-feature.Tests.ps1
@@ -37,7 +37,7 @@ Describe "choco <_>" -ForEach $Command -Tag Chocolatey, FeatureCommand {
         }
 
         It "Exits with Success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Lists available features" {
@@ -124,7 +124,7 @@ Describe "choco <_>" -ForEach $Command -Tag Chocolatey, FeatureCommand {
         }
 
         It "Exits with Success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Outputs a message indicating that it disabled the feature" {
@@ -148,7 +148,7 @@ Describe "choco <_>" -ForEach $Command -Tag Chocolatey, FeatureCommand {
         }
 
         It "Exits with Success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Outputs a message indicating that it enabled the feature" {
@@ -172,7 +172,7 @@ Describe "choco <_>" -ForEach $Command -Tag Chocolatey, FeatureCommand {
         }
 
         It "Exits with Success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Outputs a message indicating that it disabled the feature" {
@@ -192,7 +192,7 @@ Describe "choco <_>" -ForEach $Command -Tag Chocolatey, FeatureCommand {
         }
 
         It "Exits with Failure (1)" {
-            $Output.ExitCode | Should -Be 1
+            $Output.ExitCode | Should -Be 1 -Because $Output.String
         }
 
         It "Outputs a message indicating it didn't find the feature in question" {
@@ -209,7 +209,7 @@ Describe "choco <_>" -ForEach $Command -Tag Chocolatey, FeatureCommand {
         }
 
         It "Exits with Failure (1)" {
-            $Output.ExitCode | Should -Be 1
+            $Output.ExitCode | Should -Be 1 -Because $Output.String
         }
 
         It "Outputs a message indicating it didn't find the feature in question" {

--- a/tests/pester-tests/commands/choco-help.Tests.ps1
+++ b/tests/pester-tests/commands/choco-help.Tests.ps1
@@ -43,7 +43,7 @@ Describe "choco help sections with option <_>" -ForEach $HelpOptions -Tag Chocol
         }
 
         It "Exits with Success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Outputs the Top-Level Help" {
@@ -68,7 +68,7 @@ Describe "choco help sections with option <_>" -ForEach $HelpOptions -Tag Chocol
         }
 
         It "'choco <_> $helpArgument' exits with Success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Outputs help for <_>" {

--- a/tests/pester-tests/commands/choco-list.Tests.ps1
+++ b/tests/pester-tests/commands/choco-list.Tests.ps1
@@ -21,7 +21,7 @@ Describe "choco list" -Tag Chocolatey, ListCommand {
         }
 
         It "Exits with Success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Should contain packages and version with a space between them" {
@@ -43,7 +43,7 @@ Describe "choco list" -Tag Chocolatey, ListCommand {
         }
 
         It "Exits with Success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Should not contain packages and version with a space between them" {
@@ -65,7 +65,7 @@ Describe "choco list" -Tag Chocolatey, ListCommand {
         }
 
         It "Exits with Success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Should contain package name(s)" {
@@ -87,7 +87,7 @@ Describe "choco list" -Tag Chocolatey, ListCommand {
         }
 
         It "Exits with Success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Should contain package isexactversiondependency" {
@@ -105,7 +105,7 @@ Describe "choco list" -Tag Chocolatey, ListCommand {
         }
 
         It "Exits with Failure (1)" {
-            $Output.ExitCode | Should -Be 1
+            $Output.ExitCode | Should -Be 1 -Because $Output.String
         }
 
         It "Should output expected error message" {
@@ -119,7 +119,7 @@ Describe "choco list" -Tag Chocolatey, ListCommand {
         }
 
         It "Exits with Success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Should not output the error message" {

--- a/tests/pester-tests/commands/choco-new.Tests.ps1
+++ b/tests/pester-tests/commands/choco-new.Tests.ps1
@@ -35,7 +35,7 @@ Describe "choco new" -Tag Chocolatey, NewCommand {
         }
 
         It "Exits with Success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Displays chocolatey name with version" {
@@ -83,7 +83,7 @@ Describe "choco new" -Tag Chocolatey, NewCommand {
         }
 
         It "Exits with Success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Displays chocolatey name with version" {
@@ -117,7 +117,7 @@ Describe "choco new" -Tag Chocolatey, NewCommand {
             }
 
             It "Exits with Success (0)" {
-                $Output.ExitCode | Should -Be 0
+                $Output.ExitCode | Should -Be 0 -Because $Output.String
             }
 
             It "Displays chocolatey name with version" {
@@ -151,7 +151,7 @@ Describe "choco new" -Tag Chocolatey, NewCommand {
         }
 
         It "Exits with Success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Creates the empty folders expected (<_>)" -ForEach $EmptyFolders {

--- a/tests/pester-tests/commands/choco-pack.Tests.ps1
+++ b/tests/pester-tests/commands/choco-pack.Tests.ps1
@@ -61,7 +61,7 @@ Describe "choco pack" -Tag Chocolatey, PackCommand {
         }
 
         It "'choco pack' exits with Failure (1)" {
-            $Output.ExitCode | Should -Be 1
+            $Output.ExitCode | Should -Be 1 -Because $Output.String
         }
 
         It "Outputs Error Message" {
@@ -85,7 +85,7 @@ Describe "choco pack" -Tag Chocolatey, PackCommand {
         }
 
         It "'choco pack' exits with Success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Displays Chocolatey name with version" {
@@ -115,7 +115,7 @@ Describe "choco pack" -Tag Chocolatey, PackCommand {
         }
 
         It "'choco pack' exits with Success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Displays Chocolatey name with version" {
@@ -146,7 +146,7 @@ Describe "choco pack" -Tag Chocolatey, PackCommand {
         }
 
         It "'choco pack' exits with Failure (1)" {
-            $Output.ExitCode | Should -Be 1
+            $Output.ExitCode | Should -Be 1 -Because $Output.String
         }
 
         It "Displays Chocolatey name with version" {
@@ -181,7 +181,7 @@ Describe "choco pack" -Tag Chocolatey, PackCommand {
         }
 
         It "'choco pack' exits with Failure (1)" {
-            $Output.ExitCode | Should -Be 1
+            $Output.ExitCode | Should -Be 1 -Because $Output.String
         }
 
         It "Displays Chocolatey name with version" {
@@ -216,7 +216,7 @@ Describe "choco pack" -Tag Chocolatey, PackCommand {
         }
 
         It "'choco pack' exits with Failure (1)" {
-            $Output.ExitCode | Should -Be 1
+            $Output.ExitCode | Should -Be 1 -Because $Output.String
         }
 
         It "Displays serialize error" {
@@ -248,7 +248,7 @@ Describe "choco pack" -Tag Chocolatey, PackCommand {
         }
 
         It "'choco pack' exits with Failure (1)" {
-            $Output.ExitCode | Should -Be 1
+            $Output.ExitCode | Should -Be 1 -Because $Output.String
         }
 
         It "Displays Chocolatey name with version" {
@@ -283,7 +283,7 @@ Describe "choco pack" -Tag Chocolatey, PackCommand {
         }
 
         It "'choco pack' exits with Failure (1)" {
-            $Output.ExitCode | Should -Be 1
+            $Output.ExitCode | Should -Be 1 -Because $Output.String
         }
 
         It "Displays Chocolatey name with version" {
@@ -323,7 +323,7 @@ Describe "choco pack" -Tag Chocolatey, PackCommand {
         }
 
         It "'choco pack' exits with Failure (1)" {
-            $Output.ExitCode | Should -Be 1
+            $Output.ExitCode | Should -Be 1 -Because $Output.String
         }
 
         It "Displays Chocolatey name with version" {
@@ -353,7 +353,7 @@ Describe "choco pack" -Tag Chocolatey, PackCommand {
         }
 
         It "'choco pack' exits with Failure (1)" {
-            $Output.ExitCode | Should -Be 1
+            $Output.ExitCode | Should -Be 1 -Because $Output.String
         }
 
         It "Displays Chocolatey name with version" {
@@ -383,7 +383,7 @@ Describe "choco pack" -Tag Chocolatey, PackCommand {
         }
 
         It "'choco pack' exits with Success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Displays Chocolatey name with version" {
@@ -423,7 +423,7 @@ Describe "choco pack" -Tag Chocolatey, PackCommand {
         }
 
         It "'choco pack' exits with Success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Displays Chocolatey name with version" {
@@ -460,7 +460,7 @@ Describe "choco pack" -Tag Chocolatey, PackCommand {
         }
 
         It "'choco pack' exits with Success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Displays Chocolatey name with version" {
@@ -565,7 +565,7 @@ Describe "choco pack" -Tag Chocolatey, PackCommand {
         }
 
         It 'Fails to pack and exits with an error (1)' {
-            $Output.ExitCode | Should -Be 1
+            $Output.ExitCode | Should -Be 1 -Because $Output.String
         }
 
         It 'Shows an error about the unsupported nuspec metadata element "<_>"' -TestCases $testCases {

--- a/tests/pester-tests/commands/choco-pin.Tests.ps1
+++ b/tests/pester-tests/commands/choco-pin.Tests.ps1
@@ -30,7 +30,7 @@ Describe "choco pin" -Tag Chocolatey, PinCommand {
         }
 
         It "Exits with ExitCode 0" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Has no Pins listed" {
@@ -48,7 +48,7 @@ Describe "choco pin" -Tag Chocolatey, PinCommand {
         }
 
         It "Exits with ExitCode 0" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Lists the new Pin" {
@@ -67,7 +67,7 @@ Describe "choco pin" -Tag Chocolatey, PinCommand {
         }
 
         It "Exits with ExitCode 0" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Lists the Pins" {
@@ -85,7 +85,7 @@ Describe "choco pin" -Tag Chocolatey, PinCommand {
         }
 
         It "Exits with ExitCode 0" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Sets the Pin" {
@@ -105,7 +105,7 @@ Describe "choco pin" -Tag Chocolatey, PinCommand {
         }
 
         It "Exits with ExitCode 0" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Changes Nothing" {
@@ -123,7 +123,7 @@ Describe "choco pin" -Tag Chocolatey, PinCommand {
         }
 
         It "Exits with ExitCode 1" {
-            $Output.ExitCode | Should -Be 1
+            $Output.ExitCode | Should -Be 1 -Because $Output.String
         }
 
         It "Outputs a message indicating the failure" {
@@ -146,7 +146,7 @@ Describe "choco pin" -Tag Chocolatey, PinCommand {
         }
 
         It "Exits with ExitCode 0" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Removed the Pin" {
@@ -163,7 +163,7 @@ Describe "choco pin" -Tag Chocolatey, PinCommand {
         }
 
         It "Exits with ExitCode 0" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Changes Nothing" {
@@ -179,7 +179,7 @@ Describe "choco pin" -Tag Chocolatey, PinCommand {
         }
 
         It "Exits with ExitCode 1" {
-            $Output.ExitCode | Should -Be 1
+            $Output.ExitCode | Should -Be 1 -Because $Output.String
         }
 
         It "Outputs a message indicating the failure" {

--- a/tests/pester-tests/commands/choco-removed.Tests.ps1
+++ b/tests/pester-tests/commands/choco-removed.Tests.ps1
@@ -37,7 +37,7 @@ exit $command.Count
         }
 
         It 'Exits with Success (0)' {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It 'Reports the correct command name' {
@@ -68,7 +68,7 @@ exit $command.Count
         }
 
         It 'Exits with Failure (1)' {
-            $Output.ExitCode | Should -Be 1
+            $Output.ExitCode | Should -Be 1 -Because $Output.String
         }
 
         It 'Reports missing API key' {
@@ -85,7 +85,7 @@ exit $command.Count
         }
 
         It 'Exits with Failure (1)' {
-            $Output.ExitCode | Should -Be 1
+            $Output.ExitCode | Should -Be 1 -Because $Output.String
         }
 
         It "Reports that the command doesn't exist" {
@@ -113,7 +113,7 @@ exit $command.Count
         }
 
         It 'Exits with Failure (1)' {
-            $Output.ExitCode | Should -Be 1
+            $Output.ExitCode | Should -Be 1 -Because $Output.String
         }
 
         It "Reports that the path for the source could not be resolved" {
@@ -127,7 +127,7 @@ exit $command.Count
         }
 
         It 'Exits with Success (0)' {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Reports that the command doesn't exist" {

--- a/tests/pester-tests/commands/choco-search.Tests.ps1
+++ b/tests/pester-tests/commands/choco-search.Tests.ps1
@@ -43,7 +43,7 @@ Describe "choco <_>" -ForEach $Command -Tag Chocolatey, SearchCommand, FindComma
         }
 
         It "Exits with Success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Lists available packages once" {
@@ -70,7 +70,7 @@ Describe "choco <_>" -ForEach $Command -Tag Chocolatey, SearchCommand, FindComma
         }
 
         It "Exits with Success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Contains packages and versions with a space between them" {
@@ -93,7 +93,7 @@ Describe "choco <_>" -ForEach $Command -Tag Chocolatey, SearchCommand, FindComma
         }
 
         It "Exits with Success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Shows each instance of an available package" {
@@ -119,7 +119,7 @@ Describe "choco <_>" -ForEach $Command -Tag Chocolatey, SearchCommand, FindComma
         }
 
         It "Exits with Success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Shows each instance of an available package" {
@@ -149,7 +149,7 @@ Describe "choco <_>" -ForEach $Command -Tag Chocolatey, SearchCommand, FindComma
         }
 
         It "Exits with Success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Shows version <_> of the package" -ForEach @("1.1.0"; "1.0.0") {
@@ -164,7 +164,7 @@ Describe "choco <_>" -ForEach $Command -Tag Chocolatey, SearchCommand, FindComma
         }
 
         It "Exits with Success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Should contain packages and version with a space between them" {
@@ -201,7 +201,7 @@ Describe "choco <_>" -ForEach $Command -Tag Chocolatey, SearchCommand, FindComma
         }
 
         It "Exits with Failure (1)" {
-            $Output.ExitCode | Should -Be 1
+            $Output.ExitCode | Should -Be 1 -Because $Output.String
         }
 
         It "Outputs an appropriate message to indicate the failure to search no sources, and nothing else" {
@@ -215,7 +215,7 @@ Describe "choco <_>" -ForEach $Command -Tag Chocolatey, SearchCommand, FindComma
         }
 
         It "Exits with Success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Should contain packages and version with a space between them" {
@@ -265,7 +265,7 @@ Describe "choco <_>" -ForEach $Command -Tag Chocolatey, SearchCommand, FindComma
         }
 
         It "Exits with Success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Displays the package <_>" -ForEach @("mvcmusicstore-db 1.2.0"; "mvcmusicstore-web 1.2.0") {
@@ -288,7 +288,7 @@ Describe "choco <_>" -ForEach $Command -Tag Chocolatey, SearchCommand, FindComma
         }
 
         It "Exits with Success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Displays the package <_>" -ForEach @("mvcmusicstore-db 1.2.0"; "mvcmusicstore-web 1.2.0") {
@@ -309,7 +309,7 @@ Describe "choco <_>" -ForEach $Command -Tag Chocolatey, SearchCommand, FindComma
         }
 
         It "Exits with Success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Should list package isexactversiondependency v<_>" -ForEach @("1.0.1"; "1.0.0"; "2.0.0"; "1.1.0") {
@@ -329,7 +329,7 @@ Describe "choco <_>" -ForEach $Command -Tag Chocolatey, SearchCommand, FindComma
         }
 
         It "Exits with Success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Should list package isexactversiondependency v<_>" -ForEach @("1.0.1"; "1.0.0"; "2.0.0"; "1.1.0"; "1.0.0-beta") {

--- a/tests/pester-tests/commands/choco-source.Tests.ps1
+++ b/tests/pester-tests/commands/choco-source.Tests.ps1
@@ -42,7 +42,7 @@ Describe "choco <_>" -ForEach $Command -Tag Chocolatey, SourceCommand {
         }
 
         It "Exits with Success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Displays chocolatey name with version" {
@@ -76,7 +76,7 @@ Describe "choco <_>" -ForEach $Command -Tag Chocolatey, SourceCommand {
         }
 
         It "Exits with Success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Displays chocolatey name with version" {
@@ -120,7 +120,7 @@ Describe "choco <_>" -ForEach $Command -Tag Chocolatey, SourceCommand {
         }
 
         It "Exits with Success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Displays chocolatey name with version" {
@@ -167,7 +167,7 @@ Describe "choco <_>" -ForEach $Command -Tag Chocolatey, SourceCommand {
         }
 
         It "Exits with Success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Displays chocolatey name with version" {
@@ -206,7 +206,7 @@ Describe "choco <_>" -ForEach $Command -Tag Chocolatey, SourceCommand {
         }
 
         It "Exits with Success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Displays chocolatey name with version" {
@@ -232,7 +232,7 @@ Describe "choco <_>" -ForEach $Command -Tag Chocolatey, SourceCommand {
         }
 
         It "Exits with Success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Displays chocolatey name with version" {
@@ -263,7 +263,7 @@ Describe "choco <_>" -ForEach $Command -Tag Chocolatey, SourceCommand {
         }
 
         It "Exits with Success (0)" {
-            $Output.ExitCode | Should -Be 1
+            $Output.ExitCode | Should -Be 1 -Because $Output.String
         }
 
         It "Displays chocolatey name with version" {
@@ -287,7 +287,7 @@ Describe "choco <_>" -ForEach $Command -Tag Chocolatey, SourceCommand {
         }
 
         It "Exits with Success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Displays chocolatey name with version" {
@@ -311,7 +311,7 @@ Describe "choco <_>" -ForEach $Command -Tag Chocolatey, SourceCommand {
         }
 
         It "Exits with Success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Displays chocolatey name with version" {
@@ -335,7 +335,7 @@ Describe "choco <_>" -ForEach $Command -Tag Chocolatey, SourceCommand {
         }
 
         It "Exits with Success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Displays chocolatey name with version" {
@@ -366,7 +366,7 @@ Describe "choco <_>" -ForEach $Command -Tag Chocolatey, SourceCommand {
         }
 
         It "Exits with Success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Displays chocolatey name with version" {
@@ -394,7 +394,7 @@ Describe "choco <_>" -ForEach $Command -Tag Chocolatey, SourceCommand {
         }
 
         It "Exits with Success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Displays chocolatey name with version" {
@@ -415,7 +415,7 @@ Describe "choco <_>" -ForEach $Command -Tag Chocolatey, SourceCommand {
         }
 
         It "Exits with Success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Displays chocolatey name with version" {

--- a/tests/pester-tests/commands/choco-template.Tests.ps1
+++ b/tests/pester-tests/commands/choco-template.Tests.ps1
@@ -28,7 +28,7 @@ Describe "choco <_>" -ForEach @(
         }
 
         It "Exits with Success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Displays the templates expected" {
@@ -51,7 +51,7 @@ Describe "choco <_>" -ForEach @(
         }
 
         It "Exits with Success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Displays the templates expected" {
@@ -74,7 +74,7 @@ Describe "choco <_>" -ForEach @(
         }
 
         It "Exits with Failure (1)" {
-            $Output.ExitCode | Should -Be 1
+            $Output.ExitCode | Should -Be 1 -Because $Output.String
         }
 
         It "Displays error with correct format" {
@@ -92,7 +92,7 @@ Describe "choco <_>" -ForEach @(
         }
 
         It "Exits with Success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Displays template information" {
@@ -139,7 +139,7 @@ Describe "choco <_>" -ForEach @(
         }
 
         It "Exits with Success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Displays template name and version" {
@@ -159,7 +159,7 @@ Describe "choco <_>" -ForEach @(
         }
 
         It "Exits with Success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Displays the templates marking the default as expected" {
@@ -184,7 +184,7 @@ Describe "choco <_>" -ForEach @(
         }
 
         It "Exits with Success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Displays the templates marking the default as expected" {
@@ -207,7 +207,7 @@ Describe "choco <_>" -ForEach @(
         }
 
         It "Exits with Success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Displays <Name> template information" -ForEach @(

--- a/tests/pester-tests/commands/choco-uninstall.Tests.ps1
+++ b/tests/pester-tests/commands/choco-uninstall.Tests.ps1
@@ -407,7 +407,7 @@ Describe "choco uninstall" -Tag Chocolatey, UninstallCommand {
         }
 
         It "Exits with Success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Uninstall package successfully" {

--- a/tests/pester-tests/commands/choco-upgrade.Tests.ps1
+++ b/tests/pester-tests/commands/choco-upgrade.Tests.ps1
@@ -491,7 +491,7 @@ To upgrade a local, or remote file, you may use:
 
         # This was broken in v1.3.1
         It "Exits with Success (0)" -Tag Broken {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Outputs a message showing that installation was successful" {
@@ -513,7 +513,7 @@ To upgrade a local, or remote file, you may use:
         }
 
         It "Exits with Success (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Outputs line with package name version and old version" {

--- a/tests/pester-tests/commands/choco-version.Tests.ps1
+++ b/tests/pester-tests/commands/choco-version.Tests.ps1
@@ -17,7 +17,7 @@ Describe "choco version" -Tag Chocolatey, VersionCommand -Skip:(Test-ChocolateyV
         }
 
         It "Exits successfully (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Reports that the command is deprecated" {
@@ -36,7 +36,7 @@ Describe "choco version" -Tag Chocolatey, VersionCommand -Skip:(Test-ChocolateyV
         }
 
         It "Exits successfully (0)" {
-            $Output.ExitCode | Should -Be 0
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
         It "Outputs Help for Version" {


### PR DESCRIPTION
## Description Of Changes

Normalize the exit code checking of the Pester tests.

## Motivation and Context

This normalizes the exit code checking of the pester tests so that if they don't return as expected we have the output of the command.

## Testing

Ran through Test Kitchen in Team City (see link to gep13 in Slack)

### Operating Systems Testing

Windows Server 2016/2019

## Change Types Made

* [ ] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.
* [x] Pester test changes

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [x] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue

* Related to #2712 
