### PR TITLE
(#3191) Pass options to Get-WebHeaders

### DIFF
--- a/src/chocolatey.resources/helpers/functions/Get-ChocolateyWebFile.ps1
+++ b/src/chocolatey.resources/helpers/functions/Get-ChocolateyWebFile.ps1
@@ -301,7 +301,7 @@ Get-FtpFile
             $fileFullPath = $fileFullPath -replace '\\chocolatey\\chocolatey\\', '\chocolatey\'
             $fileDirectory = [System.IO.Path]::GetDirectoryName($fileFullPath)
             $originalFileName = [System.IO.Path]::GetFileName($fileFullPath)
-            $fileFullPath = Get-WebFileName -Url $url -DefaultName $originalFileName
+            $fileFullPath = Get-WebFileName -Url $url -DefaultName $originalFileName -Options $options
             $fileFullPath = Join-Path $fileDirectory $fileFullPath
             $fileFullPath = [System.IO.Path]::GetFullPath($fileFullPath)
         }
@@ -324,7 +324,7 @@ Get-FtpFile
     $headers = @{}
     if ($url.StartsWith('http')) {
         try {
-            $headers = Get-WebHeaders -Url $url -ErrorAction "Stop"
+            $headers = Get-WebHeaders -Url $url -ErrorAction "Stop" -Options $options
         }
         catch {
             if ($PSVersionTable.PSVersion -lt (New-Object 'Version' 3, 0)) {
@@ -333,7 +333,7 @@ Get-FtpFile
                 $originalProtocol = [System.Net.ServicePointManager]::SecurityProtocol
                 [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]::Ssl3
                 try {
-                    $headers = Get-WebHeaders -Url $url -ErrorAction "Stop"
+                    $headers = Get-WebHeaders -Url $url -ErrorAction "Stop" -Options $options
                 }
                 catch {
                     Write-Host "Attempt to get headers for $url failed.`n  $($_.Exception.Message)"

--- a/src/chocolatey.resources/helpers/functions/Get-WebFile.ps1
+++ b/src/chocolatey.resources/helpers/functions/Get-WebFile.ps1
@@ -199,7 +199,12 @@ Get-WebFileName
                     $req.UserAgent = $options.headers.$key
                 }
                 Default {
-                    $req.Headers.Add($key, $options.headers.$key)
+                    if ([System.Net.WebHeaderCollection]::IsRestricted($key)) {
+                        Write-Warning "Skipping restricted header `'$key`' not currently supported by Chocolatey"
+                    }
+                    else {
+                        $req.Headers.Add($key, $options.headers.$key)
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Description Of Changes

Pass $options through to Get-WebFileName and Get-WebHeaders

- For remaining headers that don't require special support, check that they aren't 'restricted' before adding them to the `Headers` collection.

## Motivation and Context

Allows being able to set headers via functions like Install-ChocolateyPackage and ensure that those headers are used appropriately.

## Testing

### Operating Systems Testing

## Change Types Made

* [ ] Bug fix (non-breaking change).
* [x] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [x] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [x] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue

Fixes #3191
