### PR TITLE
Improved help description for flag: "list --includeprograms"

### DIFF
--- a/src/chocolatey/infrastructure.app/commands/ChocolateyListCommand.cs
+++ b/src/chocolatey/infrastructure.app/commands/ChocolateyListCommand.cs
@@ -95,7 +95,7 @@ namespace chocolatey.infrastructure.app.commands
                      "Prerelease - Include Prereleases? Defaults to false.",
                      option => configuration.Prerelease = option != null)
                 .Add("i|includeprograms|include-programs",
-                     "IncludePrograms - Filters out apps Chocolatey has listed as packages and includes those in the list. Defaults to false.",
+                     "IncludePrograms - Also list applications not managed by Chocolatey. Defaults to false.",
                      option => configuration.ListCommand.IncludeRegistryPrograms = option != null)
                 .Add("version=",
                      "Version - Specific version of a package to return.",


### PR DESCRIPTION
## Description Of Changes

* Improved the help/documentation description for the flag:  `choco list --includeprograms`
  * ❌ Old: `Filters out apps Chocolatey has listed as packages and includes those in the list. Defaults to false.`
  * ✔️ New: `Also list applications not managed by Chocolatey. Defaults to false.`

## Motivation and Context

* Old description was very confusing.  Felt like I was having a brain aneurysm every time I read it. 😄

## Testing
N/A

## Change Types Made
* [ ] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [X] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [X] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [ ] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue

Fixes #147
