### PR TITLE
(build) Install dotnet-6.0-runtime for QA Build

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -189,7 +189,7 @@ object ChocolateyQA : BuildType({
                         Install-WindowsFeature -Name NET-Framework-Features
                     }
 
-                    choco install windows-sdk-7.1 netfx-4.0.3-devpack --confirm --no-progress
+                    choco install windows-sdk-7.1 netfx-4.0.3-devpack dotnet-6.0-runtime --confirm --no-progress
                     exit ${'$'}LastExitCode
                 """.trimIndent()
             }


### PR DESCRIPTION
## Description Of Changes

This PR installs the `dotnet-6.0-runtime` package required for the QA Build / Dependency-Check to run.

## Motivation and Context

Older versions of the build agent had this baked in, but it is no longer in newer versions. Instead of re-introducing it to the build agent image, we'll install it when needed in order to run the Dependency-Check task.

## Testing

To test that the build agents can install `dotnet-6.0-runtime` and that installing it allows the Dependency-Check task to run, the user data script was temporarily amended to add this install at that point in the build process.

This worked and the Dependency-Check task ran as expected.

### Operating Systems Testing

- Windows Server 2019

## Change Types Made

Build

* [ ] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [ ] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue

N/A
