### PR TITLE
(build) Linux Dockerfile switch to archive backports repository

### DIFF
--- a/docker/Dockerfile.linux
+++ b/docker/Dockerfile.linux
@@ -14,7 +14,7 @@ ENV GITHUB_BASE_REF=$github_base_ref
 ENV GITHUB_HEAD_REF=$github_head_ref
 ENV GITHUB_RUN_NUMBER=$github_run_number
 
-RUN echo deb http://deb.debian.org/debian buster-backports main | tee /etc/apt/sources.list.d/buster-backports.list; \
+RUN echo deb http://archive.debian.org/debian buster-backports main | tee /etc/apt/sources.list.d/buster-backports.list; \
     apt-get update && apt-get install -t buster-backports git -y
 
 RUN curl -o packages-microsoft-prod.deb https://packages.microsoft.com/config/debian/10/packages-microsoft-prod.deb; \


### PR DESCRIPTION
## Description Of Changes

Updates the dockerfile to use the archive backports repository to install git, as the backports for debian 10 (buster) are no longer actively maintained.

## Motivation and Context

Docker build was failing.
https://github.com/chocolatey/choco/actions/runs/8707820224/job/23883728475

## Testing

Tested in docker locally, and GitHub actions passes.
https://github.com/TheCakeIsNaOH/choco/actions/runs/8715912320/job/23908561086

### Operating Systems Testing

N/A

## Change Types Made

* [x] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [x] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue

N/A, build maintenance. 

