### PR TITLE
(#3426) Add deprecation notice for unpackself

### DIFF
--- a/src/chocolatey/infrastructure.app/commands/ChocolateyUnpackSelfCommand.cs
+++ b/src/chocolatey/infrastructure.app/commands/ChocolateyUnpackSelfCommand.cs
@@ -32,7 +32,7 @@ namespace chocolatey.infrastructure.app.commands
 {
 #endif
 
-    [CommandFor("unpackself", "re-installs Chocolatey base files")]
+    [CommandFor("unpackself", "[DEPRECATED] will be removed in v3.0.0 - re-installs Chocolatey base files")]
     public class ChocolateyUnpackSelfCommand : ICommand
     {
         private readonly IFileSystem _fileSystem;
@@ -69,12 +69,17 @@ namespace chocolatey.infrastructure.app.commands
 
         public virtual void Validate(ChocolateyConfiguration configuration)
         {
+            this.Log().Warn(ChocolateyLoggers.Important, @"
+DEPRECATION NOTICE - choco unpackself command is deprecated and will be 
+ removed in version 3.0.0.");
         }
 
         public virtual void HelpMessage(ChocolateyConfiguration configuration)
         {
-            this.Log().Info(ChocolateyLoggers.Important, "UnpackSelf Command");
+            this.Log().Info(ChocolateyLoggers.Important, "[DEPRECATED] UnpackSelf Command");
             this.Log().Info(@"
+NOTE: Unpackself has been deprecated and will be removed in version 3.0.0. 
+
 This will unpack files needed by choco. It will overwrite existing
  files only if --force is specified.
 


### PR DESCRIPTION
## Description Of Changes

This commit adds deprecation notices around the `unpackself` command, in order to make people aware
that this command in going away in v3.0.0.

## Motivation and Context

Based on internal conversations, while the unpackself command is currently being used as part of the overall build process, it is not something that is "required". So, rather than leave this command in place, let's deprecate it, and then remove the command completely in the next major version of Chocolatey CLI.

With this command removed, it will be necessary to change the build process to sign the PowerShell files earlier in the build process than they currently are, but it shouldn't impact on the end result at all.


## Testing

1. Run `choco -h`
2. Ensure that the deprecation notice can be seen in the section that lists out all the commands
3. Run `choco unpackself -h`
4. Ensure that the deprecation notice can be seen
5. Run `choco unpackself`
6. Ensure that the deprecation notice can be seen

### Operating Systems Testing

- Windows 10

## Change Types Made

* [ ] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [x] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [x] Requires a change to the documentation.
* [x] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [x] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue

Fixes #3426 