### PR TITLE
(#3433) Optimize queries used when resolving dependencies of exact versions

### DIFF
--- a/src/chocolatey/infrastructure.app/nuget/NugetList.cs
+++ b/src/chocolatey/infrastructure.app/nuget/NugetList.cs
@@ -356,7 +356,7 @@ namespace chocolatey.infrastructure.app.nuget
             string packageName,
             ChocolateyConfiguration config,
             ILogger nugetLogger,
-            ChocolateySourceCacheContext cacheContext,
+            SourceCacheContext cacheContext,
             IEnumerable<NuGetEndpointResources> resources,
             NuGetVersion version = null)
         {

--- a/src/chocolatey/infrastructure.app/services/NugetService.cs
+++ b/src/chocolatey/infrastructure.app/services/NugetService.cs
@@ -642,7 +642,10 @@ Please see https://docs.chocolatey.org/en-us/troubleshooting for more
                     continue;
                 }
 
+                var oldPrerelease = config.Prerelease;
+                config.Prerelease = config.Prerelease || availablePackage.Identity.Version.IsPrerelease;
                 NugetCommon.GetPackageDependencies(availablePackage.Identity, NuGetFramework.AnyFramework, sourceCacheContext, _nugetLogger, remoteEndpoints, sourcePackageDependencyInfos, new HashSet<PackageDependency>(), config).GetAwaiter().GetResult();
+                config.Prerelease = oldPrerelease;
 
                 if (installedPackage != null && (installedPackage.PackageMetadata.Version == availablePackage.Identity.Version) && config.Force)
                 {
@@ -764,6 +767,7 @@ Please see https://docs.chocolatey.org/en-us/troubleshooting for more
                         this.Log().Error(ChocolateyLoggers.Important, logMessage);
 
                         foreach (var pkgMetadata in packagesToInstall)
+                        
                         {
                             var errorResult = packageResultsToReturn.GetOrAdd(pkgMetadata.Identity.Id, new PackageResult(pkgMetadata, pathResolver.GetInstallPath(pkgMetadata.Identity)));
                             errorResult.Messages.Add(new ResultMessage(ResultType.Error, logMessage));
@@ -1281,7 +1285,10 @@ Please see https://docs.chocolatey.org/en-us/troubleshooting for more
                     {
                         localPackageListValid = false;
 
+                        var oldPrerelease = config.Prerelease;
+                        config.Prerelease = config.Prerelease || availablePackage.Identity.Version.IsPrerelease;
                         NugetCommon.GetPackageDependencies(availablePackage.Identity, NuGetFramework.AnyFramework, sourceCacheContext, _nugetLogger, remoteEndpoints, sourcePackageDependencyInfos, sourceDependencyCache, config).GetAwaiter().GetResult();
+                        config.Prerelease = oldPrerelease;
 
                         packagesToUninstall.Add(installedPackage);
 
@@ -1323,7 +1330,10 @@ Please see https://docs.chocolatey.org/en-us/troubleshooting for more
 
                                 if (requestedPackageDependency != null)
                                 {
+                                    oldPrerelease = config.Prerelease;
+                                    config.Prerelease = config.Prerelease || availablePackage.Identity.Version.IsPrerelease;
                                     NugetCommon.GetPackageDependencies(requestedPackageDependency.Identity, NuGetFramework.AnyFramework, sourceCacheContext, _nugetLogger, remoteEndpoints, sourcePackageDependencyInfos, sourceDependencyCache, config).GetAwaiter().GetResult();
+                                    config.Prerelease = oldPrerelease;
                                 }
                             }
 
@@ -1336,7 +1346,10 @@ Please see https://docs.chocolatey.org/en-us/troubleshooting for more
 
                             if (availablePackageDependency != null)
                             {
+                                oldPrerelease = config.Prerelease;
+                                config.Prerelease = config.Prerelease || availablePackage.Identity.Version.IsPrerelease;
                                 NugetCommon.GetPackageDependencies(availablePackageDependency.Identity, NuGetFramework.AnyFramework, sourceCacheContext, _nugetLogger, remoteEndpoints, sourcePackageDependencyInfos, sourceDependencyCache, config).GetAwaiter().GetResult();
+                                config.Prerelease = oldPrerelease;
                             }
                             else
                             {
@@ -1456,7 +1469,10 @@ Please see https://docs.chocolatey.org/en-us/troubleshooting for more
                                     {
                                         foreach (var packageVersion in NugetList.FindAllPackageVersions(parentPackage.Id, config, _nugetLogger, sourceCacheContext, remoteEndpoints))
                                         {
+                                            oldPrerelease = config.Prerelease;
+                                            config.Prerelease = config.Prerelease || availablePackage.Identity.Version.IsPrerelease;
                                             NugetCommon.GetPackageDependencies(packageVersion.Identity, NuGetFramework.AnyFramework, sourceCacheContext, _nugetLogger, remoteEndpoints, sourcePackageDependencyInfos, sourceDependencyCache, config).GetAwaiter().GetResult();
+                                            config.Prerelease = oldPrerelease;
                                         }
                                     }
 


### PR DESCRIPTION
## Description Of Changes

This updates the NuGetCommon class to better handle lookups of package dependencies when an exact version range is used as the dependency.

Additionally, some optimizations when looking up valid packages are also implemented, by only look up the dependencies of a dependency that is inside of the valid version range that the package specifies.

## Motivation and Context

Some optimizations, and better handling of exact version ranges. Additionally, without this change users of CCR will not be able to install a meta package and its dependency until both have been approved or exempted.

## Testing

Testing have been performed against an internal testing repository which will be called out as hermes.

1. `choco install hasbetadependency --version 1.1.0-beta --ignore-http-cache --verbose --source hermes`
2. Verify queries used for `hasbetadependency` and `isexactversiondependency` is looked up using a specific version.
3. Repeat 1 and 2, using `--pre` instead of `--version`.
4. Run `choco install toplevelhasexactversiondependency --ignore-http-cache --verbose --source hermes`
5. Verify queries used for `toplevelhasexactversiondependency` and `childdependencywithlooserversiondependency` is looked up using a specific verison.
6. Run `choco install toplevelwithnesteddependencies --ignore-http-cache --verbose --source hermes`
7. Verify queries used for `toplevelwithnesteddependencies` and `childdependencywithlooserversiondependency` is looked up using a specific version.
8. Run `choco install hasoutofrangedependency --version 2.0.2 --ignore-http-cache --verbose --source hermes`
9. Verify queries used for `hasoutofrangedependency` and `hasdependency` is looked up using a specific version.
10. Verify the query for `hasdependency` falled back to attempting the `FindPackagesById` endpoint.

### Operating Systems Testing

- Windows 10

## Change Types Made

* [x] Bug fix (non-breaking change).
* [x] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added. (Not really any tests that can be added)
* [x] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue

Fixes #3433