### PR TITLE
(maint) Enhance local testing developer experience

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -139,4 +139,8 @@ The Pester tests have been modelled in a way to be testable without installing C
 
 To run them locally on your system: Open an administrative PowerShell prompt to the root of the repository, and run `./Invoke-Tests.ps1`. This script will then "install" Chocolatey to a temporary test directory, run the tests, and when complete attempt to restore the system as close to when it started as possible. The script takes the following parameters: `TestPath` The location to use as the base for the Chocolatey Tests, defaults to `$env:TEMP\chocolateyTests`. `TestPackage` The path to the `.nupkg` package to run tests against, defaults to `$chocolateyRepository\code_drop\Packages\Chocolatey\chocolatey.<version>.nupkg`. `SkipPackaging` Optionally skip the packaging of the test packages.
 
-To use the `Vagrantfile` you need to change directory into the `tests` directory, then run `vagrant up`. The Vagrantfile has been tested with VirtualBox. The [box being used](https://app.vagrantup.com/StefanScherer/boxes/windows_2019) is currently only updated for vmware_desktop and virtualbox providers, but there is a dated hyperv one that should work.
+#### Using the provided Vagrantfile
+
+To use the `Vagrantfile` you need to change directory into the `tests` directory, then run `vagrant up`. The Vagrantfile has been tested with VirtualBox. The [box being used](https://app.vagrantup.com/StefanScherer/boxes/windows_2019) is currently only updated for vmware_desktop and virtualbox providers, but there is a dated hyperv one that may work.
+
+Once the Vagrant box is booted, you can re-run just the tests by running `vagrant provision default --provision-with test`. If you would like to clear the packages and run fresh tests, you can run `vagrant provision default --provision-with clear-packages,test`.

--- a/tests/Vagrantfile
+++ b/tests/Vagrantfile
@@ -64,12 +64,19 @@ Vagrant.configure("2") do |config|
 
     Write-Host "($(Get-Date -Format "dddd MM/dd/yyyy HH:mm:ss K")) Build complete."
   SHELL
+  config.vm.provision "shell", name: "clear-packages", inline: <<-SHELL
+    Write-Host "($(Get-Date -Format "dddd MM/dd/yyyy HH:mm:ss K")) Clearing the packages directory"
+    Remove-Item "$env:TEMP/chocolateyTests/packages" -Recurse -Force -ErrorAction SilentlyContinue
+  SHELL
   config.vm.provision "shell", name: "test", inline: <<-SHELL
+    $null = robocopy c:/chocoRoot/tests c:/code/choco/tests /e /copy:dt /purge
     Write-Host "($(Get-Date -Format "dddd MM/dd/yyyy HH:mm:ss K")) Starting Test Execution"
     Push-Location c:/code/choco
     # $env:TEST_KITCHEN = 1
     $env:VM_RUNNING = 1
-    ./Invoke-Tests.ps1
+    # The Invoke-Tests file will build the packages if the directory does not exist.
+    # This will allow to rerun tests without packaging each time.
+    ./Invoke-Tests.ps1 -SkipPackaging
     Copy-Item $env:ALLUSERSPROFILE/chocolatey/logs/testInvocations.log C:/vagrant
   SHELL
 end


### PR DESCRIPTION
## Description Of Changes

Enhance the local testing setup to allow faster writing and iterating on Pester tests

## Motivation and Context

The existing setup required rebuilding the Chocolatey CLI package every time you wanted to test changes to tests.

## Testing

1. In the `tests` directory run `vagrant up`
2. Verify that the tests run.
3. Delete some (or all) of the pester test files.
4. Run `vagrant provision default --provision-with test`.
5. Verify that the deleted pester file is no longer executed (when I tested, I went from 29 files evaluated to 28 files evaluated).
6. Run `vagrant provision default --provision-with clear-packages,test`.
7. Verify that the `clear-packages` provisioning script runs, followed by the test packages being packaged during the `test` provisioning script.

### Operating Systems Testing

- Host: Windows 10

## Change Types Made

* [ ] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.
* [x] Pester Test execution changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [ ] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue

N/A
