### PR TITLE
Add Pester tests to cover functionality added in Chocolatey CLI 2.3.0

### DIFF
--- a/nuspec/chocolatey/chocolatey/tools/chocolateysetup.psm1
+++ b/nuspec/chocolatey/chocolatey/tools/chocolateysetup.psm1
@@ -858,7 +858,7 @@ function Invoke-Chocolatey-Initial {
     try {
         $chocoInstallationFolder = Get-ChocolateyInstallFolder
         $chocoExe = Join-Path -Path $chocoInstallationFolder -ChildPath "choco.exe"
-        $runResult = & $chocoExe -v *>&1
+        $runResult = & $chocoExe -v 2>&1
         if ($LASTEXITCODE -eq 0) {
             Write-Debug "Chocolatey CLI execution completed successfully."
         }

--- a/src/Chocolatey.PowerShell/Helpers/EnvironmentHelper.cs
+++ b/src/Chocolatey.PowerShell/Helpers/EnvironmentHelper.cs
@@ -166,7 +166,14 @@ namespace Chocolatey.PowerShell.Helpers
 
                 cmdlet.WriteDebug($"Registry type for {name} is/will be {registryType}");
 
-                registryKey.SetValue(name, value, registryType);
+                if (string.IsNullOrEmpty(value))
+                {
+                    registryKey.DeleteValue(name, throwOnMissingValue: false);
+                }
+                else
+                {
+                    registryKey.SetValue(name, value, registryType);
+                }
             }
 
             try
@@ -219,7 +226,10 @@ namespace Chocolatey.PowerShell.Helpers
                 foreach (var name in GetVariableNames(scope))
                 {
                     var value = GetVariable(cmdlet, name, scope);
-                    SetVariable(cmdlet, name, EnvironmentVariableTarget.Process, value);
+                    if (!string.IsNullOrEmpty(value))
+                    {
+                        SetVariable(cmdlet, name, EnvironmentVariableTarget.Process, value);
+                    }
                 }
             }
 

--- a/tests/pester-tests/chocolatey.Tests.ps1
+++ b/tests/pester-tests/chocolatey.Tests.ps1
@@ -195,20 +195,6 @@ Describe "Ensuring Chocolatey is correctly installed" -Tag Environment, Chocolat
             # $null = Invoke-Choco install MicrosoftWindowsPowerShellV2 -s windowsfeatures
         }
 
-        # This is Foss only as PowerShell running under version 2 doesn't have .net available and can't import the Licensed DLL.
-        # Tests on Windows 7 show no issues with running Chocolatey under Windows 7 with PowerShell v2 aside from issues surrounding TLS versions that we cannot resolve without an upgrade to Windows 7.
-        It "Imports ChocolateyInstaller module successfully in PowerShell v2" -Tag FossOnly {
-            $command = 'try { $ErrorActionPreference = ''Stop''; Import-Module $env:ChocolateyInstall\helpers\chocolateyInstaller.psm1 } catch { $_ ; exit 1 }'
-            $result = & powershell.exe -Version 2 -noprofile -command $command
-            $LastExitCode | Should -BeExactly 0 -Because $result
-        }
-
-        It "Imports ChocolateyProfile module successfully in PowerShell v2" {
-            $command = 'try { $ErrorActionPreference = ''Stop''; Import-Module $env:ChocolateyInstall\helpers\chocolateyProfile.psm1 } catch { $_ ; exit 1 }'
-            $result = & powershell.exe -Version 2 -noprofile -command $command
-            $LastExitCode | Should -BeExactly 0 -Because $result
-        }
-
         Context "chocolateyScriptRunner.ps1" {
             BeforeAll {
                 $Command = @'

--- a/tests/pester-tests/commands/choco-apikey.Tests.ps1
+++ b/tests/pester-tests/commands/choco-apikey.Tests.ps1
@@ -371,6 +371,41 @@ Describe "choco <_>" -ForEach $Command -Tag Chocolatey, ApiKeyCommand {
         }
     }
 
+    Context "Adding an apikey when it is already added" {
+        BeforeAll {
+            Restore-ChocolateyInstallSnapshot
+
+            # Ensure that the apikey is indeed set
+            $null = Invoke-Choco apikey add --source "https://somewhere.out/there/" --api-key "123-4567-89"
+
+            $Output = Invoke-Choco apikey add --source "https://somewhere.out/there/" --api-key "123-4567-89"
+        }
+
+        It "Exits with ExitCode 0" {
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
+        }
+
+        It "Changes Nothing" {
+            $Output.Lines | Should -Contain "Nothing to change. Config already set."
+        }
+
+        Context "when using enhanced exit codes" {
+            BeforeAll {
+                $null = Enable-ChocolateyFeature -Name "useEnhancedExitCodes"
+
+                $Output = Invoke-Choco apikey add --source "https://somewhere.out/there/" --api-key "123-4567-89"
+            }
+
+            It "Exits with ExitCode 2" {
+                $Output.ExitCode | Should -Be 2 -Because $Output.String
+            }
+
+            It "Changes Nothing" {
+                $Output.Lines | Should -Contain "Nothing to change. Config already set."
+            }
+        }
+    }
+
     # This needs to be the last test in this block, to ensure NuGet configurations aren't being created.
     Test-NuGetPaths
 }

--- a/tests/pester-tests/commands/choco-feature.Tests.ps1
+++ b/tests/pester-tests/commands/choco-feature.Tests.ps1
@@ -112,6 +112,76 @@ Describe "choco <_>" -ForEach $Command -Tag Chocolatey, FeatureCommand {
         }
     }
 
+    Context "Enabling a feature when it is already enabled" {
+        BeforeAll {
+            Restore-ChocolateyInstallSnapshot
+
+            # Ensure that the feature is already enabled
+            $null = Invoke-Choco feature enable --name allowGlobalConfirmation
+
+            $Output = Invoke-Choco feature enable --name allowGlobalConfirmation
+        }
+
+        It "Exits with ExitCode 0" {
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
+        }
+
+        It "Changes Nothing" {
+            $Output.Lines | Should -Contain "Nothing to change. Config already set."
+        }
+
+        Context "when using enhanced exit codes" {
+            BeforeAll {
+                $null = Enable-ChocolateyFeature -Name "useEnhancedExitCodes"
+
+                $Output = Invoke-Choco feature enable --name allowGlobalConfirmation
+            }
+
+            It "Exits with ExitCode 2" {
+                $Output.ExitCode | Should -Be 2 -Because $Output.String
+            }
+
+            It "Changes Nothing" {
+                $Output.Lines | Should -Contain "Nothing to change. Config already set."
+            }
+        }
+    }
+
+    Context "Disabling a feature when it is already disabled" {
+        BeforeAll {
+            Restore-ChocolateyInstallSnapshot
+
+            # Ensure that the feature is already disabled
+            $null = Invoke-Choco feature disable --name allowGlobalConfirmation
+
+            $Output = Invoke-Choco feature disable --name allowGlobalConfirmation
+        }
+
+        It "Exits with ExitCode 0" {
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
+        }
+
+        It "Changes Nothing" {
+            $Output.Lines | Should -Contain "Nothing to change. Config already set."
+        }
+
+        Context "when using enhanced exit codes" {
+            BeforeAll {
+                $null = Enable-ChocolateyFeature -Name "useEnhancedExitCodes"
+
+                $Output = Invoke-Choco feature disable --name allowGlobalConfirmation
+            }
+
+            It "Exits with ExitCode 2" {
+                $Output.ExitCode | Should -Be 2 -Because $Output.String
+            }
+
+            It "Changes Nothing" {
+                $Output.Lines | Should -Contain "Nothing to change. Config already set."
+            }
+        }
+    }
+
     Context "Disabling usePackageRepositoryOptimizations" {
         BeforeAll {
             Restore-ChocolateyInstallSnapshot

--- a/tests/pester-tests/commands/choco-info.Tests.ps1
+++ b/tests/pester-tests/commands/choco-info.Tests.ps1
@@ -12,6 +12,26 @@
         Remove-ChocolateyTestInstall
     }
 
+    Context "Should include remembered arguments (including redacted) when using option --local-only" {
+        BeforeAll {
+            Remove-NuGetPaths
+            Initialize-ChocolateyTestInstall -Source $PSScriptRoot\testpackages
+            Invoke-Choco install installpackage --package-parameters="bob" --user="bill" --password="secure-password" --confirm
+
+            $Output = Invoke-Choco info installpackage --local-only
+        }
+
+        It "Exits with Success (0)" {
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
+        }
+
+        It "Should contain a summary" {
+            $Output.Lines | Should -Contain "Remembered Package Arguments:" -Because $Output.String
+            $Output.Lines | Should -Contain "--package-parameters='bob'" -Because $Output.String
+            $Output.Lines | Should -Contain "--password=[REDACTED ARGUMENT]" -Because $Output.String
+        }
+    }
+
     Context "Listing package information when package can be found" {
         BeforeDiscovery {
             $infoItems = @(
@@ -187,11 +207,11 @@
         }
 
         It 'Outputs warning about unable to load service index' {
-            $Output.Lines | Should -Contain "Unable to load the service index for source $InvalidSource."
+            $Output.Lines | Should -Contain "Unable to load the service index for source $InvalidSource." -Because $Output.String
         }
 
         It 'Output information about the package' {
-            $Output.String | Should -Match "Title: Chocolatey "
+            $Output.String | Should -Match "Title: Chocolatey " -Because $Output.String
         }
     }
 

--- a/tests/pester-tests/commands/choco-info.Tests.ps1
+++ b/tests/pester-tests/commands/choco-info.Tests.ps1
@@ -16,7 +16,9 @@
         BeforeAll {
             Remove-NuGetPaths
             Initialize-ChocolateyTestInstall -Source $PSScriptRoot\testpackages
-            Invoke-Choco install installpackage --package-parameters="bob" --user="bill" --password="secure-password" --confirm
+
+            $Setup = Invoke-Choco install installpackage --package-parameters="bob" --user="bill" --password="secure-password" --confirm
+            $Setup.ExitCode | Should -Be 0 -Because $Setup.String
 
             $Output = Invoke-Choco info installpackage --local-only
         }

--- a/tests/pester-tests/commands/choco-info.Tests.ps1
+++ b/tests/pester-tests/commands/choco-info.Tests.ps1
@@ -14,10 +14,10 @@
 
     Context "Should include remembered arguments (including redacted) when using option --local-only" {
         BeforeAll {
-            Remove-NuGetPaths
             Initialize-ChocolateyTestInstall -Source $PSScriptRoot\testpackages
 
-            $Setup = Invoke-Choco install installpackage --package-parameters="bob" --user="bill" --password="secure-password" --confirm
+            $Setup = Invoke-Choco install installpackage --package-parameters="bob" --password="secure-password" --confirm
+
             $Setup.ExitCode | Should -Be 0 -Because $Setup.String
 
             $Output = Invoke-Choco info installpackage --local-only
@@ -36,7 +36,6 @@
 
     Context "Should include configured sources" {
         BeforeAll {
-            Remove-NuGetPaths
             Initialize-ChocolateyTestInstall -Source $PSScriptRoot\testpackages
             Invoke-Choco install installpackage --confirm
 

--- a/tests/pester-tests/commands/choco-info.Tests.ps1
+++ b/tests/pester-tests/commands/choco-info.Tests.ps1
@@ -32,6 +32,24 @@
         }
     }
 
+    Context "Should include configured sources" {
+        BeforeAll {
+            Remove-NuGetPaths
+            Initialize-ChocolateyTestInstall -Source $PSScriptRoot\testpackages
+            Invoke-Choco install installpackage --confirm
+
+            $Output = Invoke-Choco info installpackage --include-configured-sources --debug
+        }
+
+        It "Exits with Success (0)" {
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
+        }
+
+        It "Should mention that configured sources have been included" {
+            $Output.Lines | Should -Contain "Including sources from chocolatey.config file." -Because $Output.String
+        }
+    }
+
     Context "Listing package information when package can be found" {
         BeforeDiscovery {
             $infoItems = @(

--- a/tests/pester-tests/commands/choco-install.Tests.ps1
+++ b/tests/pester-tests/commands/choco-install.Tests.ps1
@@ -83,7 +83,7 @@
 
             $PackageUnderTest = "installpackage"
 
-            $Output = Invoke-Choco install $PackageUnderTest --confirm
+            $Output = Invoke-Choco install $PackageUnderTest --debug --confirm
         }
 
         It "Exits with Success (0)" {
@@ -140,6 +140,86 @@
 
         It "Outputs a message showing that installation was successful" {
             $Output.String | Should -Match "Chocolatey installed 1/1 packages\."
+        }
+
+        It "Should mention that package hash verification has been skipped" {
+            $Output.Lines | Should -Contain "Skipping package hash validation as feature 'usePackageHashValidation' is not enabled." -Because $Output.String
+        }
+    }
+
+    Context "Installing a Package (Happy Path) with hash validation enabled" {
+        BeforeAll {
+            Restore-ChocolateyInstallSnapshot
+
+            $null = Enable-ChocolateyFeature -Name "usePackageHashValidation"
+
+            $PackageUnderTest = "installpackage"
+
+            $Output = Invoke-Choco install $PackageUnderTest --debug --confirm
+        }
+
+        It "Exits with Success (0)" {
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
+        }
+
+        It "Installed a package to the lib directory" {
+            "$env:ChocolateyInstall\lib\$PackageUnderTest" | Should -Exist
+        }
+
+        # We are skipping this for now, until we have stabilized the directory
+        # path reporting functionality. There are times that this test will
+        # fail due to Chocolatey not reporting the path.
+        # This failure seems to happen randomly, and is therefore not a
+        # reliable test we can make.
+        It "Outputs the installation directory (which should exist)" -Skip {
+            $directoryPath = "$env:ChocolateyInstall\lib\$PackageUnderTest"
+            $lineRegex = [regex]::Escape($directoryPath)
+
+            $foundPath = $Output.Lines -match $lineRegex
+            $foundPath | Should -Not -BeNullOrEmpty
+            $foundPath | Should -Exist
+        }
+
+        It "Installs the expected version of the package" {
+            "$env:ChocolateyInstall\lib\$PackageUnderTest\$PackageUnderTest.nuspec" | Should -Exist
+            [xml]$XML = Get-Content "$env:ChocolateyInstall\lib\$PackageUnderTest\$PackageUnderTest.nuspec"
+            $XML.package.metadata.version | Should -Be "1.0.0"
+        }
+
+        It "Creates a Console Shim in the Bin Directory" {
+            "$env:ChocolateyInstall\bin\console.exe" | Should -Exist
+        }
+
+        It "Creates a Graphical Shim in the Bin Directory" {
+            "$env:ChocolateyInstall\bin\graphical.exe" | Should -Exist
+        }
+
+        It "Does not create a Shim for Ignored Executable in the Bin Directory" {
+            "$env:ChocolateyInstall\bin\not.installed.exe" | Should -Not -Exist
+        }
+
+        It "Does not create a Shim for Ignored Executable (with mismatched case) in the Bin Directory" {
+            "$env:ChocolateyInstall\bin\casemismatch.exe" | Should -Not -Exist
+        }
+
+        It "Does not create an extensions folder for the package" {
+            "$env:ChocolateyInstall\extensions\$PackageUnderTest" | Should -Not -Exist
+        }
+
+        It "Contains the output of the ChocolateyInstall.ps1 script" {
+            $Output.Lines | Should -Contain "Ya!"
+        }
+
+        It "Outputs a message showing that installation was successful" {
+            $Output.String | Should -Match "Chocolatey installed 1/1 packages\."
+        }
+
+        It "Should mention that package hash verification was skipped since local folder source is being used" {
+            if ((Test-HasNuGetV3Source) -or (-not $env:TEST_KITCHEN)) {
+                $Output.Lines | Should -Contain "Source does not provide a package hash, skipping package hash validation." -Because $Output.String
+            } else {
+                $Output.Lines | Should -Contain "Package hash matches expected hash." -Because $Output.String
+            }
         }
     }
 

--- a/tests/pester-tests/commands/choco-outdated.Tests.ps1
+++ b/tests/pester-tests/commands/choco-outdated.Tests.ps1
@@ -23,6 +23,20 @@ Describe "choco outdated" -Tag Chocolatey, OutdatedCommand {
         Remove-ChocolateyTestInstall
     }
 
+    Context "Should include configured sources" {
+        BeforeAll {
+            $Output = Invoke-Choco outdated --include-configured-sources --debug
+        }
+
+        It "Exits with Success (0)" {
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
+        }
+
+        It "Should mention that configured sources have been included" {
+            $Output.Lines | Should -Contain "Including sources from chocolatey.config file." -Because $Output.String
+        }
+    }
+
     Context "outdated ignore-pinned uses correct enhanced exit codes" -ForEach @(
         @{ Argument = '' ; ExitCode = 2 }
         @{ Argument = '--ignore-pinned' ; ExitCode = 0 }

--- a/tests/pester-tests/commands/choco-pin.Tests.ps1
+++ b/tests/pester-tests/commands/choco-pin.Tests.ps1
@@ -112,6 +112,24 @@ Describe "choco pin" -Tag Chocolatey, PinCommand {
             $Output.Lines | Should -Contain "Nothing to change. Pin already set or removed."
             $CurrentPins | Should -Contain "upgradepackage|1.0.0$listSuffix"
         }
+
+        Context "when using enhanced exit codes" {
+            BeforeAll {
+                $null = Enable-ChocolateyFeature -Name "useEnhancedExitCodes"
+
+                $Output = Invoke-Choco pin add --name upgradepackage
+                $CurrentPins = Invoke-Choco pin list --LimitOutput | ForEach-Object Lines
+            }
+
+            It "Exits with ExitCode 2" {
+                $Output.ExitCode | Should -Be 2 -Because $Output.String
+            }
+
+            It "Changes Nothing" {
+                $Output.Lines | Should -Contain "Nothing to change. Pin already set or removed."
+                $CurrentPins | Should -Contain "upgradepackage|1.0.0$listSuffix"
+            }
+        }
     }
 
     Context "Setting a Pin for a non-installed Package" {

--- a/tests/pester-tests/commands/choco-push.Tests.ps1
+++ b/tests/pester-tests/commands/choco-push.Tests.ps1
@@ -40,8 +40,8 @@ Describe "choco push" -Tag Chocolatey, PushCommand, ProxySkip -Skip:($null -eq $
 
         It "Should Report the actual cause of the error" {
             $Output.Lines | Should -Contain "Attempting to push $PackageUnderTest.$VersionUnderTest.nupkg to $RepositoryToUse" -Because $Output.String
-            $Output.Lines | Should -Contain "An error has occurred. It's possible the package version already exists on the repository or a nuspec element is invalid. See error below..." -Because $Output.String
-            $Output.Lines | Should -Contain "Response status code does not indicate success: 409 (Conflict)." -Because $Output.String
+            $Output.Lines | Should -Contain "An error has occurred. This package version already exists on the repository and cannot be modified." -Because $Output.String
+            $Output.Lines | Should -Contain "Package versions that are approved, rejected, or exempted cannot be modified." -Because $Output.String
         }
     }
 
@@ -71,7 +71,7 @@ Describe "choco push" -Tag Chocolatey, PushCommand, ProxySkip -Skip:($null -eq $
         It "Should Report the actual cause of the error" {
             $Output.Lines | Should -Contain "Attempting to push $PackageUnderTest.$VersionUnderTest.nupkg to $RepositoryToUse" -Because $Output.String
             $Output.Lines | Should -Contain "An error has occurred. It's possible the package version already exists on the repository or a nuspec element is invalid. See error below..." -Because $Output.String
-            $Output.Lines | Should -Contain "Response status code does not indicate success: 409 (Conflict)." -Because $Output.String
+            $Output.Lines | Should -Contain "Response status code does not indicate success: 409 (This package had an issue pushing: A nuget package's Description property may not be more than 4000 characters long.)." -Because $Output.String
         }
     }
 
@@ -101,7 +101,7 @@ Describe "choco push" -Tag Chocolatey, PushCommand, ProxySkip -Skip:($null -eq $
         It "Should Report the actual cause of the error" {
             $Output.Lines | Should -Contain "Attempting to push $PackageUnderTest.$VersionUnderTest.nupkg to $RepositoryToUse" -Because $Output.String
             $Output.Lines | Should -Contain "An error has occurred. It's possible the package version already exists on the repository or a nuspec element is invalid. See error below..." -Because $Output.String
-            $Output.Lines | Should -Contain "Response status code does not indicate success: 409 (Conflict)." -Because $Output.String
+            $Output.Lines | Should -Contain "Response status code does not indicate success: 409 (This package had an issue pushing: A nuget package's Title property may not be more than 256 characters long.)." -Because $Output.String
         }
     }
 

--- a/tests/pester-tests/commands/choco-rule.Tests.ps1
+++ b/tests/pester-tests/commands/choco-rule.Tests.ps1
@@ -1,0 +1,92 @@
+﻿Import-Module helpers/common-helpers
+
+Describe "choco rule" -Tag Chocolatey, RuleCommand {
+    BeforeDiscovery {
+    }
+
+    BeforeAll {
+        Remove-NuGetPaths
+        Initialize-ChocolateyTestInstall
+
+        New-ChocolateyInstallSnapshot
+    }
+
+    AfterAll {
+        Remove-ChocolateyTestInstall
+    }
+
+    Context "Running without subcommand specified" {
+        BeforeAll {
+            Restore-ChocolateyInstallSnapshot
+
+            $Output = Invoke-Choco rule
+        }
+
+        It "Exits with Success (0)" {
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
+        }
+
+        It "Displays the rules expected" {
+            $Output.Lines | Should -Contain 'CHCR0001: A required element is missing or has no content in the package nuspec file.' -Because $Output.String
+            $Output.Lines | Should -Contain 'CHCR0002: Enabling license acceptance requires a license url.' -Because $Output.String
+            $Output.Lines | Should -Contain 'CHCU0001: The specified content of the element is not of the expected type and can not be accepted.' -Because $Output.String
+            $Output.Lines | Should -Contain 'CHCU0002: Unsupported element is used.' -Because $Output.String
+        }
+    }
+
+    Context "Running with list subcommand" {
+        BeforeAll {
+            Restore-ChocolateyInstallSnapshot
+
+            $Output = Invoke-Choco rule list
+        }
+
+        It "Exits with Success (0)" {
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
+        }
+
+        It "Displays the rules expected" {
+            $Output.Lines | Should -Contain 'CHCR0001: A required element is missing or has no content in the package nuspec file.' -Because $Output.String
+            $Output.Lines | Should -Contain 'CHCR0002: Enabling license acceptance requires a license url.' -Because $Output.String
+            $Output.Lines | Should -Contain 'CHCU0001: The specified content of the element is not of the expected type and can not be accepted.' -Because $Output.String
+            $Output.Lines | Should -Contain 'CHCU0002: Unsupported element is used.' -Because $Output.String
+        }
+    }
+
+    Context "Running with get subcommand specified with no additional parameters" {
+        BeforeAll {
+            Restore-ChocolateyInstallSnapshot
+
+            $Output = Invoke-Choco rule get
+        }
+
+        It "Exits with Failure (1)" {
+            $Output.ExitCode | Should -Be 1 -Because $Output.String
+        }
+
+        It "Displays error with correct format" {
+            $Output.Lines | Should -Contain "A Rule Name (-n|--name) is required when getting information for a specific rule." -Because $Output.String
+        }
+    }
+
+    Context "Running with get subcommand specified with --name parameter" {
+        BeforeAll {
+            Restore-ChocolateyInstallSnapshot
+
+            $Output = Invoke-Choco rule get --name CHCU0001
+        }
+
+        It "Exits with Success (0)" {
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
+        }
+
+        It "Displays rule information" {
+            $Output.Lines | Should -Contain "Name: CHCU0001 | Severity: Error" -Because $Output.String
+            $Output.Lines | Should -Contain "Summary: The specified content of the element is not of the expected type and can not be accepted." -Because $Output.String
+            $Output.Lines | Should -Contain "Help URL:" -Because $Output.String
+        }
+    }
+
+    # This needs to be the last test in this block, to ensure NuGet configurations aren't being created.
+    Test-NuGetPaths
+}

--- a/tests/pester-tests/commands/choco-search.Tests.ps1
+++ b/tests/pester-tests/commands/choco-search.Tests.ps1
@@ -64,6 +64,20 @@ Describe "choco <_>" -ForEach $Command -Tag Chocolatey, SearchCommand, FindComma
         }
     }
 
+    Context "Should include configured sources" {
+        BeforeAll {
+            $Output = Invoke-Choco $_ upgradepackage --include-configured-sources --debug
+        }
+
+        It "Exits with Success (0)" {
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
+        }
+
+        It "Should mention that configured sources have been included" {
+            $Output.Lines | Should -Contain "Including sources from chocolatey.config file." -Because $Output.String
+        }
+    }
+
     Context "Searching for a particular package" {
         BeforeAll {
             $Output = Invoke-Choco $_ upgradepackage

--- a/tests/pester-tests/commands/choco-source.Tests.ps1
+++ b/tests/pester-tests/commands/choco-source.Tests.ps1
@@ -67,6 +67,45 @@ Describe "choco <_>" -ForEach $Command -Tag Chocolatey, SourceCommand {
         }
     }
 
+    Context "Add source that already exists" {
+        BeforeAll {
+            $null = Disable-ChocolateyFeature -Name "useEnhancedExitCodes"
+
+            # Ensure source is already added
+            Invoke-Choco $CurrentCommand add --name "already-exists" --source "https://somewhere/out/there/"
+
+            $Output = Invoke-Choco $CurrentCommand add --name "already-exists" --source "https://somewhere/out/there/"
+        }
+
+        It "Exits with Success (0)" {
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
+        }
+
+        It "Displays chocolatey name with version" {
+            $Output.Lines | Should -Contain $expectedHeader
+        }
+
+        It "Displays no change made" {
+            $Output.Lines | Should -Contain "Nothing to change. Config already set."
+        }
+
+        Context "when using enhanced exit codes" {
+            BeforeAll {
+                $null = Enable-ChocolateyFeature -Name "useEnhancedExitCodes"
+
+                $Output = Invoke-Choco $CurrentCommand add --name "already-exists" --source "https://somewhere/out/there/"
+            }
+
+            It "Exits with ExitCode 2" {
+                $Output.ExitCode | Should -Be 2 -Because $Output.String
+            }
+
+            It "Changes Nothing" {
+                $Output.Lines | Should -Contain "Nothing to change. Config already set."
+            }
+        }
+    }
+
     Context "Add single unauthenticated source with priority" {
         BeforeAll {
             $Output = Invoke-Choco $CurrentCommand add --name "dummy-long" --source "https://priority.test.com/api" --priority 1
@@ -304,6 +343,8 @@ Describe "choco <_>" -ForEach $Command -Tag Chocolatey, SourceCommand {
 
     Context "Removing missing source" {
         BeforeAll {
+            $null = Disable-ChocolateyFeature -Name "useEnhancedExitCodes"
+
             # Make sure the source is removed
             Invoke-Choco $CurrentCommand remove --name "not-existing"
 
@@ -320,6 +361,22 @@ Describe "choco <_>" -ForEach $Command -Tag Chocolatey, SourceCommand {
 
         It "Displays message about no change made" {
             $Output.Lines | Should -Contain "Nothing to change. Config already set."
+        }
+
+        Context "when using enhanced exit codes" {
+            BeforeAll {
+                $null = Enable-ChocolateyFeature -Name "useEnhancedExitCodes"
+
+                $Output = Invoke-Choco $CurrentCommand remove --name "not-existing"
+            }
+
+            It "Exits with ExitCode 2" {
+                $Output.ExitCode | Should -Be 2 -Because $Output.String
+            }
+
+            It "Changes Nothing" {
+                $Output.Lines | Should -Contain "Nothing to change. Config already set."
+            }
         }
     }
 
@@ -387,6 +444,8 @@ Describe "choco <_>" -ForEach $Command -Tag Chocolatey, SourceCommand {
 
     Context "Disabling missing source" {
         BeforeAll {
+            $null = Disable-ChocolateyFeature -Name "useEnhancedExitCodes"
+
             # Ensure source is not available
             Invoke-Choco $CurrentCommand remove --name "not-existing"
 
@@ -404,10 +463,68 @@ Describe "choco <_>" -ForEach $Command -Tag Chocolatey, SourceCommand {
         It "Displays no change made" {
             $Output.Lines | Should -Contain "Nothing to change. Config already set."
         }
+
+        Context "when using enhanced exit codes" {
+            BeforeAll {
+                $null = Enable-ChocolateyFeature -Name "useEnhancedExitCodes"
+
+                $Output = Invoke-Choco $CurrentCommand disable --name "not-existing"
+            }
+
+            It "Exits with ExitCode 2" {
+                $Output.ExitCode | Should -Be 2 -Because $Output.String
+            }
+
+            It "Changes Nothing" {
+                $Output.Lines | Should -Contain "Nothing to change. Config already set."
+            }
+        }
+    }
+
+    Context "Disabling source that is already disabled" {
+        BeforeAll {
+            $null = Disable-ChocolateyFeature -Name "useEnhancedExitCodes"
+
+            # Ensure source is not available
+            Invoke-Choco $CurrentCommand add --name "already-disabled" --source "https://somewhere/out/there/"
+            Invoke-Choco $CurrentCommand disable --name "already-disabled"
+
+            $Output = Invoke-Choco $CurrentCommand disable --name "already-disabled"
+        }
+
+        It "Exits with Success (0)" {
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
+        }
+
+        It "Displays chocolatey name with version" {
+            $Output.Lines | Should -Contain $expectedHeader
+        }
+
+        It "Displays no change made" {
+            $Output.Lines | Should -Contain "Nothing to change. Config already set."
+        }
+
+        Context "when using enhanced exit codes" {
+            BeforeAll {
+                $null = Enable-ChocolateyFeature -Name "useEnhancedExitCodes"
+
+                $Output = Invoke-Choco $CurrentCommand disable --name "already-disabled"
+            }
+
+            It "Exits with ExitCode 2" {
+                $Output.ExitCode | Should -Be 2 -Because $Output.String
+            }
+
+            It "Changes Nothing" {
+                $Output.Lines | Should -Contain "Nothing to change. Config already set."
+            }
+        }
     }
 
     Context "Enabling missing source" {
         BeforeAll {
+            $null = Disable-ChocolateyFeature -Name "useEnhancedExitCodes"
+
             # Ensure source is not available
             Invoke-Choco $CurrentCommand remove --name "not-existing"
 
@@ -424,6 +541,61 @@ Describe "choco <_>" -ForEach $Command -Tag Chocolatey, SourceCommand {
 
         It "Displays no change made" {
             $Output.Lines | Should -Contain "Nothing to change. Config already set."
+        }
+
+        Context "when using enhanced exit codes" {
+            BeforeAll {
+                $null = Enable-ChocolateyFeature -Name "useEnhancedExitCodes"
+
+                $Output = Invoke-Choco $CurrentCommand enable --name "not-existing"
+            }
+
+            It "Exits with ExitCode 2" {
+                $Output.ExitCode | Should -Be 2 -Because $Output.String
+            }
+
+            It "Changes Nothing" {
+                $Output.Lines | Should -Contain "Nothing to change. Config already set."
+            }
+        }
+    }
+
+    Context "Enabling source that is already enabled" {
+        BeforeAll {
+            $null = Disable-ChocolateyFeature -Name "useEnhancedExitCodes"
+
+            # Ensure source is enable
+            Invoke-Choco $CurrentCommand add --name "already-enabled" --source "https://somewhere/out/there/"
+
+            $Output = Invoke-Choco $CurrentCommand enable --name "already-enabled"
+        }
+
+        It "Exits with Success (0)" {
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
+        }
+
+        It "Displays chocolatey name with version" {
+            $Output.Lines | Should -Contain $expectedHeader
+        }
+
+        It "Displays no change made" {
+            $Output.Lines | Should -Contain "Nothing to change. Config already set."
+        }
+
+        Context "when using enhanced exit codes" {
+            BeforeAll {
+                $null = Enable-ChocolateyFeature -Name "useEnhancedExitCodes"
+
+                $Output = Invoke-Choco $CurrentCommand enable --name "already-enabled"
+            }
+
+            It "Exits with ExitCode 2" {
+                $Output.ExitCode | Should -Be 2 -Because $Output.String
+            }
+
+            It "Changes Nothing" {
+                $Output.Lines | Should -Contain "Nothing to change. Config already set."
+            }
         }
     }
 

--- a/tests/pester-tests/commands/choco-source.Tests.ps1
+++ b/tests/pester-tests/commands/choco-source.Tests.ps1
@@ -566,6 +566,7 @@ Describe "choco <_>" -ForEach $Command -Tag Chocolatey, SourceCommand {
 
             # Ensure source is enable
             Invoke-Choco $CurrentCommand add --name "already-enabled" --source "https://somewhere/out/there/"
+            Invoke-Choco $CurrentCommand enable --name "already-enabled"
 
             $Output = Invoke-Choco $CurrentCommand enable --name "already-enabled"
         }

--- a/tests/pester-tests/commands/choco-upgrade.Tests.ps1
+++ b/tests/pester-tests/commands/choco-upgrade.Tests.ps1
@@ -11,6 +11,36 @@
         Remove-ChocolateyTestInstall
     }
 
+    Context "Upgrade pinned package using (<Command>) option" -ForEach @(
+        @{ Command = '--ignore-pinned' ; Contains = $true }
+        @{ Command = '' ; Contains = $false }
+    ) {
+        BeforeAll {
+            Restore-ChocolateyInstallSnapshot
+
+            $Package = 'upgradepackage'
+
+            # This test relies on the correct usage of the --pin option on the install
+            # command, but this is tested elsewhere
+            $null = Invoke-Choco install $Package --pin --version 1.0.0 --confirm
+            $null = Invoke-Choco upgrade $Package $Command --confirm
+            $Output = Invoke-Choco pin list
+        }
+
+        It "Exits with Success (0)" {
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
+        }
+
+        It "Output should include upgraded package, with new pin in place" {
+            if ($Contains) {
+                $Output.String | Should -Match "$Package|1.1.0"
+            }
+            else {
+                $Output.String | Should -Match "$Package|1.0.0"
+            }
+        }
+    }
+
     Context "Upgrade package with (<Command>) specified" -ForEach @(
         @{ Command = '--pin' ; Contains = $true }
         @{ Command = '' ; Contains = $false }

--- a/tests/pester-tests/commands/choco-upgrade.Tests.ps1
+++ b/tests/pester-tests/commands/choco-upgrade.Tests.ps1
@@ -73,6 +73,77 @@
         }
     }
 
+    Context "Attempt to upgrade a package when there isn't an upgrade available" -Tag Internal {
+        BeforeAll {
+            Restore-ChocolateyInstallSnapshot
+
+            Enable-ChocolateySource -Name hermes-setup
+            $null = Invoke-Choco install wget
+
+            $Output = Invoke-Choco upgrade wget
+        }
+
+        It 'Exits with Success (0)' {
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
+        }
+
+        It 'Displays that upgrade was attempted but wasnt required' {
+            $Output.Lines | Should -Contain "Chocolatey upgraded 0/1 packages." -Because $Output.String
+        }
+
+        Context "when using enhanced exit codes" {
+            BeforeAll {
+                $null = Enable-ChocolateyFeature -Name "useEnhancedExitCodes"
+
+                $Output = Invoke-Choco upgrade wget
+            }
+
+            It "Exits with ExitCode 2" {
+                $Output.ExitCode | Should -Be 2 -Because $Output.String
+            }
+
+            It 'Displays that upgrade was attempted but wasnt required' {
+                $Output.Lines | Should -Contain "Chocolatey upgraded 0/1 packages." -Because $Output.String
+            }
+        }
+    }
+
+    Context "Attempt to run upgrade all when there isn't any upgrade available" -Tag Internal {
+        BeforeAll {
+            Restore-ChocolateyInstallSnapshot
+
+            Enable-ChocolateySource -Name hermes-setup
+            $null = Invoke-Choco install wget
+            $null = Invoke-Choco install curl
+
+            $Output = Invoke-Choco upgrade all
+        }
+
+        It 'Exits with Success (0)' {
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
+        }
+
+        It 'Displays that upgrade was attempted but wasnt required' {
+            $Output.Lines | Should -Contain "Chocolatey upgraded 0/2 packages." -Because $Output.String
+        }
+
+        Context "when using enhanced exit codes" {
+            BeforeAll {
+                $null = Enable-ChocolateyFeature -Name "useEnhancedExitCodes"
+
+                $Output = Invoke-Choco upgrade all
+            }
+
+            It "Exits with ExitCode 2" {
+                $Output.ExitCode | Should -Be 2 -Because $Output.String
+            }
+
+            It 'Displays that upgrade was attempted but wasnt required' {
+                $Output.Lines | Should -Contain "Chocolatey upgraded 0/2 packages." -Because $Output.String
+            }
+        }
+    }
+
     # We exclude this test when running CCM, as it will install and remove
     # the firefox package which is used through other tests that will be affected.
     Context "Upgrading packages while remembering arguments with multiple packages using arguments" -Tag CCMExcluded, Internal, VMOnly {

--- a/tests/pester-tests/commands/choco-upgrade.Tests.ps1
+++ b/tests/pester-tests/commands/choco-upgrade.Tests.ps1
@@ -73,6 +73,25 @@
         }
     }
 
+    Context "Should include configured sources" {
+        BeforeAll {
+            Restore-ChocolateyInstallSnapshot
+
+            Enable-ChocolateySource -Name hermes-setup
+            $null = Invoke-Choco install wget
+
+            $Output = Invoke-Choco upgrade wget --include-configured-sources --debug
+        }
+
+        It "Exits with Success (0)" {
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
+        }
+
+        It "Should mention that configured sources have been included" {
+            $Output.Lines | Should -Contain "Including sources from chocolatey.config file." -Because $Output.String
+        }
+    }
+
     Context "Attempt to upgrade a package when there isn't an upgrade available" -Tag Internal {
         BeforeAll {
             Restore-ChocolateyInstallSnapshot

--- a/tests/pester-tests/commands/choco-upgrade.Tests.ps1
+++ b/tests/pester-tests/commands/choco-upgrade.Tests.ps1
@@ -173,7 +173,7 @@
         }
 
         It 'Displays that upgrade was attempted but wasnt required' {
-            $Output.Lines | Should -Contain "Chocolatey upgraded 0/2 packages." -Because $Output.String
+            $Output.String | Should -MatchExactly "Chocolatey upgraded 0"
         }
 
         Context "when using enhanced exit codes" {
@@ -188,7 +188,7 @@
             }
 
             It 'Displays that upgrade was attempted but wasnt required' {
-                $Output.Lines | Should -Contain "Chocolatey upgraded 0/2 packages." -Because $Output.String
+                $Output.String | Should -MatchExactly "Chocolatey upgraded 0"
             }
         }
     }

--- a/tests/pester-tests/features/CygwinSource.Tests.ps1
+++ b/tests/pester-tests/features/CygwinSource.Tests.ps1
@@ -1,0 +1,30 @@
+﻿Import-Module helpers/common-helpers
+
+# This is skipped when not run in CI because it modifies the local system.
+Describe "Cygwin Source" -Tag Chocolatey, CygwinSource -Skip:(-not $env:TEST_KITCHEN) {
+    BeforeAll {
+        Initialize-ChocolateyTestInstall
+        New-ChocolateyInstallSnapshot
+        Enable-ChocolateySource -Name hermes-setup
+        $null = Invoke-Choco install cygwin
+    }
+
+    AfterAll {
+        $null = Invoke-Choco uninstall cygwin --remove-dependencies
+        Remove-ChocolateyTestInstall
+    }
+
+    Context "install all" {
+        BeforeAll {
+            $Output = Invoke-Choco install all --source=cygwin
+        }
+
+        It 'Exits with exit code (1)' {
+            $Output.ExitCode | Should -Be 1 -Because $Output.String
+        }
+
+        It 'Outputs exception' {
+            $Output.Lines | Should -Contain "Alternative sources do not allow the use of the 'all' package name/keyword." -Because $Output.String
+        }
+    }
+}

--- a/tests/pester-tests/features/PythonSource.Tests.ps1
+++ b/tests/pester-tests/features/PythonSource.Tests.ps1
@@ -27,12 +27,29 @@ Describe "Python Source" -Tag Chocolatey, UpgradeCommand, PythonSource, ProxySki
         }
 
         It 'Exits with correct exit code (<ExitCode>)' {
-            $Output.ExitCode | Should -Be $ExitCode
+            $Output.ExitCode | Should -Be $ExitCode -Because $Output.String
         }
 
         It 'Outputs properly' {
-            $Output.Lines | Should -Not:($ExitCode -eq 0) -Contain "Alternative sources do not allow the use of the 'all' package name/keyword."
-            $Output.Lines | Should  -Contain "Chocolatey upgraded $Count/$Count packages."
+            $Output.Lines | Should -Not:($ExitCode -eq 0) -Contain "Alternative sources do not allow the use of the 'all' package name/keyword." -Because $Output.String
+            $Output.Lines | Should  -Contain "Chocolatey upgraded $Count/$Count packages." -Because $Output.String
+        }
+    }
+
+    Context "install all" {
+        BeforeAll {
+            # For some reason under kitchen-pester we don't have pip on the path. This might be due to our snapshotting...
+            Import-Module $env:ChocolateyInstall/helpers/ChocolateyProfile.psm1
+            Update-SessionEnvironment
+            $Output = Invoke-Choco install all --source=python
+        }
+
+        It 'Exits with exit code (1)' {
+            $Output.ExitCode | Should -Be 1 -Because $Output.String
+        }
+
+        It 'Outputs exception' {
+            $Output.Lines | Should -Contain "Alternative sources do not allow the use of the 'all' package name/keyword." -Because $Output.String
         }
     }
 }

--- a/tests/pester-tests/features/RubySource.Tests.ps1
+++ b/tests/pester-tests/features/RubySource.Tests.ps1
@@ -1,0 +1,30 @@
+﻿Import-Module helpers/common-helpers
+
+# This is skipped when not run in CI because it modifies the local system.
+Describe "Ruby Source" -Tag Chocolatey, RubySource -Skip:(-not $env:TEST_KITCHEN) {
+    BeforeAll {
+        Initialize-ChocolateyTestInstall
+        New-ChocolateyInstallSnapshot
+        Enable-ChocolateySource -Name hermes-setup
+        $null = Invoke-Choco install ruby.portable
+    }
+
+    AfterAll {
+        $null = Invoke-Choco uninstall ruby.portable --remove-dependencies
+        Remove-ChocolateyTestInstall
+    }
+
+    Context "install all" {
+        BeforeAll {
+            $Output = Invoke-Choco install all --source=ruby
+        }
+
+        It 'Exits with exit code (1)' {
+            $Output.ExitCode | Should -Be 1 -Because $Output.String
+        }
+
+        It 'Outputs exception' {
+            $Output.Lines | Should -Contain "Alternative sources do not allow the use of the 'all' package name/keyword." -Because $Output.String
+        }
+    }
+}

--- a/tests/pester-tests/features/WindowsFeaturesSource.Tests.ps1
+++ b/tests/pester-tests/features/WindowsFeaturesSource.Tests.ps1
@@ -1,0 +1,26 @@
+﻿Import-Module helpers/common-helpers
+
+Describe "Windows Features Source" -Tag Chocolatey, WindowsFeaturesSource {
+    BeforeAll {
+        Initialize-ChocolateyTestInstall
+        New-ChocolateyInstallSnapshot
+    }
+
+    AfterAll {
+        Remove-ChocolateyTestInstall
+    }
+
+    Context "install all" {
+        BeforeAll {
+            $Output = Invoke-Choco install all --source=windowsfeatures
+        }
+
+        It 'Exits with exit code (1)' {
+            $Output.ExitCode | Should -Be 1 -Because $Output.String
+        }
+
+        It 'Outputs exception' {
+            $Output.Lines | Should -Contain "Alternative sources do not allow the use of the 'all' package name/keyword." -Because $Output.String
+        }
+    }
+}

--- a/tests/pester-tests/powershell-commands/Get-EnvironmentVariable.Tests.ps1
+++ b/tests/pester-tests/powershell-commands/Get-EnvironmentVariable.Tests.ps1
@@ -21,9 +21,11 @@ Describe 'Get-EnvironmentVariable helper function tests' -Tags Cmdlets {
         }
     }
 
-    Context 'Can retrieve the PATH variable without expanding environment names for the <Scope> scope' {
-        It 'Retrieves the <Scope> PATH value with un-expanded environment names' {
-            Get-EnvironmentVariable -Name 'PATH' -Scope 'Machine' | Should -Match '%[^%;\]+%'
+    Context 'Can retrieve the PATH variable without expanding environment names for the Machine scope' {
+        It 'Retrieves the Machine PATH value with un-expanded environment names' {
+            # We expect there to be an entry similar to the following: "%SystemRoot%\system32", since this
+            # is there by default in a Windows install
+            Get-EnvironmentVariable -Name 'PATH' -Scope 'Machine' | Should -Match '%[^%;\\]+%'
         }
     }
 }

--- a/tests/pester-tests/powershell-commands/Get-EnvironmentVariable.Tests.ps1
+++ b/tests/pester-tests/powershell-commands/Get-EnvironmentVariable.Tests.ps1
@@ -22,10 +22,18 @@ Describe 'Get-EnvironmentVariable helper function tests' -Tags Cmdlets {
     }
 
     Context 'Can retrieve the PATH variable without expanding environment names for the Machine scope' {
+        BeforeAll {
+            Install-ChocolateyPath -Path "%systemroot%\test" -PathType Machine
+        }
+
+        AfterAll {
+            Uninstall-ChocolateyPath -Path "%systemroot%\test" -PathType Machine
+        }
+
         It 'Retrieves the Machine PATH value with un-expanded environment names' {
             # We expect there to be an entry similar to the following: "%SystemRoot%\system32", since this
             # is there by default in a Windows install
-            Get-EnvironmentVariable -Name 'PATH' -Scope 'Machine' | Should -Match '%[^%;\\]+%'
+            Get-EnvironmentVariable -Name 'PATH' -Scope 'Machine' -PreserveVariables | Should -Match '%systemroot%\\test'
         }
     }
 }

--- a/tests/pester-tests/powershell-commands/Install-ChocolateyPath.Tests.ps1
+++ b/tests/pester-tests/powershell-commands/Install-ChocolateyPath.Tests.ps1
@@ -16,9 +16,13 @@
         @{ Scope = 'Machine' }
     ) {
         Context 'Path "<_>"' -ForEach @("C:\test", "C:\tools") {
+            AfterEach {
+                Uninstall-ChocolateyPath -Path $_ -Scope $Scope
+            }
+
             It 'stores the value in the desired PATH scope' {
                 Install-ChocolateyPath -Path $_ -Scope $Scope
-                [Environment]::GetEnvironmentVariable('PATH', $_, $Scope) -split [IO.Path]::PathSeparator | Should -Contain $_
+                [Environment]::GetEnvironmentVariable('PATH', $Scope) -split [IO.Path]::PathSeparator | Should -Contain $_
             }
         }
     }

--- a/tests/pester-tests/powershell-commands/Set-EnvironmentVariable.Tests.ps1
+++ b/tests/pester-tests/powershell-commands/Set-EnvironmentVariable.Tests.ps1
@@ -6,7 +6,7 @@ Describe 'Set-EnvironmentVariable helper function tests' -Tags Cmdlets {
         Import-Module "$testLocation\helpers\chocolateyInstaller.psm1"
     }
 
-    Context 'Sets an environment variable value at the target scope' -ForEach @(
+    Context 'Sets an environment variable value at the target <Scope>' -ForEach @(
         @{ Scope = 'Process' }
         @{ Scope = 'User' }
         @{ Scope = 'Machine' }
@@ -24,9 +24,8 @@ Describe 'Set-EnvironmentVariable helper function tests' -Tags Cmdlets {
                 Set-EnvironmentVariable -Name $Name -Value $Value -Scope $Scope
                 [Environment]::GetEnvironmentVariable($Name, $Scope) | Should -BeExactly $Value
 
-                if ($Scope -ne 'Process') {
-                    [Environment]::GetEnvironmentVariable($Name) | Should -BeExactly $Value
-                }
+                # We are explicitly checking the Process variable here.
+                [Environment]::GetEnvironmentVariable($Name, 'Process') | Should -BeExactly $Value
             }
             
             AfterAll {

--- a/tests/pester-tests/powershell-commands/Set-EnvironmentVariable.Tests.ps1
+++ b/tests/pester-tests/powershell-commands/Set-EnvironmentVariable.Tests.ps1
@@ -20,16 +20,20 @@ Describe 'Set-EnvironmentVariable helper function tests' -Tags Cmdlets {
         }
 
         Describe 'Setting environment variable <Name>' -ForEach $variables {
-            It 'Sets the target environment variable in the proper scope, as well as current process scope' {
+            BeforeAll {
                 Set-EnvironmentVariable -Name $Name -Value $Value -Scope $Scope
-                [Environment]::GetEnvironmentVariable($Name, $Scope) | Should -BeExactly $Value
-
-                # We are explicitly checking the Process variable here.
-                [Environment]::GetEnvironmentVariable($Name, 'Process') | Should -BeExactly $Value
             }
             
             AfterAll {
                 Set-EnvironmentVariable -Name $Name -Value "" -Scope $Scope
+            }
+
+            It 'sets the target environment variable in the proper scope' {
+                [Environment]::GetEnvironmentVariable($Name, $Scope) | Should -BeExactly $Value
+            }
+
+            It 'propagates the change to the current process' {
+                Get-Content "Env:\$Name" | Should -BeExactly $Value
             }
         }
     }

--- a/tests/pester-tests/powershell-commands/Uninstall-ChocolateyPath.Tests.ps1
+++ b/tests/pester-tests/powershell-commands/Uninstall-ChocolateyPath.Tests.ps1
@@ -18,7 +18,7 @@
 
             It 'removes a stored PATH value in the desired PATH scope' {
                 Uninstall-ChocolateyPath -Path $_ -Scope $Scope
-                [Environment]::GetEnvironmentVariable('PATH', $_, $Scope) -split [IO.Path]::PathSeparator | Should -Not -Contain $_
+                [Environment]::GetEnvironmentVariable('PATH', $Scope) -split [IO.Path]::PathSeparator | Should -Not -Contain $_
             }
         }
     }

--- a/tests/pester-tests/powershell-commands/Update-SessionEnvironment.Tests.ps1
+++ b/tests/pester-tests/powershell-commands/Update-SessionEnvironment.Tests.ps1
@@ -17,12 +17,13 @@
             Update-SessionEnvironment
             $env:Test | Should -BeExactly 'user-value'
             $env:Test2 | Should -BeExactly 'machine-value'
-            $env:Test3 | Should -BeNullOrEmpty -Because 'Process-only values should not be preserved'
+            $env:Test3 | Should -BeExactly 'process-value'
         }
 
         AfterAll {
             [Environment]::SetEnvironmentVariable("Test", [string]::Empty, "User")
             [Environment]::SetEnvironmentVariable("Test2", [string]::Empty, "Machine")
+            $env:Test3 = ''
         }
     }
 }


### PR DESCRIPTION
## Description Of Changes

A number of new Pester tests have been added to cover functionality that has been added.

## Motivation and Context

A lot of new functionality has been added into the develop branch ahead of the 2.3.0 CLI release.

We need to add tests to verify all of this new functionality, and to ensure that there are no regressions going forward.

This also includes a minor bugfix for an issue that surfaced in our test environment.

## Testing

These tests have been validated locally, but we will also kick off some tests runs once this PR is raised.

## Change Types Made

* [ ] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [x] Tests to cover my changes, have been added.
* [x] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue

N/A