### PR TITLE
(#310) Fix issue with environment handling

### DIFF
--- a/src/Chocolatey.PowerShell/Helpers/EnvironmentHelper.cs
+++ b/src/Chocolatey.PowerShell/Helpers/EnvironmentHelper.cs
@@ -118,7 +118,10 @@ namespace Chocolatey.PowerShell.Helpers
             {
                 using (var registryKey = GetEnvironmentKey(scope))
                 {
-                    return registryKey.GetValueNames();
+                    // .NET seems to cache the value names even if they're set to null (removed) at some point
+                    // so we need to only return the names of things that have non-null values.
+                    var names = registryKey.GetValueNames();
+                    return names.Where(n => !string.IsNullOrEmpty((string)registryKey.GetValue(n))).ToArray();
                 }
             }
             catch
@@ -219,7 +222,10 @@ namespace Chocolatey.PowerShell.Helpers
                 foreach (var name in GetVariableNames(scope))
                 {
                     var value = GetVariable(cmdlet, name, scope);
-                    SetVariable(cmdlet, name, EnvironmentVariableTarget.Process, value);
+                    if (!string.IsNullOrEmpty(value))
+                    {
+                        SetVariable(cmdlet, name, EnvironmentVariableTarget.Process, value);
+                    }
                 }
             }
 


### PR DESCRIPTION
## Description Of Changes

- Only return environment variable names that have an associated value from Get-EnvironmentVariableNames
- When calling Update-SessionEnvironment, don't call SetVariable if the value at the queried scope is null.

## Motivation and Context

- .NET's registry handling seems to get value names around that have been set to null previously in the session, causing issues with the UpdateSession logic path.

## Testing

Testing in test kitchen where we noticed the issue.

### Operating Systems Testing

Windows Server 2016 & 2019

## Change Types Made
<!-- Tick the boxes for the type of changes that have been made -->

* [x] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [ ] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue

#310
