### PR TITLE
(#3433) Add overload for FindPackages method

### DIFF
--- a/src/chocolatey/infrastructure.app/nuget/NugetList.cs
+++ b/src/chocolatey/infrastructure.app/nuget/NugetList.cs
@@ -248,7 +248,7 @@ namespace chocolatey.infrastructure.app.nuget
                 }
                 else
                 {
-                    var exactPackage = FindPackage(searchTermLower, configuration, nugetLogger, cacheContext, packageRepositoryResources, version);
+                    var exactPackage = FindPackage(searchTermLower, configuration, nugetLogger, (SourceCacheContext)cacheContext, packageRepositoryResources, version);
 
                     if (exactPackage == null)
                     {
@@ -340,6 +340,28 @@ namespace chocolatey.infrastructure.app.nuget
                 metadataList.AddRange(resource.GetMetadataAsync(packageName, config.Prerelease, false, cacheContext, nugetLogger, CancellationToken.None).GetAwaiter().GetResult());
             }
             return metadataList;
+        }
+
+        /// <summary>
+        ///   Searches for packages that are available based on name and other options
+        /// </summary>
+        /// <param name="packageName">Name of package to search for</param>
+        /// <param name="config">Chocolatey configuration used to help supply the search parameters</param>
+        /// <param name="nugetLogger">The nuget logger</param>
+        /// <param name="resources">The resources that should be queried</param>
+        /// <param name="version">Version to search for</param>
+        /// <param name="cacheContext">Settings for caching of results from sources</param>
+        /// <returns>One result or nothing</returns>
+        [Obsolete("Use the overload that uses the base source cache context instead.")]
+        public static IPackageSearchMetadata FindPackage(
+            string packageName,
+            ChocolateyConfiguration config,
+            ILogger nugetLogger,
+            ChocolateySourceCacheContext cacheContext,
+            IEnumerable<NuGetEndpointResources> resources,
+            NuGetVersion version)
+        {
+            return FindPackage(packageName, config, nugetLogger, (SourceCacheContext)cacheContext, resources, version);
         }
 
         /// <summary>

--- a/src/chocolatey/infrastructure.app/services/NugetService.cs
+++ b/src/chocolatey/infrastructure.app/services/NugetService.cs
@@ -628,7 +628,7 @@ folder.");
                     latestPackageVersion = version;
                 }
 
-                var availablePackage = NugetList.FindPackage(packageName, config, _nugetLogger, sourceCacheContext, remoteEndpoints, latestPackageVersion);
+                var availablePackage = NugetList.FindPackage(packageName, config, _nugetLogger, (SourceCacheContext)sourceCacheContext, remoteEndpoints, latestPackageVersion);
 
                 if (availablePackage == null)
                 {
@@ -1149,7 +1149,7 @@ Please see https://docs.chocolatey.org/en-us/troubleshooting for more
                     // this is a prerelease - opt in for newer prereleases.
                     config.Prerelease = true;
                 }
-                var availablePackage = NugetList.FindPackage(packageName, config, _nugetLogger, sourceCacheContext, remoteEndpoints, version);
+                var availablePackage = NugetList.FindPackage(packageName, config, _nugetLogger, (SourceCacheContext)sourceCacheContext, remoteEndpoints, version);
 
                 config.Prerelease = originalPrerelease;
 
@@ -1334,7 +1334,7 @@ Please see https://docs.chocolatey.org/en-us/troubleshooting for more
                         {
                             if (version != null)
                             {
-                                var requestedPackageDependency = NugetList.FindPackage(parentPackage.Id, config, _nugetLogger, sourceCacheContext, remoteEndpoints, version);
+                                var requestedPackageDependency = NugetList.FindPackage(parentPackage.Id, config, _nugetLogger, (SourceCacheContext)sourceCacheContext, remoteEndpoints, version);
 
                                 if (requestedPackageDependency != null)
                                 {


### PR DESCRIPTION
## Description Of Changes

Adds back the overload in NuGetList that had been changed to only used the base class.

## Motivation and Context

This is reintroduced, as it was causing problems with Chocolatey Licensed Extension.

## Testing

Not possible to properly test, until it has been built by soteria.

1. Install Chocolatey CLI from this PR (officially strong named)
2. Install Chocolatey Licensed Extension
3. Attempt to install a package that have dependencies.
4. Verify no errors are reported.

### Operating Systems Testing

- Windows 10

## Change Types Made

* [x] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [x] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue

Related to #3433