### PR TITLE
Revert change made to way that IoC Container verification is performed

### DIFF
--- a/src/chocolatey/infrastructure/registration/SimpleInjectorContainer.cs
+++ b/src/chocolatey/infrastructure/registration/SimpleInjectorContainer.cs
@@ -38,11 +38,10 @@ namespace chocolatey.infrastructure.registration
         private const string RegisterComponentsMethod = "RegisterComponents";
 
 #if DEBUG
-#else
-        private static bool _verifyContainer = false;
-#endif
-
         public static bool VerifyContainer { get; set; } = true;
+#else
+        public static bool VerifyContainer { get; set; } = false;
+#endif
 
         /// <summary>
         ///   Add a component registry class to the container.


### PR DESCRIPTION
## Description Of Changes

This commit puts back in place the default values for the property,
using the exisitng cmpilers directives.

## Motivation and Context

In a previous commit:

https://github.com/chocolatey/choco/commit/8c422301e4589b879d866e710d1261abf0bdab4e#diff-56c83e4e3e69e032ca2de3fefe172645908c9db983ef1a9080cc3aa87ea5b773R45

A change was made to fix IDE0032 on some parts of the
SimpleInjectorContainer class.  However, the change that was made
missed the fact that there was a compiler directive in place that
changed the default value for the property. While in debug mode, it
defaulted to true, but in anything else, it defaulted to false.

Initially during testing, this didn't cause any problems, however, when
using Chocolatey Agent, it caused errors to occur during start up of
the service.  This was due to the fact that in Chocolatey Agent some
additional IoC registrations are performed, but with the default value
now set to true, the Verify method on the container instance was being
called, which then prevents any additional registrations from being
allowed, which meant the Chocolatey Agent service couldn't be started.

## Testing

1. Build this PR for Chocolatey CLI
2. Build hotfix branch for CLE
3. Build hotfix branch for Agent
4. Install all packages on a fresh VM
5. Check Chocolatey Agent log and make sure that the service starts correctly

### Operating Systems Testing

N/A

## Change Types Made

* [x] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [ ] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue

N/A - This is reverting a change that was done under a `maint` commit, and this commit is done under the same `maint`.