### PR TITLE
(#3364) Fix broken tab completion (expansion) in PowerShell v7.4+

### DIFF
--- a/src/chocolatey.resources/helpers/ChocolateyTabExpansion.ps1
+++ b/src/chocolatey.resources/helpers/ChocolateyTabExpansion.ps1
@@ -264,25 +264,49 @@ if ($PowerTab_RegisterTabExpansion) {
     return
 }
 
-if (Test-Path Function:\TabExpansion) {
-    Rename-Item Function:\TabExpansion TabExpansionBackup
-}
+# PowerShell up to v7.3.x: use a custom TabExpansion function.
+if ($PSVersionTable.PSVersion.Major -lt 7 -or ($PSVersionTable.PSVersion.Major -eq 7 -and $PSVersionTable.PSVersion.Minor -lt 4)) { 
+    if (Test-Path Function:\TabExpansion) {
+        Rename-Item Function:\TabExpansion TabExpansionBackup
+    }
 
-function TabExpansion($line, $lastWord) {
-    $lastBlock = [System.Text.RegularExpressions.Regex]::Split($line, '[|;]')[-1].TrimStart()
+    function TabExpansion($line, $lastWord) {
+        $lastBlock = [System.Text.RegularExpressions.Regex]::Split($line, '[|;]')[-1].TrimStart()
+    
 
-    switch -regex ($lastBlock) {
-        # Execute Chocolatey tab completion for all choco-related commands
-        "^$(Get-AliasPattern choco) (.*)" {
-            ChocolateyTabExpansion $lastBlock
-        }
-
-        # Fall back on existing tab expansion
-        default {
-            if (Test-Path Function:\TabExpansionBackup) {
-                TabExpansionBackup $line $lastWord
+        switch -regex ($lastBlock) {
+            # Execute Chocolatey tab completion for all choco-related commands
+            "^$(Get-AliasPattern choco) (.*)" {
+                ChocolateyTabExpansion $lastBlock
+            }
+    
+            # Fall back on existing tab expansion
+            default {
+                if (Test-Path Function:\TabExpansionBackup) {
+                    TabExpansionBackup $line $lastWord
+                }
             }
         }
+    }
+} else { # PowerShell v7.4+: use the Register-ArgumentCompleter cmdlet (PowerShell no longer calls TabExpansion)
+    function script:Get-AliasNames($exe) {
+        @($exe) + @(Get-Alias | Where-Object { $_.Definition -eq $exe } | Select-Object -Exp Name)
+    }
+    
+    Register-ArgumentCompleter -Native -CommandName (Get-AliasNames choco) -ScriptBlock {
+        param($wordToComplete, $commandAst, $cursorColumn)
+    
+        # NOTE:
+        # * The stringified form of $commandAst is the command's own command line (irrespective of
+        #   whether other statements are on the same line or whether it is part of a pipeline).
+        # * However, trailing whitespace is trimmed in the string representation of $commandAst. 
+        #   Therefore, when the actual command line ends in space(s), they must be added back
+        #   so that ChocolateyTabExpansion recognizes the start of a new argument.
+        $ownCommandLine = [string] $commandAst
+        $ownCommandLine = $ownCommandLine.Substring(0, [Math]::Min($ownCommandLine.Length, $cursorColumn))
+        $ownCommandLine += ' ' * ($cursorColumn - $ownCommandLine.Length)
+    
+        ChocolateyTabExpansion $ownCommandLine
     }
 }
 

--- a/src/chocolatey.resources/helpers/ChocolateyTabExpansion.ps1
+++ b/src/chocolatey.resources/helpers/ChocolateyTabExpansion.ps1
@@ -264,8 +264,8 @@ if ($PowerTab_RegisterTabExpansion) {
     return
 }
 
-# PowerShell up to v7.3.x: use a custom TabExpansion function.
-if ($PSVersionTable.PSVersion.Major -lt 7 -or ($PSVersionTable.PSVersion.Major -eq 7 -and $PSVersionTable.PSVersion.Minor -lt 4)) { 
+# PowerShell up to v5.x: use a custom TabExpansion function.
+if ($PSVersionTable.PSVersion.Major -lt 5) { 
     if (Test-Path Function:\TabExpansion) {
         Rename-Item Function:\TabExpansion TabExpansionBackup
     }
@@ -288,7 +288,8 @@ if ($PSVersionTable.PSVersion.Major -lt 7 -or ($PSVersionTable.PSVersion.Major -
             }
         }
     }
-} else { # PowerShell v7.4+: use the Register-ArgumentCompleter cmdlet (PowerShell no longer calls TabExpansion)
+}
+else { # PowerShell v5+: use the Register-ArgumentCompleter cmdlet (PowerShell no longer calls TabExpansion after 7.4, but this available from 5.x)
     function script:Get-AliasNames($exe) {
         @($exe) + @(Get-Alias | Where-Object { $_.Definition -eq $exe } | Select-Object -Exp Name)
     }

--- a/src/chocolatey.resources/helpers/chocolateyProfile.psm1
+++ b/src/chocolatey.resources/helpers/chocolateyProfile.psm1
@@ -28,8 +28,8 @@ Import-Module "$thisDirectory\Chocolatey.PowerShell.dll" -Cmdlet "Get-Environmen
 Set-Alias refreshenv Update-SessionEnvironment
 
 Export-ModuleMember -Alias refreshenv -Cmdlet 'Update-SessionEnvironment'
-if ($PSVersionTable.PSVersion.Major -lt 7 -or ($PSVersionTable.PSVersion.Major -eq 7 -and $PSVersionTable.PSVersion.Minor -lt 4)) { 
-    Export-ModuleMember -Function 'TabExpansion' # Legacy TabExpansion function is only used up to PowerShell v7.3.x
+if ($PSVersionTable.PSVersion.Major -lt 5) { 
+    Export-ModuleMember -Function 'TabExpansion' # Legacy TabExpansion function is only used up to PowerShell v5.x
 }
 
 # SIG # Begin signature block

--- a/src/chocolatey.resources/helpers/chocolateyProfile.psm1
+++ b/src/chocolatey.resources/helpers/chocolateyProfile.psm1
@@ -27,7 +27,10 @@ Import-Module "$thisDirectory\Chocolatey.PowerShell.dll" -Cmdlet "Get-Environmen
 
 Set-Alias refreshenv Update-SessionEnvironment
 
-Export-ModuleMember -Alias refreshenv -Cmdlet 'Update-SessionEnvironment' -Function 'TabExpansion'
+Export-ModuleMember -Alias refreshenv -Cmdlet 'Update-SessionEnvironment'
+if ($PSVersionTable.PSVersion.Major -lt 7 -or ($PSVersionTable.PSVersion.Major -eq 7 -and $PSVersionTable.PSVersion.Minor -lt 4)) { 
+    Export-ModuleMember -Function 'TabExpansion' # Legacy TabExpansion function is only used up to PowerShell v7.3.x
+}
 
 # SIG # Begin signature block
 # MIInKwYJKoZIhvcNAQcCoIInHDCCJxgCAQExDzANBglghkgBZQMEAgEFADB5Bgor


### PR DESCRIPTION
(A continuation of https://github.com/chocolatey/choco/pull/3387. Most descriptions below are copied from there)

## Description Of Changes

Fix broken tab completion (expansion) in PowerShell v7.4+ by using the new Register-ArgumentCompleter API

TabExpansion is not used since PowerShell 7.4, so the export of legacy `TabExpansion` function is made conditional on the PowerShell version.

## Motivation and Context

As discussed in https://github.com/chocolatey/choco/issues/3364:

* Chocolatey's tab completion broke in v7.4.0, due to an intentional breaking change in PowerShell (removal of legacy code, as a side effect of which PowerShell no longer calls custom TabExpansion functions, if defined).

* The recommended approach (since v5.0) is to use Register-ArgumentCompleter

## Testing

Interactively (tab completion).

### Operating Systems Testing

Windows 10 22H2

## Change Types Made

* [x] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [x] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [ ] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

I don't have access to PowerShell v2, but I _think_ the changes are compatible.

## Related Issue

Fixes https://github.com/chocolatey/choco/issues/3364