### PR TITLE
(#3465) Allow building an MSI during outside of tagged commits.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,7 +50,7 @@ jobs:
         key: ${{ runner.os }}-tools-${{ hashFiles('recipe.cake') }}
     - name: Build with .Net Framework
       shell: powershell
-      run: ./build.ps1 --verbosity=diagnostic --target=CI --testExecutionType=unit --shouldRunOpenCover=false
+      run: ./build.ps1 --verbosity=diagnostic --target=CI --testExecutionType=unit --shouldRunOpenCover=false --shouldBuildMsi=true
     - name: Upload Windows build results
       uses: actions/upload-artifact@v3
       # Always upload build results
@@ -67,6 +67,7 @@ jobs:
           code_drop\Packages\NuGet\*.nupkg
           code_drop\Packages\Chocolatey\*.nupkg
           code_drop\MsBuild.log
+          code_drop\MSIs\en-US\chocolatey-*.msi
   #  - uses: coverallsapp/github-action@master
   #    with:
   #      github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -65,7 +65,7 @@ object Chocolatey : BuildType({
         script {
             name = "Call Cake"
             scriptContent = """
-                build.official.bat --verbosity=diagnostic --target=CI --testExecutionType=unit --shouldRunOpenCover=false
+                build.official.bat --verbosity=diagnostic --target=CI --testExecutionType=unit --shouldRunOpenCover=false --shouldBuildMsi=true
             """.trimIndent()
         }
     }

--- a/recipe.cake
+++ b/recipe.cake
@@ -364,7 +364,6 @@ Task("Prepare-NuGet-Packages")
 
 Task("Prepare-MSI")
     .WithCriteria(() => BuildParameters.ShouldBuildMsi, "Skipping because creation of MSI has been disabled")
-    .WithCriteria(() => BuildParameters.IsTagged, "Skipping because build is not tagged")
     .IsDependeeOf("Build-MSI")
     .Does(() =>
 {
@@ -378,9 +377,6 @@ Task("Prepare-MSI")
         );
     }
 });
-
-BuildParameters.Tasks.BuildMsiTask
-    .WithCriteria(() => BuildParameters.IsTagged, "Skipping because build is not tagged");
 
 Task("Create-TarGz-Packages")
     .IsDependentOn("Build")
@@ -439,7 +435,7 @@ BuildParameters.SetParameters(context: Context,
                             getMsisToSign: getMsisToSign,
                             getILMergeConfigs: getILMergeConfigs,
                             preferDotNetGlobalToolUsage: !IsRunningOnWindows(),
-                            shouldBuildMsi: true,
+                            shouldBuildMsi: false,
                             msiUsedWithinNupkg: false,
                             shouldAuthenticodeSignMsis: true,
                             shouldRunNuGet: IsRunningOnWindows(),

--- a/recipe.cake
+++ b/recipe.cake
@@ -167,6 +167,7 @@ Task("Prepare-Chocolatey-Packages")
     .IsDependeeOf("Create-Chocolatey-Packages")
     .IsDependeeOf("Verify-PowerShellScripts")
     .IsDependeeOf("Sign-Assemblies")
+    .IsDependentOn("Copy-Nuspec-Folders")
     .WithCriteria(() => BuildParameters.BuildAgentOperatingSystem == PlatformFamily.Windows, "Skipping because not running on Windows")
     .WithCriteria(() => BuildParameters.ShouldRunChocolatey, "Skipping because execution of Chocolatey has been disabled")
     .Does(() =>

--- a/tests/pester-tests/features/ArgumentsDecryption.Tests.ps1
+++ b/tests/pester-tests/features/ArgumentsDecryption.Tests.ps1
@@ -97,6 +97,8 @@
             Invoke-Choco install upgradepackage --version 1.0.0
             $argumentsFile = Join-Path $env:ChocolateyInstall ".chocolatey/upgradepackage.1.0.0/.arguments"
             $FileContents | Set-Content -Path $argumentsFile -Encoding utf8 -Force
+            # Remove the `download` directory so the download command doesn't fail the second test.
+            Remove-Item -Path $PWD/download -Recurse -Force -ErrorAction SilentlyContinue
 
             $Output = Invoke-Choco $Command @Parameters --debug
         }


### PR DESCRIPTION
## Description Of Changes

Update the Recipe used to default to not build an MSI. Update the CI configurations to allow building the MSI with the addition of the `--shouldBuildMsi=true` parameter.

## Motivation and Context

Ease the experience of making adjustments to the MSI. Allow us to get an MSI more regularly for testing.

## Testing

1. Ran `./build.bat --target=Build-Msi`
2. Noted that it failed to build as a previous task was skipped.
3. Ran `./build.bat --target=Build-Msi --shouldBuildMsi=true`
4. Noted that it completed successfully.
5. Checked the `code_drop/Artifacts` and `code_drop/MSIs/en-US` directories to confirm that an MSI was generated.
6. Monitored the GHA for this PR to note that an MSI was generated and included with the artifacts.
7. Monitored the Team City build for this PR to note that an MSI was not generated (because it's not a tagged build and the settings haven't been merged yet)

### Operating Systems Testing

- Windows 10

## Change Types Made

* [ ] Bug fix (non-breaking change).
* [x] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [ ] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue

Fixes #3465