### PR TITLE
(build) Add templated notifications to all build configurations

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -22,6 +22,8 @@ object Chocolatey : BuildType({
     id = AbsoluteId("Chocolatey")
     name = "Chocolatey CLI (Built with Unit Tests)"
 
+    templates(AbsoluteId("SlackNotificationTemplate"))
+
     artifactRules = """
     """.trimIndent()
 
@@ -94,6 +96,8 @@ object ChocolateySchd : BuildType({
     id = AbsoluteId("ChocolateySchd")
     name = "Chocolatey CLI (Scheduled Integration Testing)"
 
+    templates(AbsoluteId("SlackNotificationTemplate"))
+
     artifactRules = """
     """.trimIndent()
 
@@ -158,6 +162,8 @@ object ChocolateySchd : BuildType({
 object ChocolateyQA : BuildType({
     id = AbsoluteId("ChocolateyQA")
     name = "Chocolatey CLI (SonarQube)"
+
+    templates(AbsoluteId("SlackNotificationTemplate"))
 
     artifactRules = """
     """.trimIndent()
@@ -225,6 +231,8 @@ object ChocolateyQA : BuildType({
 object ChocolateySign : BuildType({
     id = AbsoluteId("ChocolateySign")
     name = "Chocolatey CLI (Script Signing)"
+
+    templates(AbsoluteId("SlackNotificationTemplate"))
 
     artifactRules = """
     """.trimIndent()
@@ -297,6 +305,8 @@ object ChocolateyDockerWin : BuildType({
     id = AbsoluteId("ChocolateyDockerWin")
     name = "Docker (Windows)"
 
+    templates(AbsoluteId("SlackNotificationTemplate"))
+
     params {
         // TeamCity has suggested "${Chocolatey.depParamRefs.buildNumber}"
         param("env.CHOCOLATEY_VERSION", "%dep.Chocolatey.build.number%")
@@ -351,6 +361,8 @@ object ChocolateyDockerWin : BuildType({
 object ChocolateyPosix : BuildType({
     id = AbsoluteId("ChocolateyPosix")
     name = "Docker (Linux)"
+
+    templates(AbsoluteId("SlackNotificationTemplate"))
 
     params {
         param("env.CAKE_NUGET_SOURCE", "") // The Cake version we use has issues with authing to our private source on Linux


### PR DESCRIPTION
## Description Of Changes

This PR makes each build configuration in the TeamCity KTS file reference a template containing standard Slack notification configuration, which applies said configuration to the build configuration without having to duplicate it in each.

## Motivation and Context

Enables standard notification configuration across all build configurations in this project.

## Testing

This has been tested by pointing a development TeamCity instance at the branch from which this merge request is originating.

### Operating Systems Testing

N/A

## Change Types Made

Build configuration change (non-breaking)

~~* [ ] Bug fix (non-breaking change).~~
~~* [ ] Feature / Enhancement (non-breaking change).~~
~~* [ ] Breaking change (fix or feature that could cause existing functionality to change).~~
~~* [ ] Documentation changes.~~
~~* [ ] PowerShell code changes.~~

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [ ] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue

N/A
