### PR TITLE
(doc) Update CREDITS.md file to match what is actually being used

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ code_drop
 obj
 src/packages
 /.vscode/**
+!.vscode/extensions.json
 !/.vscode/settings.json
 .vs
 

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+	"recommendations": [
+		"yzhang.markdown-all-in-one"
+	]
+}

--- a/docs/legal/CREDITS.md
+++ b/docs/legal/CREDITS.md
@@ -8,20 +8,20 @@
 - [Third Party Licenses - Runtime](#third-party-licenses---runtime)
   - [7-Zip @ 23.01](#7-zip--2301)
   - [AlphaFS @ 2.1.3](#alphafs--213)
-  - [Checksum @ 0.2.0](#checksum--020)
+  - [Checksum @ 0.3.1](#checksum--031)
   - [log4net @ 2.0.12](#log4net--2012)
   - [Microsoft.Bcl.HashCode @ 1.1.1](#microsoftbclhashcode--111)
-  - [Microsoft.Web.Xdt @ 2.1.1](#microsoftwebxdt--211)
-  - [Chocolatey.NuGet.Client @ 3.4.0](#chocolateynugetclient--340)
+  - [Microsoft.Web.Xdt @ 3.1.0](#microsoftwebxdt--310)
+  - [Newtonsoft.Json @ 13.0.1](#newtonsoftjson--1301)
+  - [Chocolatey.NuGet.Client @ 3.4.2](#chocolateynugetclient--342)
   - [Rhino.Licensing @ 1.4.1 (modified)](#rhinolicensing--141-modified)
-  - [Shim Generator (shimgen) @ 1.0.0](#shim-generator-shimgen--100)
+  - [Shim Generator (shimgen) @ 2.0.0](#shim-generator-shimgen--200)
   - [SimpleInjector @ 2.8.3](#simpleinjector--283)
   - [System.Reactive @ 5.0.0](#systemreactive--500)
   - [System.Runtime.CompilerServices.Unsafe @ 4.5.3](#systemruntimecompilerservicesunsafe--453)
   - [System.Threading.Tasks.Extensions @ 4.5.4](#systemthreadingtasksextensions--454)
 
 <!-- /TOC -->
-
 ## Committers & Contributors
 
 Chocolatey has been the thoughts, ideas, and work of a large community. While [Rob](https://github.com/ferventcoder) heads up direction and plays a primary role in development, there are several people that have really been a part of making Chocolatey what it is today.
@@ -198,7 +198,7 @@ Chocolatey uses [AlphaFS](https://github.com/alphaleonis/AlphaFS) for long file 
   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 ```
 
-### Checksum @ 0.2.0
+### Checksum @ 0.3.1
 
 Chocolatey uses [Checksum](https://github.com/chocolatey/checksum) to determine checksums.
 [License terms](https://github.com/chocolatey/checksum/blob/e6f5645610c7bc15084b48f69d4cdb056106f956/LICENSE):
@@ -598,113 +598,205 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 ```
 
-### Microsoft.Web.Xdt @ 2.1.1
+### Microsoft.Web.Xdt @ 3.1.0
 
 Chocolatey uses [Microsoft.Web.Xdt](https://www.nuget.org/packages/Microsoft.Web.xdt) to perform Xml Document Transformation.
-[License terms](https://www.microsoft.com/web/webpi/eula/microsoft_web_xmltransform.htm):
+[License terms](https://github.com/dotnet/xdt/blob/01eb67319c7e9a852799734dfb7c29fa64b48c69/LICENSE.txt):
 
 ```txt
-  MICROSOFT SOFTWARE LICENSE TERMS
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
 
-  MICROSOFT.WEB.XDT
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
-  These license terms are an agreement between Microsoft Corporation (or based on where you live, one of its affiliates) and you. Please read them. They apply to the software named above, which includes the media on which you received it, if any. The terms also apply to any Microsoft
+   1. Definitions.
 
-  ·         updates,
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
 
-  ·         supplements,
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
 
-  ·         Internet-based services, and
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
 
-  ·         support services
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
 
-  for this software, unless other terms accompany those items. If so, those terms apply.
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
 
-  By using the software, you accept these terms. If you do not accept them, do not use the software.
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
 
-  If you comply with these license terms, you have the perpetual rights below.
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
 
-  1.    INSTALLATION AND USE RIGHTS. You may install and use any number of copies of the software on your devices.
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
 
-  2.    ADDITIONAL LICENSING REQUIREMENTS AND/OR USE RIGHTS.
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
 
-  a.    Distributable Code. The software contains code that you are permitted to distribute in programs you develop if you comply with the terms below.
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
 
-  i.  Right to Use and Distribute.  You may copy and distribute the object code form of Microsoft.Web.XmlTransform.dll file.
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
 
-  ·         Third Party Distribution. You may permit distributors of your programs to copy and distribute the Distributable Code as part of those programs.
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
 
-  ii.Distribution Requirements. For any Distributable Code you distribute, you must
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
 
-  ·         add significant primary functionality to it in your programs;
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
 
-  ·         require distributors and external end users to agree to terms that protect it at least as much as this agreement;
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
 
-  ·         display your valid copyright notice on your programs; and
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
 
-  ·         indemnify, defend, and hold harmless Microsoft from any claims, including attorneys’ fees, related to the distribution or use of your programs.
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
 
-  iii.   Distribution Restrictions. You may not
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
 
-  ·         alter any copyright, trademark or patent notice in the Distributable Code;
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
 
-  ·         use Microsoft’s trademarks in your programs’ names or in a way that suggests your programs come from or are endorsed by Microsoft;
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
 
-  ·         distribute Distributable Code to run on a platform other than the Windows platform;
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
 
-  ·         include Distributable Code in malicious, deceptive or unlawful programs; or
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
 
-  ·         modify or distribute the source code of any Distributable Code so that any part of it becomes subject to an Excluded License. An Excluded License is one that requires, as a condition of use, modification or distribution, that
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
 
-  ·         the code be disclosed or distributed in source code form; or
+   END OF TERMS AND CONDITIONS
+```
 
-  ·         others have the right to modify it.
+### Newtonsoft.Json @ 13.0.1
 
-  3.    SCOPE OF LICENSE. The software is licensed, not sold. This agreement only gives you some rights to use the software. Microsoft reserves all other rights. Unless applicable law gives you more rights despite this limitation, you may use the software only as expressly permitted in this agreement. In doing so, you must comply with any technical limitations in the software that only allow you to use it in certain ways. You may not
+Chocolatey uses [Newtonsoft.Json](https://www.nuget.org/packages/Newtonsoft.Json) to help serialize/deserialze JSON files.
+[License terms](https://github.com/JamesNK/Newtonsoft.Json/blob/415b563806c218e9270331ea98c584fe84e58880/LICENSE.md):
 
-  ·         work around any technical limitations in the software;
+```txt
+The MIT License (MIT)
 
-  ·         reverse engineer, decompile or disassemble the software, except and only to the extent that applicable law expressly permits, despite this limitation;
+Copyright (c) 2007 James Newton-King
 
-  ·         make more copies of the software than specified in this agreement or allowed by applicable law, despite this limitation;
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 
-  ·         publish the software for others to copy;
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 
-  ·         rent, lease or lend the software; or
-
-  ·         transfer the software or this agreement to any third party.
-
-  4.    BACKUP COPY. You may make one backup copy of the software. You may use it only to reinstall the software.
-
-  5.    DOCUMENTATION. Any person that has valid access to your computer or internal network may copy and use the documentation for your internal, reference purposes.
-
-  6.    EXPORT RESTRICTIONS. The software is subject to United States export laws and regulations. You must comply with all domestic and international export laws and regulations that apply to the software. These laws include restrictions on destinations, end users and end use. For additional information, see www.microsoft.com/exporting.
-
-  7.    SUPPORT SERVICES. Because this software is “as is,” we may not provide support services for it.
-
-  8.    ENTIRE AGREEMENT. This agreement, and the terms for supplements, updates, Internet-based services and support services that you use, are the entire agreement for the software and support services.
-
-  9.    APPLICABLE LAW.
-
-  a.    United States. If you acquired the software in the United States, Washington state law governs the interpretation of this agreement and applies to claims for breach of it, regardless of conflict of laws principles. The laws of the state where you live govern all other claims, including claims under state consumer protection laws, unfair competition laws, and in tort.
-
-  b.    Outside the United States. If you acquired the software in any other country, the laws of that country apply.
-
-  10.  LEGAL EFFECT. This agreement describes certain legal rights. You may have other rights under the laws of your country. You may also have rights with respect to the party from whom you acquired the software. This agreement does not change your rights under the laws of your country if the laws of your country do not permit it to do so.
-
-  11.  DISCLAIMER OF WARRANTY. The software is licensed “as-is.” You bear the risk of using it. Microsoft gives no express warranties, guarantees or conditions. You may have additional consumer rights or statutory guarantees under your local laws which this agreement cannot change. To the extent permitted under your local laws, Microsoft excludes the implied warranties of merchantability, fitness for a particular purpose and non-infringement.
-
-  FOR AUSTRALIA – You have statutory guarantees under the Australian Consumer Law and nothing in these terms is intended to affect those rights.
-
-  12.  LIMITATION ON AND EXCLUSION OF REMEDIES AND DAMAGES. You can recover from Microsoft and its suppliers only direct damages up to U.S. $5.00. You cannot recover any other damages, including consequential, lost profits, special, indirect or incidental damages.
-
-  This limitation applies to
-
-  ·         anything related to the software, services, content (including code) on third party Internet sites, or third party programs; and
-
-  ·         claims for breach of contract, breach of warranty, guarantee or condition, strict liability, negligence, or other tort to the extent permitted by applicable law.
-
-  It also applies even if Microsoft knew or should have known about the possibility of the damages. The above limitation or exclusion may not apply to you because your country may not allow the exclusion or limitation of incidental, consequential or other damages.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 ```
 
 ### Chocolatey.NuGet.Client @ 3.4.2
@@ -763,7 +855,7 @@ Chocolatey uses [Rhino.Licensing](https://github.com/ayende/rhino-licensing) [(m
   THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ```
 
-### Shim Generator (shimgen) @ 1.0.0
+### Shim Generator (shimgen) @ 2.0.0
 
 Chocolatey uses [shimgen](https://github.com/chocolatey/shimgen) to generate shim executables that call the original binaries.
 [License terms](https://github.com/chocolatey/choco/blob/96a796297641807094f1f56d130a7413e583d0ac/src/chocolatey.resources/tools/shimgen.license.txt):
@@ -892,7 +984,7 @@ SOFTWARE.
 ### System.Runtime.CompilerServices.Unsafe @ 4.5.3
 
 This is a dependency of System.Threading.Tasks.Extensions.
-[Licensed terms](https://github.com/dotnet/runtime/blob/5bdc36e1d956fc39cd768b6cf59ac4b4bf5f56a5/LICENSE.TXT):
+[License terms](https://github.com/dotnet/runtime/blob/5bdc36e1d956fc39cd768b6cf59ac4b4bf5f56a5/LICENSE.TXT):
 
 ```txt
 The MIT License (MIT)
@@ -923,7 +1015,7 @@ SOFTWARE.
 ### System.Threading.Tasks.Extensions @ 4.5.4
 
 This is a dependency of System.Reactive.
-[Licensed terms](https://github.com/dotnet/runtime/blob/5bdc36e1d956fc39cd768b6cf59ac4b4bf5f56a5/LICENSE.TXT):
+[License terms](https://github.com/dotnet/runtime/blob/5bdc36e1d956fc39cd768b6cf59ac4b4bf5f56a5/LICENSE.TXT):
 
 ```txt
 The MIT License (MIT)


### PR DESCRIPTION
## Description Of Changes

This commit addresses this by updating all version numbers, both in the
table of contents, and the main body of the document, to match what is
actually being used.  In addition, the license that is in place for the
Microsoft.Web.Xdt dependency is updated to reflect that correct one, as
this was recently updated.

Finally, a small typo was fixed:
Licensed Terms -> License Terms

Also, adds a new extension recommendation for VSCode.

This extension is useful when editing Markdown files, especially when
it contains a Table Of Contents. This extension will update the TOC
simply by making changes to the main body.

In order to get this new file to be included, it was necessary to add
another exclusion to the rules in the .gitignore file.

## Motivation and Context

During a review, it was found that the CREDITS.md file, which contains
information about all the 3rd party dependencies that Chocolatey CLI
takes, was not up to date.

## Testing

N/A

### Operating Systems Testing

N/A

## Change Types Made

* [ ] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [x] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [ ] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v3 compatibility checked?

## Related Issue

N/A