### PR TITLE
(#3461,#3487) Prevent dependency resolution from downgrading packages

### DIFF
--- a/src/chocolatey/StringResources.cs
+++ b/src/chocolatey/StringResources.cs
@@ -56,5 +56,12 @@ namespace chocolatey
             [Browsable(false)]
             internal const string PackageNuspecVersion = "packageNuspecVersion";
         }
+
+        public static class ErrorMessages
+        {
+            [EditorBrowsable(EditorBrowsableState.Never)]
+            [Browsable(false)]
+            internal const string UnableToDowngrade = "A newer version of {0} (v{1}) is already installed.{2} Use --allow-downgrade or --force to attempt to install older versions.";
+        }
     }
 }

--- a/src/chocolatey/StringResources.cs
+++ b/src/chocolatey/StringResources.cs
@@ -62,6 +62,7 @@ namespace chocolatey
             [EditorBrowsable(EditorBrowsableState.Never)]
             [Browsable(false)]
             internal const string UnableToDowngrade = "A newer version of {0} (v{1}) is already installed.{2} Use --allow-downgrade or --force to attempt to install older versions.";
+            internal const string DependencyFailedToInstall = "Failed to install {0} because a previous dependency failed.";
         }
     }
 }

--- a/src/chocolatey/infrastructure.app/services/NugetService.cs
+++ b/src/chocolatey/infrastructure.app/services/NugetService.cs
@@ -809,6 +809,16 @@ Please see https://docs.chocolatey.org/en-us/troubleshooting for more
                     var packageToUninstall = packagesToUninstall.FirstOrDefault(p => p.PackageMetadata.Id.Equals(packageDependencyInfo.Id, StringComparison.OrdinalIgnoreCase));
                     if (packageToUninstall != null)
                     {
+                        // Are we attempting a downgrade? We need to ensure it's allowed...
+                        if (!config.AllowDowngrade && packageToUninstall.Identity.HasVersion && packageDependencyInfo.HasVersion && packageDependencyInfo.Version < packageToUninstall.Identity.Version)
+                        {
+                            var logMessage = StringResources.ErrorMessages.UnableToDowngrade.FormatWith(packageToUninstall.Name, packageToUninstall.Version, Environment.NewLine);
+                            var nullResult = packageResultsToReturn.GetOrAdd(packageToUninstall.Name, packageToUninstall);
+                            nullResult.Messages.Add(new ResultMessage(ResultType.Error, logMessage));
+                            this.Log().Error(ChocolateyLoggers.Important, logMessage);
+                            continue;
+                        }
+
                         shouldAddForcedResultMessage = true;
                         BackupAndRunBeforeModify(packageToUninstall, config, beforeModifyAction);
                         packageToUninstall.InstallLocation = pathResolver.GetInstallPath(packageToUninstall.Identity);
@@ -1576,6 +1586,16 @@ Please see https://docs.chocolatey.org/en-us/troubleshooting for more
                             {
                                 if (packageToUninstall != null)
                                 {
+                                    // Are we attempting a downgrade? We need to ensure it's allowed...
+                                    if (!config.AllowDowngrade && packageToUninstall.Identity.HasVersion && packageDependencyInfo.HasVersion && packageDependencyInfo.Version < packageToUninstall.Identity.Version)
+                                    {
+                                        var logMessage = StringResources.ErrorMessages.UnableToDowngrade.FormatWith(packageToUninstall.Name, packageToUninstall.Version, Environment.NewLine);
+                                        var nullResult = packageResultsToReturn.GetOrAdd(packageToUninstall.Name, packageToUninstall);
+                                        nullResult.Messages.Add(new ResultMessage(ResultType.Error, logMessage));
+                                        this.Log().Error(ChocolateyLoggers.Important, logMessage);
+                                        continue;
+                                    }
+
                                     var oldPkgInfo = _packageInfoService.Get(packageToUninstall.PackageMetadata);
 
                                     BackupAndRunBeforeModify(packageToUninstall, oldPkgInfo, config, beforeUpgradeAction);

--- a/src/chocolatey/infrastructure.app/services/NugetService.cs
+++ b/src/chocolatey/infrastructure.app/services/NugetService.cs
@@ -619,7 +619,7 @@ folder.");
 
                 if (installedPackage != null && version != null && version < installedPackage.PackageMetadata.Version && !config.AllowDowngrade)
                 {
-                    var logMessage = "A newer version of {0} (v{1}) is already installed.{2} Use --allow-downgrade or --force to attempt to install older versions.".FormatWith(installedPackage.Name, installedPackage.Version, Environment.NewLine);
+                    var logMessage = StringResources.ErrorMessages.UnableToDowngrade.FormatWith(installedPackage.Name, installedPackage.Version, Environment.NewLine);
                     var nullResult = packageResultsToReturn.GetOrAdd(packageName, installedPackage);
                     nullResult.Messages.Add(new ResultMessage(ResultType.Error, logMessage));
                     this.Log().Error(ChocolateyLoggers.Important, logMessage);
@@ -1138,7 +1138,7 @@ Please see https://docs.chocolatey.org/en-us/troubleshooting for more
 
                 if (version != null && version < installedPackage.PackageMetadata.Version && !config.AllowDowngrade)
                 {
-                    var logMessage = "A newer version of {0} (v{1}) is already installed.{2} Use --allow-downgrade or --force to attempt to upgrade to older versions.".FormatWith(installedPackage.PackageMetadata.Id, installedPackage.Version, Environment.NewLine);
+                    var logMessage = StringResources.ErrorMessages.UnableToDowngrade.FormatWith(installedPackage.PackageMetadata.Id, installedPackage.Version, Environment.NewLine);
                     var nullResult = packageResultsToReturn.GetOrAdd(packageName, new PackageResult(installedPackage.PackageMetadata, pathResolver.GetInstallPath(installedPackage.PackageMetadata.Id)));
                     nullResult.Messages.Add(new ResultMessage(ResultType.Error, logMessage));
                     this.Log().Error(ChocolateyLoggers.Important, logMessage);

--- a/src/chocolatey/infrastructure.app/services/NugetService.cs
+++ b/src/chocolatey/infrastructure.app/services/NugetService.cs
@@ -801,13 +801,13 @@ Please see https://docs.chocolatey.org/en-us/troubleshooting for more
                 foreach (SourcePackageDependencyInfo packageDependencyInfo in resolvedPackages)
                 {
                     // Don't attempt to action this package if dependencies failed.
-                    if (packageDependencyInfo != null && packageResultsToReturn.Any(r => r.Value.Success != true && packageDependencyInfo.Dependencies.Any(d => d.Id == r.Value.Identity.Id)))
+                    if (packageDependencyInfo != null && packageResultsToReturn.Any(r => r.Value.Success != true && packageDependencyInfo.Dependencies.Any(d => d.Id.Equals(r.Value.Identity.Id, StringComparison.OrdinalIgnoreCase))))
                     {
                         var logMessage = StringResources.ErrorMessages.DependencyFailedToInstall.FormatWith(packageDependencyInfo.Id);
                         packageResultsToReturn
                             .GetOrAdd(
                                 packageDependencyInfo.Id,
-                                new PackageResult(packageDependencyInfo.Id, packageDependencyInfo.Version.ToStringSafe(), string.Empty)
+                                new PackageResult(packageDependencyInfo.Id, packageDependencyInfo.Version.ToFullStringChecked(), string.Empty)
                             )
                             .Messages.Add(new ResultMessage(ResultType.Error, logMessage));
                         this.Log().Error(ChocolateyLoggers.Important, logMessage);
@@ -1609,12 +1609,12 @@ Please see https://docs.chocolatey.org/en-us/troubleshooting for more
                             }
 
                             // Don't attempt to action this package if dependencies failed.
-                            if (packageResultsToReturn.Any(r => r.Value.Success != true && packageDependencyInfo.Dependencies.Any(d => d.Id == r.Value.Identity.Id)))
+                            if (packageResultsToReturn.Any(r => r.Value.Success != true && packageDependencyInfo.Dependencies.Any(d => d.Id.Equals(r.Value.Identity.Id, StringComparison.OrdinalIgnoreCase))))
                             {
                                 var logMessage = StringResources.ErrorMessages.DependencyFailedToInstall.FormatWith(packageDependencyInfo.Id, packageDependencyInfo.Version);
                                 packageResultsToReturn.GetOrAdd(
                                         packageDependencyInfo.Id, 
-                                        new PackageResult(packageDependencyInfo.Id, packageDependencyInfo.Version.ToStringSafe(), string.Empty)
+                                        new PackageResult(packageDependencyInfo.Id, packageDependencyInfo.Version.ToFullStringChecked(), string.Empty)
                                     )
                                     .Messages.Add(new ResultMessage(ResultType.Error, logMessage));
                                 this.Log().Error(ChocolateyLoggers.Important, logMessage);

--- a/src/chocolatey/infrastructure.app/services/NugetService.cs
+++ b/src/chocolatey/infrastructure.app/services/NugetService.cs
@@ -605,6 +605,7 @@ folder.");
                 if (installedPackage != null && (version == null || version == installedPackage.PackageMetadata.Version) && !config.Force)
                 {
                     var logMessage = "{0} v{1} already installed.{2} Use --force to reinstall, specify a version to install, or try upgrade.".FormatWith(installedPackage.Name, installedPackage.Version, Environment.NewLine);
+                    // We need a temporary PackageResult so that we can add to the Messages collection.
                     var nullResult = packageResultsToReturn.GetOrAdd(packageName, installedPackage);
                     nullResult.Messages.Add(new ResultMessage(ResultType.Warn, logMessage));
                     nullResult.Messages.Add(new ResultMessage(ResultType.Inconclusive, logMessage));
@@ -626,8 +627,8 @@ folder.");
                 if (installedPackage != null && version != null && version < installedPackage.PackageMetadata.Version && !config.AllowDowngrade)
                 {
                     var logMessage = StringResources.ErrorMessages.UnableToDowngrade.FormatWith(installedPackage.Name, installedPackage.Version, Environment.NewLine);
-                    var nullResult = packageResultsToReturn.GetOrAdd(packageName, installedPackage);
-                    nullResult.Messages.Add(new ResultMessage(ResultType.Error, logMessage));
+                    packageResultsToReturn.GetOrAdd(packageName, installedPackage)
+                        .Messages.Add(new ResultMessage(ResultType.Error, logMessage));
                     this.Log().Error(ChocolateyLoggers.Important, logMessage);
                     continue;
                 }
@@ -803,9 +804,12 @@ Please see https://docs.chocolatey.org/en-us/troubleshooting for more
                     if (packageDependencyInfo != null && packageResultsToReturn.Any(r => r.Value.Success != true && packageDependencyInfo.Dependencies.Any(d => d.Id == r.Value.Identity.Id)))
                     {
                         var logMessage = StringResources.ErrorMessages.DependencyFailedToInstall.FormatWith(packageDependencyInfo.Id);
-                        var x = new PackageResult(packageDependencyInfo.Id, packageDependencyInfo.Version.ToStringSafe(), string.Empty);
-                        var nullResult = packageResultsToReturn.GetOrAdd(packageDependencyInfo.Id, x);
-                        nullResult.Messages.Add(new ResultMessage(ResultType.Error, logMessage));
+                        packageResultsToReturn
+                            .GetOrAdd(
+                                packageDependencyInfo.Id,
+                                new PackageResult(packageDependencyInfo.Id, packageDependencyInfo.Version.ToStringSafe(), string.Empty)
+                            )
+                            .Messages.Add(new ResultMessage(ResultType.Error, logMessage));
                         this.Log().Error(ChocolateyLoggers.Important, logMessage);
 
                         if (config.Features.StopOnFirstPackageFailure)
@@ -836,8 +840,8 @@ Please see https://docs.chocolatey.org/en-us/troubleshooting for more
                         if (!config.AllowDowngrade && packageToUninstall.Identity.HasVersion && packageDependencyInfo.HasVersion && packageDependencyInfo.Version < packageToUninstall.Identity.Version)
                         {
                             var logMessage = StringResources.ErrorMessages.UnableToDowngrade.FormatWith(packageToUninstall.Name, packageToUninstall.Version, Environment.NewLine);
-                            var nullResult = packageResultsToReturn.GetOrAdd(packageToUninstall.Name, packageToUninstall);
-                            nullResult.Messages.Add(new ResultMessage(ResultType.Error, logMessage));
+                            packageResultsToReturn.GetOrAdd(packageToUninstall.Name, packageToUninstall)
+                                .Messages.Add(new ResultMessage(ResultType.Error, logMessage));
                             this.Log().Error(ChocolateyLoggers.Important, logMessage);
                             
                             if (config.Features.StopOnFirstPackageFailure)
@@ -1184,8 +1188,8 @@ Please see https://docs.chocolatey.org/en-us/troubleshooting for more
                 if (version != null && version < installedPackage.PackageMetadata.Version && !config.AllowDowngrade)
                 {
                     var logMessage = StringResources.ErrorMessages.UnableToDowngrade.FormatWith(installedPackage.PackageMetadata.Id, installedPackage.Version, Environment.NewLine);
-                    var nullResult = packageResultsToReturn.GetOrAdd(packageName, new PackageResult(installedPackage.PackageMetadata, pathResolver.GetInstallPath(installedPackage.PackageMetadata.Id)));
-                    nullResult.Messages.Add(new ResultMessage(ResultType.Error, logMessage));
+                    packageResultsToReturn.GetOrAdd(packageName, new PackageResult(installedPackage.PackageMetadata, pathResolver.GetInstallPath(installedPackage.PackageMetadata.Id)))
+                        .Messages.Add(new ResultMessage(ResultType.Error, logMessage));
                     this.Log().Error(ChocolateyLoggers.Important, logMessage);
                     continue;
                 }
@@ -1608,9 +1612,11 @@ Please see https://docs.chocolatey.org/en-us/troubleshooting for more
                             if (packageResultsToReturn.Any(r => r.Value.Success != true && packageDependencyInfo.Dependencies.Any(d => d.Id == r.Value.Identity.Id)))
                             {
                                 var logMessage = StringResources.ErrorMessages.DependencyFailedToInstall.FormatWith(packageDependencyInfo.Id, packageDependencyInfo.Version);
-                                var x = new PackageResult(packageDependencyInfo.Id, packageDependencyInfo.Version.ToStringSafe(), string.Empty);
-                                var nullResult = packageResultsToReturn.GetOrAdd(packageDependencyInfo.Id, x);
-                                nullResult.Messages.Add(new ResultMessage(ResultType.Error, logMessage));
+                                packageResultsToReturn.GetOrAdd(
+                                        packageDependencyInfo.Id, 
+                                        new PackageResult(packageDependencyInfo.Id, packageDependencyInfo.Version.ToStringSafe(), string.Empty)
+                                    )
+                                    .Messages.Add(new ResultMessage(ResultType.Error, logMessage));
                                 this.Log().Error(ChocolateyLoggers.Important, logMessage);
 
                                 if (config.Features.StopOnFirstPackageFailure)
@@ -1642,8 +1648,8 @@ Please see https://docs.chocolatey.org/en-us/troubleshooting for more
                                     if (!config.AllowDowngrade && packageToUninstall.Identity.HasVersion && packageDependencyInfo.HasVersion && packageDependencyInfo.Version < packageToUninstall.Identity.Version)
                                     {
                                         var logMessage = StringResources.ErrorMessages.UnableToDowngrade.FormatWith(packageToUninstall.Name, packageToUninstall.Version, Environment.NewLine);
-                                        var nullResult = packageResultsToReturn.GetOrAdd(packageToUninstall.Name, packageToUninstall);
-                                        nullResult.Messages.Add(new ResultMessage(ResultType.Error, logMessage));
+                                        packageResultsToReturn.GetOrAdd(packageToUninstall.Name, packageToUninstall)
+                                            .Messages.Add(new ResultMessage(ResultType.Error, logMessage));
                                         this.Log().Error(ChocolateyLoggers.Important, logMessage);
                                         
                                         if (config.Features.StopOnFirstPackageFailure)
@@ -1655,7 +1661,7 @@ Please see https://docs.chocolatey.org/en-us/troubleshooting for more
                                     }
 
                                     // Package was previously marked inconclusive (not upgraded). We need remove the message since we are now upgrading it.
-                                    // Packages that are inconclusive but successfull are not labeled as successful at the end of the run.
+                                    // Packages that are inconclusive but successful are not labeled as successful at the end of the run.
                                     var checkResult = packageResultsToReturn.GetOrAdd(packageToUninstall.Name, packageToUninstall);
 
                                     while (checkResult.Inconclusive)

--- a/tests/Vagrantfile
+++ b/tests/Vagrantfile
@@ -69,6 +69,7 @@ Vagrant.configure("2") do |config|
   config.vm.provision "shell", name: "clear-packages", inline: <<-SHELL
     Write-Host "($(Get-Date -Format "dddd MM/dd/yyyy HH:mm:ss K")) Clearing the packages directory"
     Remove-Item "$env:TEMP/chocolateyTests/packages" -Recurse -Force -ErrorAction SilentlyContinue
+    Remove-Item "$env:TEMP/chocolateyTests/all-packages" -Recurse -Force -ErrorAction SilentlyContinue
   SHELL
   config.vm.provision "shell", name: "test", inline: <<-SHELL
     # Copy changed files.

--- a/tests/helpers/common/Chocolatey/Get-ChocolateyInstalledPackages.ps1
+++ b/tests/helpers/common/Chocolatey/Get-ChocolateyInstalledPackages.ps1
@@ -1,0 +1,3 @@
+﻿function Get-ChocolateyInstalledPackages {
+    (Invoke-Choco list -r).Lines | ConvertFrom-ChocolateyOutput -Command List
+}

--- a/tests/packages/dependencyfailure/dependencyfailure.nuspec
+++ b/tests/packages/dependencyfailure/dependencyfailure.nuspec
@@ -7,8 +7,12 @@
     <authors>__REPLACE_AUTHORS_OF_SOFTWARE_COMMA_SEPARATED__</authors>
     <projectUrl>https://_Software_Location_REMOVE_OR_FILL_OUT_</projectUrl>
     <tags>dependencyfailure admin SPACE_SEPARATED</tags>
-    <summary>__REPLACE__</summary>
-    <description>__REPLACE__MarkDown_Okay </description>
+    <summary>Package includes a dependency for a package that is known to fail installation.</summary>
+    <description>
+      Package includes a dependency for a package that is known to fail installation.
+
+      It can be used in tests to ensure that failing dependencies do not allow the package to install.
+    </description>
     <dependencies>
       <dependency id="failingdependency" version="1.0.0" />
     </dependencies>

--- a/tests/packages/dependencyfailure/dependencyfailure.nuspec
+++ b/tests/packages/dependencyfailure/dependencyfailure.nuspec
@@ -1,0 +1,19 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
+  <metadata>
+    <id>dependencyfailure</id>
+    <version>1.0.0</version>
+    <title>dependencyfailure (Install)</title>
+    <authors>__REPLACE_AUTHORS_OF_SOFTWARE_COMMA_SEPARATED__</authors>
+    <projectUrl>https://_Software_Location_REMOVE_OR_FILL_OUT_</projectUrl>
+    <tags>dependencyfailure admin SPACE_SEPARATED</tags>
+    <summary>__REPLACE__</summary>
+    <description>__REPLACE__MarkDown_Okay </description>
+    <dependencies>
+      <dependency id="failingdependency" version="1.0.0" />
+    </dependencies>
+  </metadata>
+  <files>
+    <file src="tools\**" target="tools" />
+  </files>
+</package>

--- a/tests/packages/dependencyfailure/tools/chocolateyinstall.ps1
+++ b/tests/packages/dependencyfailure/tools/chocolateyinstall.ps1
@@ -1,0 +1,1 @@
+﻿Write-Host "I'm successful!"

--- a/tests/packages/failingdependency/failingdependency.nuspec
+++ b/tests/packages/failingdependency/failingdependency.nuspec
@@ -7,8 +7,8 @@
     <authors>__REPLACE_AUTHORS_OF_SOFTWARE_COMMA_SEPARATED__</authors>
     <projectUrl>https://_Software_Location_REMOVE_OR_FILL_OUT_</projectUrl>
     <tags>dependencyfailure admin SPACE_SEPARATED</tags>
-    <summary>__REPLACE__</summary>
-    <description>__REPLACE__MarkDown_Okay </description>
+    <summary>Package that fails to install. Used as part of dependency tree.</summary>
+    <description>Package that fails to install. Used as part of dependency tree.</description>
   </metadata>
   <files>
     <file src="tools\**" target="tools" />

--- a/tests/packages/failingdependency/failingdependency.nuspec
+++ b/tests/packages/failingdependency/failingdependency.nuspec
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
+  <metadata>
+    <id>failingdependency</id>
+    <version>1.0.0</version>
+    <title>dependencyfailure (Install)</title>
+    <authors>__REPLACE_AUTHORS_OF_SOFTWARE_COMMA_SEPARATED__</authors>
+    <projectUrl>https://_Software_Location_REMOVE_OR_FILL_OUT_</projectUrl>
+    <tags>dependencyfailure admin SPACE_SEPARATED</tags>
+    <summary>__REPLACE__</summary>
+    <description>__REPLACE__MarkDown_Okay </description>
+  </metadata>
+  <files>
+    <file src="tools\**" target="tools" />
+  </files>
+</package>

--- a/tests/packages/failingdependency/tools/chocolateyinstall.ps1
+++ b/tests/packages/failingdependency/tools/chocolateyinstall.ps1
@@ -1,0 +1,3 @@
+﻿Write-Error "This should fail!"
+$env:ChocolateyExitCode = '15608'
+#throw "This is crap"

--- a/tests/packages/failingdependency/tools/chocolateyinstall.ps1
+++ b/tests/packages/failingdependency/tools/chocolateyinstall.ps1
@@ -1,3 +1,2 @@
 ﻿Write-Error "This should fail!"
 $env:ChocolateyExitCode = '15608'
-#throw "This is crap"

--- a/tests/packages/get-chocolateyunzip-licensed/get-chocolateyunzip-licensed.nuspec
+++ b/tests/packages/get-chocolateyunzip-licensed/get-chocolateyunzip-licensed.nuspec
@@ -1,59 +1,23 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- Read this before creating packages: https://docs.chocolatey.org/en-us/create/create-packages -->
-<!-- It is especially important to read the above link to understand additional requirements when publishing packages to the community feed aka dot org (https://chocolatey.org/packages). -->
-<!-- Test your packages in a test environment: https://github.com/chocolatey/chocolatey-test-environment -->
-
-<!--
-This is a nuspec. It mostly adheres to https://docs.nuget.org/create/Nuspec-Reference. Chocolatey uses a special version of NuGet.Core that allows us to do more than was initially possible. As such there are certain things to be aware of:
-
-* the package xmlns schema url may cause issues with nuget.exe
-* Any of the following elements can ONLY be used by choco tools - projectSourceUrl, docsUrl, mailingListUrl, bugTrackerUrl, packageSourceUrl, provides, conflicts, replaces
-* nuget.exe can still install packages with those elements but they are ignored. Any authoring tools or commands will error on those elements
--->
-<!-- You can embed software files directly into packages, as long as you are not bound by distribution rights. -->
-<!-- * If you are an organization making private packages, you probably have no issues here -->
-<!-- * If you are releasing to the community feed, you need to consider distribution rights. -->
 <!-- Do not remove this test for UTF-8: if “Ω” doesn’t appear as greek uppercase omega letter enclosed in quotation marks, you should use an editor that supports UTF-8, not this one. -->
-
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
-    <!-- == PACKAGE SPECIFIC SECTION == -->
-    <!-- This section is about this package, although id and version have ties back to the software -->
-    <!-- id is lowercase and if you want a good separator for words, use '-', not '.'. Dots are only acceptable as suffixes for certain types of packages, e.g. .install, .portable, .extension, .template -->
-    <!-- If the software is cross-platform, attempt to use the same id as the debian/rpm package(s) if possible. -->
     <id>get-chocolateyunzip-licensed</id>
-    <!-- version should MATCH as closely as possible with the underlying software -->
-    <!-- Is the version a prerelease of a version? https://docs.nuget.org/create/versioning#creating-prerelease-packages -->
-    <!-- Note that unstable versions like 0.0.1 can be considered a released version, but it's possible that one can release a 0.0.1-beta before you release a 0.0.1 version. If the version number is final, that is considered a released version and not a prerelease. -->
     <version>3.21.2</version>
-    <!-- owners is a poor name for maintainers of the package. It sticks around by this name for compatibility reasons. It basically means you. -->
-    <owners>__REPLACE__</owners>
-    <!-- ============================== -->
-
-    <!-- == SOFTWARE SPECIFIC SECTION == -->
-    <!-- This section is about the software itself -->
-    <title>__REPLACE__ (Portable)</title>
-    <authors>__REPLACE__</authors>
+    <owners>chocolatey</owners>
+    <title>get-chocolateyunzip-licensed (Portable)</title>
+    <authors>Chocolatey Software</authors>
     <!-- copyright is usually years and software vendor, but not required for internal feeds -->
-    <copyright>__REPLACE__</copyright>
+    <copyright>Chocolatey Software</copyright>
     <tags>get-chocolateyunzip-licensed</tags>
-    <description>__REPLACE__MarkDown_Okay</description>
-    <!-- =============================== -->
+    <description>
+      This package contains a commercial edition of the cmdlet `Get-ChocolateyUnzip`, and can be used to verify that installation with that cmdlet works as intended.
 
-    <!-- Specifying dependencies and version ranges? https://docs.nuget.org/create/versioning#specifying-version-ranges-in-.nuspec-files -->
-    <!--<dependencies>
-      <dependency id="" version="__MINIMUM_VERSION__" />
-      <dependency id="" version="[__EXACT_VERSION__]" />
-      <dependency id="" version="[_MIN_VERSION_INCLUSIVE, MAX_VERSION_INCLUSIVE]" />
-      <dependency id="" version="[_MIN_VERSION_INCLUSIVE, MAX_VERSION_EXCLUSIVE)" />
-      <dependency id="" />
-    </dependencies>-->
+Additionally it can be tested that the package will fail if being installed on FOSS Edition of Chocolatey.
 
-    <!--<provides>NOT YET IMPLEMENTED</provides>-->
-    <!--<conflicts>NOT YET IMPLEMENTED</conflicts>-->
-    <!--<replaces>NOT YET IMPLEMENTED</replaces>-->
+The package defines the license types `business`, `Education` and `professional` as being valid licenses.
+    </description>
   </metadata>
-  <!-- this section controls what actually gets packaged into the Chocolatey package -->
   <files>
     <file src="tools\**" target="tools" />
   </files>

--- a/tests/packages/hasfailingnesteddependency/1.0.0/hasfailingnesteddependency.nuspec
+++ b/tests/packages/hasfailingnesteddependency/1.0.0/hasfailingnesteddependency.nuspec
@@ -1,0 +1,23 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+    <metadata>
+        <id>hasfailingnesteddependency</id>
+        <version>1.0.0</version>
+        <title>hasfailingnesteddependency</title>
+        <authors>__REPLACE_AUTHORS_OF_SOFTWARE__</authors>
+        <owners>__REPLACE_YOUR_NAME__</owners>
+        <requireLicenseAcceptance>false</requireLicenseAcceptance>
+        <description>__REPLACE__</description>
+        <summary>__REPLACE__</summary>
+        <releaseNotes />
+        <copyright />
+        <tags>hasfailingnesteddependency admin</tags>
+        <dependencies>
+            <dependency id="dependencyfailure" version="1.0.0" />
+            <dependency id="downgradesdependency" version="2.0.0" />
+        </dependencies>
+    </metadata>
+  <files>
+    <file src="tools\**" target="tools" />
+  </files>
+</package>

--- a/tests/packages/hasfailingnesteddependency/1.0.0/hasfailingnesteddependency.nuspec
+++ b/tests/packages/hasfailingnesteddependency/1.0.0/hasfailingnesteddependency.nuspec
@@ -4,8 +4,8 @@
         <id>hasfailingnesteddependency</id>
         <version>1.0.0</version>
         <title>hasfailingnesteddependency</title>
-        <authors>__REPLACE_AUTHORS_OF_SOFTWARE__</authors>
-        <owners>__REPLACE_YOUR_NAME__</owners>
+        <authors>Chocolatey Software</authors>
+        <owners>chocolatey</owners>
         <requireLicenseAcceptance>false</requireLicenseAcceptance>
         <description>
           Package that contains dependencies that have dependencies that may fail to install.

--- a/tests/packages/hasfailingnesteddependency/1.0.0/hasfailingnesteddependency.nuspec
+++ b/tests/packages/hasfailingnesteddependency/1.0.0/hasfailingnesteddependency.nuspec
@@ -7,8 +7,12 @@
         <authors>__REPLACE_AUTHORS_OF_SOFTWARE__</authors>
         <owners>__REPLACE_YOUR_NAME__</owners>
         <requireLicenseAcceptance>false</requireLicenseAcceptance>
-        <description>__REPLACE__</description>
-        <summary>__REPLACE__</summary>
+        <description>
+          Package that contains dependencies that have dependencies that may fail to install.
+
+          Used for testing dependency resolution and ensuring dependency failures do not allow package installation.
+        </description>
+        <summary>Package that contains dependencies that have dependencies that may fail to install.</summary>
         <releaseNotes />
         <copyright />
         <tags>hasfailingnesteddependency admin</tags>

--- a/tests/packages/hasfailingnesteddependency/1.0.0/tools/chocolateyinstall.ps1
+++ b/tests/packages/hasfailingnesteddependency/1.0.0/tools/chocolateyinstall.ps1
@@ -1,0 +1,1 @@
+﻿Write-Output "$env:PackageName $env:PackageVersion Installed"

--- a/tests/packages/hasfailingnesteddependency/1.0.0/tools/chocolateyuninstall.ps1
+++ b/tests/packages/hasfailingnesteddependency/1.0.0/tools/chocolateyuninstall.ps1
@@ -1,0 +1,1 @@
+﻿Write-Output "$env:PackageName $env:PackageVersion Uninstalled"

--- a/tests/packages/hasnesteddependency/1.0.0/hasnesteddependency.nuspec
+++ b/tests/packages/hasnesteddependency/1.0.0/hasnesteddependency.nuspec
@@ -4,11 +4,11 @@
         <id>hasnesteddependency</id>
         <version>1.0.0</version>
         <title>hasnesteddependency</title>
-        <authors>__REPLACE_AUTHORS_OF_SOFTWARE__</authors>
-        <owners>__REPLACE_YOUR_NAME__</owners>
+        <authors>Chocolatey Software</authors>
+        <owners>chocolatey</owners>
         <requireLicenseAcceptance>false</requireLicenseAcceptance>
-        <description>__REPLACE__</description>
-        <summary>__REPLACE__</summary>
+        <description>Package used for testing nested dependencies.</description>
+        <summary>Package used for testing nested dependencies.</summary>
         <releaseNotes />
         <copyright />
         <tags>hasnesteddependency admin</tags>

--- a/tests/packages/hasnesteddependency/1.0.0/hasnesteddependency.nuspec
+++ b/tests/packages/hasnesteddependency/1.0.0/hasnesteddependency.nuspec
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+    <metadata>
+        <id>hasnesteddependency</id>
+        <version>1.0.0</version>
+        <title>hasnesteddependency</title>
+        <authors>__REPLACE_AUTHORS_OF_SOFTWARE__</authors>
+        <owners>__REPLACE_YOUR_NAME__</owners>
+        <requireLicenseAcceptance>false</requireLicenseAcceptance>
+        <description>__REPLACE__</description>
+        <summary>__REPLACE__</summary>
+        <releaseNotes />
+        <copyright />
+        <tags>hasnesteddependency admin</tags>
+        <dependencies>
+            <dependency id="hasdependency" version="1.0.0" />
+        </dependencies>
+    </metadata>
+  <files>
+    <file src="tools\**" target="tools" />
+  </files>
+</package>

--- a/tests/packages/hasnesteddependency/1.0.0/tools/chocolateyinstall.ps1
+++ b/tests/packages/hasnesteddependency/1.0.0/tools/chocolateyinstall.ps1
@@ -1,0 +1,1 @@
+﻿Write-Output "$env:PackageName $env:PackageVersion Installed"

--- a/tests/packages/hasnesteddependency/1.0.0/tools/chocolateyuninstall.ps1
+++ b/tests/packages/hasnesteddependency/1.0.0/tools/chocolateyuninstall.ps1
@@ -1,0 +1,1 @@
+﻿Write-Output "$env:PackageName $env:PackageVersion Uninstalled"

--- a/tests/packages/test-chocolateypath/test-chocolateypath.nuspec
+++ b/tests/packages/test-chocolateypath/test-chocolateypath.nuspec
@@ -1,81 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- Read this before creating packages: https://docs.chocolatey.org/en-us/create/create-packages -->
-<!-- It is especially important to read the above link to understand additional requirements when publishing packages to the community feed aka dot org (https://community.chocolatey.org/packages). -->
-
-<!-- Test your packages in a test environment: https://github.com/chocolatey/chocolatey-test-environment -->
-
-<!--
-This is a nuspec. It mostly adheres to https://docs.nuget.org/create/Nuspec-Reference. Chocolatey uses a special version of NuGet.Core that allows us to do more than was initially possible. As such there are certain things to be aware of:
-
-* the package xmlns schema url may cause issues with nuget.exe
-* Any of the following elements can ONLY be used by choco tools - projectSourceUrl, docsUrl, mailingListUrl, bugTrackerUrl, packageSourceUrl, provides, conflicts, replaces
-* nuget.exe can still install packages with those elements but they are ignored. Any authoring tools or commands will error on those elements
--->
-
-<!-- You can embed software files directly into packages, as long as you are not bound by distribution rights. -->
-<!-- * If you are an organization making private packages, you probably have no issues here -->
-<!-- * If you are releasing to the community feed, you need to consider distribution rights. -->
 <!-- Do not remove this test for UTF-8: if “Ω” doesn’t appear as greek uppercase omega letter enclosed in quotation marks, you should use an editor that supports UTF-8, not this one. -->
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
-    <!-- == PACKAGE SPECIFIC SECTION == -->
-    <!-- This section is about this package, although id and version have ties back to the software -->
-    <!-- id is lowercase and if you want a good separator for words, use '-', not '.'. Dots are only acceptable as suffixes for certain types of packages, e.g. .install, .portable, .extension, .template -->
-    <!-- If the software is cross-platform, attempt to use the same id as the debian/rpm package(s) if possible. -->
     <id>test-chocolateypath</id>
-    <!-- version should MATCH as closely as possible with the underlying software -->
-    <!-- Is the version a prerelease of a version? https://docs.nuget.org/create/versioning#creating-prerelease-packages -->
-    <!-- Note that unstable versions like 0.0.1 can be considered a released version, but it's possible that one can release a 0.0.1-beta before you release a 0.0.1 version. If the version number is final, that is considered a released version and not a prerelease. -->
     <version>0.1.0</version>
-    <!-- <packageSourceUrl>Where is this Chocolatey package located (think GitHub)? packageSourceUrl is highly recommended for the community feed</packageSourceUrl>-->
-    <!-- owners is a poor name for maintainers of the package. It sticks around by this name for compatibility reasons. It basically means you. -->
-    <!--<owners>__REPLACE_YOUR_NAME__</owners>-->
-    <!-- ============================== -->
-
-    <!-- == SOFTWARE SPECIFIC SECTION == -->
-    <!-- This section is about the software itself -->
     <title>test-packagepath (Install)</title>
     <authors>__REPLACE_AUTHORS_OF_SOFTWARE_COMMA_SEPARATED__</authors>
-    <!-- projectUrl is required for the community feed -->
     <projectUrl>https://_Software_Location_REMOVE_OR_FILL_OUT_</projectUrl>
-    <!-- There are a number of CDN Services that can be used for hosting the Icon for a package. More information can be found here: https://docs.chocolatey.org/en-us/create/create-packages#package-icon-guidelines -->
-    <!-- Here is an example using Githack -->
-    <!--<iconUrl>http://rawcdn.githack.com/__REPLACE_YOUR_REPO__/master/icons/test-packagepath.png</iconUrl>-->
-    <!-- <copyright>Year Software Vendor</copyright> -->
-    <!-- If there is a license Url available, it is required for the community feed -->
-    <!-- <licenseUrl>Software License Location __REMOVE_OR_FILL_OUT__</licenseUrl>
-    <requireLicenseAcceptance>true</requireLicenseAcceptance>-->
-    <!--<projectSourceUrl>Software Source Location - is the software FOSS somewhere? Link to it with this</projectSourceUrl>-->
-    <!--<docsUrl>At what url are the software docs located?</docsUrl>-->
-    <!--<mailingListUrl></mailingListUrl>-->
-    <!--<bugTrackerUrl></bugTrackerUrl>-->
     <tags>test-packagepath SPACE_SEPARATED</tags>
-    <summary>__REPLACE__</summary>
-    <description>__REPLACE__MarkDown_Okay </description>
-    <!-- <releaseNotes>__REPLACE_OR_REMOVE__MarkDown_Okay</releaseNotes> -->
-    <!-- =============================== -->
-
-    <!-- Specifying dependencies and version ranges? https://docs.nuget.org/create/versioning#specifying-version-ranges-in-.nuspec-files -->
-    <!--<dependencies>
-      <dependency id="" version="__MINIMUM_VERSION__" />
-      <dependency id="" version="[__EXACT_VERSION__]" />
-      <dependency id="" version="[_MIN_VERSION_INCLUSIVE, MAX_VERSION_INCLUSIVE]" />
-      <dependency id="" version="[_MIN_VERSION_INCLUSIVE, MAX_VERSION_EXCLUSIVE)" />
-      <dependency id="" />
-      <dependency id="chocolatey-core.extension" version="1.1.0" />
-    </dependencies>-->
-    <!-- chocolatey-core.extension - https://community.chocolatey.org/packages/chocolatey-core.extension
-         - You want to use Get-UninstallRegistryKey on less than 0.9.10 (in chocolateyUninstall.ps1)
-         - You want to use Get-PackageParameters and on less than 0.11.0
-         - You want to take advantage of other functions in the core community maintainer's team extension package
-    -->
-
-    <!--<provides>NOT YET IMPLEMENTED</provides>-->
-    <!--<conflicts>NOT YET IMPLEMENTED</conflicts>-->
-    <!--<replaces>NOT YET IMPLEMENTED</replaces>-->
+    <summary>Package to test the Get-ChocolateyPath Chocolatey PowerShell function.</summary>
+    <description>Package to test the Get-ChocolateyPath Chocolatey PowerShell function.</description>
   </metadata>
   <files>
-    <!-- this section controls what actually gets packaged into the Chocolatey package -->
     <file src="tools\**" target="tools" />
   </files>
 </package>

--- a/tests/packages/upgradedowngradesdependency/1.0.0/downgradesdependency.nuspec
+++ b/tests/packages/upgradedowngradesdependency/1.0.0/downgradesdependency.nuspec
@@ -4,8 +4,8 @@
         <id>downgradesdependency</id>
         <version>1.0.0</version>
         <title>Has out of range Dependency</title>
-        <authors>__REPLACE_AUTHORS_OF_SOFTWARE__</authors>
-        <owners>__REPLACE_YOUR_NAME__</owners>
+        <authors>Chocolatey Software</authors>
+        <owners>chocolatey</owners>
         <requireLicenseAcceptance>false</requireLicenseAcceptance>
         <description>
           These packages can be used to test the installation or upgrading of packages that require an existing package to downgrade.

--- a/tests/packages/upgradedowngradesdependency/1.0.0/downgradesdependency.nuspec
+++ b/tests/packages/upgradedowngradesdependency/1.0.0/downgradesdependency.nuspec
@@ -7,7 +7,14 @@
         <authors>__REPLACE_AUTHORS_OF_SOFTWARE__</authors>
         <owners>__REPLACE_YOUR_NAME__</owners>
         <requireLicenseAcceptance>false</requireLicenseAcceptance>
-        <description>__REPLACE__</description>
+        <description>
+          These packages can be used to test the installation or upgrading of packages that require an existing package to downgrade.
+
+Each version is available as `upgradedowngradesdependency` and `downgradesdependency`. This is to allow testing of scenarios where `choco upgrade all` would process the dependency before and after the parent package.
+
+- Version 1.0.0 contains a range that can be used in an upgrade scenario and has a dependency on `isdependency 1.0.0 or greater`
+- Version 2.0.0 contains an exact dependency on `isdependency` with a version of `1.0.0`
+        </description>
         <summary>Package to test for out of range dependencies. This 1st version have a valid exact range.</summary>
         <releaseNotes />
         <copyright />

--- a/tests/packages/upgradedowngradesdependency/1.0.0/downgradesdependency.nuspec
+++ b/tests/packages/upgradedowngradesdependency/1.0.0/downgradesdependency.nuspec
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+    <metadata>
+        <id>downgradesdependency</id>
+        <version>1.0.0</version>
+        <title>Has out of range Dependency</title>
+        <authors>__REPLACE_AUTHORS_OF_SOFTWARE__</authors>
+        <owners>__REPLACE_YOUR_NAME__</owners>
+        <requireLicenseAcceptance>false</requireLicenseAcceptance>
+        <description>__REPLACE__</description>
+        <summary>Package to test for out of range dependencies. This 1st version have a valid exact range.</summary>
+        <releaseNotes />
+        <copyright />
+        <tags>upgradedowngradesdependency admin</tags>
+        <dependencies>
+            <dependency id="isdependency" version="[1.0.0,)" />
+        </dependencies>
+    </metadata>
+  <files>
+    <file src="tools\**" target="tools" />
+  </files>
+</package>

--- a/tests/packages/upgradedowngradesdependency/1.0.0/tools/chocolateybeforemodify.ps1
+++ b/tests/packages/upgradedowngradesdependency/1.0.0/tools/chocolateybeforemodify.ps1
@@ -1,0 +1,1 @@
+﻿Write-Output "Upgrading or Uninstalling $env:PackageName $env:PackageVersion"

--- a/tests/packages/upgradedowngradesdependency/1.0.0/tools/chocolateyinstall.ps1
+++ b/tests/packages/upgradedowngradesdependency/1.0.0/tools/chocolateyinstall.ps1
@@ -1,0 +1,1 @@
+﻿Write-Output "$env:PackageName $env:PackageVersion Installed"

--- a/tests/packages/upgradedowngradesdependency/1.0.0/tools/chocolateyuninstall.ps1
+++ b/tests/packages/upgradedowngradesdependency/1.0.0/tools/chocolateyuninstall.ps1
@@ -1,0 +1,1 @@
+﻿Write-Output "$env:PackageName $env:PackageVersion Uninstalled"

--- a/tests/packages/upgradedowngradesdependency/1.0.0/upgradedowngradesdependency.nuspec
+++ b/tests/packages/upgradedowngradesdependency/1.0.0/upgradedowngradesdependency.nuspec
@@ -7,7 +7,14 @@
         <authors>__REPLACE_AUTHORS_OF_SOFTWARE__</authors>
         <owners>__REPLACE_YOUR_NAME__</owners>
         <requireLicenseAcceptance>false</requireLicenseAcceptance>
-        <description>__REPLACE__</description>
+        <description>
+          These packages can be used to test the installation or upgrading of packages that require an existing package to downgrade.
+
+Each version is available as `upgradedowngradesdependency` and `downgradesdependency`. This is to allow testing of scenarios where `choco upgrade all` would process the dependency before and after the parent package.
+
+- Version 1.0.0 contains a range that can be used in an upgrade scenario and has a dependency on `isdependency 1.0.0 or greater`
+- Version 2.0.0 contains an exact dependency on `isdependency` with a version of `1.0.0`
+        </description>
         <summary>Package to test for out of range dependencies. This 1st version have a valid exact range.</summary>
         <releaseNotes />
         <copyright />

--- a/tests/packages/upgradedowngradesdependency/1.0.0/upgradedowngradesdependency.nuspec
+++ b/tests/packages/upgradedowngradesdependency/1.0.0/upgradedowngradesdependency.nuspec
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+    <metadata>
+        <id>upgradedowngradesdependency</id>
+        <version>1.0.0</version>
+        <title>Has out of range Dependency</title>
+        <authors>__REPLACE_AUTHORS_OF_SOFTWARE__</authors>
+        <owners>__REPLACE_YOUR_NAME__</owners>
+        <requireLicenseAcceptance>false</requireLicenseAcceptance>
+        <description>__REPLACE__</description>
+        <summary>Package to test for out of range dependencies. This 1st version have a valid exact range.</summary>
+        <releaseNotes />
+        <copyright />
+        <tags>upgradedowngradesdependency admin</tags>
+        <dependencies>
+            <dependency id="isdependency" version="[1.0.0,)" />
+        </dependencies>
+    </metadata>
+  <files>
+    <file src="tools\**" target="tools" />
+  </files>
+</package>

--- a/tests/packages/upgradedowngradesdependency/1.0.0/upgradedowngradesdependency.nuspec
+++ b/tests/packages/upgradedowngradesdependency/1.0.0/upgradedowngradesdependency.nuspec
@@ -4,8 +4,8 @@
         <id>upgradedowngradesdependency</id>
         <version>1.0.0</version>
         <title>Has out of range Dependency</title>
-        <authors>__REPLACE_AUTHORS_OF_SOFTWARE__</authors>
-        <owners>__REPLACE_YOUR_NAME__</owners>
+        <authors>Chocolatey Software</authors>
+        <owners>chocolatey</owners>
         <requireLicenseAcceptance>false</requireLicenseAcceptance>
         <description>
           These packages can be used to test the installation or upgrading of packages that require an existing package to downgrade.

--- a/tests/packages/upgradedowngradesdependency/2.0.0/downgradesdependency.nuspec
+++ b/tests/packages/upgradedowngradesdependency/2.0.0/downgradesdependency.nuspec
@@ -7,7 +7,14 @@
         <authors>__REPLACE_AUTHORS_OF_SOFTWARE__</authors>
         <owners>__REPLACE_YOUR_NAME__</owners>
         <requireLicenseAcceptance>false</requireLicenseAcceptance>
-        <description>__REPLACE__</description>
+        <description>
+          These packages can be used to test the installation or upgrading of packages that require an existing package to downgrade.
+
+Each version is available as `upgradedowngradesdependency` and `downgradesdependency`. This is to allow testing of scenarios where `choco upgrade all` would process the dependency before and after the parent package.
+
+- Version 1.0.0 contains a range that can be used in an upgrade scenario and has a dependency on `isdependency 1.0.0 or greater`
+- Version 2.0.0 contains an exact dependency on `isdependency` with a version of `1.0.0`
+        </description>
         <summary>Package to test for out of range dependencies. This version uses a dependency that require a lower version.</summary>
         <releaseNotes />
         <copyright />

--- a/tests/packages/upgradedowngradesdependency/2.0.0/downgradesdependency.nuspec
+++ b/tests/packages/upgradedowngradesdependency/2.0.0/downgradesdependency.nuspec
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+    <metadata>
+        <id>downgradesdependency</id>
+        <version>2.0.0</version>
+        <title>Has out of range Dependency (Below available)</title>
+        <authors>__REPLACE_AUTHORS_OF_SOFTWARE__</authors>
+        <owners>__REPLACE_YOUR_NAME__</owners>
+        <requireLicenseAcceptance>false</requireLicenseAcceptance>
+        <description>__REPLACE__</description>
+        <summary>Package to test for out of range dependencies. This version uses a dependency that require a lower version.</summary>
+        <releaseNotes />
+        <copyright />
+        <tags>upgradedowngradesdependency admin</tags>
+        <dependencies>
+            <dependency id="isdependency" version="[1.0.0]" />
+        </dependencies>
+    </metadata>
+  <files>
+    <file src="tools\**" target="tools" />
+  </files>
+</package>

--- a/tests/packages/upgradedowngradesdependency/2.0.0/downgradesdependency.nuspec
+++ b/tests/packages/upgradedowngradesdependency/2.0.0/downgradesdependency.nuspec
@@ -4,8 +4,8 @@
         <id>downgradesdependency</id>
         <version>2.0.0</version>
         <title>Has out of range Dependency (Below available)</title>
-        <authors>__REPLACE_AUTHORS_OF_SOFTWARE__</authors>
-        <owners>__REPLACE_YOUR_NAME__</owners>
+        <authors>Chocolatey Software</authors>
+        <owners>chocolatey</owners>
         <requireLicenseAcceptance>false</requireLicenseAcceptance>
         <description>
           These packages can be used to test the installation or upgrading of packages that require an existing package to downgrade.

--- a/tests/packages/upgradedowngradesdependency/2.0.0/tools/chocolateybeforemodify.ps1
+++ b/tests/packages/upgradedowngradesdependency/2.0.0/tools/chocolateybeforemodify.ps1
@@ -1,0 +1,1 @@
+﻿Write-Output "Upgrading or Uninstalling $env:PackageName $env:PackageVersion"

--- a/tests/packages/upgradedowngradesdependency/2.0.0/tools/chocolateyinstall.ps1
+++ b/tests/packages/upgradedowngradesdependency/2.0.0/tools/chocolateyinstall.ps1
@@ -1,0 +1,1 @@
+﻿Write-Output "$env:PackageName $env:PackageVersion Installed"

--- a/tests/packages/upgradedowngradesdependency/2.0.0/tools/chocolateyuninstall.ps1
+++ b/tests/packages/upgradedowngradesdependency/2.0.0/tools/chocolateyuninstall.ps1
@@ -1,0 +1,1 @@
+﻿Write-Output "$env:PackageName $env:PackageVersion Uninstalled"

--- a/tests/packages/upgradedowngradesdependency/2.0.0/upgradedowngradesdependency.nuspec
+++ b/tests/packages/upgradedowngradesdependency/2.0.0/upgradedowngradesdependency.nuspec
@@ -7,7 +7,14 @@
         <authors>__REPLACE_AUTHORS_OF_SOFTWARE__</authors>
         <owners>__REPLACE_YOUR_NAME__</owners>
         <requireLicenseAcceptance>false</requireLicenseAcceptance>
-        <description>__REPLACE__</description>
+        <description>
+          These packages can be used to test the installation or upgrading of packages that require an existing package to downgrade.
+
+Each version is available as `upgradedowngradesdependency` and `downgradesdependency`. This is to allow testing of scenarios where `choco upgrade all` would process the dependency before and after the parent package.
+
+- Version 1.0.0 contains a range that can be used in an upgrade scenario and has a dependency on `isdependency 1.0.0 or greater`
+- Version 2.0.0 contains an exact dependency on `isdependency` with a version of `1.0.0`
+        </description>
         <summary>Package to test for out of range dependencies. This version uses a dependency that require a lower version.</summary>
         <releaseNotes />
         <copyright />

--- a/tests/packages/upgradedowngradesdependency/2.0.0/upgradedowngradesdependency.nuspec
+++ b/tests/packages/upgradedowngradesdependency/2.0.0/upgradedowngradesdependency.nuspec
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+    <metadata>
+        <id>upgradedowngradesdependency</id>
+        <version>2.0.0</version>
+        <title>Has out of range Dependency (Below available)</title>
+        <authors>__REPLACE_AUTHORS_OF_SOFTWARE__</authors>
+        <owners>__REPLACE_YOUR_NAME__</owners>
+        <requireLicenseAcceptance>false</requireLicenseAcceptance>
+        <description>__REPLACE__</description>
+        <summary>Package to test for out of range dependencies. This version uses a dependency that require a lower version.</summary>
+        <releaseNotes />
+        <copyright />
+        <tags>upgradedowngradesdependency admin</tags>
+        <dependencies>
+            <dependency id="isdependency" version="[1.0.0]" />
+        </dependencies>
+    </metadata>
+  <files>
+    <file src="tools\**" target="tools" />
+  </files>
+</package>

--- a/tests/packages/upgradedowngradesdependency/2.0.0/upgradedowngradesdependency.nuspec
+++ b/tests/packages/upgradedowngradesdependency/2.0.0/upgradedowngradesdependency.nuspec
@@ -4,8 +4,8 @@
         <id>upgradedowngradesdependency</id>
         <version>2.0.0</version>
         <title>Has out of range Dependency (Below available)</title>
-        <authors>__REPLACE_AUTHORS_OF_SOFTWARE__</authors>
-        <owners>__REPLACE_YOUR_NAME__</owners>
+        <authors>Chocolatey Software</authors>
+        <owners>chocolatey</owners>
         <requireLicenseAcceptance>false</requireLicenseAcceptance>
         <description>
           These packages can be used to test the installation or upgrading of packages that require an existing package to downgrade.

--- a/tests/packages/upgradedowngradesdependency/Readme.md
+++ b/tests/packages/upgradedowngradesdependency/Readme.md
@@ -1,0 +1,6 @@
+These packages can be used to test the installation or upgrading of packages that have require an existing package to downgrade.
+
+Each version is available as `upgradedowngradesdependency` and `downgradesdependency`. This is to allow testing of scenarios where `choco upgrade all` would process the dependency before and after the parent package.
+
+- Version 1.0.0 Contains a range that can be used in an upgrade scenario and has a dependency on `isdependency 1.0.0 or greater`
+- Version 2.0.0 Contains an exact dependency on `isdependency` with a version of `1.0.0`

--- a/tests/packages/upgradedowngradesdependency/Readme.md
+++ b/tests/packages/upgradedowngradesdependency/Readme.md
@@ -1,6 +1,6 @@
-These packages can be used to test the installation or upgrading of packages that have require an existing package to downgrade.
+These packages can be used to test the installation or upgrading of packages that require an existing package to downgrade.
 
 Each version is available as `upgradedowngradesdependency` and `downgradesdependency`. This is to allow testing of scenarios where `choco upgrade all` would process the dependency before and after the parent package.
 
-- Version 1.0.0 Contains a range that can be used in an upgrade scenario and has a dependency on `isdependency 1.0.0 or greater`
-- Version 2.0.0 Contains an exact dependency on `isdependency` with a version of `1.0.0`
+- Version 1.0.0 contains a range that can be used in an upgrade scenario and has a dependency on `isdependency 1.0.0 or greater`
+- Version 2.0.0 contains an exact dependency on `isdependency` with a version of `1.0.0`

--- a/tests/pester-tests/commands/choco-install.Tests.ps1
+++ b/tests/pester-tests/commands/choco-install.Tests.ps1
@@ -1,4 +1,4 @@
-Describe "choco install" -Tag Chocolatey, InstallCommand {
+﻿Describe "choco install" -Tag Chocolatey, InstallCommand {
     BeforeDiscovery {
         $isLicensed30OrMissingVersion = Test-PackageIsEqualOrHigher 'chocolatey.extension' '3.0.0-beta' -AllowMissingPackage
         $licensedProxyFixed = Test-PackageIsEqualOrHigher 'chocolatey.extension' 2.2.0-beta -AllowMissingPackage
@@ -217,7 +217,8 @@ Describe "choco install" -Tag Chocolatey, InstallCommand {
         It "Should mention that package hash verification was skipped since local folder source is being used" {
             if ((Test-HasNuGetV3Source) -or (-not $env:TEST_KITCHEN)) {
                 $Output.Lines | Should -Contain "Source does not provide a package hash, skipping package hash validation." -Because $Output.String
-            } else {
+            }
+            else {
                 $Output.Lines | Should -Contain "Package hash matches expected hash." -Because $Output.String
             }
         }
@@ -1690,7 +1691,7 @@ To install a local, or remote file, you may use:
 
             $PackageUnderTest = "installpackage", "packagewithscript"
 
-            $Output = "a`n"*2 | Invoke-Choco install @PackageUnderTest
+            $Output = "a`n" * 2 | Invoke-Choco install @PackageUnderTest
         }
 
         It "Installs successfully and exits with success (0)" {
@@ -1740,7 +1741,8 @@ To install a local, or remote file, you may use:
         It 'Outputs download completed' {
             $testMessage = if ($features.License) {
                 "Download of 'cmake-3.21.2-windows-x86_64.zip' (36.01 MB) completed."
-            } else {
+            }
+            else {
                 "Download of cmake-3.21.2-windows-x86_64.zip (36.01 MB) completed."
             }
             $Output.Lines | Should -Contain $testMessage -Because $Output.String
@@ -1749,7 +1751,8 @@ To install a local, or remote file, you may use:
         It 'Outputs extracting correct archive' {
             $testMessage = if ($features.License) {
                 "Extracting cmake-3.21.2-windows-x86_64.zip to $env:ChocolateyInstall\lib\install-chocolateyzip\tools..."
-            } else {
+            }
+            else {
                 "Extracting $($paths.CachePathLong)\install-chocolateyzip\3.21.2\cmake-3.21.2-windows-x86_64.zip to $env:ChocolateyInstall\lib\install-chocolateyzip\tools..."
             }
             $Output.Lines | Should -Contain $testMessage -Because $Output.String
@@ -1925,8 +1928,8 @@ To install a local, or remote file, you may use:
     }
 
     Context "Installing a package with a non-normalized version number" -ForEach @(
-        @{ ExpectedPackageVersion = '1.0.0' ; SearchVersion = '1' ; NuspecVersion = '01.0.0.0'}
-        @{ ExpectedPackageVersion = '1.0.0' ; SearchVersion = '1.0' ; NuspecVersion = '01.0.0.0'}
+        @{ ExpectedPackageVersion = '1.0.0' ; SearchVersion = '1' ; NuspecVersion = '01.0.0.0' }
+        @{ ExpectedPackageVersion = '1.0.0' ; SearchVersion = '1.0' ; NuspecVersion = '01.0.0.0' }
         @{ ExpectedPackageVersion = '1.0.0' ; SearchVersion = '1.0.0' ; NuspecVersion = '01.0.0.0' }
         @{ ExpectedPackageVersion = '4.0.1' ; SearchVersion = '4.0.1' ; NuspecVersion = '004.0.01.0' }
         @{ ExpectedPackageVersion = '1.0.0' ; SearchVersion = '01.0.0.0' ; NuspecVersion = '01.0.0.0' }
@@ -2027,21 +2030,21 @@ To install a local, or remote file, you may use:
         }
 
         It 'Outputs <Name> as <Value>' -ForEach @(@{
-            Name = 'chocolateyPackageVersion'
-            Value= '0.9.0'
-        }
-        @{
-            Name = 'packageVersion'
-            Value= '0.9.0'
-        }
-        @{
-            Name = 'chocolateyPackageNuspecVersion'
-            Value= '0.9'
-        }
-        @{
-            Name = 'packageNuspecVersion'
-            Value= '0.9'
-        }) {
+                Name  = 'chocolateyPackageVersion'
+                Value = '0.9.0'
+            }
+            @{
+                Name  = 'packageVersion'
+                Value = '0.9.0'
+            }
+            @{
+                Name  = 'chocolateyPackageNuspecVersion'
+                Value = '0.9'
+            }
+            @{
+                Name  = 'packageNuspecVersion'
+                Value = '0.9'
+            }) {
             $Output.Lines | Should -Contain "$Name=$Value"
         }
     }
@@ -2070,51 +2073,200 @@ To install a local, or remote file, you may use:
         }
     }
 
-    Context 'Installing a package should not downgrade an existing package dependency.' -Tag Downgrade {
+    Context 'Installing a package with argument (<Argument>) should (<AllowsDowngrade>) downgrade an existing package dependency.' -Tag Downgrade -ForEach @(
+        @{
+            Argument        = '--force'
+            AllowsDowngrade = $true
+            ExpectedExit    = 0
+        }
+        @{
+            Argument        = '--allow-downgrade'
+            AllowsDowngrade = $true
+            ExpectedExit    = 0
+        }
+        @{
+            Argument        = ''
+            AllowsDowngrade = $false
+            ExpectedExit    = 1
+        }
+    ) {
         BeforeAll {
             $DependentPackage = @{
-                Name = 'isexactversiondependency'
-                Version = '2.0.0'
+                Name    = 'isdependency'
+                Version = '2.1.0'
             }
 
             Restore-ChocolateyInstallSnapshot
 
             $Setup = Invoke-Choco install $DependentPackage.Name --version $DependentPackage.Version --confirm
-            $Output = Invoke-Choco install toplevelhasexactversiondependency
+            $Output = Invoke-Choco install downgradesdependency --confirm $Argument
+            $Packages = Get-ChocolateyInstalledPackages
         }
 
-        It "Exits with Failure (1)" {
-            $Output.ExitCode | Should -Be 1 -Because $Output.String
+        It "Exits correctly (<ExpectedExit>)" {
+            $Output.ExitCode | Should -Be $ExpectedExit -Because $Output.String
         }
 
-        It "Reports that it cannot downgrade isexactversiondependency" {
-            $Output.Lines | Should -Contain 'A newer version of isexactversiondependency (v2.0.0) is already installed.' -Because $Output.String
-            $Output.Lines | Should -Contain 'Use --allow-downgrade or --force to attempt to install older versions.' -Because $Output.String
-            $Output.Lines | Should -Contain 'Chocolatey installed 0/3 packages. 3 packages failed.' -Because $Output.String
+        It "Reports that it can (<AllowsDowngrade>) downgrade isdependency" {
+            if ($AllowsDowngrade) {
+                $Output.Lines | Should -Contain 'Chocolatey installed 2/2 packages.' -Because $Output.String
+            }
+            else {
+                $Output.Lines | Should -Contain 'Chocolatey installed 0/2 packages. 2 packages failed.' -Because $Output.String
+            }
+
+            $Output.Lines | Should -Contain -Not:($AllowsDowngrade) "A newer version of $($DependentPackage.Name) (v$($DependentPackage.Version)) is already installed." -Because $Output.String
+            $Output.Lines | Should -Contain -Not:($AllowsDowngrade) 'Use --allow-downgrade or --force to attempt to install older versions.' -Because $Output.String
+        }
+
+        It "Should have the expected packages" {
+            if ($AllowsDowngrade) {
+                $Packages | where { $_.Name -eq $DependentPackage.Name -and $_.Version -eq '1.0.0' } | Should -Not -BeNullOrEmpty -Because "Packages: $Packages $($Output.String)"
+            }
+            else {
+                $Packages | where { $_.Name -eq $DependentPackage.Name -and $_.Version -eq $DependentPackage.Version } | Should -Not -BeNullOrEmpty -Because "Packages: $Packages $($Output.String)"
+            }
         }
     }
 
-    Context 'Installing a package should downgrade an existing package dependency when <_> is used.' -ForEach @('--force', '--allow-downgrade') -Tag Downgrade {
+    Context 'Installing a package with argument (<Argument>) should (<AllowsDowngrade>) downgrade an existing package dependency.' -Tag Downgrade, StopOnFirstPackageFailure -ForEach @(
+        @{
+            Argument        = '--force'
+            AllowsDowngrade = $true
+            ExpectedExit    = 0
+        }
+        @{
+            Argument        = '--allow-downgrade'
+            AllowsDowngrade = $true
+            ExpectedExit    = 0
+        }
+        @{
+            Argument        = ''
+            AllowsDowngrade = $false
+            ExpectedExit    = 1
+        }
+    ) {
         BeforeAll {
             $DependentPackage = @{
-                Name = 'isexactversiondependency'
-                Version = '2.0.0'
+                Name    = 'isdependency'
+                Version = '2.1.0'
             }
 
             Restore-ChocolateyInstallSnapshot
 
             $Setup = Invoke-Choco install $DependentPackage.Name --version $DependentPackage.Version --confirm
-            $Output = Invoke-Choco install toplevelhasexactversiondependency $_
+            $null = Enable-ChocolateyFeature -Name StopOnFirstPackageFailure
+            $Output = Invoke-Choco install downgradesdependency installpackage --confirm $Argument
+            $Packages = Get-ChocolateyInstalledPackages
         }
 
-        It "Exits with Success (0)" {
-            $Output.ExitCode | Should -Be 0 -Because $Output.String
+        It "Exits correctly (<ExpectedExit>)" {
+            $Output.ExitCode | Should -Be $ExpectedExit -Because $Output.String
         }
 
-        It "Does not report that it cannot downgrade isexactversiondependency" {
-            $Output.Lines | Should -Not -Contain 'A newer version of isexactversiondependency (v2.0.0) is already installed.' -Because $Output.String
-            $Output.Lines | Should -Not -Contain 'Use --allow-downgrade or --force to attempt to install older versions.' -Because $Output.String
-            $Output.Lines | Should -Contain 'Chocolatey installed 3/3 packages.' -Because $Output.String
+        It "Reports that it can (<AllowsDowngrade>) downgrade isdependency" {
+            $Output.Lines | Should -Contain -Not:($AllowsDowngrade) "A newer version of $($DependentPackage.Name) (v$($DependentPackage.Version)) is already installed." -Because $Output.String
+            $Output.Lines | Should -Contain -Not:($AllowsDowngrade) 'Use --allow-downgrade or --force to attempt to install older versions.' -Because $Output.String
+        }
+
+        It "Should have the expected packages" {
+            if ($AllowsDowngrade) {
+                $Packages | where { $_.Name -eq $DependentPackage.Name -and $_.Version -eq '1.0.0' } | Should -Not -BeNullOrEmpty -Because "Packages: $Packages $($Output.String)"
+            }
+            else {
+                $Packages | where { $_.Name -eq $DependentPackage.Name -and $_.Version -eq $DependentPackage.Version } | Should -Not -BeNullOrEmpty -Because "Packages: $Packages $($Output.String)"
+            }
+        }
+    }
+
+    Context 'Installing a package (<PackageName>) with a failing nested dependency should not install the package with failing dependencies' -ForEach @(
+        @{
+            PackageName = 'dependencyfailure;downgradesdependency;failingdependency;hasdependency;hasfailingnesteddependency;hasnesteddependency;isdependency;isexactversiondependency'.Split(';')
+        }
+        @{
+            PackageName = @('packages.config')
+        }
+        @{
+            PackageName = @('all')
+        }
+    ) {
+        BeforeAll {
+
+            Restore-ChocolateyInstallSnapshot -SetWorkingDirectory
+
+            Copy-Item "$PSScriptRoot/failingnested.packages.config" './packages.config'
+            Disable-ChocolateySource -All
+            Enable-ChocolateySource -Name 'hermes-all'
+
+            $Output = Invoke-Choco install @PackageName --confirm
+            $Packages = Get-ChocolateyInstalledPackages
+        }
+
+        It "Exits correctly (15608)" {
+            # failingdependency exits with 15608, so Chocolatey exits with that.
+            $Output.ExitCode | Should -Be 15608 -Because $Output.String
+        }
+
+        It "Should have the expected packages" {
+            $ExpectedPackages = @(
+                "downgradesdependency"
+                "isdependency"
+                "isexactversiondependency"
+            )
+            $UnexpectedPackages = @(
+                'dependencyfailure'
+                "dependencyfailure"
+                'hasfailingnesteddependency'
+            )
+
+            foreach ($package in $ExpectedPackages) {
+                $Packages.Name | Should -Contain $package -Because "Package: $package $($Output.String)"
+            }
+
+            foreach ($package in $UnexpectedPackages) {
+                $Packages.Name | Should -Not -Contain $package -Because "Package: $package $($Output.String)"
+            }
+        }
+    }
+
+    Context 'Installing a package (<PackageName>) with a failing nested dependency should not install the package with failing dependencies' -ForEach @( @{ PackageName = 'hasfailingnesteddependency;hasnesteddependency' } ) {
+        BeforeAll {
+
+            Restore-ChocolateyInstallSnapshot -SetWorkingDirectory
+
+            Disable-ChocolateySource -All
+            Enable-ChocolateySource -Name 'hermes-all'
+
+            $Output = Invoke-Choco install $PackageName --confirm
+            $Packages = Get-ChocolateyInstalledPackages
+        }
+
+        It "Exits correctly (15608)" {
+            # failingdependency exits with 15608, so Chocolatey exits with that.
+            $Output.ExitCode | Should -Be 15608 -Because $Output.String
+        }
+
+        It "Should have the expected packages" {
+            $ExpectedPackages = @(
+                "downgradesdependency"
+                "hasnesteddependency"
+                "isdependency"
+                "hasdependency"
+            )
+            $UnexpectedPackages = @(
+                "dependencyfailure"
+                "isexactversiondependency"
+                'dependencyfailure'
+                'hasfailingnesteddependency'
+            )
+
+            foreach ($package in $ExpectedPackages) {
+                $Packages.Name | Should -Contain $package -Because "Package: $package $($Output.String)"
+            }
+
+            foreach ($package in $UnexpectedPackages) {
+                $Packages.Name | Should -Not -Contain $package -Because "Package: $package $($Output.String)"
+            }
         }
     }
 

--- a/tests/pester-tests/commands/choco-install.Tests.ps1
+++ b/tests/pester-tests/commands/choco-install.Tests.ps1
@@ -2129,7 +2129,7 @@ To install a local, or remote file, you may use:
         }
     }
 
-    Context 'Installing a package with argument (<Argument>) should (<AllowsDowngrade>) downgrade an existing package dependency.' -Tag Downgrade, StopOnFirstPackageFailure -ForEach @(
+    Context 'Installing a package with argument (<Argument>) and StopOnFirstPackageFailure enabled should (<AllowsDowngrade>) downgrade an existing package dependency and correctly handle installpackage.' -Tag Downgrade, StopOnFirstPackageFailure -ForEach @(
         @{
             Argument        = '--force'
             AllowsDowngrade = $true

--- a/tests/pester-tests/commands/failingnested.packages.config
+++ b/tests/pester-tests/commands/failingnested.packages.config
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="dependencyfailure" />
+  <package id="downgradesdependency" />
+  <package id="failingdependency" />
+  <package id="hasdependency" />
+  <package id="hasfailingnesteddependency" />
+  <package id="hasnesteddependency" />
+  <package id="isdependency" />
+  <package id="isexactversiondependency" />
+</packages>


### PR DESCRIPTION
## Description Of Changes

- Prevent dependency resolution from downgrading packages when `--allow-downgrade` is not specified.
- Prevent packages from installing if a dependent package fails installation.

## Motivation and Context

- Chocolatey 2.3.0 incorrectly allows a package to be downgraded to resolve a dependency when it has not been specified to allow downgrades.
- Chocolatey 2.3.0 installs a package even if one or more of the packages it depends on fails to install resulting in a broken state.

## Testing

1. Run tests through TeamCity/Test Kitchen
2. Run all integration tests with `./build.bat --testExecutionType=all --shouldRunOpenCover=false`
3. Run a spattering of manual tests.

### Operating Systems Testing

- Windows Server 2019/2016
- Windows 10

## Change Types Made

* [x] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [x] Tests to cover my changes, have been added.
* [x] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v3 compatibility checked?

## Related Issue

- Fixes #3461 
- Fixes #3487 
- ENGTASKS-3814
