### PR TITLE
(#3489) Return early when folder doesn't exist

### DIFF
--- a/src/chocolatey.tests.integration/App.config
+++ b/src/chocolatey.tests.integration/App.config
@@ -1,6 +1,60 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <runtime>
-    <loadFromRemoteSources enabled="true"/>
+    <loadFromRemoteSources enabled="true" />
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Threading.Tasks.Extensions" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.2.0.1" newVersion="4.2.0.1" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.6.0" newVersion="4.0.6.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="NJsonSchema" publicKeyToken="c2f9c3bdfae56102" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.7.2.0" newVersion="10.7.2.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Stef.Validation" publicKeyToken="8f3400880c321038" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-0.1.1.0" newVersion="0.1.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Memory" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.1.1" newVersion="4.0.1.1" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Buffers" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Text.Encodings.Web" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.5.1" newVersion="4.0.5.1" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Numerics.Vectors" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.1.4.0" newVersion="4.1.4.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Security.Cryptography.Cng" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.3.1.0" newVersion="4.3.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.AspNetCore.Server.IIS" publicKeyToken="adb9793829ddae60" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.2.6.0" newVersion="2.2.6.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.ValueTuple" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="FluentAssertions" publicKeyToken="33f2691a05b67b6a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-6.11.0.0" newVersion="6.11.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
   </runtime>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8"/></startup></configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8" /></startup></configuration>

--- a/src/chocolatey.tests.integration/chocolatey.tests.integration.csproj
+++ b/src/chocolatey.tests.integration/chocolatey.tests.integration.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\Microsoft.Extensions.Configuration.UserSecrets.2.2.0\build\netstandard2.0\Microsoft.Extensions.Configuration.UserSecrets.props" Condition="Exists('..\packages\Microsoft.Extensions.Configuration.UserSecrets.2.2.0\build\netstandard2.0\Microsoft.Extensions.Configuration.UserSecrets.props')" />
   <Import Project="..\packages\NUnit3TestAdapter.4.5.0\build\net462\NUnit3TestAdapter.props" Condition="Exists('..\packages\NUnit3TestAdapter.4.5.0\build\net462\NUnit3TestAdapter.props')" />
   <Import Project="..\packages\NUnit.3.13.3\build\NUnit.props" Condition="Exists('..\packages\NUnit.3.13.3\build\NUnit.props')" />
   <PropertyGroup>
@@ -79,6 +80,9 @@
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="AnyOf, Version=0.3.0.0, Culture=neutral, PublicKeyToken=b35e6abbb527c6b1, processorArchitecture=MSIL">
+      <HintPath>..\packages\AnyOf.0.3.0\lib\net45\AnyOf.dll</HintPath>
+    </Reference>
     <Reference Include="Chocolatey.NuGet.Common">
       <HintPath>..\packages\Chocolatey.NuGet.Common.3.4.2\lib\net472\Chocolatey.NuGet.Common.dll</HintPath>
     </Reference>
@@ -97,11 +101,230 @@
     <Reference Include="Chocolatey.NuGet.Versioning">
       <HintPath>..\packages\Chocolatey.NuGet.Versioning.3.4.2\lib\net472\Chocolatey.NuGet.Versioning.dll</HintPath>
     </Reference>
+    <Reference Include="Fare, Version=2.2.0.0, Culture=neutral, PublicKeyToken=ea68d375bf33a7c8, processorArchitecture=MSIL">
+      <HintPath>..\packages\Fare.2.2.1\lib\net35\Fare.dll</HintPath>
+    </Reference>
     <Reference Include="FluentAssertions, Version=6.11.0.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
       <HintPath>..\packages\FluentAssertions.6.11.0\lib\net47\FluentAssertions.dll</HintPath>
     </Reference>
+    <Reference Include="Handlebars, Version=2.1.6.0, Culture=neutral, PublicKeyToken=22225d0bf33cd661, processorArchitecture=MSIL">
+      <HintPath>..\packages\Handlebars.Net.2.1.6\lib\net451\Handlebars.dll</HintPath>
+    </Reference>
+    <Reference Include="Handlebars.Net.Helpers, Version=2.4.4.0, Culture=neutral, PublicKeyToken=00d131fae0c250bc, processorArchitecture=MSIL">
+      <HintPath>..\packages\Handlebars.Net.Helpers.2.4.4\lib\net46\Handlebars.Net.Helpers.dll</HintPath>
+    </Reference>
+    <Reference Include="HandlebarsDotNet.Helpers.Core, Version=2.4.4.0, Culture=neutral, PublicKeyToken=00d131fae0c250bc, processorArchitecture=MSIL">
+      <HintPath>..\packages\Handlebars.Net.Helpers.Core.2.4.4\lib\net46\HandlebarsDotNet.Helpers.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="HandlebarsDotNet.Helpers.DynamicLinq, Version=2.4.4.0, Culture=neutral, PublicKeyToken=00d131fae0c250bc, processorArchitecture=MSIL">
+      <HintPath>..\packages\Handlebars.Net.Helpers.DynamicLinq.2.4.4\lib\net46\HandlebarsDotNet.Helpers.DynamicLinq.dll</HintPath>
+    </Reference>
+    <Reference Include="HandlebarsDotNet.Helpers.Humanizer, Version=2.4.4.0, Culture=neutral, PublicKeyToken=00d131fae0c250bc, processorArchitecture=MSIL">
+      <HintPath>..\packages\Handlebars.Net.Helpers.Humanizer.2.4.4\lib\net46\HandlebarsDotNet.Helpers.Humanizer.dll</HintPath>
+    </Reference>
+    <Reference Include="HandlebarsDotNet.Helpers.Json, Version=2.4.4.0, Culture=neutral, PublicKeyToken=00d131fae0c250bc, processorArchitecture=MSIL">
+      <HintPath>..\packages\Handlebars.Net.Helpers.Json.2.4.4\lib\net46\HandlebarsDotNet.Helpers.Json.dll</HintPath>
+    </Reference>
+    <Reference Include="HandlebarsDotNet.Helpers.Random, Version=2.4.4.0, Culture=neutral, PublicKeyToken=00d131fae0c250bc, processorArchitecture=MSIL">
+      <HintPath>..\packages\Handlebars.Net.Helpers.Random.2.4.4\lib\net46\HandlebarsDotNet.Helpers.Random.dll</HintPath>
+    </Reference>
+    <Reference Include="HandlebarsDotNet.Helpers.Xeger, Version=2.4.4.0, Culture=neutral, PublicKeyToken=00d131fae0c250bc, processorArchitecture=MSIL">
+      <HintPath>..\packages\Handlebars.Net.Helpers.Xeger.2.4.4\lib\net46\HandlebarsDotNet.Helpers.Xeger.dll</HintPath>
+    </Reference>
+    <Reference Include="HandlebarsDotNet.Helpers.XPath, Version=2.4.4.0, Culture=neutral, PublicKeyToken=00d131fae0c250bc, processorArchitecture=MSIL">
+      <HintPath>..\packages\Handlebars.Net.Helpers.XPath.2.4.4\lib\net46\HandlebarsDotNet.Helpers.XPath.dll</HintPath>
+    </Reference>
+    <Reference Include="HandlebarsDotNet.Helpers.Xslt, Version=2.4.4.0, Culture=neutral, PublicKeyToken=00d131fae0c250bc, processorArchitecture=MSIL">
+      <HintPath>..\packages\Handlebars.Net.Helpers.Xslt.2.4.4\lib\net46\HandlebarsDotNet.Helpers.Xslt.dll</HintPath>
+    </Reference>
+    <Reference Include="Humanizer, Version=2.14.0.0, Culture=neutral, PublicKeyToken=979442b78dfc278e, processorArchitecture=MSIL">
+      <HintPath>..\packages\Humanizer.Core.2.14.1\lib\netstandard2.0\Humanizer.dll</HintPath>
+    </Reference>
+    <Reference Include="JmesPath.Net, Version=1.0.125.0, Culture=neutral, PublicKeyToken=b29d616b7f4faff0, processorArchitecture=MSIL">
+      <HintPath>..\packages\JmesPath.Net.1.0.125\lib\net45\JmesPath.Net.dll</HintPath>
+    </Reference>
+    <Reference Include="JsonConverter.Abstractions, Version=0.5.0.0, Culture=neutral, PublicKeyToken=7ba85365b500f2e2, processorArchitecture=MSIL">
+      <HintPath>..\packages\JsonConverter.Abstractions.0.5.0\lib\net461\JsonConverter.Abstractions.dll</HintPath>
+    </Reference>
     <Reference Include="log4net, Version=2.0.12.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
       <HintPath>..\packages\log4net.2.0.12\lib\net45\log4net.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.AspNetCore, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNetCore.2.2.0\lib\netstandard2.0\Microsoft.AspNetCore.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.AspNetCore.Authentication.Abstractions, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNetCore.Authentication.Abstractions.2.2.0\lib\netstandard2.0\Microsoft.AspNetCore.Authentication.Abstractions.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.AspNetCore.Authentication.Core, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNetCore.Authentication.Core.2.2.0\lib\netstandard2.0\Microsoft.AspNetCore.Authentication.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.AspNetCore.Connections.Abstractions, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNetCore.Connections.Abstractions.2.2.0\lib\netstandard2.0\Microsoft.AspNetCore.Connections.Abstractions.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.AspNetCore.Diagnostics, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNetCore.Diagnostics.2.2.0\lib\netstandard2.0\Microsoft.AspNetCore.Diagnostics.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.AspNetCore.Diagnostics.Abstractions, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNetCore.Diagnostics.Abstractions.2.2.0\lib\netstandard2.0\Microsoft.AspNetCore.Diagnostics.Abstractions.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.AspNetCore.HostFiltering, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNetCore.HostFiltering.2.2.0\lib\netstandard2.0\Microsoft.AspNetCore.HostFiltering.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.AspNetCore.Hosting, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNetCore.Hosting.2.2.0\lib\netstandard2.0\Microsoft.AspNetCore.Hosting.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.AspNetCore.Hosting.Abstractions, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNetCore.Hosting.Abstractions.2.2.0\lib\netstandard2.0\Microsoft.AspNetCore.Hosting.Abstractions.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.AspNetCore.Hosting.Server.Abstractions, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNetCore.Hosting.Server.Abstractions.2.2.0\lib\netstandard2.0\Microsoft.AspNetCore.Hosting.Server.Abstractions.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.AspNetCore.Http, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNetCore.Http.2.2.0\lib\netstandard2.0\Microsoft.AspNetCore.Http.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.AspNetCore.Http.Abstractions, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNetCore.Http.Abstractions.2.2.0\lib\netstandard2.0\Microsoft.AspNetCore.Http.Abstractions.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.AspNetCore.Http.Extensions, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNetCore.Http.Extensions.2.2.0\lib\netstandard2.0\Microsoft.AspNetCore.Http.Extensions.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.AspNetCore.Http.Features, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNetCore.Http.Features.2.2.0\lib\netstandard2.0\Microsoft.AspNetCore.Http.Features.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.AspNetCore.HttpOverrides, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNetCore.HttpOverrides.2.2.0\lib\netstandard2.0\Microsoft.AspNetCore.HttpOverrides.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.AspNetCore.Routing, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNetCore.Routing.2.2.0\lib\netstandard2.0\Microsoft.AspNetCore.Routing.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.AspNetCore.Routing.Abstractions, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNetCore.Routing.Abstractions.2.2.0\lib\netstandard2.0\Microsoft.AspNetCore.Routing.Abstractions.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.AspNetCore.Server.IIS, Version=2.2.6.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNetCore.Server.IIS.2.2.6\lib\netstandard2.0\Microsoft.AspNetCore.Server.IIS.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.AspNetCore.Server.IISIntegration, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNetCore.Server.IISIntegration.2.2.0\lib\netstandard2.0\Microsoft.AspNetCore.Server.IISIntegration.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.AspNetCore.Server.Kestrel, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNetCore.Server.Kestrel.2.2.0\lib\netstandard2.0\Microsoft.AspNetCore.Server.Kestrel.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.AspNetCore.Server.Kestrel.Core, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNetCore.Server.Kestrel.Core.2.2.0\lib\netstandard2.0\Microsoft.AspNetCore.Server.Kestrel.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.AspNetCore.Server.Kestrel.Https, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNetCore.Server.Kestrel.Https.2.2.0\lib\netstandard2.0\Microsoft.AspNetCore.Server.Kestrel.Https.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions.2.2.0\lib\netstandard2.0\Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.2.2.0\lib\netstandard2.0\Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.AspNetCore.WebUtilities, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNetCore.WebUtilities.2.2.0\lib\netstandard2.0\Microsoft.AspNetCore.WebUtilities.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Bcl.AsyncInterfaces, Version=1.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Bcl.AsyncInterfaces.1.1.0\lib\net461\Microsoft.Bcl.AsyncInterfaces.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.Configuration, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Configuration.2.2.0\lib\netstandard2.0\Microsoft.Extensions.Configuration.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.Configuration.Abstractions, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Configuration.Abstractions.2.2.0\lib\netstandard2.0\Microsoft.Extensions.Configuration.Abstractions.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.Configuration.Binder, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Configuration.Binder.2.2.0\lib\netstandard2.0\Microsoft.Extensions.Configuration.Binder.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.Configuration.CommandLine, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Configuration.CommandLine.2.2.0\lib\netstandard2.0\Microsoft.Extensions.Configuration.CommandLine.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.Configuration.EnvironmentVariables, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Configuration.EnvironmentVariables.2.2.0\lib\netstandard2.0\Microsoft.Extensions.Configuration.EnvironmentVariables.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.Configuration.FileExtensions, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Configuration.FileExtensions.2.2.0\lib\netstandard2.0\Microsoft.Extensions.Configuration.FileExtensions.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.Configuration.Json, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Configuration.Json.2.2.0\lib\netstandard2.0\Microsoft.Extensions.Configuration.Json.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.Configuration.UserSecrets, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Configuration.UserSecrets.2.2.0\lib\netstandard2.0\Microsoft.Extensions.Configuration.UserSecrets.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.DependencyInjection, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.DependencyInjection.2.2.0\lib\net461\Microsoft.Extensions.DependencyInjection.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.DependencyInjection.Abstractions, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.DependencyInjection.Abstractions.2.2.0\lib\netstandard2.0\Microsoft.Extensions.DependencyInjection.Abstractions.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.FileProviders.Abstractions, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.FileProviders.Abstractions.2.2.0\lib\netstandard2.0\Microsoft.Extensions.FileProviders.Abstractions.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.FileProviders.Physical, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.FileProviders.Physical.2.2.0\lib\netstandard2.0\Microsoft.Extensions.FileProviders.Physical.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.FileSystemGlobbing, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.FileSystemGlobbing.2.2.0\lib\netstandard2.0\Microsoft.Extensions.FileSystemGlobbing.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.Hosting.Abstractions, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Hosting.Abstractions.2.2.0\lib\netstandard2.0\Microsoft.Extensions.Hosting.Abstractions.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.Logging, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Logging.2.2.0\lib\netstandard2.0\Microsoft.Extensions.Logging.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.Logging.Abstractions, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Logging.Abstractions.2.2.0\lib\netstandard2.0\Microsoft.Extensions.Logging.Abstractions.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.Logging.Configuration, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Logging.Configuration.2.2.0\lib\netstandard2.0\Microsoft.Extensions.Logging.Configuration.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.Logging.Console, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Logging.Console.2.2.0\lib\netstandard2.0\Microsoft.Extensions.Logging.Console.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.Logging.Debug, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Logging.Debug.2.2.0\lib\netstandard2.0\Microsoft.Extensions.Logging.Debug.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.Logging.EventSource, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Logging.EventSource.2.2.0\lib\netstandard2.0\Microsoft.Extensions.Logging.EventSource.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.ObjectPool, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.ObjectPool.2.2.0\lib\netstandard2.0\Microsoft.Extensions.ObjectPool.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.Options, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Options.2.2.0\lib\netstandard2.0\Microsoft.Extensions.Options.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.Options.ConfigurationExtensions, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Options.ConfigurationExtensions.2.2.0\lib\netstandard2.0\Microsoft.Extensions.Options.ConfigurationExtensions.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Extensions.Primitives, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Extensions.Primitives.2.2.0\lib\netstandard2.0\Microsoft.Extensions.Primitives.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.IdentityModel.Abstractions, Version=6.34.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.IdentityModel.Abstractions.6.34.0\lib\net472\Microsoft.IdentityModel.Abstractions.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.IdentityModel.JsonWebTokens, Version=6.34.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.IdentityModel.JsonWebTokens.6.34.0\lib\net472\Microsoft.IdentityModel.JsonWebTokens.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.IdentityModel.Logging, Version=6.34.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.IdentityModel.Logging.6.34.0\lib\net472\Microsoft.IdentityModel.Logging.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.IdentityModel.Protocols, Version=6.34.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.IdentityModel.Protocols.6.34.0\lib\net472\Microsoft.IdentityModel.Protocols.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect, Version=6.34.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.IdentityModel.Protocols.OpenIdConnect.6.34.0\lib\net472\Microsoft.IdentityModel.Protocols.OpenIdConnect.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.IdentityModel.Tokens, Version=6.34.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.IdentityModel.Tokens.6.34.0\lib\net472\Microsoft.IdentityModel.Tokens.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Net.Http.Headers, Version=2.2.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Net.Http.Headers.2.2.0\lib\netstandard2.0\Microsoft.Net.Http.Headers.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.OpenApi, Version=1.2.3.0, Culture=neutral, PublicKeyToken=3f5743946376f042, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.OpenApi.1.2.3\lib\net46\Microsoft.OpenApi.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.OpenApi.Readers, Version=1.2.3.0, Culture=neutral, PublicKeyToken=3f5743946376f042, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.OpenApi.Readers.1.2.3\lib\net46\Microsoft.OpenApi.Readers.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Web.XmlTransform, Version=3.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Web.Xdt.3.1.0\lib\net40\Microsoft.Web.XmlTransform.dll</HintPath>
@@ -109,32 +332,111 @@
     <Reference Include="Moq">
       <HintPath>..\packages\Moq.4.2.1402.2112\lib\net40\Moq.dll</HintPath>
     </Reference>
+    <Reference Include="Namotion.Reflection, Version=2.0.10.0, Culture=neutral, PublicKeyToken=c2f9c3bdfae56102, processorArchitecture=MSIL">
+      <HintPath>..\packages\Namotion.Reflection.2.0.10\lib\net45\Namotion.Reflection.dll</HintPath>
+    </Reference>
     <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.13.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <HintPath>..\packages\Newtonsoft.Json.13.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
+    <Reference Include="NJsonSchema, Version=10.7.2.0, Culture=neutral, PublicKeyToken=c2f9c3bdfae56102, processorArchitecture=MSIL">
+      <HintPath>..\packages\NJsonSchema.10.7.2\lib\net45\NJsonSchema.dll</HintPath>
+    </Reference>
+    <Reference Include="NJsonSchema.Extensions, Version=0.1.0.0, Culture=neutral, PublicKeyToken=e52fadf300daf456, processorArchitecture=MSIL">
+      <HintPath>..\packages\NJsonSchema.Extensions.0.1.0\lib\net45\NJsonSchema.Extensions.dll</HintPath>
+    </Reference>
+    <Reference Include="NSwag.Core, Version=13.16.1.0, Culture=neutral, PublicKeyToken=c2d88086e098d109, processorArchitecture=MSIL">
+      <HintPath>..\packages\NSwag.Core.13.16.1\lib\net45\NSwag.Core.dll</HintPath>
     </Reference>
     <Reference Include="nunit.framework, Version=3.13.3.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
       <HintPath>..\packages\NUnit.3.13.3\lib\net40\nunit.framework.dll</HintPath>
     </Reference>
+    <Reference Include="RamlToOpenApiConverter, Version=0.6.1.0, Culture=neutral, PublicKeyToken=f82a9044f86aaeda, processorArchitecture=MSIL">
+      <HintPath>..\packages\RamlToOpenApiConverter.0.6.1\lib\net46\RamlToOpenApiConverter.dll</HintPath>
+    </Reference>
+    <Reference Include="RandomDataGenerator, Version=1.0.16.0, Culture=neutral, PublicKeyToken=ae5c571d29a3b8d9, processorArchitecture=MSIL">
+      <HintPath>..\packages\RandomDataGenerator.Net.1.0.17\lib\net45\RandomDataGenerator.dll</HintPath>
+    </Reference>
+    <Reference Include="Scriban.Signed, Version=2.1.4.0, Culture=neutral, PublicKeyToken=5675fb69b15f2433, processorArchitecture=MSIL">
+      <HintPath>..\packages\Scriban.Signed.2.1.4\lib\net45\Scriban.Signed.dll</HintPath>
+    </Reference>
+    <Reference Include="SharpYaml, Version=1.6.5.0, Culture=neutral, PublicKeyToken=1ced8108e942bc02, processorArchitecture=MSIL">
+      <HintPath>..\packages\SharpYaml.1.6.5\lib\net45\SharpYaml.dll</HintPath>
+    </Reference>
+    <Reference Include="SimMetrics.Net, Version=1.0.5.0, Culture=neutral, PublicKeyToken=c58dc06d59f3391b, processorArchitecture=MSIL">
+      <HintPath>..\packages\SimMetrics.Net.1.0.5\lib\net45\SimMetrics.Net.dll</HintPath>
+    </Reference>
     <Reference Include="SimpleInjector, Version=2.8.3.0, Culture=neutral, PublicKeyToken=984cb50dea722e99, processorArchitecture=MSIL">
       <HintPath>..\packages\SimpleInjector.2.8.3\lib\net45\SimpleInjector.dll</HintPath>
     </Reference>
+    <Reference Include="Stef.Validation, Version=0.1.1.0, Culture=neutral, PublicKeyToken=8f3400880c321038, processorArchitecture=MSIL">
+      <HintPath>..\packages\Stef.Validation.0.1.1\lib\net40\Stef.Validation.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Buffers, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Buffers.4.5.1\lib\net461\System.Buffers.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Collections.Immutable, Version=1.2.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Collections.Immutable.1.5.0\lib\netstandard2.0\System.Collections.Immutable.dll</HintPath>
+    </Reference>
+    <Reference Include="System.ComponentModel.Annotations, Version=4.2.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.ComponentModel.Annotations.4.5.0\lib\net461\System.ComponentModel.Annotations.dll</HintPath>
+    </Reference>
+    <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Diagnostics.DiagnosticSource, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Diagnostics.DiagnosticSource.4.5.0\lib\net46\System.Diagnostics.DiagnosticSource.dll</HintPath>
+    </Reference>
     <Reference Include="System.IdentityModel" />
+    <Reference Include="System.IdentityModel.Tokens.Jwt, Version=6.34.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.IdentityModel.Tokens.Jwt.6.34.0\lib\net472\System.IdentityModel.Tokens.Jwt.dll</HintPath>
+    </Reference>
     <Reference Include="System.IO.Compression" />
+    <Reference Include="System.IO.Pipelines, Version=4.0.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.IO.Pipelines.4.5.3\lib\netstandard2.0\System.IO.Pipelines.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Linq.Dynamic.Core, Version=1.3.12.0, Culture=neutral, PublicKeyToken=0f07ec44de6ac832, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Linq.Dynamic.Core.1.3.12\lib\net46\System.Linq.Dynamic.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Memory, Version=4.0.1.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Memory.4.5.4\lib\net461\System.Memory.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Net" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Net.Http.WebRequest" />
+    <Reference Include="System.Numerics" />
+    <Reference Include="System.Numerics.Vectors, Version=4.1.4.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Numerics.Vectors.4.5.0\lib\net46\System.Numerics.Vectors.dll</HintPath>
+    </Reference>
     <Reference Include="System.Reactive, Version=5.0.0.0, Culture=neutral, PublicKeyToken=94bc3704cddfc263, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Reactive.5.0.0\lib\net472\System.Reactive.dll</HintPath>
     </Reference>
-    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=4.0.4.1, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.4.5.3\lib\net461\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    <Reference Include="System.Reflection.Metadata, Version=1.4.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Reflection.Metadata.1.6.0\lib\netstandard2.0\System.Reflection.Metadata.dll</HintPath>
     </Reference>
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=4.0.6.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.4.7.1\lib\net461\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Security" />
+    <Reference Include="System.Security.Cryptography.Cng, Version=4.3.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Security.Cryptography.Cng.4.5.0\lib\net47\System.Security.Cryptography.Cng.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Security.Principal.Windows, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Security.Principal.Windows.4.5.0\lib\net461\System.Security.Principal.Windows.dll</HintPath>
+    </Reference>
     <Reference Include="System.ServiceModel" />
+    <Reference Include="System.Text.Encodings.Web, Version=4.0.5.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Text.Encodings.Web.4.7.2\lib\net461\System.Text.Encodings.Web.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Text.Json, Version=4.0.1.2, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Text.Json.4.7.2\lib\net461\System.Text.Json.dll</HintPath>
+    </Reference>
     <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Threading.Tasks.Extensions.4.5.4\lib\net461\System.Threading.Tasks.Extensions.dll</HintPath>
+    </Reference>
+    <Reference Include="System.ValueTuple, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.ValueTuple.4.5.0\lib\net47\System.ValueTuple.dll</HintPath>
     </Reference>
     <Reference Include="System.Web" />
     <Reference Include="System.Windows" />
@@ -144,7 +446,42 @@
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
+    <Reference Include="System.Xml.XmlDocument, Version=4.0.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Xml.XmlDocument.4.3.0\lib\net46\System.Xml.XmlDocument.dll</HintPath>
+      <Private>True</Private>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="TinyMapper, Version=3.0.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\TinyMapper.3.0.3\lib\net40\TinyMapper.dll</HintPath>
+    </Reference>
     <Reference Include="WindowsBase" />
+    <Reference Include="WireMock.Net, Version=1.5.62.0, Culture=neutral, PublicKeyToken=c8d65537854e1f03, processorArchitecture=MSIL">
+      <HintPath>..\packages\WireMock.Net.1.5.62\lib\net461\WireMock.Net.dll</HintPath>
+    </Reference>
+    <Reference Include="WireMock.Net.Abstractions, Version=1.5.62.0, Culture=neutral, PublicKeyToken=c8d65537854e1f03, processorArchitecture=MSIL">
+      <HintPath>..\packages\WireMock.Net.Abstractions.1.5.62\lib\net461\WireMock.Net.Abstractions.dll</HintPath>
+    </Reference>
+    <Reference Include="WireMock.Net.FluentAssertions, Version=1.5.62.0, Culture=neutral, PublicKeyToken=c8d65537854e1f03, processorArchitecture=MSIL">
+      <HintPath>..\packages\WireMock.Net.FluentAssertions.1.5.62\lib\net47\WireMock.Net.FluentAssertions.dll</HintPath>
+    </Reference>
+    <Reference Include="WireMock.Net.OpenApiParser, Version=1.5.62.0, Culture=neutral, PublicKeyToken=c8d65537854e1f03, processorArchitecture=MSIL">
+      <HintPath>..\packages\WireMock.Net.OpenApiParser.1.5.62\lib\net46\WireMock.Net.OpenApiParser.dll</HintPath>
+    </Reference>
+    <Reference Include="WireMock.Org.Abstractions, Version=1.5.62.0, Culture=neutral, PublicKeyToken=c8d65537854e1f03, processorArchitecture=MSIL">
+      <HintPath>..\packages\WireMock.Org.Abstractions.1.5.62\lib\net45\WireMock.Org.Abstractions.dll</HintPath>
+    </Reference>
+    <Reference Include="XPath2, Version=1.1.5.0, Culture=neutral, PublicKeyToken=463c6d7fb740c7e5, processorArchitecture=MSIL">
+      <HintPath>..\packages\XPath2.1.1.5\lib\net452\XPath2.dll</HintPath>
+    </Reference>
+    <Reference Include="XPath2.Extensions, Version=1.1.5.0, Culture=neutral, PublicKeyToken=463c6d7fb740c7e5, processorArchitecture=MSIL">
+      <HintPath>..\packages\XPath2.Extensions.1.1.5\lib\net452\XPath2.Extensions.dll</HintPath>
+    </Reference>
+    <Reference Include="YamlDotNet, Version=8.0.0.0, Culture=neutral, PublicKeyToken=ec19458f3c15af5e, processorArchitecture=MSIL">
+      <HintPath>..\packages\YamlDotNet.8.1.0\lib\net45\YamlDotNet.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <Reference Include="netstandard" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="infrastructure.app\builders\ConfigurationBuilderSpecs.cs" />
@@ -218,7 +555,14 @@
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\NUnit.3.13.3\build\NUnit.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\NUnit.3.13.3\build\NUnit.props'))" />
     <Error Condition="!Exists('..\packages\NUnit3TestAdapter.4.5.0\build\net462\NUnit3TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\NUnit3TestAdapter.4.5.0\build\net462\NUnit3TestAdapter.props'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.Extensions.Configuration.UserSecrets.2.2.0\build\netstandard2.0\Microsoft.Extensions.Configuration.UserSecrets.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Extensions.Configuration.UserSecrets.2.2.0\build\netstandard2.0\Microsoft.Extensions.Configuration.UserSecrets.props'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.Extensions.Configuration.UserSecrets.2.2.0\build\netstandard2.0\Microsoft.Extensions.Configuration.UserSecrets.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Extensions.Configuration.UserSecrets.2.2.0\build\netstandard2.0\Microsoft.Extensions.Configuration.UserSecrets.targets'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.AspNetCore.Server.IIS.2.2.6\build\netstandard2.0\Microsoft.AspNetCore.Server.IIS.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.AspNetCore.Server.IIS.2.2.6\build\netstandard2.0\Microsoft.AspNetCore.Server.IIS.targets'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.AspNetCore.Server.IISIntegration.2.2.0\build\netstandard2.0\Microsoft.AspNetCore.Server.IISIntegration.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.AspNetCore.Server.IISIntegration.2.2.0\build\netstandard2.0\Microsoft.AspNetCore.Server.IISIntegration.targets'))" />
   </Target>
+  <Import Project="..\packages\Microsoft.Extensions.Configuration.UserSecrets.2.2.0\build\netstandard2.0\Microsoft.Extensions.Configuration.UserSecrets.targets" Condition="Exists('..\packages\Microsoft.Extensions.Configuration.UserSecrets.2.2.0\build\netstandard2.0\Microsoft.Extensions.Configuration.UserSecrets.targets')" />
+  <Import Project="..\packages\Microsoft.AspNetCore.Server.IIS.2.2.6\build\netstandard2.0\Microsoft.AspNetCore.Server.IIS.targets" Condition="Exists('..\packages\Microsoft.AspNetCore.Server.IIS.2.2.6\build\netstandard2.0\Microsoft.AspNetCore.Server.IIS.targets')" />
+  <Import Project="..\packages\Microsoft.AspNetCore.Server.IISIntegration.2.2.0\build\netstandard2.0\Microsoft.AspNetCore.Server.IISIntegration.targets" Condition="Exists('..\packages\Microsoft.AspNetCore.Server.IISIntegration.2.2.0\build\netstandard2.0\Microsoft.AspNetCore.Server.IISIntegration.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/src/chocolatey.tests.integration/packages.config
+++ b/src/chocolatey.tests.integration/packages.config
@@ -1,21 +1,181 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="AnyOf" version="0.3.0" targetFramework="net48" />
   <package id="Chocolatey.NuGet.Common" version="3.4.2" targetFramework="net48" />
   <package id="Chocolatey.NuGet.Configuration" version="3.4.2" targetFramework="net48" />
   <package id="Chocolatey.NuGet.Frameworks" version="3.4.2" targetFramework="net48" />
   <package id="Chocolatey.NuGet.Packaging" version="3.4.2" targetFramework="net48" />
   <package id="Chocolatey.NuGet.Protocol" version="3.4.2" targetFramework="net48" />
   <package id="Chocolatey.NuGet.Versioning" version="3.4.2" targetFramework="net48" />
+  <package id="Fare" version="2.2.1" targetFramework="net48" />
   <package id="FluentAssertions" version="6.11.0" targetFramework="net48" />
   <package id="FluentAssertions.Analyzers" version="0.19.1" targetFramework="net48" developmentDependency="true" />
+  <package id="Handlebars.Net" version="2.1.6" targetFramework="net48" />
+  <package id="Handlebars.Net.Helpers" version="2.4.4" targetFramework="net48" />
+  <package id="Handlebars.Net.Helpers.Core" version="2.4.4" targetFramework="net48" />
+  <package id="Handlebars.Net.Helpers.DynamicLinq" version="2.4.4" targetFramework="net48" />
+  <package id="Handlebars.Net.Helpers.Humanizer" version="2.4.4" targetFramework="net48" />
+  <package id="Handlebars.Net.Helpers.Json" version="2.4.4" targetFramework="net48" />
+  <package id="Handlebars.Net.Helpers.Random" version="2.4.4" targetFramework="net48" />
+  <package id="Handlebars.Net.Helpers.Xeger" version="2.4.4" targetFramework="net48" />
+  <package id="Handlebars.Net.Helpers.XPath" version="2.4.4" targetFramework="net48" />
+  <package id="Handlebars.Net.Helpers.Xslt" version="2.4.4" targetFramework="net48" />
+  <package id="Humanizer" version="2.14.1" targetFramework="net48" />
+  <package id="Humanizer.Core" version="2.14.1" targetFramework="net48" />
+  <package id="Humanizer.Core.af" version="2.14.1" targetFramework="net48" />
+  <package id="Humanizer.Core.ar" version="2.14.1" targetFramework="net48" />
+  <package id="Humanizer.Core.az" version="2.14.1" targetFramework="net48" />
+  <package id="Humanizer.Core.bg" version="2.14.1" targetFramework="net48" />
+  <package id="Humanizer.Core.bn-BD" version="2.14.1" targetFramework="net48" />
+  <package id="Humanizer.Core.cs" version="2.14.1" targetFramework="net48" />
+  <package id="Humanizer.Core.da" version="2.14.1" targetFramework="net48" />
+  <package id="Humanizer.Core.de" version="2.14.1" targetFramework="net48" />
+  <package id="Humanizer.Core.el" version="2.14.1" targetFramework="net48" />
+  <package id="Humanizer.Core.es" version="2.14.1" targetFramework="net48" />
+  <package id="Humanizer.Core.fa" version="2.14.1" targetFramework="net48" />
+  <package id="Humanizer.Core.fi-FI" version="2.14.1" targetFramework="net48" />
+  <package id="Humanizer.Core.fr" version="2.14.1" targetFramework="net48" />
+  <package id="Humanizer.Core.fr-BE" version="2.14.1" targetFramework="net48" />
+  <package id="Humanizer.Core.he" version="2.14.1" targetFramework="net48" />
+  <package id="Humanizer.Core.hr" version="2.14.1" targetFramework="net48" />
+  <package id="Humanizer.Core.hu" version="2.14.1" targetFramework="net48" />
+  <package id="Humanizer.Core.hy" version="2.14.1" targetFramework="net48" />
+  <package id="Humanizer.Core.id" version="2.14.1" targetFramework="net48" />
+  <package id="Humanizer.Core.is" version="2.14.1" targetFramework="net48" />
+  <package id="Humanizer.Core.it" version="2.14.1" targetFramework="net48" />
+  <package id="Humanizer.Core.ja" version="2.14.1" targetFramework="net48" />
+  <package id="Humanizer.Core.ko-KR" version="2.14.1" targetFramework="net48" />
+  <package id="Humanizer.Core.ku" version="2.14.1" targetFramework="net48" />
+  <package id="Humanizer.Core.lv" version="2.14.1" targetFramework="net48" />
+  <package id="Humanizer.Core.ms-MY" version="2.14.1" targetFramework="net48" />
+  <package id="Humanizer.Core.mt" version="2.14.1" targetFramework="net48" />
+  <package id="Humanizer.Core.nb" version="2.14.1" targetFramework="net48" />
+  <package id="Humanizer.Core.nb-NO" version="2.14.1" targetFramework="net48" />
+  <package id="Humanizer.Core.nl" version="2.14.1" targetFramework="net48" />
+  <package id="Humanizer.Core.pl" version="2.14.1" targetFramework="net48" />
+  <package id="Humanizer.Core.pt" version="2.14.1" targetFramework="net48" />
+  <package id="Humanizer.Core.ro" version="2.14.1" targetFramework="net48" />
+  <package id="Humanizer.Core.ru" version="2.14.1" targetFramework="net48" />
+  <package id="Humanizer.Core.sk" version="2.14.1" targetFramework="net48" />
+  <package id="Humanizer.Core.sl" version="2.14.1" targetFramework="net48" />
+  <package id="Humanizer.Core.sr" version="2.14.1" targetFramework="net48" />
+  <package id="Humanizer.Core.sr-Latn" version="2.14.1" targetFramework="net48" />
+  <package id="Humanizer.Core.sv" version="2.14.1" targetFramework="net48" />
+  <package id="Humanizer.Core.th-TH" version="2.14.1" targetFramework="net48" />
+  <package id="Humanizer.Core.tr" version="2.14.1" targetFramework="net48" />
+  <package id="Humanizer.Core.uk" version="2.14.1" targetFramework="net48" />
+  <package id="Humanizer.Core.uz-Cyrl-UZ" version="2.14.1" targetFramework="net48" />
+  <package id="Humanizer.Core.uz-Latn-UZ" version="2.14.1" targetFramework="net48" />
+  <package id="Humanizer.Core.vi" version="2.14.1" targetFramework="net48" />
+  <package id="Humanizer.Core.zh-CN" version="2.14.1" targetFramework="net48" />
+  <package id="Humanizer.Core.zh-Hans" version="2.14.1" targetFramework="net48" />
+  <package id="Humanizer.Core.zh-Hant" version="2.14.1" targetFramework="net48" />
+  <package id="JmesPath.Net" version="1.0.125" targetFramework="net48" />
+  <package id="JsonConverter.Abstractions" version="0.5.0" targetFramework="net48" />
   <package id="log4net" version="2.0.12" targetFramework="net48" />
+  <package id="Microsoft.AspNetCore" version="2.2.0" targetFramework="net48" />
+  <package id="Microsoft.AspNetCore.Authentication.Abstractions" version="2.2.0" targetFramework="net48" />
+  <package id="Microsoft.AspNetCore.Authentication.Core" version="2.2.0" targetFramework="net48" />
+  <package id="Microsoft.AspNetCore.Connections.Abstractions" version="2.2.0" targetFramework="net48" />
+  <package id="Microsoft.AspNetCore.Diagnostics" version="2.2.0" targetFramework="net48" />
+  <package id="Microsoft.AspNetCore.Diagnostics.Abstractions" version="2.2.0" targetFramework="net48" />
+  <package id="Microsoft.AspNetCore.HostFiltering" version="2.2.0" targetFramework="net48" />
+  <package id="Microsoft.AspNetCore.Hosting" version="2.2.0" targetFramework="net48" />
+  <package id="Microsoft.AspNetCore.Hosting.Abstractions" version="2.2.0" targetFramework="net48" />
+  <package id="Microsoft.AspNetCore.Hosting.Server.Abstractions" version="2.2.0" targetFramework="net48" />
+  <package id="Microsoft.AspNetCore.Http" version="2.2.0" targetFramework="net48" />
+  <package id="Microsoft.AspNetCore.Http.Abstractions" version="2.2.0" targetFramework="net48" />
+  <package id="Microsoft.AspNetCore.Http.Extensions" version="2.2.0" targetFramework="net48" />
+  <package id="Microsoft.AspNetCore.Http.Features" version="2.2.0" targetFramework="net48" />
+  <package id="Microsoft.AspNetCore.HttpOverrides" version="2.2.0" targetFramework="net48" />
+  <package id="Microsoft.AspNetCore.Routing" version="2.2.0" targetFramework="net48" />
+  <package id="Microsoft.AspNetCore.Routing.Abstractions" version="2.2.0" targetFramework="net48" />
+  <package id="Microsoft.AspNetCore.Server.IIS" version="2.2.6" targetFramework="net48" />
+  <package id="Microsoft.AspNetCore.Server.IISIntegration" version="2.2.0" targetFramework="net48" />
+  <package id="Microsoft.AspNetCore.Server.Kestrel" version="2.2.0" targetFramework="net48" />
+  <package id="Microsoft.AspNetCore.Server.Kestrel.Core" version="2.2.0" targetFramework="net48" />
+  <package id="Microsoft.AspNetCore.Server.Kestrel.Https" version="2.2.0" targetFramework="net48" />
+  <package id="Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions" version="2.2.0" targetFramework="net48" />
+  <package id="Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets" version="2.2.0" targetFramework="net48" />
+  <package id="Microsoft.AspNetCore.WebUtilities" version="2.2.0" targetFramework="net48" />
+  <package id="Microsoft.Bcl.AsyncInterfaces" version="1.1.0" targetFramework="net48" />
+  <package id="Microsoft.CSharp" version="4.5.0" targetFramework="net48" />
+  <package id="Microsoft.Extensions.Configuration" version="2.2.0" targetFramework="net48" />
+  <package id="Microsoft.Extensions.Configuration.Abstractions" version="2.2.0" targetFramework="net48" />
+  <package id="Microsoft.Extensions.Configuration.Binder" version="2.2.0" targetFramework="net48" />
+  <package id="Microsoft.Extensions.Configuration.CommandLine" version="2.2.0" targetFramework="net48" />
+  <package id="Microsoft.Extensions.Configuration.EnvironmentVariables" version="2.2.0" targetFramework="net48" />
+  <package id="Microsoft.Extensions.Configuration.FileExtensions" version="2.2.0" targetFramework="net48" />
+  <package id="Microsoft.Extensions.Configuration.Json" version="2.2.0" targetFramework="net48" />
+  <package id="Microsoft.Extensions.Configuration.UserSecrets" version="2.2.0" targetFramework="net48" />
+  <package id="Microsoft.Extensions.DependencyInjection" version="2.2.0" targetFramework="net48" />
+  <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="2.2.0" targetFramework="net48" />
+  <package id="Microsoft.Extensions.FileProviders.Abstractions" version="2.2.0" targetFramework="net48" />
+  <package id="Microsoft.Extensions.FileProviders.Physical" version="2.2.0" targetFramework="net48" />
+  <package id="Microsoft.Extensions.FileSystemGlobbing" version="2.2.0" targetFramework="net48" />
+  <package id="Microsoft.Extensions.Hosting.Abstractions" version="2.2.0" targetFramework="net48" />
+  <package id="Microsoft.Extensions.Logging" version="2.2.0" targetFramework="net48" />
+  <package id="Microsoft.Extensions.Logging.Abstractions" version="2.2.0" targetFramework="net48" />
+  <package id="Microsoft.Extensions.Logging.Configuration" version="2.2.0" targetFramework="net48" />
+  <package id="Microsoft.Extensions.Logging.Console" version="2.2.0" targetFramework="net48" />
+  <package id="Microsoft.Extensions.Logging.Debug" version="2.2.0" targetFramework="net48" />
+  <package id="Microsoft.Extensions.Logging.EventSource" version="2.2.0" targetFramework="net48" />
+  <package id="Microsoft.Extensions.ObjectPool" version="2.2.0" targetFramework="net48" />
+  <package id="Microsoft.Extensions.Options" version="2.2.0" targetFramework="net48" />
+  <package id="Microsoft.Extensions.Options.ConfigurationExtensions" version="2.2.0" targetFramework="net48" />
+  <package id="Microsoft.Extensions.Primitives" version="2.2.0" targetFramework="net48" />
+  <package id="Microsoft.IdentityModel.Abstractions" version="6.34.0" targetFramework="net48" />
+  <package id="Microsoft.IdentityModel.JsonWebTokens" version="6.34.0" targetFramework="net48" />
+  <package id="Microsoft.IdentityModel.Logging" version="6.34.0" targetFramework="net48" />
+  <package id="Microsoft.IdentityModel.Protocols" version="6.34.0" targetFramework="net48" />
+  <package id="Microsoft.IdentityModel.Protocols.OpenIdConnect" version="6.34.0" targetFramework="net48" />
+  <package id="Microsoft.IdentityModel.Tokens" version="6.34.0" targetFramework="net48" />
+  <package id="Microsoft.Net.Http.Headers" version="2.2.0" targetFramework="net48" />
+  <package id="Microsoft.OpenApi" version="1.2.3" targetFramework="net48" />
+  <package id="Microsoft.OpenApi.Readers" version="1.2.3" targetFramework="net48" />
   <package id="Microsoft.Web.Xdt" version="3.1.0" targetFramework="net48" />
   <package id="Moq" version="4.2.1402.2112" targetFramework="net40" />
-  <package id="Newtonsoft.Json" version="13.0.1" targetFramework="net48" />
+  <package id="Namotion.Reflection" version="2.0.10" targetFramework="net48" />
+  <package id="Newtonsoft.Json" version="13.0.3" targetFramework="net48" />
+  <package id="NJsonSchema" version="10.7.2" targetFramework="net48" />
+  <package id="NJsonSchema.Extensions" version="0.1.0" targetFramework="net48" />
+  <package id="NSwag.Core" version="13.16.1" targetFramework="net48" />
   <package id="NUnit" version="3.13.3" targetFramework="net48" />
   <package id="NUnit3TestAdapter" version="4.5.0" targetFramework="net48" />
+  <package id="RamlToOpenApiConverter" version="0.6.1" targetFramework="net48" />
+  <package id="RandomDataGenerator.Net" version="1.0.17" targetFramework="net48" />
+  <package id="Scriban.Signed" version="2.1.4" targetFramework="net48" />
+  <package id="SharpYaml" version="1.6.5" targetFramework="net48" />
+  <package id="SimMetrics.Net" version="1.0.5" targetFramework="net48" />
   <package id="SimpleInjector" version="2.8.3" targetFramework="net48" />
+  <package id="Stef.Validation" version="0.1.1" targetFramework="net48" />
+  <package id="System.Buffers" version="4.5.1" targetFramework="net48" />
+  <package id="System.Collections.Immutable" version="1.5.0" targetFramework="net48" />
+  <package id="System.ComponentModel.Annotations" version="4.5.0" targetFramework="net48" />
+  <package id="System.Diagnostics.DiagnosticSource" version="4.5.0" targetFramework="net48" />
+  <package id="System.IdentityModel.Tokens.Jwt" version="6.34.0" targetFramework="net48" />
+  <package id="System.IO.Pipelines" version="4.5.3" targetFramework="net48" />
+  <package id="System.Linq.Dynamic.Core" version="1.3.12" targetFramework="net48" />
+  <package id="System.Memory" version="4.5.4" targetFramework="net48" />
+  <package id="System.Numerics.Vectors" version="4.5.0" targetFramework="net48" />
   <package id="System.Reactive" version="5.0.0" targetFramework="net48" />
-  <package id="System.Runtime.CompilerServices.Unsafe" version="4.5.3" targetFramework="net48" />
+  <package id="System.Reflection.Metadata" version="1.6.0" targetFramework="net48" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="4.7.1" targetFramework="net48" />
+  <package id="System.Security.Cryptography.Cng" version="4.5.0" targetFramework="net48" />
+  <package id="System.Security.Principal.Windows" version="4.5.0" targetFramework="net48" />
+  <package id="System.Text.Encoding" version="4.3.0" targetFramework="net48" />
+  <package id="System.Text.Encodings.Web" version="4.7.2" targetFramework="net48" />
+  <package id="System.Text.Json" version="4.7.2" targetFramework="net48" />
   <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net48" />
+  <package id="System.ValueTuple" version="4.5.0" targetFramework="net48" />
+  <package id="System.Xml.XmlDocument" version="4.3.0" targetFramework="net48" />
+  <package id="TinyMapper" version="3.0.3" targetFramework="net48" />
+  <package id="WireMock.Net" version="1.5.62" targetFramework="net48" />
+  <package id="WireMock.Net.Abstractions" version="1.5.62" targetFramework="net48" />
+  <package id="WireMock.Net.FluentAssertions" version="1.5.62" targetFramework="net48" />
+  <package id="WireMock.Net.OpenApiParser" version="1.5.62" targetFramework="net48" />
+  <package id="WireMock.Org.Abstractions" version="1.5.62" targetFramework="net48" />
+  <package id="XPath2" version="1.1.5" targetFramework="net48" />
+  <package id="XPath2.Extensions" version="1.1.5" targetFramework="net48" />
+  <package id="YamlDotNet" version="8.1.0" targetFramework="net48" />
 </packages>

--- a/src/chocolatey.tests.integration/scenarios/UpgradeScenarios.cs
+++ b/src/chocolatey.tests.integration/scenarios/UpgradeScenarios.cs
@@ -28,6 +28,10 @@ using NuGet.Configuration;
 using NuGet.Packaging;
 using NUnit.Framework;
 using FluentAssertions;
+using WireMock.Server;
+using WireMock.RequestBuilders;
+using WireMock.ResponseBuilders;
+using WireMock.FluentAssertions;
 
 namespace chocolatey.tests.integration.scenarios
 {
@@ -4241,6 +4245,7 @@ namespace chocolatey.tests.integration.scenarios
                     .WhoseValue.Should().NotContain(m => m.Contains("pre-beforemodify-all.ps1 hook ran for upgradepackage 1.1.0"));
             }
         }
+        
         public class When_upgrading_an_existing_package_with_uppercase_id : ScenariosBase
         {
             private PackageResult _packageResult;
@@ -4789,7 +4794,6 @@ namespace chocolatey.tests.integration.scenarios
             }
         }
 
-
         public class When_upgrading_a_package_with_beforeModify_script_with_dependencies_with_beforeModify_scripts_and_hooks : ScenariosBase
         {
             private const string TargetPackageName = "hasdependencywithbeforemodify";
@@ -4955,6 +4959,402 @@ namespace chocolatey.tests.integration.scenarios
             public void Should_not_have_warning_package_result()
             {
                 Results.Should().AllSatisfy(r => r.Value.Warning.Should().BeFalse());
+            }
+        }
+
+        [WindowsOnly]
+        public class When_upgrading_a_package_when_there_is_an_exception_thrown_from_server_when_downloading_nupkg_file : ScenariosBase
+        {
+            private WireMockServer _wireMockServer;
+
+            private PackageResult _packageResult;
+
+            public override void Context()
+            {
+                base.Context();
+
+                // Force outgoing Chocolatey CLI HTTP requests to go to WireMock.NET Server
+                Configuration.Sources = "http://localhost:24626/api/v2/";
+                // Set configuration to prevent re-use of cached HTTP Requests
+                Configuration.CacheExpirationInMinutes = -1;
+
+                _wireMockServer = WireMockServer.Start(24626);
+
+                _wireMockServer.Given(
+                    Request.Create().WithPath("/api/v2/").UsingGet()
+                )
+                .RespondWith(
+                    Response.Create()
+                    .WithStatusCode(200)
+                        .WithHeader("Content-Type", "application/xml;charset=utf-8")
+                        .WithHeader("DataServiceVersion", "1.0;")
+                        .WithBody(@"<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes""?>
+<service xml:base=""http://localhost:24626/api/v2/"" xmlns:atom=""http://www.w3.org/2005/Atom"" xmlns:app=""http://www.w3.org/2007/app"" xmlns=""http://www.w3.org/2007/app"">
+<workspace>
+<atom:title>Default</atom:title>
+<collection href=""Packages"">
+<atom:title>Packages</atom:title>
+</collection>
+</workspace>
+</service>")
+                );
+
+                _wireMockServer.Given(
+                    Request.Create().WithPath("/api/v2/$metadata").UsingGet()
+                )
+                .RespondWith(
+                    Response.Create()
+                    .WithStatusCode(200)
+                    .WithHeader("Content-Type", "application/xml;charset=utf-8")
+                    .WithHeader("DataServiceVersion", "2.0;")
+                    .WithBody(@"<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes""?>
+<edmx:Edmx Version=""1.0"" xmlns:edmx=""http://schemas.microsoft.com/ado/2007/06/edmx"">
+  <edmx:DataServices xmlns:m=""http://schemas.microsoft.com/ado/2007/08/dataservices/metadata"" m:DataServiceVersion=""2.0"">
+    <Schema Namespace=""CCR.Website"" xmlns:d=""http://schemas.microsoft.com/ado/2007/08/dataservices"" xmlns:m=""http://schemas.microsoft.com/ado/2007/08/dataservices/metadata"" xmlns=""http://schemas.microsoft.com/ado/2006/04/edm"">
+      <EntityType Name=""V2FeedPackage"" m:HasStream=""true"">
+        <Key>
+          <PropertyRef Name=""Id"" />
+          <PropertyRef Name=""Version"" />
+        </Key>
+        <Property Name=""Id"" Type=""Edm.String"" Nullable=""false"" m:FC_TargetPath=""SyndicationTitle"" m:FC_ContentKind=""text"" m:FC_KeepInContent=""false"" />
+        <Property Name=""Version"" Type=""Edm.String"" Nullable=""false"" />
+        <Property Name=""Title"" Type=""Edm.String"" Nullable=""true"" />
+        <Property Name=""Summary"" Type=""Edm.String"" Nullable=""true"" m:FC_TargetPath=""SyndicationSummary"" m:FC_ContentKind=""text"" m:FC_KeepInContent=""false"" />
+        <Property Name=""Description"" Type=""Edm.String"" Nullable=""true"" />
+        <Property Name=""Tags"" Type=""Edm.String"" Nullable=""true"" />
+        <Property Name=""Authors"" Type=""Edm.String"" Nullable=""true"" m:FC_TargetPath=""SyndicationAuthorName"" m:FC_ContentKind=""text"" m:FC_KeepInContent=""false"" />
+        <Property Name=""Copyright"" Type=""Edm.String"" Nullable=""true"" />
+        <Property Name=""Created"" Type=""Edm.DateTime"" Nullable=""false"" />
+        <Property Name=""Dependencies"" Type=""Edm.String"" Nullable=""true"" />
+        <Property Name=""DownloadCount"" Type=""Edm.Int32"" Nullable=""false"" />
+        <Property Name=""VersionDownloadCount"" Type=""Edm.Int32"" Nullable=""false"" />
+        <Property Name=""GalleryDetailsUrl"" Type=""Edm.String"" Nullable=""true"" />
+        <Property Name=""ReportAbuseUrl"" Type=""Edm.String"" Nullable=""true"" />
+        <Property Name=""IconUrl"" Type=""Edm.String"" Nullable=""true"" />
+        <Property Name=""IsLatestVersion"" Type=""Edm.Boolean"" Nullable=""false"" />
+        <Property Name=""IsAbsoluteLatestVersion"" Type=""Edm.Boolean"" Nullable=""false"" />
+        <Property Name=""IsPrerelease"" Type=""Edm.Boolean"" Nullable=""false"" />
+        <Property Name=""Language"" Type=""Edm.String"" Nullable=""true"" />
+        <Property Name=""LastUpdated"" Type=""Edm.DateTime"" Nullable=""false"" m:FC_TargetPath=""SyndicationUpdated"" m:FC_ContentKind=""text"" m:FC_KeepInContent=""false"" />
+        <Property Name=""Published"" Type=""Edm.DateTime"" Nullable=""false"" />
+        <Property Name=""LicenseUrl"" Type=""Edm.String"" Nullable=""true"" />
+        <Property Name=""RequireLicenseAcceptance"" Type=""Edm.Boolean"" Nullable=""false"" />
+        <Property Name=""PackageHash"" Type=""Edm.String"" Nullable=""true"" />
+        <Property Name=""PackageHashAlgorithm"" Type=""Edm.String"" Nullable=""true"" />
+        <Property Name=""PackageSize"" Type=""Edm.Int64"" Nullable=""false"" />
+        <Property Name=""ProjectUrl"" Type=""Edm.String"" Nullable=""true"" />
+        <Property Name=""ReleaseNotes"" Type=""Edm.String"" Nullable=""true"" />
+        <Property Name=""ProjectSourceUrl"" Type=""Edm.String"" Nullable=""true"" />
+        <Property Name=""PackageSourceUrl"" Type=""Edm.String"" Nullable=""true"" />
+        <Property Name=""DocsUrl"" Type=""Edm.String"" Nullable=""true"" />
+        <Property Name=""MailingListUrl"" Type=""Edm.String"" Nullable=""true"" />
+        <Property Name=""BugTrackerUrl"" Type=""Edm.String"" Nullable=""true"" />
+        <Property Name=""IsApproved"" Type=""Edm.Boolean"" Nullable=""false"" />
+        <Property Name=""PackageStatus"" Type=""Edm.String"" Nullable=""true"" />
+        <Property Name=""PackageSubmittedStatus"" Type=""Edm.String"" Nullable=""true"" />
+        <Property Name=""PackageTestResultUrl"" Type=""Edm.String"" Nullable=""true"" />
+        <Property Name=""PackageTestResultStatus"" Type=""Edm.String"" Nullable=""true"" />
+        <Property Name=""PackageTestResultStatusDate"" Type=""Edm.DateTime"" Nullable=""true"" />
+        <Property Name=""PackageValidationResultStatus"" Type=""Edm.String"" Nullable=""true"" />
+        <Property Name=""PackageValidationResultDate"" Type=""Edm.DateTime"" Nullable=""true"" />
+        <Property Name=""PackageCleanupResultDate"" Type=""Edm.DateTime"" Nullable=""true"" />
+        <Property Name=""PackageReviewedDate"" Type=""Edm.DateTime"" Nullable=""true"" />
+        <Property Name=""PackageApprovedDate"" Type=""Edm.DateTime"" Nullable=""true"" />
+        <Property Name=""PackageReviewer"" Type=""Edm.String"" Nullable=""true"" />
+        <Property Name=""IsDownloadCacheAvailable"" Type=""Edm.Boolean"" Nullable=""false"" />
+        <Property Name=""DownloadCacheStatus"" Type=""Edm.String"" Nullable=""true"" />
+        <Property Name=""DownloadCacheDate"" Type=""Edm.DateTime"" Nullable=""true"" />
+        <Property Name=""DownloadCache"" Type=""Edm.String"" Nullable=""true"" />
+        <Property Name=""PackageScanStatus"" Type=""Edm.String"" Nullable=""true"" />
+        <Property Name=""PackageScanResultDate"" Type=""Edm.DateTime"" Nullable=""true"" />
+        <Property Name=""PackageScanFlagResult"" Type=""Edm.String"" Nullable=""true"" />
+      </EntityType>
+      <EntityContainer Name=""FeedContext_x0060_1"" m:IsDefaultEntityContainer=""true"">
+        <EntitySet Name=""Packages"" EntityType=""CCR.Website.V2FeedPackage"" />
+        <FunctionImport Name=""Packages"" EntitySet=""Packages"" ReturnType=""Collection(CCR.Website.V2FeedPackage)"" m:HttpMethod=""GET"" />
+        <FunctionImport Name=""Search"" EntitySet=""Packages"" ReturnType=""Collection(CCR.Website.V2FeedPackage)"" m:HttpMethod=""GET"">
+          <Parameter Name=""searchTerm"" Type=""Edm.String"" Mode=""In"" />
+          <Parameter Name=""targetFramework"" Type=""Edm.String"" Mode=""In"" />
+          <Parameter Name=""includePrerelease"" Type=""Edm.Boolean"" Mode=""In"" />
+        </FunctionImport>
+        <FunctionImport Name=""FindPackagesById"" EntitySet=""Packages"" ReturnType=""Collection(CCR.Website.V2FeedPackage)"" m:HttpMethod=""GET"">
+          <Parameter Name=""id"" Type=""Edm.String"" Mode=""In"" />
+        </FunctionImport>
+        <FunctionImport Name=""GetUpdates"" EntitySet=""Packages"" ReturnType=""Collection(CCR.Website.V2FeedPackage)"" m:HttpMethod=""GET"">
+          <Parameter Name=""packageIds"" Type=""Edm.String"" Mode=""In"" />
+          <Parameter Name=""versions"" Type=""Edm.String"" Mode=""In"" />
+          <Parameter Name=""includePrerelease"" Type=""Edm.Boolean"" Mode=""In"" />
+          <Parameter Name=""includeAllVersions"" Type=""Edm.Boolean"" Mode=""In"" />
+          <Parameter Name=""targetFrameworks"" Type=""Edm.String"" Mode=""In"" />
+        </FunctionImport>
+      </EntityContainer>
+    </Schema>
+  </edmx:DataServices>
+</edmx:Edmx>")
+                );
+
+                _wireMockServer.Given(
+                    Request.Create()
+                    .WithPath("/api/v2/FindPackagesById()")
+                    .UsingGet()
+                )
+                .RespondWith(
+                    Response.Create()
+                    .WithStatusCode(200)
+                    .WithHeader("Content-Type", "application/atom+xml;charset=utf-8")
+                    .WithHeader("DataServiceVersion", "2.0;")
+                    .WithBody(@"<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes""?>
+<feed xml:base=""http://localhost:24626/api/v2/"" xmlns:d=""http://schemas.microsoft.com/ado/2007/08/dataservices"" xmlns:m=""http://schemas.microsoft.com/ado/2007/08/dataservices/metadata"" xmlns=""http://www.w3.org/2005/Atom"">
+  <title type=""text"">Packages</title>
+  <id>http://localhost:24626/api/v2/Packages</id>
+  <updated>2024-08-13T21:56:43Z</updated>
+  <link rel=""self"" title=""Packages"" href=""Packages"" />
+  <entry>
+    <id>http://localhost:24626/api/v2/Packages(Id='upgradepackage',Version='2.0.0')</id>
+    <title type=""text"">upgradepackage</title>
+    <summary type=""text"">A package used to test upgrading of packages.</summary>
+    <updated>2024-08-08T05:11:50Z</updated>
+    <author>
+      <name>Chocolatey Software, Inc.</name>
+    </author>
+    <link rel=""edit-media"" title=""V2FeedPackage"" href=""Packages(Id='upgradepackage',Version='2.0.0')/$value"" />
+    <link rel=""edit"" title=""V2FeedPackage"" href=""Packages(Id='upgradepackage',Version='2.0.0')"" />
+    <category term=""CCR.Website.V2FeedPackage"" scheme=""http://schemas.microsoft.com/ado/2007/08/dataservices/scheme"" />
+    <content type=""application/zip"" src=""http://localhost:24626/api/v2/package/upgradepackage/2.0.0"" />
+    <m:properties xmlns:m=""http://schemas.microsoft.com/ado/2007/08/dataservices/metadata"" xmlns:d=""http://schemas.microsoft.com/ado/2007/08/dataservices"">
+      <d:Version>2.0.0</d:Version>
+      <d:Title>Upgrade Package</d:Title>
+      <d:Description>My Description!</d:Description>
+      <d:Tags>a b c d</d:Tags>
+      <d:Copyright>Chocolatey Software, Inc.</d:Copyright>
+      <d:Created m:type=""Edm.DateTime"">2024-08-07T00:06:31.233</d:Created>
+      <d:Dependencies></d:Dependencies>
+      <d:DownloadCount m:type=""Edm.Int32"">289183</d:DownloadCount>
+      <d:VersionDownloadCount m:type=""Edm.Int32"">63</d:VersionDownloadCount>
+      <d:GalleryDetailsUrl>http://localhost:24626/packages/upgradepackage/2.0.0</d:GalleryDetailsUrl>
+      <d:ReportAbuseUrl>http://localhost:24626/package/ReportAbuse/upgradepackage/2.0.0</d:ReportAbuseUrl>
+      <d:IconUrl>https://chocolatey.org/assets/images/nupkg/chocolateyicon.png</d:IconUrl>
+      <d:IsLatestVersion m:type=""Edm.Boolean"">true</d:IsLatestVersion>
+      <d:IsAbsoluteLatestVersion m:type=""Edm.Boolean"">false</d:IsAbsoluteLatestVersion>
+      <d:IsPrerelease m:type=""Edm.Boolean"">false</d:IsPrerelease>
+      <d:Language></d:Language>
+      <d:Published m:type=""Edm.DateTime"">2024-08-07T00:06:31.233</d:Published>
+      <d:LicenseUrl>https://raw.githubusercontent.com/chocolatey/choco/master/LICENSE</d:LicenseUrl>
+      <d:RequireLicenseAcceptance m:type=""Edm.Boolean"">false</d:RequireLicenseAcceptance>
+      <d:PackageHash>GUXyvEC3y5y5S371LWHRbkEQ+fBxHAcm7d+/fweK+FYx1N2xMSlph+NGLyC3MEvecWY+EXNgRF7L7Km/u0oS8g==</d:PackageHash>
+      <d:PackageHashAlgorithm>SHA512</d:PackageHashAlgorithm>
+      <d:PackageSize m:type=""Edm.Int64"">5358</d:PackageSize>
+      <d:ProjectUrl>https://github.com/chocolatey/choco</d:ProjectUrl>
+      <d:ReleaseNotes>See all - https://docs.chocolatey.org/en-us/choco/release-notes</d:ReleaseNotes>
+      <d:ProjectSourceUrl></d:ProjectSourceUrl>
+      <d:PackageSourceUrl>https://github.com/chocolatey/choco/tree/develop/nuspec/chocolatey/chocolatey</d:PackageSourceUrl>
+      <d:DocsUrl>https://docs.chocolatey.org/en-us/</d:DocsUrl>
+      <d:MailingListUrl>https://groups.google.com/forum/#!forum/chocolatey</d:MailingListUrl>
+      <d:BugTrackerUrl>https://github.com/chocolatey/choco/issues</d:BugTrackerUrl>
+      <d:IsApproved m:type=""Edm.Boolean"">true</d:IsApproved>
+      <d:PackageStatus>Approved</d:PackageStatus>
+      <d:PackageSubmittedStatus>Ready</d:PackageSubmittedStatus>
+      <d:PackageTestResultUrl></d:PackageTestResultUrl>
+      <d:PackageTestResultStatus>Exempted</d:PackageTestResultStatus>
+      <d:PackageTestResultStatusDate m:type=""Edm.DateTime"" m:null=""true""></d:PackageTestResultStatusDate>
+      <d:PackageValidationResultStatus>Passing</d:PackageValidationResultStatus>
+      <d:PackageValidationResultDate m:type=""Edm.DateTime"">2024-08-07T02:36:24.62</d:PackageValidationResultDate>
+      <d:PackageCleanupResultDate m:type=""Edm.DateTime"" m:null=""true""></d:PackageCleanupResultDate>
+      <d:PackageReviewedDate m:type=""Edm.DateTime"">2024-08-07T03:58:15.683</d:PackageReviewedDate>
+      <d:PackageApprovedDate m:type=""Edm.DateTime"">2024-08-07T03:58:15.683</d:PackageApprovedDate>
+      <d:PackageReviewer></d:PackageReviewer>
+      <d:IsDownloadCacheAvailable m:type=""Edm.Boolean"">false</d:IsDownloadCacheAvailable>
+      <d:DownloadCacheStatus>Checked</d:DownloadCacheStatus>
+      <d:DownloadCacheDate m:type=""Edm.DateTime"">2024-08-07T04:59:31.147</d:DownloadCacheDate>
+      <d:DownloadCache></d:DownloadCache>
+      <d:PackageScanStatus>NotFlagged</d:PackageScanStatus>
+      <d:PackageScanResultDate m:type=""Edm.DateTime"">2024-08-07T03:58:15.683</d:PackageScanResultDate>
+      <d:PackageScanFlagResult>None</d:PackageScanFlagResult>
+    </m:properties>
+  </entry>
+</feed>")
+                );
+
+                _wireMockServer.Given(
+                    Request.Create()
+                    .WithPath("/api/v2/Packages(Id='upgradepackage',Version='2.0.0')")
+                    .UsingGet()
+                )
+                .RespondWith(
+                    Response.Create()
+                    .WithStatusCode(200)
+                    .WithHeader("Content-Type", "application/xml;charset=utf-8")
+                    .WithHeader("DataServiceVersion", "2.0;")
+                    .WithBody(@"<?xml version=""1.0"" encoding=""utf-8"" standalone=""yes""?>
+<entry>
+  <id>http://localhost:24626/api/v2/Packages(Id='upgradepackage',Version='2.0.0')</id>
+  <title type=""text"">upgradepackage</title>
+  <summary type=""text"">A package used to test upgrading of packages.</summary>
+  <updated>2024-08-08T05:11:50Z</updated>
+  <author>
+    <name>Chocolatey Software, Inc.</name>
+  </author>
+  <link rel=""edit-media"" title=""V2FeedPackage"" href=""Packages(Id='upgradepackage',Version='2.0.0')/$value"" />
+  <link rel=""edit"" title=""V2FeedPackage"" href=""Packages(Id='upgradepackage',Version='2.0.0')"" />
+  <category term=""CCR.Website.V2FeedPackage"" scheme=""http://schemas.microsoft.com/ado/2007/08/dataservices/scheme"" />
+  <content type=""application/zip"" src=""http://localhost:24626/api/v2/package/upgradepackage/2.0.0"" />
+  <m:properties xmlns:m=""http://schemas.microsoft.com/ado/2007/08/dataservices/metadata"" xmlns:d=""http://schemas.microsoft.com/ado/2007/08/dataservices"">
+    <d:Version>2.0.0</d:Version>
+    <d:Title>Upgrade Package</d:Title>
+    <d:Description>My Description!</d:Description>
+    <d:Tags>a b c d</d:Tags>
+    <d:Copyright>Chocolatey Software, Inc.</d:Copyright>
+    <d:Created m:type=""Edm.DateTime"">2024-08-07T00:06:31.233</d:Created>
+    <d:Dependencies></d:Dependencies>
+    <d:DownloadCount m:type=""Edm.Int32"">289183</d:DownloadCount>
+    <d:VersionDownloadCount m:type=""Edm.Int32"">63</d:VersionDownloadCount>
+    <d:GalleryDetailsUrl>http://localhost:24626/packages/upgradepackage/2.0.0</d:GalleryDetailsUrl>
+    <d:ReportAbuseUrl>http://localhost:24626/package/ReportAbuse/upgradepackage/2.0.0</d:ReportAbuseUrl>
+    <d:IconUrl>https://chocolatey.org/assets/images/nupkg/chocolateyicon.png</d:IconUrl>
+    <d:IsLatestVersion m:type=""Edm.Boolean"">true</d:IsLatestVersion>
+    <d:IsAbsoluteLatestVersion m:type=""Edm.Boolean"">false</d:IsAbsoluteLatestVersion>
+    <d:IsPrerelease m:type=""Edm.Boolean"">false</d:IsPrerelease>
+    <d:Language></d:Language>
+    <d:Published m:type=""Edm.DateTime"">2024-08-07T00:06:31.233</d:Published>
+    <d:LicenseUrl>https://raw.githubusercontent.com/chocolatey/choco/master/LICENSE</d:LicenseUrl>
+    <d:RequireLicenseAcceptance m:type=""Edm.Boolean"">false</d:RequireLicenseAcceptance>
+    <d:PackageHash>GUXyvEC3y5y5S371LWHRbkEQ+fBxHAcm7d+/fweK+FYx1N2xMSlph+NGLyC3MEvecWY+EXNgRF7L7Km/u0oS8g==</d:PackageHash>
+    <d:PackageHashAlgorithm>SHA512</d:PackageHashAlgorithm>
+    <d:PackageSize m:type=""Edm.Int64"">5358</d:PackageSize>
+    <d:ProjectUrl>https://github.com/chocolatey/choco</d:ProjectUrl>
+    <d:ReleaseNotes>See all - https://docs.chocolatey.org/en-us/choco/release-notes</d:ReleaseNotes>
+    <d:ProjectSourceUrl></d:ProjectSourceUrl>
+    <d:PackageSourceUrl>https://github.com/chocolatey/choco/tree/develop/nuspec/chocolatey/chocolatey</d:PackageSourceUrl>
+    <d:DocsUrl>https://docs.chocolatey.org/en-us/</d:DocsUrl>
+    <d:MailingListUrl>https://groups.google.com/forum/#!forum/chocolatey</d:MailingListUrl>
+    <d:BugTrackerUrl>https://github.com/chocolatey/choco/issues</d:BugTrackerUrl>
+    <d:IsApproved m:type=""Edm.Boolean"">true</d:IsApproved>
+    <d:PackageStatus>Approved</d:PackageStatus>
+    <d:PackageSubmittedStatus>Ready</d:PackageSubmittedStatus>
+    <d:PackageTestResultUrl></d:PackageTestResultUrl>
+    <d:PackageTestResultStatus>Exempted</d:PackageTestResultStatus>
+    <d:PackageTestResultStatusDate m:type=""Edm.DateTime"" m:null=""true""></d:PackageTestResultStatusDate>
+    <d:PackageValidationResultStatus>Passing</d:PackageValidationResultStatus>
+    <d:PackageValidationResultDate m:type=""Edm.DateTime"">2024-08-07T02:36:24.62</d:PackageValidationResultDate>
+    <d:PackageCleanupResultDate m:type=""Edm.DateTime"" m:null=""true""></d:PackageCleanupResultDate>
+    <d:PackageReviewedDate m:type=""Edm.DateTime"">2024-08-07T03:58:15.683</d:PackageReviewedDate>
+    <d:PackageApprovedDate m:type=""Edm.DateTime"">2024-08-07T03:58:15.683</d:PackageApprovedDate>
+    <d:PackageReviewer></d:PackageReviewer>
+    <d:IsDownloadCacheAvailable m:type=""Edm.Boolean"">false</d:IsDownloadCacheAvailable>
+    <d:DownloadCacheStatus>Checked</d:DownloadCacheStatus>
+    <d:DownloadCacheDate m:type=""Edm.DateTime"">2024-08-07T04:59:31.147</d:DownloadCacheDate>
+    <d:DownloadCache></d:DownloadCache>
+    <d:PackageScanStatus>NotFlagged</d:PackageScanStatus>
+    <d:PackageScanResultDate m:type=""Edm.DateTime"">2024-08-07T03:58:15.683</d:PackageScanResultDate>
+    <d:PackageScanFlagResult>None</d:PackageScanFlagResult>
+  </m:properties>
+</entry>")
+                );
+
+                _wireMockServer.Given(
+                    Request.Create()
+                    .WithPath("/api/v2/package/upgradepackage/2.0.0")
+                    .UsingGet()
+                )
+                .RespondWith(
+                    Response.Create()
+                    .WithStatusCode(503)
+                );
+            }
+
+            public override void AfterObservations()
+            {
+                base.AfterObservations();
+                _wireMockServer.Stop();
+            }
+
+            public override void Because()
+            {
+                Results = Service.Upgrade(Configuration);
+                _packageResult = Results.FirstOrDefault().Value;
+            }
+
+            [Fact]
+            public void Should_not_remove_package_from_the_lib_directory()
+            {
+                var packageDir = Path.Combine(Scenario.GetTopLevel(), "lib", Configuration.PackageNames);
+
+                DirectoryAssert.Exists(packageDir);
+            }
+
+            [Fact]
+            public void Should_not_upgrade_the_package()
+            {
+                var packageFile = Path.Combine(Scenario.GetTopLevel(), "lib", Configuration.PackageNames, Configuration.PackageNames + NuGetConstants.PackageExtension);
+                using (var packageReader = new PackageArchiveReader(packageFile))
+                {
+                    packageReader.NuspecReader.GetVersion().ToNormalizedStringChecked().Should().Be("1.0.0");
+                }
+            }
+
+            [Fact]
+            public void Should_not_have_the_erroring_upgraded_package_in_the_lib_bad_directory()
+            {
+                // This is due to the fact that no nupkg was actually downloaded from the server
+
+                var packageDir = Path.Combine(Scenario.GetTopLevel(), "lib-bad", Configuration.PackageNames);
+
+                DirectoryAssert.DoesNotExist(packageDir);
+            }
+
+            [Fact]
+            public void Should_delete_the_rollback()
+            {
+                var packageDir = Path.Combine(Scenario.GetTopLevel(), "lib-bkp", Configuration.PackageNames);
+
+                DirectoryAssert.DoesNotExist(packageDir);
+            }
+
+            [Fact]
+            public void Should_contain_a_warning_message_that_it_was_unable_to_upgrade_a_package()
+            {
+                MockLogger.Messages.Should().ContainKey(LogLevel.Warn.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains("0/1"));
+            }
+
+            [Fact]
+            public void Should_not_have_a_successful_package_result()
+            {
+                _packageResult.Success.Should().BeFalse();
+            }
+
+            [Fact]
+            public void Should_not_have_inconclusive_package_result()
+            {
+                _packageResult.Inconclusive.Should().BeFalse();
+            }
+
+            [Fact]
+            public void Should_not_have_warning_package_result()
+            {
+                _packageResult.Warning.Should().BeFalse();
+            }
+
+            [Fact]
+            public void Should_have_an_error_package_result()
+            {
+                _packageResult.Messages.Should().Contain(m => m.MessageType == ResultType.Error);
+            }
+
+            [Fact]
+            public void Should_have_expected_error_in_package_result()
+            {
+                Results.Should().AllSatisfy(r =>
+                    r.Value.Messages.Should().Contain(m =>
+                        m.MessageType == ResultType.Error &&
+                        m.Message.Contains(@"upgradepackage not upgraded. An error occurred during installation:
+ Error downloading 'upgradepackage.2.0.0' from 'http://localhost:24626/api/v2/package/upgradepackage/2.0.0'.")));
+            }
+
+            [Fact]
+            public void Should_have_requested_download_of_package()
+            {
+                _wireMockServer.Should().HaveReceivedACall().AtUrl("http://localhost:24626/api/v2/package/upgradepackage/2.0.0");
             }
         }
     }

--- a/src/chocolatey/infrastructure.app/services/ChocolateyPackageService.cs
+++ b/src/chocolatey/infrastructure.app/services/ChocolateyPackageService.cs
@@ -1925,6 +1925,11 @@ ATTENTION: You must take manual action to remove {1} from
                 return;
             }
 
+            if (!_fileSystem.DirectoryExists(packageDirectory))
+            {
+                return;
+            }
+
             if (packageDirectory.IsEqualTo(ApplicationParameters.InstallLocation) || packageDirectory.IsEqualTo(ApplicationParameters.PackagesLocation))
             {
                 packageResult.Messages.Add(


### PR DESCRIPTION
## Description Of Changes

This commit addresses the issue by first checking to see if the package folder exists.  If it doesn't, then it doesn't attempt to create the .chocolateyPending file, and simply returns early.  This then allows the remaining operations, i.e. returning the package folder from the lib-bkp folder, back to the lib folder.

## Motivation and Context

The MarkPackagePending method is used to create a .chocolateyPending file in the package folder to indicate that there is a pending operation that needs to be completed.

However, during an upgrade operation, the package folder is moved to the lib-bkp folder, and as a result, doesn't exist anymore in the lib folder.

If during the upgrade operation, something fails, for example, an exception when trying to download the nupkg file, a process of returning the package folder to the correct place begins.  The first thing that is attempted is to create the .chocolateyPending file in the package folder.  However, as mentioned, this folder no longer exists in the expected location.  As a result, it is possible for an exception to be thrown, as the file cannot be created in the package folder.

This problem can lead to another related problem in that the package is now "lost" from lib folder, and will not show up when doing for example choco list.

Imagine you were attempting the following command, and an exception happened during the downloading of the nupkg:

choco upgrade audacity

Chocolatey CLI would start the upgrade operation, and then it would fail downloading the package.  It would attempt to create the .chocolateyPending file, and another exception would be thrown.  The package folder is not returned to the lib folder, and now the package is "lost".  If you attempt to run choco upgrade audacity again, the operation would succeed, as it would see that the package is not installed and it would be installed, however, if this happened during the process of running choco upgrade all, then the underlying audacity application would not be upgraded, as Chocolatey CLI is no longer managing the package.

## Testing

In order to test this, you have to mimic an exception being thrown during the download of the nupkg package.  The simplest way to do that is to add the following line of code after line 1619 of the NugetService.cs file.

```
throw new Exception("Mimic failure of package download");
```

With this change in place, the code should look like the following:

<img width="1504" alt="image" src="https://github.com/user-attachments/assets/e465cf41-5c72-4d77-9b02-ac29eefe45b8">

1. Run `choco install audacity --version 3.6.0 -n`
2. The audacity package should be installed without any issues
3. Run `choco list` to verify that the package is installed and listed as version 3.6.0
4. Run `choco upgrade audacity -n`
5. This operation will fail, and it will state that the package wasn't upgrade
6. Run `choco list` to verify that 3.6.0 package of audacity is still there

### Operating Systems Testing

- Windows 10

## Change Types Made

* [x] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [x] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v3 compatibility checked?

## Related Issue

Fixes #3489