### PR TITLE
(doc) Fixed parameter name typo

### DIFF
--- a/src/chocolatey/infrastructure.app/templates/ChocolateyInstallTemplate.cs
+++ b/src/chocolatey/infrastructure.app/templates/ChocolateyInstallTemplate.cs
@@ -134,7 +134,7 @@ Install-ChocolateyPackage @packageArgs # https://docs.chocolatey.org/en-us/creat
 ## Add specific files as shortcuts to the desktop
 ## - https://docs.chocolatey.org/en-us/create/functions/install-chocolateyshortcut
 #$target = Join-Path $toolsDir ""$($packageName).exe""
-# Install-ChocolateyShortcut -shortcutFilePath ""<path>"" -targetPath ""<path>"" [-workDirectory ""C:\"" -arguments ""C:\test.txt"" -iconLocation ""C:\test.ico"" -description ""This is the description""]
+# Install-ChocolateyShortcut -shortcutFilePath ""<path>"" -targetPath ""<path>"" [-workingDirectory ""C:\"" -arguments ""C:\test.txt"" -iconLocation ""C:\test.ico"" -description ""This is the description""]
 
 ## Outputs the bitness of the OS (either ""32"" or ""64"")
 ## - https://docs.chocolatey.org/en-us/create/functions/get-osarchitecturewidth


### PR DESCRIPTION
## Description Of Changes
Fixed a type on an incorrect parameter name as pointed out on [Discord](https://discord.com/channels/778552361454141460/897090709914517544/1276269212318306324).

## Motivation and Context
The parameter name is `WorkingDirectory`, however we use `workDirectory` in the template.

## Testing
N/A

### Operating Systems Testing
N/A

## Change Types Made

* [ ] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [x] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [x] Requires a change to the documentation.
* [x] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [ ] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v3 compatibility checked?

## Related Issue
N/A
