### PR TITLE
(maint) Make threshold limit text clearer

### DIFF
--- a/src/chocolatey/infrastructure.app/services/NugetService.cs
+++ b/src/chocolatey/infrastructure.app/services/NugetService.cs
@@ -329,11 +329,11 @@ that uses these options.");
 
                 if (NugetList.ThresholdHit)
                 {
-                    this.Log().Warn(logType, "The threshold of {0:N0} packages per source has been met. Please refine your search, or specify a page to find any more results.".FormatWith(NugetList.LastPackageLimitUsed));
+                    this.Log().Warn(logType, "The threshold of {0:N0} packages, or package versions, per source has been met. Please refine your search, or specify a page number to retrieve more results.".FormatWith(NugetList.LastPackageLimitUsed));
                 }
                 else if (NugetList.LowerThresholdHit)
                 {
-                    this.Log().Warn(logType, "Over {0:N0} packages was found per source, there may be more packages available that was filtered out. Please refine your search, or specify a page to check for more packages.".FormatWith(NugetList.LastPackageLimitUsed * 0.9));
+                    this.Log().Warn(logType, "Over {0:N0} packages, or package versions, was found per source, but there may be more packages available that were filtered out. Please refine your search, or specify a page number to retrieve more results.".FormatWith(NugetList.LastPackageLimitUsed * 0.9));
                 }
             }
         }


### PR DESCRIPTION
## Description Of Changes
Updated the threshold text to make it easier to understand.

## Motivation and Context
The text that Chocolatey CLI displays can be confusing. Particularly, when the search result shows less than 1000 packages on-screen (as they have been filtered out).

## Testing
N/A

### Operating Systems Testing
N/A

## Change Types Made

* [ ] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [ ] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v3 compatibility checked?

## Related Issue
N/A
