### PR TITLE
(#3520) Deprecate Install-ChocolateyPinnedTaskBarItem

### DIFF
--- a/src/chocolatey.resources/helpers/functions/Install-ChocolateyPinnedTaskBarItem.ps1
+++ b/src/chocolatey.resources/helpers/functions/Install-ChocolateyPinnedTaskBarItem.ps1
@@ -21,7 +21,7 @@ Creates an item in the task bar linking to the provided path.
 
 .NOTES
 Does not work with SYSTEM, but does not error. It warns with the error
-message.
+message. This command is deprecated and will be removed in version 3.0.0.
 
 .INPUTS
 None
@@ -53,6 +53,7 @@ Install-ChocolateyExplorerMenuItem
     )
 
     Write-FunctionCallLogMessage -Invocation $MyInvocation -Parameters $PSBoundParameters
+    Write-Warning "Install-ChocolateyPinnedTaskBarItem has been deprecated in v2.4.0 and will be removed in v3.0.0."
 
     try {
         if (Test-Path($targetFilePath)) {


### PR DESCRIPTION
## Description Of Changes

Deprecate the Install-ChocolateyPinnedTaskBarItem command to prepare for it to be removed in v3.

## Motivation and Context

The function is being deprecated as the functionality in Windows is constantly changing and breaking.

## Testing

N/A

### Operating Systems Testing

N/A

## Change Types Made

* [ ] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [x] Documentation changes.
* [x] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [ ] All new and existing tests passed?
* [x] PowerShell code changes: PowerShell v3 compatibility checked?

## Related Issue

Fixes #3520 