### PR TITLE
(#3318) Add ShouldProcess support to rewritten helper cmdlets

### DIFF
--- a/src/Chocolatey.PowerShell/Commands/InstallChocolateyPathCommand.cs
+++ b/src/Chocolatey.PowerShell/Commands/InstallChocolateyPathCommand.cs
@@ -21,7 +21,7 @@ using Chocolatey.PowerShell.Shared;
 
 namespace Chocolatey.PowerShell.Commands
 {
-    [Cmdlet(VerbsLifecycle.Install, "ChocolateyPath")]
+    [Cmdlet(VerbsLifecycle.Install, "ChocolateyPath", SupportsShouldProcess = true, ConfirmImpact = ConfirmImpact.Medium)]
     [OutputType(typeof(void))]
     public class InstallChocolateyPathCommand : ChocolateyCmdlet
     {

--- a/src/Chocolatey.PowerShell/Commands/SetEnvironmentVariableCommand.cs
+++ b/src/Chocolatey.PowerShell/Commands/SetEnvironmentVariableCommand.cs
@@ -21,7 +21,7 @@ using Chocolatey.PowerShell.Shared;
 
 namespace Chocolatey.PowerShell.Commands
 {
-    [Cmdlet(VerbsCommon.Set, "EnvironmentVariable")]
+    [Cmdlet(VerbsCommon.Set, "EnvironmentVariable", SupportsShouldProcess = true, ConfirmImpact = ConfirmImpact.Medium)]
     [OutputType(typeof(void))]
     public sealed class SetEnvironmentVariableCommand : ChocolateyCmdlet
     {

--- a/src/Chocolatey.PowerShell/Commands/UninstallChocolateyPathCommand.cs
+++ b/src/Chocolatey.PowerShell/Commands/UninstallChocolateyPathCommand.cs
@@ -21,7 +21,7 @@ using Chocolatey.PowerShell.Shared;
 
 namespace Chocolatey.PowerShell.Commands
 {
-    [Cmdlet(VerbsLifecycle.Uninstall, "ChocolateyPath")]
+    [Cmdlet(VerbsLifecycle.Uninstall, "ChocolateyPath", SupportsShouldProcess = true, ConfirmImpact = ConfirmImpact.Medium)]
     [OutputType(typeof(void))]
     public class UninstallChocolateyPathCommand : ChocolateyCmdlet
     {

--- a/src/Chocolatey.PowerShell/Commands/UpdateSessionEnvironmentCommand.cs
+++ b/src/Chocolatey.PowerShell/Commands/UpdateSessionEnvironmentCommand.cs
@@ -20,7 +20,7 @@ using Chocolatey.PowerShell.Shared;
 
 namespace Chocolatey.PowerShell.Commands
 {
-    [Cmdlet(VerbsData.Update, "SessionEnvironment")]
+    [Cmdlet(VerbsData.Update, "SessionEnvironment", SupportsShouldProcess = true, ConfirmImpact = ConfirmImpact.Low)]
     [OutputType(typeof(void))]
     public sealed class UpdateSessionEnvironmentCommand : ChocolateyCmdlet
     {

--- a/tests/helpers/common/Get-WhatIfResult.ps1
+++ b/tests/helpers/common/Get-WhatIfResult.ps1
@@ -1,0 +1,29 @@
+﻿function Get-WhatIfResult {
+    <#
+        .SYNOPSIS
+        Runs a $Command in a new powershell.exe process, and then returns *only*
+        the output lines that are prefixed with 'What if:' which are written as
+        console output.
+    #>
+    [CmdletBinding()]
+    param( 
+        # The script to execute in the new process.
+        [Parameter(Mandatory)]
+        [scriptblock]
+        $Command,
+
+        # Any setup scripts that are required for running. All output from this
+        # script block will be suppressed, if possible.
+        [Parameter()]
+        [scriptblock]
+        $Preamble
+    )
+
+    $commandString = @'
+. {{ {0} }} *>&1 > $null
+& {{ {1} }}
+'@ -f $Preamble, $Command
+
+    powershell -NoProfile -NonInteractive -Command $commandString |
+        Where-Object { $_ -like "What if:*" }
+}

--- a/tests/pester-tests/powershell-commands/Install-ChocolateyPath.Tests.ps1
+++ b/tests/pester-tests/powershell-commands/Install-ChocolateyPath.Tests.ps1
@@ -1,4 +1,4 @@
-﻿Describe 'Install-ChocolateyPath helper function tests' -Tags Cmdlets {
+﻿Describe 'Install-ChocolateyPath helper function tests' -Tags InstallChocolateyPath, Cmdlets {
     BeforeAll {
         Initialize-ChocolateyTestInstall
 
@@ -10,7 +10,37 @@
         Remove-Module "chocolateyInstaller" -Force
     }
 
-    Context 'Adding and removing PATH values' -ForEach @(
+    Context 'Unit tests' -Tags WhatIf -ForEach @(
+        @{ Scope = 'Process' }
+        @{ Scope = 'User' }
+        @{ Scope = 'Machine' }
+    ) {
+        Context 'Path "<_>"' -ForEach @("C:\test", "C:\tools") {
+            BeforeAll {    
+                $Preamble = [scriptblock]::Create("Import-Module '$testLocation\helpers\chocolateyInstaller.psm1'")
+            }
+
+            It 'stores the value in the desired PATH scope' {
+                $Command = [scriptblock]::Create("Install-ChocolateyPath -Path '$_' -Scope $Scope -WhatIf")
+                
+                $results = @( Get-WhatIfResult -Preamble $Preamble -Command $Command )
+                $results[0] | Should -BeExactly "What if: Performing the operation ""Set $Scope environment variable"" on target ""PATH""."
+
+                if ($Scope -ne 'Process') {
+                    $results[1] | Should -BeExactly 'What if: Performing the operation "Notify system of changes" on target "Environment variables".'
+                    $results[2] | Should -BeExactly 'What if: Performing the operation "Refresh all environment variables" on target "Current process".'
+                }
+            }
+
+            It 'skips adding the value if it is already present' {
+                $targetPathEntry = [Environment]::GetEnvironmentVariable('PATH', $Scope) -split ';' | Select-Object -First 1
+                $Command = [scriptblock]::Create("Install-ChocolateyPath -Path '$targetPathEntry' -Scope $Scope -WhatIf")
+                Get-WhatIfResult -Preamble $Preamble -Command $Command | Should -BeNullOrEmpty -Because 'we should skip adding values that already exist'
+            }
+        }
+    }
+
+    Context 'Adding and removing PATH values' -Tag VMOnly -ForEach @(
         @{ Scope = 'Process' }
         @{ Scope = 'User' }
         @{ Scope = 'Machine' }
@@ -55,7 +85,7 @@
     }
 }
 
-Describe 'Install-ChocolateyPath end-to-end tests with add-path package modifying <Scope> PATH' -Tags Cmdlet -ForEach @(
+Describe 'Install-ChocolateyPath end-to-end tests with add-path package modifying <Scope> PATH' -Tags Cmdlet, UninstallChocolateyPath, VMOnly -ForEach @(
     @{ Scope = 'User' }
     @{ Scope = 'Machine' }
 ) {

--- a/tests/pester-tests/powershell-commands/Set-EnvironmentVariable.Tests.ps1
+++ b/tests/pester-tests/powershell-commands/Set-EnvironmentVariable.Tests.ps1
@@ -1,9 +1,29 @@
-Describe 'Set-EnvironmentVariable helper function tests' -Tags Cmdlets {
+Describe 'Set-EnvironmentVariable helper function tests' -Tags SetEnvironmentVariable, Cmdlets {
     BeforeAll {
         Initialize-ChocolateyTestInstall
 
         $testLocation = Get-ChocolateyTestLocation
         Import-Module "$testLocation\helpers\chocolateyInstaller.psm1"
+    }
+
+    Context 'Unit tests' -Tags WhatIf -ForEach @(
+        @{ Scope = 'Process' }
+        @{ Scope = 'User' }
+        @{ Scope = 'Machine' }
+    ) {
+        It 'Sets an environment variable value at the target <Scope>' {
+            $testVariableName = 'testVariable'
+            $Preamble = [scriptblock]::Create("Import-Module '$testLocation\helpers\chocolateyInstaller.psm1'")
+            $Command = [scriptblock]::Create("Set-EnvironmentVariable -Name $testVariableName -Value 'TEST' -Scope $Scope -WhatIf")
+            
+            $results = @( Get-WhatIfResult -Preamble $Preamble -Command $Command )
+            $results[0] | Should -BeExactly "What if: Performing the operation ""Set $Scope environment variable"" on target ""testVariable""."
+
+            if ($Scope -ne 'Process') {
+                $results[1] | Should -BeExactly 'What if: Performing the operation "Notify system of changes" on target "Environment variables".'
+                $results[2] | Should -BeExactly 'What if: Performing the operation "Refresh all environment variables" on target "Current process".'
+            }
+        }
     }
 
     Context 'Sets an environment variable value at the target <Scope>' -ForEach @(

--- a/tests/pester-tests/powershell-commands/Update-SessionEnvironment.Tests.ps1
+++ b/tests/pester-tests/powershell-commands/Update-SessionEnvironment.Tests.ps1
@@ -1,9 +1,19 @@
-﻿Describe 'Update-SessionEnvironment helper function tests' -Tag Cmdlets {
+﻿Describe 'Update-SessionEnvironment helper function tests' -Tag UpdateSessionEnvironment, Cmdlets {
     BeforeAll {
         Initialize-ChocolateyTestInstall
 
         $testLocation = Get-ChocolateyTestLocation
         Import-Module "$testLocation\helpers\chocolateyInstaller.psm1"
+    }
+    
+    Context 'Unit tests' -Tag WhatIf {
+        It 'refreshes the current session environment variables' {
+            $Preamble = [scriptblock]::Create("Import-Module '$testLocation\helpers\chocolateyInstaller.psm1'")
+            $Command = [scriptblock]::Create("Update-SessionEnvironment -WhatIf")
+            
+            $results = Get-WhatIfResult -Preamble $Preamble -Command $Command
+            $results | Should -BeExactly 'What if: Performing the operation "refresh all environment variables" on target "current process".'
+        }
     }
 
     Context 'Refreshing environment' {


### PR DESCRIPTION
## Description Of Changes

- Add ShouldProcess support to `Set-EnvironmentVariable`, `Install-ChocolateyPath`, `Uninstall-ChocolateyPath`, and `Update-SessionEnvironment`
- Add unit tests verifying just the base logic of the commands, that the ShouldProcess lines get hit when you use -WhatIf in the appropriate circumstances.
- Tag potentially destructive / system-state-modifying tests with `VMOnly` so they do not run by default in typical dev environments

## Motivation and Context

In discussion with @gep13 we realised there is value in having the ability to non-destructively verify the logic paths taken in the code here. As such, I have augmented the existing commands and associated helper classes with ShouldProcess semantics to make this workable.

## Testing

1. Run `build.ps1`
2. Run `./Invoke-Tests.ps1 -Tags WhatIf`

### Operating Systems Testing

WIn10

## Change Types Made
<!-- Tick the boxes for the type of changes that have been made -->

* [ ] Bug fix (non-breaking change).
* [x] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [x] Requires a change to the documentation -- will submit a docs PR to update these cmdlet docs as well, ShouldProcess will add -Confirm and -WhatIf to the documentation list iirc
* [x] Documentation has been updated.
* [x] Tests to cover my changes, have been added.
* [x] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v3 compatibility checked?

## Related Issue

Part of #3318

Docs PR: https://github.com/chocolatey/docs/pull/1086