### PR TITLE
(#3503, #3513) Add null check to Command Name

### DIFF
--- a/src/chocolatey/infrastructure.app/services/NugetService.cs
+++ b/src/chocolatey/infrastructure.app/services/NugetService.cs
@@ -222,7 +222,8 @@ that uses these options.");
                     // The main scenario where we desire the decrypted arguments during a list sequence is to display them when verbose output is selected.
                     // This is done by default on the `info` command, and by request on the `list` command. As such, we are going to validate it's that scenario
                     // to avoid needlessly decrypting the arguments file.
-                    var shouldDecryptArguments = (
+                    var shouldDecryptArguments = !string.IsNullOrWhiteSpace(config.CommandName) &&
+                        (
                             config.CommandName.Equals("info", StringComparison.OrdinalIgnoreCase) ||
                             config.CommandName.Equals("list", StringComparison.OrdinalIgnoreCase)
                         ) &&

--- a/tests/pester-tests/commands/choco-upgrade.Tests.ps1
+++ b/tests/pester-tests/commands/choco-upgrade.Tests.ps1
@@ -811,7 +811,8 @@ To upgrade a local, or remote file, you may use:
 
             $Setup = Invoke-Choco install $DependentPackage.Name --version $DependentPackage.Version --confirm
             $Setup2 = Invoke-Choco install $BasePackage --version 1.0.0 --confirm
-            $Output = Invoke-Choco upgrade $PackageName --confirm --except="'chocolatey'" $Argument
+            # We need to exclude packages that are in Test Kitchen but not the other environments.
+            $Output = Invoke-Choco upgrade $PackageName --confirm --except="chocolatey,chocolatey.extension,chocolatey-agent,pester,chocolatey-license-business" $Argument
         }
 
         It "Exits with expected result (<ExpectedExit>)" {


### PR DESCRIPTION
## Description Of Changes

- Add a null check to the Command Name when determining if we should decrypt the stored arguments.
- Exclude packages installed on Test Kitchen from the upgrade commands downgrade tests.

## Motivation and Context

- The CommandName is missing when calling the List method from alternate sources.
- Test Kitchen has some extra packages on it that will get upgraded unless we exclude them.

## Testing

1. Run tests through Test Kitchen.

### Operating Systems Testing

- Windows Server 2016
- Windows Server 2019

## Change Types Made

* [x] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [x] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v3 compatibility checked?

## Related Issue

- #3503 
- #3513