### PR TITLE
(#3526) Fix failing integration tests

### DIFF
--- a/src/chocolatey.tests.integration/scenarios/ListScenarios.cs
+++ b/src/chocolatey.tests.integration/scenarios/ListScenarios.cs
@@ -163,12 +163,6 @@ namespace chocolatey.tests.integration.scenarios
             {
                 MockLogger.ContainsMessage("packages installed").Should().BeFalse();
             }
-
-            [Fact]
-            public void Should_not_contain_debugging_messages()
-            {
-                MockLogger.Messages.Should().NotContainKey(LogLevel.Debug.ToStringSafe());
-            }
         }
 
         public class When_listing_local_packages_limiting_output_with_id_only : ScenariosBase

--- a/src/chocolatey.tests.integration/scenarios/ListScenarios.cs
+++ b/src/chocolatey.tests.integration/scenarios/ListScenarios.cs
@@ -116,7 +116,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_not_contain_any_version_number()
             {
-                MockLogger.ContainsMessage(".0").Should().BeFalse();
+                MockLogger.ContainsMessage(".0", LogLevel.Info).Should().BeFalse();
             }
         }
 
@@ -196,7 +196,7 @@ namespace chocolatey.tests.integration.scenarios
             [Fact]
             public void Should_not_contain_any_version_number()
             {
-                MockLogger.ContainsMessage(".0").Should().BeFalse();
+                MockLogger.ContainsMessage(".0", LogLevel.Info).Should().BeFalse();
             }
 
             [Fact]


### PR DESCRIPTION
## Description Of Changes

Fix a few of the failing integration tests after the user agent work was implemented.

## Motivation and Context

These tests were failing as they added some output that can be construed as version numbers.

## Testing

Ran `./build.bat --testExecutionType=all --shouldRunOpenCover=false`

### Operating Systems Testing

Windows 10

## Change Types Made

* [x] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [x] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v3 compatibility checked?

## Related Issue

#3526 