### PR TITLE
(#3526) Fix user agent test for licensed

### DIFF
--- a/tests/pester-tests/features/UserAgent.Tests.ps1
+++ b/tests/pester-tests/features/UserAgent.Tests.ps1
@@ -46,7 +46,7 @@ Describe "Chocolatey User Agent" -Tag Chocolatey, UserAgent {
     }
 
     It 'Logs the full process tree to debug' {
-        $logLine = $Output.Lines | Where-Object { $_ -match '^Process Tree' }
+        $logLine = $Output.Lines | Where-Object { $_ -match '^Process Tree' } | Select-Object -Last 1
 
         $logLine | Should -Not -BeNullOrEmpty -Because 'choco.exe should log the process tree to debug'
         
@@ -60,7 +60,7 @@ Describe "Chocolatey User Agent" -Tag Chocolatey, UserAgent {
     }
 
     It 'Logs the final user agent to debug' {
-        $logLine = $Output.Lines | Where-Object { $_ -match '^Updating User Agent' }
+        $logLine = $Output.Lines | Where-Object { $_ -match '^Updating User Agent' } | Select-Object -Last 1
         
         $logLine | Should -Not -BeNullOrEmpty -Because "choco.exe should log the user agent string to debug`n$($Output.Lines)"
 


### PR DESCRIPTION
## Description Of Changes

- Pick out a single user agent / process tree to check in tests

## Motivation and Context
Licensed does queries in the background before / while normal commands are running, so we can end up with multiple user-agent debug lines.

Resolve this by just looking at the most recently-outputted user agent, as these should all look the same (and if not, the last one should be the one from the actual command run).

## Testing
1. Test in test kitchen w/ CLE
### Operating Systems Testing
2019

## Change Types Made
<!-- Tick the boxes for the type of changes that have been made -->

* [ ] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [x] Tests to cover my changes, have been added.
* [x] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v3 compatibility checked?

## Related Issue

#3526