### PR TITLE
(#3565 #2421) Avoid credential bleed from saved sources with the same hostname

### DIFF
--- a/src/chocolatey.tests/chocolatey.tests.csproj
+++ b/src/chocolatey.tests/chocolatey.tests.csproj
@@ -186,6 +186,7 @@
     <Compile Include="infrastructure.app\commands\ChocolateyUnpackSelfCommandSpecs.cs" />
     <Compile Include="infrastructure.app\commands\ChocolateyUpgradeCommandSpecs.cs" />
     <Compile Include="infrastructure.app\configuration\ConfigurationOptionsSpec.cs" />
+    <Compile Include="infrastructure.app\nuget\ChocolateyNugetCredentialProviderSpecs.cs" />
     <Compile Include="infrastructure.app\nuget\ChocolateyNugetLoggerSpecs.cs" />
     <Compile Include="infrastructure.app\nuget\ChocolateyNuGetProjectContextSpecs.cs" />
     <Compile Include="infrastructure.app\nuget\NugetCommonSpecs.cs" />

--- a/src/chocolatey.tests/infrastructure.app/nuget/ChocolateyNugetCredentialProviderSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/nuget/ChocolateyNugetCredentialProviderSpecs.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
@@ -70,10 +70,9 @@ namespace chocolatey.tests.infrastructure.app.nuget
                 };
             }
 
-            [OneTimeSetUp]
-            public async Task OneTimeSetup()
+            public override void Because()
             {
-                await With();
+                With().Wait();
             }
 
             public virtual async Task With()
@@ -83,91 +82,95 @@ namespace chocolatey.tests.infrastructure.app.nuget
             }
         }
 
-        public class When_using_explicit_credentials_and_source_param : ChocolateyNugetCredentialProviderSpecsBase
+        public class When_Using_Explicit_Credentials_And_Source_Param : ChocolateyNugetCredentialProviderSpecsBase
         {
-            public override void Because()
+            public override void Context()
             {
+                base.Context();
                 Configuration.Sources = Configuration.ExplicitSources = TargetSourceUrl;
                 Configuration.SourceCommand.Username = "user";
                 Configuration.SourceCommand.Password = "totally_secure_password!!!";
             }
 
             [Fact]
-            public void Creates_a_valid_credential()
+            public void Should_Create_Credentials()
             {
                 Result.Should().NotBeNull();
             }
 
             [Fact]
-            public void Provides_the_correct_username()
+            public void Should_Provide_The_Correct_Username()
             {
                 Result.UserName.Should().Be("user");
             }
 
             [Fact]
-            public void Provides_the_correct_password()
+            public void Should_Provide_The_Correct_Password()
             {
                 Result.Password.Should().Be("totally_secure_password!!!");
             }
         }
 
-        public class When_a_source_name_is_provided : ChocolateyNugetCredentialProviderSpecsBase
+        public class When_A_Source_Name_Is_Provided : ChocolateyNugetCredentialProviderSpecsBase
         {
-            public override void Because()
+            public override void Context()
             {
+                base.Context();
                 Configuration.Sources = TargetSourceUrl;
                 Configuration.ExplicitSources = TargetSourceName;
             }
 
             [Fact]
-            public void Finds_the_saved_source_and_returns_the_credential()
+            public void Should_Find_The_Saved_Source_And_Returns_The_Credential()
             {
                 Result.Should().NotBeNull();
             }
 
             [Fact]
-            public void Provides_the_correct_username()
+            public void Should_Provide_The_Correct_Username()
             {
                 Result.UserName.Should().Be(Username);
             }
 
             [Fact]
-            public void Provides_the_correct_password()
+            public void Should_Provide_The_Correct_Password()
             {
                 Result.Password.Should().Be(Password);
             }
         }
 
-        public class When_a_source_url_matching_a_saved_source_is_provided : ChocolateyNugetCredentialProviderSpecsBase
+        public class When_A_Source_Url_Matching_A_Saved_Source_Is_Provided : ChocolateyNugetCredentialProviderSpecsBase
         {
-            public override void Because()
+            public override void Context()
             {
+                base.Context();
                 Configuration.Sources = Configuration.ExplicitSources = TargetSourceUrl;
             }
 
             [Fact]
-            public void Finds_the_saved_source_and_returns_the_credential()
+            public void Should_Find_The_Saved_Source_And_Return_The_Credential()
             {
                 Result.Should().NotBeNull();
             }
 
             [Fact]
-            public void Provides_the_correct_username()
+            public void Should_Provide_The_Correct_Username()
             {
                 Result.UserName.Should().Be(Username);
             }
 
             [Fact]
-            public void Provides_the_correct_password()
+            public void Should_Provide_The_Correct_Password()
             {
                 Result.Password.Should().Be(Password);
             }
         }
 
-        public class Looks_up_source_url_when_name_and_credentials_is_provided : ChocolateyNugetCredentialProviderSpecsBase
+        public class Looks_Up_Source_Url_When_Name_And_Credentials_Is_Provided : ChocolateyNugetCredentialProviderSpecsBase
         {
-            public override void Because()
+            public override void Context()
             {
+                base.Context();
                 Configuration.Sources = TargetSourceUrl;
                 Configuration.ExplicitSources = TargetSourceName;
 
@@ -176,28 +179,29 @@ namespace chocolatey.tests.infrastructure.app.nuget
             }
 
             [Fact]
-            public void Creates_and_returns_the_credential()
+            public void Should_Create_And_Return_The_Credential()
             {
                 Result.Should().NotBeNull();
             }
 
             [Fact]
-            public void Provides_the_correct_username()
+            public void Should_Provide_The_Correct_Username()
             {
                 Result.UserName.Should().Be(Username);
             }
 
             [Fact]
-            public void Provides_the_correct_password()
+            public void Should_Provide_The_Correct_Password()
             {
                 Result.Password.Should().Be(Password);
             }
         }
 
-        public class When_no_matching_source_is_found_by_url : ChocolateyNugetCredentialProviderSpecsBase
+        public class When_No_Matching_Source_Is_Found_By_Url : ChocolateyNugetCredentialProviderSpecsBase
         {
-            public override void Because()
+            public override void Context()
             {
+                base.Context();
                 Configuration.Sources = Configuration.ExplicitSources = "https://unknownurl.com/api/v2/";
             }
 
@@ -208,98 +212,102 @@ namespace chocolatey.tests.infrastructure.app.nuget
             }
 
             [Fact]
-            public void Returns_the_default_network_credential()
+            public void Should_Return_The_Default_Network_Credential()
             {
                 Result.Should().Be(CredentialCache.DefaultNetworkCredentials);
             }
         }
 
-        public class When_multiple_named_sources_are_provided : ChocolateyNugetCredentialProviderSpecsBase
+        public class When_Multiple_Named_Sources_Are_Provided : ChocolateyNugetCredentialProviderSpecsBase
         {
-            public override void Because()
+            public override void Context()
             {
+                base.Context();
                 Configuration.Sources = Configuration.MachineSources.Select(s => s.Key).Join(";");
                 Configuration.ExplicitSources = Configuration.MachineSources.Select(s => s.Name).Join(";");
             }
 
             [Fact]
-            public void Finds_the_correct_saved_source_for_the_target_uri_and_returns_the_credential()
+            public void Should_Find_The_Correct_Saved_Source_For_The_Target_Uri_And_Return_The_Credential()
             {
                 Result.Should().NotBeNull();
             }
 
             [Fact]
-            public void Provides_the_correct_username()
+            public void Should_Provide_The_Correct_Username()
             {
                 Result.UserName.Should().Be(Username);
             }
 
             [Fact]
-            public void Provides_the_correct_password()
+            public void Should_Provide_The_Correct_Password()
             {
                 Result.Password.Should().Be(Password);
             }
         }
 
-        public class When_multiple_source_urls_are_provided : ChocolateyNugetCredentialProviderSpecsBase
+        public class When_Multiple_Source_Urls_Are_Provided : ChocolateyNugetCredentialProviderSpecsBase
         {
-            public override void Because()
+            public override void Context()
             {
+                base.Context();
                 Configuration.Sources = Configuration.ExplicitSources = $"https://unknownurl.com/api/v2/;{TargetSourceUrl}";
             }
 
             [Fact]
-            public void Finds_the_saved_source_and_returns_the_credential()
+            public void Should_Find_The_Saved_Source_And_Return_The_Credential()
             {
                 Result.Should().NotBeNull();
             }
 
             [Fact]
-            public void Provides_the_correct_username()
+            public void Should_Provide_The_Correct_Username()
             {
                 Result.UserName.Should().Be(Username);
             }
 
             [Fact]
-            public void Provides_the_correct_password()
+            public void Should_Provide_The_Correct_Password()
             {
                 Result.Password.Should().Be(Password);
             }
         }
 
-        public class When_a_mix_of_named_and_url_sources_are_provided : ChocolateyNugetCredentialProviderSpecsBase
+        public class When_A_Mix_Of_Named_And_Url_Sources_Are_Provided : ChocolateyNugetCredentialProviderSpecsBase
         {
-            public override void Because()
+            public override void Context()
             {
+                base.Context();
                 Configuration.Sources = $"https://unknownurl.com/api/v2/;{TargetSourceUrl}";
                 Configuration.ExplicitSources = $"https://unknownurl.com/api/v2/;{TargetSourceName}";
             }
 
             [Fact]
-            public void Finds_the_saved_source_and_returns_the_credential()
+            public void Should_Find_The_Saved_Source_And_Return_The_Credential()
             {
                 Result.Should().NotBeNull();
             }
 
             [Fact]
-            public void Provides_the_correct_username()
+            public void Should_Provide_The_Correct_Username()
             {
                 Result.UserName.Should().Be(Username);
             }
 
             [Fact]
-            public void Provides_the_correct_password()
+            public void Should_Provide_The_Correct_Password()
             {
                 Result.Password.Should().Be(Password);
             }
         }
 
         // This is a regression test for issue #3565
-        public class When_a_url_matching_the_hostname_only_of_a_saved_source_is_provided : ChocolateyNugetCredentialProviderSpecsBase
+        public class When_A_Url_Matching_The_Hostname_Only_Of_A_Saved_Source_Is_Provided : ChocolateyNugetCredentialProviderSpecsBase
         {
             private Uri _otherRepoUri;
-            public override void Because()
+            public override void Context()
             {
+                base.Context();
                 _otherRepoUri = new Uri(TargetSourceUri.GetComponents(UriComponents.SchemeAndServer, UriFormat.Unescaped) + "/other_path/repository/");
                 Configuration.Sources = Configuration.ExplicitSources = _otherRepoUri.AbsoluteUri;
             }
@@ -311,7 +319,7 @@ namespace chocolatey.tests.infrastructure.app.nuget
             }
 
             [Fact]
-            public void Returns_the_default_network_credential()
+            public void Should_Return_The_Default_Network_Credential()
             {
                 Result.Should().Be(CredentialCache.DefaultNetworkCredentials);
             }

--- a/src/chocolatey.tests/infrastructure.app/nuget/ChocolateyNugetCredentialProviderSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/nuget/ChocolateyNugetCredentialProviderSpecs.cs
@@ -1,0 +1,320 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Security.Cryptography;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using chocolatey.infrastructure.app.configuration;
+using chocolatey.infrastructure.app.nuget;
+using FluentAssertions;
+using Moq;
+using NuGet.Configuration;
+using NUnit.Framework;
+
+namespace chocolatey.tests.infrastructure.app.nuget
+{
+    public class ChocolateyNugetCredentialProviderSpecs
+    {
+        public abstract class ChocolateyNugetCredentialProviderSpecsBase : TinySpec
+        {
+            protected ChocolateyConfiguration Configuration;
+            protected ChocolateyNugetCredentialProvider Provider;
+
+            protected const string Username = "user";
+            protected const string Password = "totally_secure_password!!!";
+            protected const string TargetSourceName = "testsource";
+            protected const string TargetSourceUrl = "https://testserver.org/repository/test-repository";
+            protected Uri TargetSourceUri = new Uri(TargetSourceUrl);
+
+            protected NetworkCredential Result;
+
+            private readonly CancellationTokenSource _tokenSource = new CancellationTokenSource();
+            protected CancellationToken CancellationToken
+            {
+                get
+                {
+                    return _tokenSource.Token;
+                }
+            }
+
+            public override void Context()
+            {
+                Configuration = new ChocolateyConfiguration();
+                Provider = new ChocolateyNugetCredentialProvider(Configuration);
+
+                Configuration.Information.IsInteractive = false;
+                Configuration.MachineSources = new List<MachineSourceConfiguration>
+                {
+                    new MachineSourceConfiguration
+                    {
+                        AllowSelfService = true,
+                        VisibleToAdminsOnly = false,
+                        EncryptedPassword = NugetEncryptionUtility.EncryptString("otherPassword"),
+                        Username = "otherUserName",
+                        Key = "https://someotherplace.com/repository/things/",
+                        Name = "not-this-one",
+                        Priority = 1,
+                    },
+                    new MachineSourceConfiguration
+                    {
+                        AllowSelfService = true,
+                        VisibleToAdminsOnly = false,
+                        EncryptedPassword = NugetEncryptionUtility.EncryptString(Password),
+                        Username = Username,
+                        Key = TargetSourceUrl,
+                        Name = TargetSourceName,
+                        Priority = 1,
+                    },
+                };
+            }
+
+            [OneTimeSetUp]
+            public async Task OneTimeSetup()
+            {
+                await With();
+            }
+
+            public virtual async Task With()
+            {
+                var result = await Provider.GetAsync(TargetSourceUri, proxy: null, CredentialRequestType.Unauthorized, message: string.Empty, isRetry: false, nonInteractive: true, CancellationToken);
+                Result = result.Credentials as NetworkCredential;
+            }
+        }
+
+        public class When_using_explicit_credentials_and_source_param : ChocolateyNugetCredentialProviderSpecsBase
+        {
+            public override void Because()
+            {
+                Configuration.Sources = Configuration.ExplicitSources = TargetSourceUrl;
+                Configuration.SourceCommand.Username = "user";
+                Configuration.SourceCommand.Password = "totally_secure_password!!!";
+            }
+
+            [Fact]
+            public void Creates_a_valid_credential()
+            {
+                Result.Should().NotBeNull();
+            }
+
+            [Fact]
+            public void Provides_the_correct_username()
+            {
+                Result.UserName.Should().Be("user");
+            }
+
+            [Fact]
+            public void Provides_the_correct_password()
+            {
+                Result.Password.Should().Be("totally_secure_password!!!");
+            }
+        }
+
+        public class When_a_source_name_is_provided : ChocolateyNugetCredentialProviderSpecsBase
+        {
+            public override void Because()
+            {
+                Configuration.Sources = TargetSourceUrl;
+                Configuration.ExplicitSources = TargetSourceName;
+            }
+
+            [Fact]
+            public void Finds_the_saved_source_and_returns_the_credential()
+            {
+                Result.Should().NotBeNull();
+            }
+
+            [Fact]
+            public void Provides_the_correct_username()
+            {
+                Result.UserName.Should().Be(Username);
+            }
+
+            [Fact]
+            public void Provides_the_correct_password()
+            {
+                Result.Password.Should().Be(Password);
+            }
+        }
+
+        public class When_a_source_url_matching_a_saved_source_is_provided : ChocolateyNugetCredentialProviderSpecsBase
+        {
+            public override void Because()
+            {
+                Configuration.Sources = Configuration.ExplicitSources = TargetSourceUrl;
+            }
+
+            [Fact]
+            public void Finds_the_saved_source_and_returns_the_credential()
+            {
+                Result.Should().NotBeNull();
+            }
+
+            [Fact]
+            public void Provides_the_correct_username()
+            {
+                Result.UserName.Should().Be(Username);
+            }
+
+            [Fact]
+            public void Provides_the_correct_password()
+            {
+                Result.Password.Should().Be(Password);
+            }
+        }
+
+        public class Looks_up_source_url_when_name_and_credentials_is_provided : ChocolateyNugetCredentialProviderSpecsBase
+        {
+            public override void Because()
+            {
+                Configuration.Sources = TargetSourceUrl;
+                Configuration.ExplicitSources = TargetSourceName;
+
+                Configuration.SourceCommand.Username = "user";
+                Configuration.SourceCommand.Password = "totally_secure_password!!!";
+            }
+
+            [Fact]
+            public void Creates_and_returns_the_credential()
+            {
+                Result.Should().NotBeNull();
+            }
+
+            [Fact]
+            public void Provides_the_correct_username()
+            {
+                Result.UserName.Should().Be(Username);
+            }
+
+            [Fact]
+            public void Provides_the_correct_password()
+            {
+                Result.Password.Should().Be(Password);
+            }
+        }
+
+        public class When_no_matching_source_is_found_by_url : ChocolateyNugetCredentialProviderSpecsBase
+        {
+            public override void Because()
+            {
+                Configuration.Sources = Configuration.ExplicitSources = "https://unknownurl.com/api/v2/";
+            }
+
+            public override async Task With()
+            {
+                var result = await Provider.GetAsync(new Uri("https://unknownurl.com/api/v2/"), proxy: null, CredentialRequestType.Unauthorized, message: string.Empty, isRetry: false, nonInteractive: true, CancellationToken);
+                Result = result.Credentials as NetworkCredential;
+            }
+
+            [Fact]
+            public void Returns_the_default_network_credential()
+            {
+                Result.Should().Be(CredentialCache.DefaultNetworkCredentials);
+            }
+        }
+
+        public class When_multiple_named_sources_are_provided : ChocolateyNugetCredentialProviderSpecsBase
+        {
+            public override void Because()
+            {
+                Configuration.Sources = Configuration.MachineSources.Select(s => s.Key).Join(";");
+                Configuration.ExplicitSources = Configuration.MachineSources.Select(s => s.Name).Join(";");
+            }
+
+            [Fact]
+            public void Finds_the_correct_saved_source_for_the_target_uri_and_returns_the_credential()
+            {
+                Result.Should().NotBeNull();
+            }
+
+            [Fact]
+            public void Provides_the_correct_username()
+            {
+                Result.UserName.Should().Be(Username);
+            }
+
+            [Fact]
+            public void Provides_the_correct_password()
+            {
+                Result.Password.Should().Be(Password);
+            }
+        }
+
+        public class When_multiple_source_urls_are_provided : ChocolateyNugetCredentialProviderSpecsBase
+        {
+            public override void Because()
+            {
+                Configuration.Sources = Configuration.ExplicitSources = $"https://unknownurl.com/api/v2/;{TargetSourceUrl}";
+            }
+
+            [Fact]
+            public void Finds_the_saved_source_and_returns_the_credential()
+            {
+                Result.Should().NotBeNull();
+            }
+
+            [Fact]
+            public void Provides_the_correct_username()
+            {
+                Result.UserName.Should().Be(Username);
+            }
+
+            [Fact]
+            public void Provides_the_correct_password()
+            {
+                Result.Password.Should().Be(Password);
+            }
+        }
+
+        public class When_a_mix_of_named_and_url_sources_are_provided : ChocolateyNugetCredentialProviderSpecsBase
+        {
+            public override void Because()
+            {
+                Configuration.Sources = $"https://unknownurl.com/api/v2/;{TargetSourceUrl}";
+                Configuration.ExplicitSources = $"https://unknownurl.com/api/v2/;{TargetSourceName}";
+            }
+
+            [Fact]
+            public void Finds_the_saved_source_and_returns_the_credential()
+            {
+                Result.Should().NotBeNull();
+            }
+
+            [Fact]
+            public void Provides_the_correct_username()
+            {
+                Result.UserName.Should().Be(Username);
+            }
+
+            [Fact]
+            public void Provides_the_correct_password()
+            {
+                Result.Password.Should().Be(Password);
+            }
+        }
+
+        // This is a regression test for issue #3565
+        public class When_a_url_matching_the_hostname_only_of_a_saved_source_is_provided : ChocolateyNugetCredentialProviderSpecsBase
+        {
+            private Uri _otherRepoUri;
+            public override void Because()
+            {
+                _otherRepoUri = new Uri(TargetSourceUri.GetComponents(UriComponents.SchemeAndServer, UriFormat.Unescaped) + "/other_path/repository/");
+                Configuration.Sources = Configuration.ExplicitSources = _otherRepoUri.AbsoluteUri;
+            }
+
+            public override async Task With()
+            {
+                var result = await Provider.GetAsync(new Uri("https://unknownurl.com/api/v2/"), proxy: null, CredentialRequestType.Unauthorized, message: string.Empty, isRetry: false, nonInteractive: true, CancellationToken);
+                Result = result.Credentials as NetworkCredential;
+            }
+
+            [Fact]
+            public void Returns_the_default_network_credential()
+            {
+                Result.Should().Be(CredentialCache.DefaultNetworkCredentials);
+            }
+        }
+    }
+}

--- a/src/chocolatey/infrastructure.app/commands/ChocolateyInfoCommand.cs
+++ b/src/chocolatey/infrastructure.app/commands/ChocolateyInfoCommand.cs
@@ -38,7 +38,10 @@ namespace chocolatey.infrastructure.app.commands
                 .Add(
                     "s=|source=",
                     "Source - Source location for install. Can use special 'windowsfeatures', 'ruby', 'cygwin', or 'python' sources. Defaults to configured sources.",
-                    option => configuration.Sources = option.UnquoteSafe())
+                    option => {
+                        configuration.Sources = configuration.ExplicitSources = option.UnquoteSafe();
+                        configuration.ListCommand.ExplicitSource = true;
+                    })
                 .Add(
                     "l|lo|localonly|local-only",
                     "LocalOnly - Only search against local machine items.",

--- a/src/chocolatey/infrastructure.app/commands/ChocolateyInfoCommand.cs
+++ b/src/chocolatey/infrastructure.app/commands/ChocolateyInfoCommand.cs
@@ -38,10 +38,7 @@ namespace chocolatey.infrastructure.app.commands
                 .Add(
                     "s=|source=",
                     "Source - Source location for install. Can use special 'windowsfeatures', 'ruby', 'cygwin', or 'python' sources. Defaults to configured sources.",
-                    option => {
-                        configuration.Sources = configuration.ExplicitSources = option.UnquoteSafe();
-                        configuration.ListCommand.ExplicitSource = true;
-                    })
+                    option => configuration.Sources = configuration.ExplicitSources = option.UnquoteSafe())
                 .Add(
                     "l|lo|localonly|local-only",
                     "LocalOnly - Only search against local machine items.",

--- a/src/chocolatey/infrastructure.app/commands/ChocolateyInstallCommand.cs
+++ b/src/chocolatey/infrastructure.app/commands/ChocolateyInstallCommand.cs
@@ -53,11 +53,7 @@ namespace chocolatey.infrastructure.app.commands
             optionSet
                 .Add("s=|source=",
                      "Source - The source to find the package(s) to install. Special sources include: ruby, cygwin, windowsfeatures, and python. To specify more than one source, pass it with a semi-colon separating the values (e.g. \"'source1;source2'\"). Defaults to default feeds.",
-                     option =>
-                     {
-                         configuration.Sources = configuration.ExplicitSources = option.UnquoteSafe();
-                         configuration.ListCommand.ExplicitSource = true;
-                     })
+                     option => configuration.Sources = configuration.ExplicitSources = option.UnquoteSafe())
                 .Add("version=",
                      "Version - A specific version to install. Defaults to unspecified.",
                      option => configuration.Version = option.UnquoteSafe())

--- a/src/chocolatey/infrastructure.app/commands/ChocolateyInstallCommand.cs
+++ b/src/chocolatey/infrastructure.app/commands/ChocolateyInstallCommand.cs
@@ -53,7 +53,11 @@ namespace chocolatey.infrastructure.app.commands
             optionSet
                 .Add("s=|source=",
                      "Source - The source to find the package(s) to install. Special sources include: ruby, cygwin, windowsfeatures, and python. To specify more than one source, pass it with a semi-colon separating the values (e.g. \"'source1;source2'\"). Defaults to default feeds.",
-                     option => configuration.Sources = option.UnquoteSafe())
+                     option =>
+                     {
+                         configuration.Sources = configuration.ExplicitSources = option.UnquoteSafe();
+                         configuration.ListCommand.ExplicitSource = true;
+                     })
                 .Add("version=",
                      "Version - A specific version to install. Defaults to unspecified.",
                      option => configuration.Version = option.UnquoteSafe())

--- a/src/chocolatey/infrastructure.app/commands/ChocolateyListCommand.cs
+++ b/src/chocolatey/infrastructure.app/commands/ChocolateyListCommand.cs
@@ -85,7 +85,7 @@ namespace chocolatey.infrastructure.app.commands
                      "Source - Name of alternative source to use, for example 'windowsfeatures', 'ruby', 'cygwin', or 'python'.",
                      option =>
                      {
-                         configuration.Sources = option.UnquoteSafe();
+                         configuration.Sources = configuration.ExplicitSources = option.UnquoteSafe();
                          configuration.ListCommand.ExplicitSource = true;
                      })
                 .Add("idonly|id-only",

--- a/src/chocolatey/infrastructure.app/commands/ChocolateyListCommand.cs
+++ b/src/chocolatey/infrastructure.app/commands/ChocolateyListCommand.cs
@@ -252,7 +252,7 @@ If you find other exit codes that we have not yet documented, please
         {
             // Would have liked to have done this in the Validate method, but can't, since the SourceType
             // hasn't yet been set, since the sources have not yet been parsed.
-            if (config.ListCommand.ExplicitSource && config.SourceType == SourceTypes.Normal)
+            if (!string.IsNullOrWhiteSpace(config.ExplicitSources) && config.SourceType == SourceTypes.Normal)
             {
                 throw new ApplicationException("When using the '--source' option with the 'choco list' command, only a named alternative source can be provided.");
             }

--- a/src/chocolatey/infrastructure.app/commands/ChocolateyOutdatedCommand.cs
+++ b/src/chocolatey/infrastructure.app/commands/ChocolateyOutdatedCommand.cs
@@ -40,11 +40,7 @@ namespace chocolatey.infrastructure.app.commands
             optionSet
                 .Add("s=|source=",
                      "Source - The source to find the package(s) to install. Special sources include: ruby, cygwin, windowsfeatures, and python. To specify more than one source, pass it with a semi-colon separating the values (e.g. \"'source1;source2'\"). Defaults to default feeds.",
-                     option =>
-                     {
-                         configuration.Sources = configuration.ExplicitSources = option.UnquoteSafe();
-                         configuration.ListCommand.ExplicitSource = true;
-                     })
+                     option => configuration.Sources = configuration.ExplicitSources = option.UnquoteSafe())
                 .Add("u=|user=",
                      "User - used with authenticated feeds. Defaults to empty.",
                      option => configuration.SourceCommand.Username = option.UnquoteSafe())

--- a/src/chocolatey/infrastructure.app/commands/ChocolateyOutdatedCommand.cs
+++ b/src/chocolatey/infrastructure.app/commands/ChocolateyOutdatedCommand.cs
@@ -40,7 +40,11 @@ namespace chocolatey.infrastructure.app.commands
             optionSet
                 .Add("s=|source=",
                      "Source - The source to find the package(s) to install. Special sources include: ruby, cygwin, windowsfeatures, and python. To specify more than one source, pass it with a semi-colon separating the values (e.g. \"'source1;source2'\"). Defaults to default feeds.",
-                     option => configuration.Sources = option.UnquoteSafe())
+                     option =>
+                     {
+                         configuration.Sources = configuration.ExplicitSources = option.UnquoteSafe();
+                         configuration.ListCommand.ExplicitSource = true;
+                     })
                 .Add("u=|user=",
                      "User - used with authenticated feeds. Defaults to empty.",
                      option => configuration.SourceCommand.Username = option.UnquoteSafe())

--- a/src/chocolatey/infrastructure.app/commands/ChocolateySearchCommand.cs
+++ b/src/chocolatey/infrastructure.app/commands/ChocolateySearchCommand.cs
@@ -43,11 +43,7 @@ namespace chocolatey.infrastructure.app.commands
             optionSet
                 .Add("s=|source=",
                      "Source - Source location for install. Can use special 'windowsfeatures', 'ruby', 'cygwin', or 'python' sources. Defaults to sources.",
-                     option =>
-                     {
-                         configuration.Sources = configuration.ExplicitSources = option.UnquoteSafe();
-                         configuration.ListCommand.ExplicitSource = true;
-                     })
+                     option => configuration.Sources = configuration.ExplicitSources = option.UnquoteSafe())
                 .Add("idonly|id-only",
                      "Id Only - Only return Package Ids in the list results.",
                      option => configuration.ListCommand.IdOnly = option != null)

--- a/src/chocolatey/infrastructure.app/commands/ChocolateySearchCommand.cs
+++ b/src/chocolatey/infrastructure.app/commands/ChocolateySearchCommand.cs
@@ -43,7 +43,11 @@ namespace chocolatey.infrastructure.app.commands
             optionSet
                 .Add("s=|source=",
                      "Source - Source location for install. Can use special 'windowsfeatures', 'ruby', 'cygwin', or 'python' sources. Defaults to sources.",
-                     option => configuration.Sources = option.UnquoteSafe())
+                     option =>
+                     {
+                         configuration.Sources = configuration.ExplicitSources = option.UnquoteSafe();
+                         configuration.ListCommand.ExplicitSource = true;
+                     })
                 .Add("idonly|id-only",
                      "Id Only - Only return Package Ids in the list results.",
                      option => configuration.ListCommand.IdOnly = option != null)

--- a/src/chocolatey/infrastructure.app/commands/ChocolateyUpgradeCommand.cs
+++ b/src/chocolatey/infrastructure.app/commands/ChocolateyUpgradeCommand.cs
@@ -53,11 +53,7 @@ namespace chocolatey.infrastructure.app.commands
             optionSet
                 .Add("s=|source=",
                      "Source - The source to find the package(s) to install. Special sources include: ruby, cygwin, windowsfeatures, and python. To specify more than one source, pass it with a semi-colon separating the values (e.g. \"'source1;source2'\"). Defaults to default feeds.",
-                     option =>
-                     {
-                         configuration.Sources = configuration.ExplicitSources = option.UnquoteSafe();
-                         configuration.ListCommand.ExplicitSource = true;
-                     })
+                     option => configuration.Sources = configuration.ExplicitSources = option.UnquoteSafe())
                 .Add("version=",
                      "Version - A specific version to install. Defaults to unspecified.",
                      option => configuration.Version = option.UnquoteSafe())

--- a/src/chocolatey/infrastructure.app/commands/ChocolateyUpgradeCommand.cs
+++ b/src/chocolatey/infrastructure.app/commands/ChocolateyUpgradeCommand.cs
@@ -53,7 +53,11 @@ namespace chocolatey.infrastructure.app.commands
             optionSet
                 .Add("s=|source=",
                      "Source - The source to find the package(s) to install. Special sources include: ruby, cygwin, windowsfeatures, and python. To specify more than one source, pass it with a semi-colon separating the values (e.g. \"'source1;source2'\"). Defaults to default feeds.",
-                     option => configuration.Sources = option.UnquoteSafe())
+                     option =>
+                     {
+                         configuration.Sources = configuration.ExplicitSources = option.UnquoteSafe();
+                         configuration.ListCommand.ExplicitSource = true;
+                     })
                 .Add("version=",
                      "Version - A specific version to install. Defaults to unspecified.",
                      option => configuration.Version = option.UnquoteSafe())

--- a/src/chocolatey/infrastructure.app/configuration/ChocolateyConfiguration.cs
+++ b/src/chocolatey/infrastructure.app/configuration/ChocolateyConfiguration.cs
@@ -603,6 +603,7 @@ NOTE: Hiding sensitive configuration data! Please double and triple
         public bool NotBroken { get; set; }
         public bool IncludeVersionOverrides { get; set; }
         public bool ExplicitPageSize { get; set; }
+        [Obsolete("This property is deprecated and will be removed in v3. Check if the top-level ExplicitSources property is set instead.")]
         public bool ExplicitSource { get; set; }
     }
 

--- a/src/chocolatey/infrastructure.app/configuration/ChocolateyConfiguration.cs
+++ b/src/chocolatey/infrastructure.app/configuration/ChocolateyConfiguration.cs
@@ -262,6 +262,12 @@ NOTE: Hiding sensitive configuration data! Please double and triple
         /// </summary>
         public string Sources { get; set; }
 
+        /// <summary>
+        /// One or more source locations set by comamnd line only. Semi-colon delimited.
+        /// <strong>Do not set this anywhere other than parsing CLI arguments for commands.</strong>
+        /// </summary>
+        public string ExplicitSources { get; set; }
+
         public string SourceType { get; set; }
         public bool IncludeConfiguredSources { get; set; }
 

--- a/src/chocolatey/infrastructure.app/nuget/ChocolateyNugetCredentialProvider.cs
+++ b/src/chocolatey/infrastructure.app/nuget/ChocolateyNugetCredentialProvider.cs
@@ -95,6 +95,7 @@ namespace chocolatey.infrastructure.app.nuget
             var namedExplicitSources = _config.ExplicitSources?.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries)
                 .Where(s => !Uri.IsWellFormedUriString(s, UriKind.Absolute))
                 .ToList();
+
             if (namedExplicitSources?.Count > 0)
             {
                 // Uri.Equals() and == operator compare hostnames case-insensitively and the remainder of the url case-sensitively

--- a/tests/helpers/common/Chocolatey/Disable-ChocolateySource.ps1
+++ b/tests/helpers/common/Chocolatey/Disable-ChocolateySource.ps1
@@ -8,10 +8,8 @@ function Disable-ChocolateySource {
         [Parameter()]
         [switch]$All
     )
-    # Significantly weird behaviour with piping this source list by property name.
-    $CurrentSources = (Invoke-Choco source list -r).Lines | ConvertFrom-ChocolateyOutput -Command SourceList | Where-Object {
-        $_.Name -like $Name
-    }
+
+    $CurrentSources = Get-ChocolateySource -Name $Name
     foreach ($Source in $CurrentSources) {
         $null = Invoke-Choco source disable --name $Source.Name
     }

--- a/tests/helpers/common/Chocolatey/Enable-ChocolateySource.ps1
+++ b/tests/helpers/common/Chocolatey/Enable-ChocolateySource.ps1
@@ -9,9 +9,7 @@ function Enable-ChocolateySource {
         [switch]$All
     )
     # Significantly weird behaviour with piping this source list by property name.
-    $CurrentSources = (Invoke-Choco source list -r).Lines | ConvertFrom-ChocolateyOutput -Command SourceList | Where-Object {
-        $_.Name -like $Name
-    }
+    $CurrentSources = Get-ChocolateySource -Name $Name
     foreach ($Source in $CurrentSources) {
         $null = Invoke-Choco source enable --name $Source.Name
     }

--- a/tests/helpers/common/Chocolatey/Get-ChocolateySource.ps1
+++ b/tests/helpers/common/Chocolatey/Get-ChocolateySource.ps1
@@ -1,0 +1,11 @@
+﻿function Get-ChocolateySource {
+    [CmdletBinding()]
+    param(
+        [Parameter()]
+        [string]$Name = "*"
+    )
+    # Significantly weird behaviour with piping this source list by property name.
+    (Invoke-Choco source list -r).Lines | ConvertFrom-ChocolateyOutput -Command SourceList | Where-Object {
+        $_.Name -like $Name
+    }
+}

--- a/tests/pester-tests/features/CredentialProvider.Tests.ps1
+++ b/tests/pester-tests/features/CredentialProvider.Tests.ps1
@@ -1,28 +1,35 @@
-﻿Describe 'Ensuring credentials do not bleed from configured sources' -Tag CredentialProvider -ForEach @(
+﻿# These tests are to ensure that credentials from one configured and enabled source are not
+# picked up and used when a URL is matching based on the hostname. These tests use an authenticated
+# source without explicitly providing a username/password. It is expected that Chocolatey will prompt for
+# the username and password.
+Describe 'Ensuring credentials do not bleed from configured sources' -Tag CredentialProvider -ForEach @(
+    # Info and outdated are returning 0 in all test cases we've thrown at them.
+    # Suspect the only way either of these commands actually return non-zero is in a scenario where
+    # something goes catastrophically wrong outside of the actual command calls.
     @{
         Command = 'info'
         ExitCode = 0
-}
-    @{
-        Command = 'install'
-        ExitCode = 1
-}
+    }
     @{
         Command = 'outdated'
         ExitCode = 0
-}
+    }
+    @{
+        Command = 'install'
+        ExitCode = 1
+    }
     @{
         Command = 'search'
         ExitCode = 1
-}
+    }
     @{
         Command = 'upgrade'
         ExitCode = 1
-}
+    }
     @{
         Command = 'download'
         ExitCode = 1
-}
+    }
 ) {
     BeforeDiscovery {
         $HasLicensedExtension = Test-PackageIsEqualOrHigher -PackageName 'chocolatey.extension' -Version '6.0.0'

--- a/tests/pester-tests/features/CredentialProvider.Tests.ps1
+++ b/tests/pester-tests/features/CredentialProvider.Tests.ps1
@@ -1,0 +1,63 @@
+﻿Describe 'Ensuring credentials do not bleed from configured sources' -Tag CredentialProvider -ForEach @(
+    @{
+        Command = 'info'
+        ExitCode = 0
+}
+    @{
+        Command = 'install'
+        ExitCode = 1
+}
+    @{
+        Command = 'outdated'
+        ExitCode = 0
+}
+    @{
+        Command = 'search'
+        ExitCode = 1
+}
+    @{
+        Command = 'upgrade'
+        ExitCode = 1
+}
+    @{
+        Command = 'download'
+        ExitCode = 1
+}
+) {
+    BeforeDiscovery {
+        $HasLicensedExtension = Test-PackageIsEqualOrHigher -PackageName 'chocolatey.extension' -Version '6.0.0'
+    }
+
+    BeforeAll {
+        Initialize-ChocolateyTestInstall
+        Disable-ChocolateySource -All
+        Enable-ChocolateySource -Name 'hermes'
+        $SetupSource = Get-ChocolateySource -Name 'hermes-setup'
+        Remove-Item download -force -recurse
+    }
+
+    # Skip the download command if chocolatey.extension is not installed.
+    Context 'Command (<Command>)' -Skip:($Command -eq 'download' -and -not $HasLicensedExtension) {
+        BeforeAll {
+            # The package used ultimately doesn't matter as we don't expect to find it.
+            # Picking a package that should be found if the behaviour changes.
+            $PackageUnderTest = 'chocolatey-compatibility.extension'
+            Restore-ChocolateyInstallSnapshot
+            # Chocolatey will prompt for credentials, we need to force something in there, and this will do that.
+            $Output = 'n' | Invoke-Choco $Command $PackageUnderTest --confirm --source="'$($SetupSource.Url)'"
+        }
+
+        AfterAll {
+            Remove-ChocolateyInstallSnapshot
+        }
+
+        It 'Exits Correctly (<ExitCode>)' {
+            $Output.ExitCode | Should -Be $ExitCode -Because $Output.String
+        }
+
+        It 'Outputs error message' {
+            $FilteredOutput = $Output.Lines -match "Failed to fetch results from V2 feed at '$($SetupSource.Url.Trim('/'))"
+            $FilteredOutput.Count | Should -BeGreaterOrEqual 1 -Because $Output.String
+        }
+    }
+}


### PR DESCRIPTION
## Description Of Changes

- Rework handling in ChocolateyNugetCredentialProvider to ensure we only match credentials from the full URL
- Add a config property so we can actually tell what the literal arguments passed to `--source` on the command line are, and start making use of it here to aid with looking up source credentials.
  - In discussions with Gary, we have agreed the behaviour of looking up a source based purely on the URL here is bad In General, because choco should probably just use the literal command line arguments and not assume you want it to look things up in the config when you did not ask, so this will later be expanded upon and some of the searching functionality here can be removed at a later date.
- Add unit tests for this credential provider

## Motivation and Context

See #3565 - the credentials are being reused in places that they shouldn't.

## Testing

Unit tests! :3 Including a regression test specifically for #3565

Open VS and run the tests in the `chocolatey.tests` project and make sure they pass.

Cory added: Ran `CredentialProvider` tag in Test Kitchen.

### Operating Systems Testing

Win10

## Change Types Made
<!-- Tick the boxes for the type of changes that have been made -->

* [x] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [x] Tests to cover my changes, have been added.
* [x] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v3 compatibility checked?

## Related Issue
<!-- Make sure you have raised an issue for this pull request before
continuing. -->

Fixes #3565
Fixes #2421 (different symptom, same issue, likely _somewhat_ duplicate issue)
