### PR TITLE
(#3566) Avoid credential bleed from saved sources with the same hostname

### DIFF
--- a/src/chocolatey/infrastructure.app/commands/ChocolateyInfoCommand.cs
+++ b/src/chocolatey/infrastructure.app/commands/ChocolateyInfoCommand.cs
@@ -37,7 +37,7 @@ namespace chocolatey.infrastructure.app.commands
                 .Add(
                     "s=|source=",
                     "Source - Source location for install. Can use special 'webpi' or 'windowsfeatures' sources. Defaults to sources.",
-                    option => configuration.Sources = option.remove_surrounding_quotes())
+                    option => configuration.Sources = configuration.ExplicitSources = option.remove_surrounding_quotes())
                 .Add(
                     "l|lo|localonly|local-only",
                     "LocalOnly - Only search against local machine items.",

--- a/src/chocolatey/infrastructure.app/commands/ChocolateyInstallCommand.cs
+++ b/src/chocolatey/infrastructure.app/commands/ChocolateyInstallCommand.cs
@@ -41,7 +41,7 @@ namespace chocolatey.infrastructure.app.commands
             optionSet
                 .Add("s=|source=",
                      "Source - The source to find the package(s) to install. Special sources include: ruby, webpi, cygwin, windowsfeatures, and python. To specify more than one source, pass it with a semi-colon separating the values (e.g. \"'source1;source2'\"). Defaults to default feeds.",
-                     option => configuration.Sources = option.remove_surrounding_quotes())
+                     option => configuration.Sources = configuration.ExplicitSources = option.remove_surrounding_quotes())
                 .Add("version=",
                      "Version - A specific version to install. Defaults to unspecified.",
                      option => configuration.Version = option.remove_surrounding_quotes())

--- a/src/chocolatey/infrastructure.app/commands/ChocolateyListCommand.cs
+++ b/src/chocolatey/infrastructure.app/commands/ChocolateyListCommand.cs
@@ -51,7 +51,7 @@ namespace chocolatey.infrastructure.app.commands
             optionSet
                 .Add("s=|source=",
                      "Source - Source location for install. Can use special 'webpi' or 'windowsfeatures' sources. Defaults to sources." + deprecationNotice,
-                     option => configuration.Sources = option.remove_surrounding_quotes())
+                     option => configuration.Sources = configuration.ExplicitSources = option.remove_surrounding_quotes())
                 .Add("l|lo|local|localonly|local-only",
                      localOnlyDescription,
                      option => configuration.ListCommand.LocalOnly = option != null)

--- a/src/chocolatey/infrastructure.app/commands/ChocolateyOutdatedCommand.cs
+++ b/src/chocolatey/infrastructure.app/commands/ChocolateyOutdatedCommand.cs
@@ -39,7 +39,7 @@ namespace chocolatey.infrastructure.app.commands
             optionSet
                 .Add("s=|source=",
                      "Source - The source to find the package(s) to install. Special sources include: ruby, webpi, cygwin, windowsfeatures, and python. To specify more than one source, pass it with a semi-colon separating the values (e.g. \"'source1;source2'\"). Defaults to default feeds.",
-                     option => configuration.Sources = option.remove_surrounding_quotes())
+                     option => configuration.Sources = configuration.ExplicitSources = option.remove_surrounding_quotes())
                 .Add("u=|user=",
                      "User - used with authenticated feeds. Defaults to empty.",
                      option => configuration.SourceCommand.Username = option.remove_surrounding_quotes())

--- a/src/chocolatey/infrastructure.app/commands/ChocolateySourceCommand.cs
+++ b/src/chocolatey/infrastructure.app/commands/ChocolateySourceCommand.cs
@@ -49,7 +49,7 @@ namespace chocolatey.infrastructure.app.commands
                      option => configuration.SourceCommand.Name = option.remove_surrounding_quotes())
                 .Add("s=|source=",
                      "Source - The source. This can be a folder/file share or an http location. If it is a url, it will be a location you can go to in a browser and it returns OData with something that says Packages in the browser, similar to what you see when you go to https://community.chocolatey.org/api/v2/. Required with add action. Defaults to empty.",
-                     option => configuration.Sources = option.remove_surrounding_quotes())
+                     option => configuration.Sources = configuration.ExplicitSources = option.remove_surrounding_quotes())
                 .Add("u=|user=",
                      "User - used with authenticated feeds. Defaults to empty.",
                      option => configuration.SourceCommand.Username = option.remove_surrounding_quotes())

--- a/src/chocolatey/infrastructure.app/commands/ChocolateyUpgradeCommand.cs
+++ b/src/chocolatey/infrastructure.app/commands/ChocolateyUpgradeCommand.cs
@@ -41,7 +41,7 @@ namespace chocolatey.infrastructure.app.commands
             optionSet
                 .Add("s=|source=",
                      "Source - The source to find the package(s) to install. Special sources include: ruby, webpi, cygwin, windowsfeatures, and python. To specify more than one source, pass it with a semi-colon separating the values (e.g. \"'source1;source2'\"). Defaults to default feeds.",
-                     option => configuration.Sources = option.remove_surrounding_quotes())
+                     option => configuration.Sources = configuration.ExplicitSources = option.remove_surrounding_quotes())
                 .Add("version=",
                      "Version - A specific version to install. Defaults to unspecified.",
                      option => configuration.Version = option.remove_surrounding_quotes())

--- a/src/chocolatey/infrastructure.app/configuration/ChocolateyConfiguration.cs
+++ b/src/chocolatey/infrastructure.app/configuration/ChocolateyConfiguration.cs
@@ -252,6 +252,12 @@ NOTE: Hiding sensitive configuration data! Please double and triple
         /// </summary>
         public string Sources { get; set; }
 
+        /// <summary>
+        /// One or more source locations set by comamnd line only. Semi-colon delimited.
+        /// <strong>Do not set this anywhere other than parsing CLI arguments for commands.</strong>
+        /// </summary>
+        public string ExplicitSources { get; set; }
+
         public string SourceType { get; set; }
 
         // top level commands

--- a/src/chocolatey/infrastructure.app/nuget/ChocolateyNugetCredentialProvider.cs
+++ b/src/chocolatey/infrastructure.app/nuget/ChocolateyNugetCredentialProvider.cs
@@ -79,59 +79,57 @@ namespace chocolatey.infrastructure.app.nuget
             }
 
             // credentials were not explicit
-            // discover based on closest match in sources
-            var candidateSources = _config.MachineSources.Where(
-                s =>
-                {
-                    var sourceUrl = s.Key.TrimEnd('/');
-
-                    try
-                    {
-                        var sourceUri = new Uri(sourceUrl);
-                        return sourceUri.Host.is_equal_to(uri.Host)
-                            && !string.IsNullOrWhiteSpace(s.Username)
-                            && !string.IsNullOrWhiteSpace(s.EncryptedPassword);
-                    }
-                    catch (Exception)
-                    {
-                        this.Log().Error("Source '{0}' is not a valid Uri".format_with(sourceUrl));
-                    }
-
-                    return false;
-                }).ToList();
-
+            // find matching source(s) in sources list
+            var trimmedTargetUri = new Uri(uri.AbsoluteUri.TrimEnd('/'));
             MachineSourceConfiguration source = null;
 
+            // If the user has specified --source with a *named* source and not a URL, try to find the matching one
+            // with the correct URL for this credential request.
+            // Lower case all of the explicitly named sources so that we can use .Contains to compare them.
+            var namedExplicitSources = _config.ExplicitSources?.ToLower().Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries)
+                .Where(s => !Uri.IsWellFormedUriString(s, UriKind.Absolute))
+                .ToList();
 
-            if (candidateSources.Count == 1)
+            if (namedExplicitSources?.Count > 0)
             {
-                // only one match, use it
-                source = candidateSources.FirstOrDefault();
+                // Instead of using Uri.Equals(), we're using Uri.Compare() on the HttpRequestUrl components as this allows
+                // us to ignore the case of everything.
+                source = _config.MachineSources
+                    .Where(s => namedExplicitSources.Contains(s.Name.ToLower())
+                    && Uri.TryCreate(s.Key.TrimEnd('/'), UriKind.Absolute, out var trimmedSourceUri)
+                    && Uri.Compare(trimmedSourceUri, trimmedTargetUri, UriComponents.HttpRequestUrl, UriFormat.Unescaped, StringComparison.OrdinalIgnoreCase) == 0)
+                    .FirstOrDefault();
             }
-            else if (candidateSources.Count > 1)
+            
+            if (source is null)
             {
-                // find the source that is the closest match
-                foreach (var candidateSource in candidateSources.or_empty_list_if_null())
-                {
-                    var candidateRegEx = new Regex(Regex.Escape(candidateSource.Key.TrimEnd('/')),RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
-                    if (candidateRegEx.IsMatch(uri.OriginalString.TrimEnd('/')))
-                    {
-                        this.Log().Debug("Source selected will be '{0}'".format_with(candidateSource.Key.TrimEnd('/')));
-                        source = candidateSource;
-                        break;
-                    }
-                }
+                // Could not find a valid source by name, or the source(s) specified were all URLs.
+                // Try to look up the target URL in the saved machine sources to attempt to match credentials.
+                //
+                // Note: This behaviour remains as removing it would be a breaking change.
+                var candidateSources = _config.MachineSources
+                    .Where(s => !string.IsNullOrWhiteSpace(s.Username)
+                        && !string.IsNullOrWhiteSpace(s.EncryptedPassword)
+                        && Uri.TryCreate(s.Key.TrimEnd('/'), UriKind.Absolute, out var trimmedSourceUri)
+                        && Uri.Compare(trimmedSourceUri, trimmedTargetUri, UriComponents.HttpRequestUrl, UriFormat.Unescaped, StringComparison.OrdinalIgnoreCase) == 0)
+                    .ToList();
 
-                if (source == null && !retrying)
+                if (candidateSources.Count == 1)
                 {
-                    // use the first source. If it fails, fall back to grabbing credentials from the user
+                    // only one match, use it
+                    source = candidateSources.First();
+                }
+                else if (candidateSources.Count > 1 && !retrying)
+                {
+                    // Use the credentials from the first found source, unless it's a retry (creds already tried and failed)
+                    // use the first source. If it fails, fall back to grabbing credentials from the user.
                     var candidateSource = candidateSources.First();
                     this.Log().Debug("Evaluated {0} candidate sources but was unable to find a match, using {1}".format_with(candidateSources.Count, candidateSource.Key.TrimEnd('/')));
                     source = candidateSource;
                 }
             }
 
-            if (source == null)
+            if (source is null)
             {
                 this.Log().Debug("Asking user for credentials for '{0}'".format_with(uri.OriginalString));
                 return get_credentials_from_user(uri, proxy, credentialType);

--- a/tests/helpers/common/Chocolatey/Disable-ChocolateySource.ps1
+++ b/tests/helpers/common/Chocolatey/Disable-ChocolateySource.ps1
@@ -8,10 +8,8 @@ function Disable-ChocolateySource {
         [Parameter()]
         [switch]$All
     )
-    # Significantly weird behaviour with piping this source list by property name.
-    $CurrentSources = (Invoke-Choco source list -r).Lines | ConvertFrom-ChocolateyOutput -Command SourceList | Where-Object {
-        $_.Name -like $Name
-    }
+
+    $CurrentSources = Get-ChocolateySource -Name $Name
     foreach ($Source in $CurrentSources) {
         $null = Invoke-Choco source disable --name $Source.Name
     }

--- a/tests/helpers/common/Chocolatey/Enable-ChocolateySource.ps1
+++ b/tests/helpers/common/Chocolatey/Enable-ChocolateySource.ps1
@@ -9,9 +9,7 @@ function Enable-ChocolateySource {
         [switch]$All
     )
     # Significantly weird behaviour with piping this source list by property name.
-    $CurrentSources = (Invoke-Choco source list -r).Lines | ConvertFrom-ChocolateyOutput -Command SourceList | Where-Object {
-        $_.Name -like $Name
-    }
+    $CurrentSources = Get-ChocolateySource -Name $Name
     foreach ($Source in $CurrentSources) {
         $null = Invoke-Choco source enable --name $Source.Name
     }

--- a/tests/helpers/common/Chocolatey/Get-ChocolateySource.ps1
+++ b/tests/helpers/common/Chocolatey/Get-ChocolateySource.ps1
@@ -1,0 +1,11 @@
+﻿function Get-ChocolateySource {
+    [CmdletBinding()]
+    param(
+        [Parameter()]
+        [string]$Name = "*"
+    )
+    # Significantly weird behaviour with piping this source list by property name.
+    (Invoke-Choco source list -r).Lines | ConvertFrom-ChocolateyOutput -Command SourceList | Where-Object {
+        $_.Name -like $Name
+    }
+}

--- a/tests/pester-tests/features/CredentialProvider.Tests.ps1
+++ b/tests/pester-tests/features/CredentialProvider.Tests.ps1
@@ -1,0 +1,73 @@
+﻿# These tests are to ensure that credentials from one configured and enabled source are not
+# picked up and used when a URL is matching based on the hostname. These tests use an authenticated
+# source without explicitly providing a username/password. It is expected that Chocolatey will prompt for
+# the username and password.
+Describe 'Ensuring credentials do not bleed from configured sources' -Tag CredentialProvider -ForEach @(
+    # Info and outdated are returning 0 in all test cases we've thrown at them.
+    # Suspect the only way either of these commands actually return non-zero is in a scenario where
+    # something goes catastrophically wrong outside of the actual command calls.
+    @{
+        Command = 'info'
+        ExitCode = 0
+    }
+    @{
+        Command = 'outdated'
+        ExitCode = 0
+    }
+    @{
+        Command = 'install'
+        ExitCode = 1
+    }
+    @{
+        Command = 'search'
+        ExitCode = 0
+    }
+    @{
+        Command = 'upgrade'
+        ExitCode = 1
+    }
+    @{
+        Command = 'download'
+        ExitCode = 1
+    }
+) {
+    BeforeDiscovery {
+        $HasLicensedExtension = Test-PackageIsEqualOrHigher -PackageName 'chocolatey.extension' -Version '5.0.0'
+    }
+
+    BeforeAll {
+        Initialize-ChocolateyTestInstall
+        Disable-ChocolateySource -All
+        Enable-ChocolateySource -Name 'hermes'
+        $SetupSource = Get-ChocolateySource -Name 'hermes-setup'
+        Remove-Item download -force -recurse
+    }
+
+    # Skip the download command if chocolatey.extension is not installed.
+    Context 'Command (<Command>)' -Skip:($Command -eq 'download' -and -not $HasLicensedExtension) {
+        BeforeAll {
+            # Picked a package that is on `hermes-setup` but not on `hermes`.
+            $PackageUnderTest = 'chocolatey-compatibility.extension'
+            Restore-ChocolateyInstallSnapshot
+            # Chocolatey will prompt for credentials, we need to force something in there, and this will do that.
+            $Output = 'n' | Invoke-Choco $Command $PackageUnderTest --confirm --source="'$($SetupSource.Url)'"
+        }
+
+        AfterAll {
+            Remove-ChocolateyInstallSnapshot
+        }
+
+        It 'Exits Correctly (<ExitCode>)' {
+            $Output.ExitCode | Should -Be $ExitCode -Because $Output.String
+        }
+
+        It 'Outputs error message' {
+            if ($Command -eq 'search') {
+                $Output.Lines | Should -Contain "[NuGet] Not able to contact source '$($SetupSource.Url)'. Error was The remote server returned an error: (401) Unauthorized." -Because $Output.String
+            } else {
+                $Output.Lines | Should -Contain "Error retrieving packages from source '$($SetupSource.Url)':" -Because $Output.String
+                $Output.Lines | Should -Contain "The remote server returned an error: (401) Unauthorized." -Because $Output.String
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Description Of Changes

Backport #3568 to Chocolatey CLI 1.x

## Motivation and Context

See https://github.com/chocolatey/choco/issues/3566 - the credentials are being reused in places that they shouldn't.

## Testing

Ran through Test Kitchen locally and in Team City.

To test with CLE locally I editted the `nupkg` produced by Team City and changed the  version reported to be `1.5.0-pullreques` and then tested with CLE `5.0.6`.

Screenshot from local test kitchen run:

![image](https://github.com/user-attachments/assets/e937b6de-0d4c-4563-a484-9bec5647966c)

### Operating Systems Testing

- Windows Server 2019
- Windows Server 2016

## Change Types Made

* [x] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [x] Tests to cover my changes, have been added.
* [x] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v3 compatibility checked?

## Related Issue

- Fixes #3566 
