### PR TITLE
(#3565) Update tests to be able to push when anonymous access is disabled.

### DIFF
--- a/tests/pester-tests/commands/choco-push.Tests.ps1
+++ b/tests/pester-tests/commands/choco-push.Tests.ps1
@@ -152,6 +152,9 @@ Describe 'choco push nuget <_> repository' -Tag Chocolatey, PushCommand -Skip:($
 
             if ($UseConfig) {
                 $null = Invoke-Choco apikey add --source $RepositoryToUse$RepositoryEndpoint --api-key $ApiKey
+                # Add the Nuget source so that the push doesn't prompt for credentials.
+                # See https://github.com/chocolatey/choco/issues/2026#issuecomment-2423828013
+                $null = Invoke-Choco source add --name temporary-nuget --source $RepositoryToUse$RepositoryEndpoint --user $env:NUGET_SOURCE_USERNAME --password $env:NUGET_SOURCE_PASSWORD
                 # Ensure the key is null (should always be, but scoping can be wonky)
                 $KeyParameter = $null
             } else {


### PR DESCRIPTION
## Description Of Changes

Add the push source to configuration so that we are able to push to it
successfully. When anonymous access is disabled, Chocolatey will now
only use credentials it has configured by the exact source URL, and not
just one that matches the hostname. As such, this test started failing
and needs to be updated to ensure the credentials can be used.

See https://github.com/chocolatey/choco/issues/2026 for more details.

## Motivation and Context

Ensure tests that were failing can now pass.

## Testing

Run the `PushCommand` tag in Test Kitchen.

### Operating Systems Testing

- Windows Server 2016
- Windows Server 2019

## Change Types Made

* [ ] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.
* [x] Pester tests

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [x] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v3 compatibility checked?

## Related Issue

- Related to #3568 
