### PR TITLE
(#3566) Ensure package download from authed source

### DIFF
--- a/src/chocolatey/infrastructure.app/nuget/ChocolateyNugetCredentialProvider.cs
+++ b/src/chocolatey/infrastructure.app/nuget/ChocolateyNugetCredentialProvider.cs
@@ -111,7 +111,10 @@ namespace chocolatey.infrastructure.app.nuget
                     .Where(s => !string.IsNullOrWhiteSpace(s.Username)
                         && !string.IsNullOrWhiteSpace(s.EncryptedPassword)
                         && Uri.TryCreate(s.Key.TrimEnd('/'), UriKind.Absolute, out var trimmedSourceUri)
-                        && Uri.Compare(trimmedSourceUri, trimmedTargetUri, UriComponents.HttpRequestUrl, UriFormat.Unescaped, StringComparison.OrdinalIgnoreCase) == 0)
+                        && (Uri.Compare(trimmedSourceUri, trimmedTargetUri, UriComponents.HttpRequestUrl, UriFormat.Unescaped, StringComparison.OrdinalIgnoreCase) == 0
+                            // If the target starts with a machine source, we're in a scenario where NuGet is now trying to download the package.
+                            // For whatever reason NuGet sometimes forgets the credentials between discovering the package and downloading the package.
+                            || trimmedTargetUri.ToString().StartsWith(trimmedSourceUri.ToString(), StringComparison.OrdinalIgnoreCase)))
                     .ToList();
 
                 if (candidateSources.Count == 1)


### PR DESCRIPTION
## Description Of Changes

Update the Credential lookup logic to account for the scenario where NuGet has forgotten the credentials for the source between determining the download Uri and trying to download from it. In this instance the target Uri is a superstring of the source Uri (that is for a source of `https://repo/repository/my-repository/`, the download might be `https://repo/repository/my-repository/my-package/1.1.1`). This would not match the credential lookup, but it should use the configured credential.

## Motivation and Context

Sometimes NuGet forgets where it's downloading from, and needs to get the credentials again.

## Testing

Ran tests through Test Kitchen.

### Operating Systems Testing

- Windows Server 2016
- Windows Server 2019

## Change Types Made

* [x] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [x] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v3 compatibility checked?

## Related Issue

Fixes #3566 