### PR TITLE
(maint) Correct some typos and fix some tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,7 +28,7 @@ _ReSharper*
 *userprefs
 *.nupkg
 
-TestResult.xml
+TestResult[s].xml
 submit.xml
 SolutionVersion.cs
 SolutionVersion.vb

--- a/nuspec/chocolatey/chocolatey/chocolatey.nuspec
+++ b/nuspec/chocolatey/chocolatey/chocolatey.nuspec
@@ -39,7 +39,7 @@ There are quite a few commands you can call - you should check out the [command 
 
 - Help - choco -? or choco command -?
 - Search - choco search something
-- List - choco list -lo
+- List - choco list
 - Config - choco config list
 - Install - choco install baretail
 - Pin - choco pin windirstat

--- a/nuspec/chocolatey/chocolatey/tools/chocolateysetup.psm1
+++ b/nuspec/chocolatey/chocolatey/tools/chocolateysetup.psm1
@@ -208,9 +208,9 @@ You need to restart this machine prior to using choco.
     } else {
         @"
 Chocolatey CLI (choco.exe) is now ready.
-You can call choco from anywhere, command line or powershell by typing choco.
+You can call choco from anywhere, command line or PowerShell by typing choco.
 Run choco /? for a list of functions.
-You may need to shut down and restart powershell and/or consoles
+You may need to shut down and restart PowerShell and/or consoles
  first prior to using choco.
 "@ | Write-Output
     }

--- a/nuspec/chocolatey/chocolatey/tools/init.ps1
+++ b/nuspec/chocolatey/chocolatey/tools/init.ps1
@@ -1,4 +1,4 @@
-﻿param($installPath, $toolsPath, $package, $project)
+param($installPath, $toolsPath, $package, $project)
 
 $modules = Get-ChildItem $ToolsPath -Filter *.psm1
 $modules | ForEach-Object { Import-Module -Name  $_.FullName }
@@ -8,7 +8,7 @@ $modules | ForEach-Object { Import-Module -Name  $_.FullName }
 Chocolatey
 ========================
 Welcome to Chocolatey, your local machine repository built on the NuGet infrastructure. Chocolatey allows you to install application packages to your machine with the goodness of a #chocolatey #nuget combo.
-Application executables get added to the path automatically so you can call them from anywhere (command line/powershell prompt), not just in Visual Studio.
+Application executables get added to the path automatically so you can call them from anywhere (command line/PowerShell prompt), not just in Visual Studio.
 
 Lets get Chocolatey!
 ----------

--- a/tests/Vagrantfile
+++ b/tests/Vagrantfile
@@ -2,7 +2,7 @@
 # vi: set ft=ruby :
 
 Vagrant.configure("2") do |config|
-  config.vm.box = "StefanScherer/windows_2022"
+  config.vm.box = "chocolatey/test-environment"
   # Set Hostname to prevent error messages. https://github.com/hashicorp/vagrant/issues/12644
   config.vm.hostname = 'chocolatey-tests'
   config.vm.boot_timeout = 600
@@ -84,5 +84,6 @@ Vagrant.configure("2") do |config|
     # This will allow to rerun tests without packaging each time.
     ./Invoke-Tests.ps1 -SkipPackaging
     Copy-Item $env:ALLUSERSPROFILE/chocolatey/logs/testInvocations.log C:/vagrant
+    Copy-Item ./tests/testResults.xml C:/vagrant
   SHELL
 end

--- a/tests/pester-tests/commands/choco-upgrade.Tests.ps1
+++ b/tests/pester-tests/commands/choco-upgrade.Tests.ps1
@@ -165,7 +165,8 @@
             $null = Invoke-Choco install wget
             $null = Invoke-Choco install curl
 
-            $Output = Invoke-Choco upgrade all
+            # Exclude packages not involved in these tests to ensure that they don't report false positives
+            $Output = Invoke-Choco upgrade all --except="chocolatey,chocolatey.extension,chocolatey-agent,pester,chocolatey-license-business"
         }
 
         It 'Exits with Success (0)' {

--- a/tests/pester-tests/powershell-commands/Get-EnvironmentVariableNames.Tests.ps1
+++ b/tests/pester-tests/powershell-commands/Get-EnvironmentVariableNames.Tests.ps1
@@ -11,9 +11,9 @@ Describe 'Get-EnvironmentVariable helper function tests' -Tags Cmdlets {
         @{ Scope = 'User' }
         @{ Scope = 'Machine' }
     ) {
-        It 'Gets the complete list of environment variables in the <Scope> scope"' -ForEach $variables {
-            $expectedValue = [Environment]::GetEnvironmentVariables($Scope).Keys
-            Get-EnvironmentVariableNames -Scope $Scope | Should -Be $expectedValue
+        It 'Gets the complete list of environment variables in the <Scope> scope"' {
+            $expectedValue = [Environment]::GetEnvironmentVariables($Scope).Keys | Sort-Object
+            Get-EnvironmentVariableNames -Scope $Scope | Sort-Object | Should -Be $expectedValue
         }
     }
 }


### PR DESCRIPTION
## Description Of Changes

1. Remove the mention of `choco list -lo` from the NuSpec file.
2. Update an `upgrade all` test to ensure that it does not report failure if a newer Chocolatey version is available on internal repositories.
3. Use `PowerShell` instead of `powershell`.
4. Fix `Get-EnvironmentVariableNames` tests to run.
5. Update Vagrant box used for building and running tests to use the `chocolatey/test-environment` box.

## Motivation and Context

1. Local Only on the `list` command was removed in 2.0, and is an error now.
2. When tests are running as we come up towards a release, we end up with reports of failures of the upgrade all command because for instance it will be testing version `2.4.1-beta-20241204`, but because of the way the builds work, CI will have build and published to our repository version `2.5.0-alpha-20241204` which is deemed an upgrade for the pre-release version being tested.
3. The correct casing is PowerShell.
4. Due to a misconfiguration, these tests were not running, and would start failing in Pester 6.x.
5. The previous box hasn't been updated for several years. We also encourage testing on the `chocolatey/test-environment` box, so running out tests on it makes sense.

## Testing

- Run through Test Kitchen
- Run tests through `vagrant up` in the `tests` directory. (There are some known failures here, the important thing is that the majority of them run successfully)

### Operating Systems Testing

- Windows Server 2016
- Windows Server 2019
- Windows Server 2022

## Change Types Made

* [ ] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.
* [x] Pester test changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [x] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v3 compatibility checked?

## Related Issue

N/A - These are things that I found doing the recent 2.4.1 release.