### PR TITLE
(#3603) Don't allow trace logging when no elevated

### DIFF
--- a/src/chocolatey.console/Program.cs
+++ b/src/chocolatey.console/Program.cs
@@ -142,7 +142,23 @@ namespace chocolatey.console
                 var traceAppenderName = "{0}LoggingColoredConsoleAppender".format_with(ChocolateyLoggers.Trace.to_string());
                 Log4NetAppenderConfiguration.set_logging_level_debug_when_debug(config.Debug, verboseAppenderName, traceAppenderName);
                 Log4NetAppenderConfiguration.set_verbose_logger_when_verbose(config.Verbose, config.Debug, verboseAppenderName);
-                Log4NetAppenderConfiguration.set_trace_logger_when_trace(config.Trace, traceAppenderName);
+                
+                if (config.Information.IsProcessElevated)
+                {
+                    Log4NetAppenderConfiguration.set_trace_logger_when_trace(config.Trace, traceAppenderName);
+                }
+                else
+                {
+                    var logger = ChocolateyLoggers.Normal;
+
+                    if (!config.RegularOutput)
+                    {
+                        logger = ChocolateyLoggers.LogFileOnly;
+                    }
+
+                    "chocolatey".Log().Warn(logger, "Usage of the --trace option is only allowed when running from an elevated session.");
+                }
+
                 "chocolatey".Log().Debug(() => "{0} is running on {1} v {2}".format_with(ApplicationParameters.Name, config.Information.PlatformType, config.Information.PlatformVersion.to_string()));
                 //"chocolatey".Log().Debug(() => "Command Line: {0}".format_with(Environment.CommandLine));
 

--- a/src/chocolatey/GetChocolatey.cs
+++ b/src/chocolatey/GetChocolatey.cs
@@ -446,7 +446,22 @@ namespace chocolatey
                 var traceAppenderName = "{0}LoggingColoredConsoleAppender".format_with(ChocolateyLoggers.Trace.to_string());
                 Log4NetAppenderConfiguration.set_logging_level_debug_when_debug(configuration.Debug, verboseAppenderName, traceAppenderName);
                 Log4NetAppenderConfiguration.set_verbose_logger_when_verbose(configuration.Verbose, configuration.Debug, verboseAppenderName);
-                Log4NetAppenderConfiguration.set_trace_logger_when_trace(configuration.Trace, traceAppenderName);
+
+                if (configuration.Information.IsProcessElevated)
+                {
+                    Log4NetAppenderConfiguration.set_trace_logger_when_trace(configuration.Trace, traceAppenderName);
+                }
+                else
+                {
+                    var logger = ChocolateyLoggers.Normal;
+
+                    if (!configuration.RegularOutput)
+                    {
+                        logger = ChocolateyLoggers.LogFileOnly;
+                    }
+
+                    "chocolatey".Log().Warn(logger, "Usage of the --trace option is only allowed when running from an elevated session.");
+                }
             }
             finally
             {


### PR DESCRIPTION
## Description Of Changes

When an attempt is made to use trace logging in a non-elevated session, a warning will be shown, and no trace logging will be shown.  In addition, if the -r option is in play, the warning about no trace logging will go to the log file, but won't be displayed.

## Motivation and Context

Prior to this change, trace level logging was available to everyone. However, due to the sensitive nature of some of the output, the decision has been taken to restrict trace logging to only elevated sessions.

## Testing

1. Run `choco search --trace` as an administrator - see the trace logging displayed
2. Run `choco search --trace` as a non-administrator - see a warning about not using --trace and no trace logging
3. Run `choco search --trace -r` as a non-administrator - see that there isn't a warning and also no trace logging, check the log file, and find the warning still in place

### Operating Systems Testing

- Windows 11

## Change Types Made

* [x] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [x] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v3 compatibility checked?

## Related Issue

Fixes #3603