### PR TITLE
(build) Update GHA to pin ubuntu version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   # Build using mono on Ubuntu
   ubuntu-build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
       with:


### PR DESCRIPTION
## Description Of Changes

Update GitHub Actions to use `ubuntu-22.04` so they have access to `mono`

## Motivation and Context

`mono` is not available on `ubuntu-latest` and this is causing our GitHub Actions to fail.

## Testing

This PR should have all of the GitHub Actions pass.

### Operating Systems Testing

N/A

## Change Types Made

* [ ] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.
* [x] Build Automation

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [ ] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v3 compatibility checked?

## Related Issue

* Fixes #3607 
