### PR TITLE
(#3613) Add source uri override for download uris

### DIFF
--- a/src/chocolatey/chocolatey.csproj
+++ b/src/chocolatey/chocolatey.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -135,6 +135,7 @@
     <Compile Include="infrastructure.app\commands\ChocolateyExportCommand.cs" />
     <Compile Include="infrastructure.app\commands\ChocolateyInfoCommand.cs" />
     <Compile Include="infrastructure.app\commands\ChocolateyHelpCommand.cs" />
+    <Compile Include="infrastructure.app\nuget\ChocolateyPackageDownloader.cs" />
     <Compile Include="infrastructure.app\registration\ChocolateyRegistrationModule.cs" />
     <Compile Include="infrastructure.app\registration\IContainerRegistrator.cs" />
     <Compile Include="infrastructure.app\registration\IContainerResolver.cs" />

--- a/src/chocolatey/infrastructure.app/commands/ChocolateyPinCommand.cs
+++ b/src/chocolatey/infrastructure.app/commands/ChocolateyPinCommand.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -146,7 +146,7 @@ If you find other exit codes that we have not yet documented, please
         public virtual void run(ChocolateyConfiguration configuration)
         {
             var packageManager = NugetCommon.GetPackageManager(configuration, _nugetLogger,
-                                                               new PackageDownloader(),
+                                                               new ChocolateyPackageDownloader(),
                                                                installSuccessAction: null,
                                                                uninstallSuccessAction: null,
                                                                addUninstallHandler: false);

--- a/src/chocolatey/infrastructure.app/nuget/ChocolateyPackageDownloader.cs
+++ b/src/chocolatey/infrastructure.app/nuget/ChocolateyPackageDownloader.cs
@@ -1,0 +1,39 @@
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
+// Copyright © 2011 - 2017 RealDimensions Software, LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace chocolatey.infrastructure.app.nuget
+{
+    using System;
+    using System.IO;
+    using NuGet;
+
+    internal class ChocolateyPackageDownloader : PackageDownloader
+    {
+        public override void DownloadPackage(Uri uri, IPackageMetadata package, Stream targetStream)
+        {
+            ChocolateyNugetCredentialProvider.add_download_url_from_package(package);
+
+            base.DownloadPackage(uri, package, targetStream);
+        }
+
+        public override void DownloadPackage(IHttpClient downloadClient, IPackageName package, Stream targetStream)
+        {
+            ChocolateyNugetCredentialProvider.add_download_url_from_package(package);
+
+            base.DownloadPackage(downloadClient, package, targetStream);
+        }
+    }
+}

--- a/src/chocolatey/infrastructure.app/nuget/NugetCommon.cs
+++ b/src/chocolatey/infrastructure.app/nuget/NugetCommon.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -173,7 +173,7 @@ namespace chocolatey.infrastructure.app.nuget
         // keep this here for the licensed edition for now
         public static IPackageManager GetPackageManager(ChocolateyConfiguration configuration, ILogger nugetLogger, Action<PackageOperationEventArgs> installSuccessAction, Action<PackageOperationEventArgs> uninstallSuccessAction, bool addUninstallHandler)
         {
-            return GetPackageManager(configuration, nugetLogger, new PackageDownloader(), installSuccessAction, uninstallSuccessAction, addUninstallHandler);
+            return GetPackageManager(configuration, nugetLogger, new ChocolateyPackageDownloader(), installSuccessAction, uninstallSuccessAction, addUninstallHandler);
         }
 
         public static IPackageManager GetPackageManager(ChocolateyConfiguration configuration, ILogger nugetLogger, IPackageDownloader packageDownloader, Action<PackageOperationEventArgs> installSuccessAction, Action<PackageOperationEventArgs> uninstallSuccessAction, bool addUninstallHandler)

--- a/src/chocolatey/infrastructure.app/nuget/NugetList.cs
+++ b/src/chocolatey/infrastructure.app/nuget/NugetList.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -40,7 +40,7 @@ namespace chocolatey.infrastructure.app.nuget
 
         private static IQueryable<IPackage> execute_package_search(ChocolateyConfiguration configuration, ILogger nugetLogger)
         {
-            var packageRepository = NugetCommon.GetRemoteRepository(configuration, nugetLogger, new PackageDownloader());
+            var packageRepository = NugetCommon.GetRemoteRepository(configuration, nugetLogger, new ChocolateyPackageDownloader());
             var searchTermLower = configuration.Input.to_lower();
 
             // Whether or not the package is remote determines two things:

--- a/src/chocolatey/infrastructure.app/registration/ChocolateyRegistrationModule.cs
+++ b/src/chocolatey/infrastructure.app/registration/ChocolateyRegistrationModule.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2022 Chocolatey Software, Inc
+// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -44,7 +44,7 @@ namespace chocolatey.infrastructure.app.registration
             //nuget
             registrator.register_service<ILogger, ChocolateyNugetLogger>();
             registrator.register_service<INugetService, NugetService>();
-            registrator.register_service<IPackageDownloader, PackageDownloader>();
+            registrator.register_service<IPackageDownloader, ChocolateyPackageDownloader>();
             registrator.register_service<IPowershellService, PowershellService>();
             registrator.register_service<IChocolateyPackageInformationService, ChocolateyPackageInformationService>();
             registrator.register_service<IShimGenerationService, ShimGenerationService>();

--- a/src/chocolatey/infrastructure.app/services/TemplateService.cs
+++ b/src/chocolatey/infrastructure.app/services/TemplateService.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -221,7 +221,7 @@ namespace chocolatey.infrastructure.app.services
         public void list(ChocolateyConfiguration configuration)
         {
             var packageManager = NugetCommon.GetPackageManager(configuration, _nugetLogger,
-                new PackageDownloader(),
+                new ChocolateyPackageDownloader(),
                 installSuccessAction: null,
                 uninstallSuccessAction: null,
                 addUninstallHandler: false);


### PR DESCRIPTION
## Description Of Changes

This adds a new Package Downloader class and have it call a resolve
redirection for download URIs to the original source URI.

This allows the same credentials to be used for the download URI as with
the source URI when the server is configured to store binary files in
a different location.

## Motivation and Context

Without this change, it makes it impossible to install packages that have a download location that do not have the source URI as its prefix.

## Testing

1. Install a package from the following location. CCR, Licensed Feed, Nexus Feed and ProGet feed, local package directory and a remote package directory.
2. Install another package, that have one or more dependencies with the above feed types.

### Operating Systems Testing

- Windows 10

## Change Types Made

* [x] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [ ] All new and existing tests passed? (_A few failures locally, but these have been seen before and only on my VM_)
* [ ] PowerShell code changes: PowerShell v3 compatibility checked?

## Related Issue

- Fixes #3613