### PR TITLE
(maint) Update version for upload-artifact

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
         chmod +x build.sh
         $GITHUB_WORKSPACE//build.sh --verbosity=diagnostic --target=CI --testExecutionType=unit
     - name: Upload Ubuntu build results
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       # Always upload build results
       if: ${{ always() }}
       with:
@@ -52,7 +52,7 @@ jobs:
       shell: powershell
       run: ./build.ps1 --verbosity=diagnostic --target=CI --testExecutionType=unit --shouldRunOpenCover=false --shouldBuildMsi=true
     - name: Upload Windows build results
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       # Always upload build results
       if: ${{ always() }}
       with:
@@ -92,7 +92,7 @@ jobs:
         chmod +x build.sh
         $GITHUB_WORKSPACE//build.sh --verbosity=diagnostic --target=CI --testExecutionType=unit
     - name: Upload MacOS build results
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       # Always upload build results
       if: ${{ always() }}
       with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ jobs:
         chmod +x build.sh
         $GITHUB_WORKSPACE//build.sh --verbosity=diagnostic --target=test --testExecutionType=all
     - name: Upload Ubuntu build results
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       # Always upload build results
       if: ${{ always() }}
       with:
@@ -50,7 +50,7 @@ jobs:
     - name: Test with NUnit on .Net Framework
       run: .\build.bat  --verbosity=diagnostic --target=test --testExecutionType=all --shouldRunOpenCover=false
     - name: Upload Windows build results
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       # Always upload build results
       if: ${{ always() }}
       with:
@@ -78,7 +78,7 @@ jobs:
           chmod +x build.sh
           $GITHUB_WORKSPACE//build.sh --verbosity=diagnostic --target=test --testExecutionType=all
     - name: Upload MacOS build results
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       # Always upload build results
       if: ${{ always() }}
       with:


### PR DESCRIPTION
## Description Of Changes

This updates the version used in the GitHub workflows to be a version
of upload-artifact that does not throw an exception.

## Motivation and Context

The current version we are using started throwing an exception yesterday
due to it no longer being recommended to be used.

So to be able to continue building through the GitHub workflows, we must update this dependency.

## Testing

N/A

### Operating Systems Testing

N/A

## Change Types Made
<!-- Tick the boxes for the type of changes that have been made -->

* [x] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [ ] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v3 compatibility checked?

## Related Issue

N/A