### PR TITLE
(maint) Remove unused dependency

### DIFF
--- a/src/chocolatey.tests.integration/chocolatey.tests.integration.csproj
+++ b/src/chocolatey.tests.integration/chocolatey.tests.integration.csproj
@@ -377,9 +377,6 @@
     <Reference Include="System.IO.Pipelines, Version=4.0.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\System.IO.Pipelines.4.5.3\lib\netstandard2.0\System.IO.Pipelines.dll</HintPath>
     </Reference>
-    <Reference Include="System.Linq.Dynamic.Core, Version=1.3.12.0, Culture=neutral, PublicKeyToken=0f07ec44de6ac832, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Linq.Dynamic.Core.1.3.12\lib\net46\System.Linq.Dynamic.Core.dll</HintPath>
-    </Reference>
     <Reference Include="System.Memory, Version=4.0.1.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Memory.4.5.4\lib\net461\System.Memory.dll</HintPath>
     </Reference>

--- a/src/chocolatey.tests.integration/packages.config
+++ b/src/chocolatey.tests.integration/packages.config
@@ -155,7 +155,6 @@
   <package id="System.Diagnostics.DiagnosticSource" version="4.5.0" targetFramework="net48" />
   <package id="System.IdentityModel.Tokens.Jwt" version="6.34.0" targetFramework="net48" />
   <package id="System.IO.Pipelines" version="4.5.3" targetFramework="net48" />
-  <package id="System.Linq.Dynamic.Core" version="1.3.12" targetFramework="net48" />
   <package id="System.Memory" version="4.5.4" targetFramework="net48" />
   <package id="System.Numerics.Vectors" version="4.5.0" targetFramework="net48" />
   <package id="System.Reactive" version="5.0.0" targetFramework="net48" />


### PR DESCRIPTION
## Description Of Changes

The System.Linq.Dynamic.Core package is actually not being used, so it is safe to remove from the project.

## Motivation and Context

This came up as a Depdendabot security report, which prompted us to check whether this was being used.  When it was found that it isn't, the decision was made to remove it, rather than updating it.

## Testing

Run full suite of integration tests.

### Operating Systems Testing

N/A

## Change Types Made

* [ ] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.
* [x] Dependency change.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [x] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v3 compatibility checked?

## Related Issue

N/A