### PR TITLE
(#3621) Skip trace warning when trace not used

### DIFF
--- a/recipe.cake
+++ b/recipe.cake
@@ -1,4 +1,4 @@
-#load nuget:?package=Chocolatey.Cake.Recipe&version=0.28.4
+#load nuget:?package=Chocolatey.Cake.Recipe&version=0.29.0
 
 ///////////////////////////////////////////////////////////////////////////////
 // TOOLS

--- a/src/chocolatey.console/Program.cs
+++ b/src/chocolatey.console/Program.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2022 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -147,7 +147,7 @@ namespace chocolatey.console
                 {
                     Log4NetAppenderConfiguration.set_trace_logger_when_trace(config.Trace, traceAppenderName);
                 }
-                else
+                else if (config.Trace)
                 {
                     var logger = ChocolateyLoggers.Normal;
 

--- a/src/chocolatey/GetChocolatey.cs
+++ b/src/chocolatey/GetChocolatey.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2022 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -451,7 +451,7 @@ namespace chocolatey
                 {
                     Log4NetAppenderConfiguration.set_trace_logger_when_trace(configuration.Trace, traceAppenderName);
                 }
-                else
+                else if (configuration.Trace)
                 {
                     var logger = ChocolateyLoggers.Normal;
 


### PR DESCRIPTION
## Description Of Changes

This updates the warning that is outputted in non-elevated mode to not
be outputted when the user has not specified `--trace` on the
commandline.

## Motivation and Context

Without this change, any time a use are running in a non-elevated mode,
they will always have the trace warning outputted even when they haven't
used the argument.

## Testing

Do the following tests in a non-elevated window.

1. Run `choco search chocolatey` (or any other command not requiring admin privileges).
2. Ensure that the warning about `--trace` not being supported are not shown.
3. Run the same command again and specify `--trace` .
4. Ensure that the warning about `--trace` are now outputted.

In an admin window repeat the above tests, verifying that the trace warning is not outputted.

### Operating Systems Testing

- Windows 10

## Change Types Made

* [x] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added. (_No relevant tests to add_)
* [x] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v3 compatibility checked?

## Related Issue

Fixes #3621
