### PR TITLE
(maint) Exclude support branches to branch filters

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -39,6 +39,7 @@ object Chocolatey : BuildType({
 
         branchFilter = """
             +:*
+            -:support/*
         """.trimIndent()
     }
 

--- a/recipe.cake
+++ b/recipe.cake
@@ -1,4 +1,4 @@
-#load nuget:?package=Chocolatey.Cake.Recipe&version=0.28.4
+#load nuget:?package=Chocolatey.Cake.Recipe&version=0.29.0
 #tool nuget:?package=WiX&version=3.11.2
 
 ///////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
## Description Of Changes

This updates the branch filter for the normal Chocolatey build to
exclude any support branches from being built by our internal build
server.

## Motivation and Context

We do not want support branches to build directly when they are not tagged, similar to how we are expecting builds to happen for the master branch.

## Testing

N/A, can this be tested?

### Operating Systems Testing

N/A

## Change Types Made
<!-- Tick the boxes for the type of changes that have been made -->

* [ ] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [ ] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v3 compatibility checked?

## Related Issue

N/A