### PR TITLE
(maint) Update file license headers

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -478,3 +478,5 @@ e9515c247972ecf22ece68e080ae96ef0e8ebd6c
 #(maint) formatting 
 f6393c625416250e87294bb4f20b94495a1ed923
 
+#(maint) Update file license headers
+b8f37f3f0da4ec1b1d4675e0526fdfd7c6c4f645

--- a/src/Chocolatey.PowerShell/Commands/GetEnvironmentVariableCommand.cs
+++ b/src/Chocolatey.PowerShell/Commands/GetEnvironmentVariableCommand.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2024 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/Chocolatey.PowerShell/Commands/GetEnvironmentVariableNamesCommand.cs
+++ b/src/Chocolatey.PowerShell/Commands/GetEnvironmentVariableNamesCommand.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2024 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/Chocolatey.PowerShell/Commands/InstallChocolateyPathCommand.cs
+++ b/src/Chocolatey.PowerShell/Commands/InstallChocolateyPathCommand.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2024 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/Chocolatey.PowerShell/Commands/SetEnvironmentVariableCommand.cs
+++ b/src/Chocolatey.PowerShell/Commands/SetEnvironmentVariableCommand.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2024 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/Chocolatey.PowerShell/Commands/TestProcessAdminRightsCommand.cs
+++ b/src/Chocolatey.PowerShell/Commands/TestProcessAdminRightsCommand.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2024 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/Chocolatey.PowerShell/Commands/UninstallChocolateyPathCommand.cs
+++ b/src/Chocolatey.PowerShell/Commands/UninstallChocolateyPathCommand.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2024 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/Chocolatey.PowerShell/Commands/UpdateSessionEnvironmentCommand.cs
+++ b/src/Chocolatey.PowerShell/Commands/UpdateSessionEnvironmentCommand.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2024 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/Chocolatey.PowerShell/Helpers/Elevation.cs
+++ b/src/Chocolatey.PowerShell/Helpers/Elevation.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2024 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/Chocolatey.PowerShell/Helpers/EnvironmentHelper.cs
+++ b/src/Chocolatey.PowerShell/Helpers/EnvironmentHelper.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2024 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -37,7 +37,7 @@ namespace Chocolatey.PowerShell.Helpers
         /// <param name="scope">The scope to look in for the environment variable.</param>
         /// <returns>The value of the environment variable as a string.</returns>
         public static string GetVariable(PSCmdlet cmdlet, string name, EnvironmentVariableTarget scope)
-        { 
+        {
             return GetVariable(cmdlet, name, scope, preserveVariables: false);
         }
 

--- a/src/Chocolatey.PowerShell/Helpers/PSHelper.cs
+++ b/src/Chocolatey.PowerShell/Helpers/PSHelper.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2024 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/Chocolatey.PowerShell/Helpers/Paths.cs
+++ b/src/Chocolatey.PowerShell/Helpers/Paths.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2024 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/Chocolatey.PowerShell/Helpers/ProcessInformation.cs
+++ b/src/Chocolatey.PowerShell/Helpers/ProcessInformation.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2024 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/Chocolatey.PowerShell/Properties/AssemblyInfo.cs
+++ b/src/Chocolatey.PowerShell/Properties/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2024 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/Chocolatey.PowerShell/Shared/ChocolateyCmdlet.cs
+++ b/src/Chocolatey.PowerShell/Shared/ChocolateyCmdlet.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2024 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/Chocolatey.PowerShell/Shared/EnvironmentVariables.cs
+++ b/src/Chocolatey.PowerShell/Shared/EnvironmentVariables.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2024 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/Chocolatey.PowerShell/Win32/NativeMethods.cs
+++ b/src/Chocolatey.PowerShell/Win32/NativeMethods.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2024 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey.benchmark/BenchmarkConfig.cs
+++ b/src/chocolatey.benchmark/BenchmarkConfig.cs
@@ -1,4 +1,20 @@
-﻿using System;
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
+// Copyright © 2011 - 2017 RealDimensions Software, LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/chocolatey.benchmark/ParentProcessBenchmarks.cs
+++ b/src/chocolatey.benchmark/ParentProcessBenchmarks.cs
@@ -1,4 +1,20 @@
-﻿using System.Runtime.CompilerServices;
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
+// Copyright © 2011 - 2017 RealDimensions Software, LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Runtime.CompilerServices;
 using BenchmarkDotNet.Attributes;
 using chocolatey.benchmark.helpers;
 using chocolatey.infrastructure.information;

--- a/src/chocolatey.benchmark/ProcessTreeBenchmark.cs
+++ b/src/chocolatey.benchmark/ProcessTreeBenchmark.cs
@@ -1,4 +1,20 @@
-﻿using System;
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
+// Copyright © 2011 - 2017 RealDimensions Software, LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;

--- a/src/chocolatey.benchmark/Program.cs
+++ b/src/chocolatey.benchmark/Program.cs
@@ -1,4 +1,20 @@
-﻿using System.Linq;
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
+// Copyright © 2011 - 2017 RealDimensions Software, LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Linq;
 using BenchmarkDotNet.Running;
 
 namespace chocolatey.benchmark

--- a/src/chocolatey.benchmark/Properties/AssemblyInfo.cs
+++ b/src/chocolatey.benchmark/Properties/AssemblyInfo.cs
@@ -1,4 +1,20 @@
-﻿using System.Reflection;
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
+// Copyright © 2011 - 2017 RealDimensions Software, LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 

--- a/src/chocolatey.benchmark/helpers/ManagedProcessHelper.cs
+++ b/src/chocolatey.benchmark/helpers/ManagedProcessHelper.cs
@@ -1,4 +1,20 @@
-﻿using System;
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
+// Copyright © 2011 - 2017 RealDimensions Software, LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
 using System.Diagnostics;
 using System.Linq;
 using chocolatey.infrastructure.information;
@@ -47,7 +63,7 @@ namespace chocolatey.benchmark.helpers
                 }
 
                 var foundProcess = FindPidFromIndexedProcessName(processName);
-                
+
                 if (foundProcess == null)
                 {
                     break;

--- a/src/chocolatey.benchmark/helpers/PinvokeProcessHelper.cs
+++ b/src/chocolatey.benchmark/helpers/PinvokeProcessHelper.cs
@@ -1,4 +1,20 @@
-﻿using System;
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
+// Copyright © 2011 - 2017 RealDimensions Software, LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Linq;

--- a/src/chocolatey.console/Program.cs
+++ b/src/chocolatey.console/Program.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2023 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -161,7 +161,7 @@ namespace chocolatey.console
 
                     "chocolatey".Log().Warn(logger, "Usage of the --trace option is only allowed when running from an elevated session.");
                 }
-                
+
                 "chocolatey".Log().Debug(() => "{0} is running on {1} v {2}".FormatWith(ApplicationParameters.Name, config.Information.PlatformType, config.Information.PlatformVersion.ToStringSafe()));
                 //"chocolatey".Log().Debug(() => "Command Line: {0}".FormatWith(Environment.CommandLine));
 

--- a/src/chocolatey.console/Properties/AssemblyInfo.cs
+++ b/src/chocolatey.console/Properties/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey.resources/ChocolateyResourcesAssembly.cs
+++ b/src/chocolatey.resources/ChocolateyResourcesAssembly.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey.resources/Properties/AssemblyInfo.cs
+++ b/src/chocolatey.resources/Properties/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey.tests.integration/MockEventSubscriptionManager.cs
+++ b/src/chocolatey.tests.integration/MockEventSubscriptionManager.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey.tests.integration/NUnitSetup.cs
+++ b/src/chocolatey.tests.integration/NUnitSetup.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey.tests.integration/Properties/AssemblyInfo.cs
+++ b/src/chocolatey.tests.integration/Properties/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey.tests.integration/Scenario.cs
+++ b/src/chocolatey.tests.integration/Scenario.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey.tests.integration/TODO.cs
+++ b/src/chocolatey.tests.integration/TODO.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey.tests.integration/infrastructure.app/builders/ConfigurationBuilderSpecs.cs
+++ b/src/chocolatey.tests.integration/infrastructure.app/builders/ConfigurationBuilderSpecs.cs
@@ -1,4 +1,4 @@
-// Copyright © 2017 - 2023 Chocolatey Software, Inc
+// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey.tests.integration/infrastructure.app/nuget/NugetListSpecs.cs
+++ b/src/chocolatey.tests.integration/infrastructure.app/nuget/NugetListSpecs.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2024 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey.tests.integration/infrastructure.app/services/FilesServiceSpecs.cs
+++ b/src/chocolatey.tests.integration/infrastructure.app/services/FilesServiceSpecs.cs
@@ -1,4 +1,4 @@
-// Copyright © 2017 - 2021 Chocolatey Software, Inc
+// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey.tests.integration/infrastructure/commands/CommandExecutorSpecs.cs
+++ b/src/chocolatey.tests.integration/infrastructure/commands/CommandExecutorSpecs.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey.tests.integration/infrastructure/cryptography/CryptoHashProviderSpecs.cs
+++ b/src/chocolatey.tests.integration/infrastructure/cryptography/CryptoHashProviderSpecs.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey.tests.integration/infrastructure/filesystem/DotNetFileSystemSpecs.cs
+++ b/src/chocolatey.tests.integration/infrastructure/filesystem/DotNetFileSystemSpecs.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey.tests.integration/scenarios/InfoScenarios.cs
+++ b/src/chocolatey.tests.integration/scenarios/InfoScenarios.cs
@@ -1,3 +1,19 @@
+// Copyright © 2017 - 2025 Chocolatey Software, Inc
+// Copyright © 2011 - 2017 RealDimensions Software, LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 using System;
 using System.Collections.Generic;
 using System.IO;

--- a/src/chocolatey.tests.integration/scenarios/InstallScenarios.cs
+++ b/src/chocolatey.tests.integration/scenarios/InstallScenarios.cs
@@ -1,4 +1,4 @@
-// Copyright © 2017 - 2021 Chocolatey Software, Inc
+// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -344,9 +344,9 @@ namespace chocolatey.tests.integration.scenarios
             [Platform(Exclude = "Mono")]
             public void Should_contain_message_with_download_uri()
             {
-                var packagePath = "file:///{0}/{1}.{2}{3}".FormatWith(Configuration.Sources.Replace("\\","/"), Configuration.PackageNames,
+                var packagePath = "file:///{0}/{1}.{2}{3}".FormatWith(Configuration.Sources.Replace("\\", "/"), Configuration.PackageNames,
                     TestVersion(), NuGetConstants.PackageExtension);
-               var message = "Package download location '{0}'".FormatWith(packagePath);
+                var message = "Package download location '{0}'".FormatWith(packagePath);
 
                 MockLogger.Messages.Should().ContainKey(LogLevel.Debug.ToString()).WhoseValue.Should()
                     .Contain(message);

--- a/src/chocolatey.tests.integration/scenarios/ListScenarios.cs
+++ b/src/chocolatey.tests.integration/scenarios/ListScenarios.cs
@@ -1,4 +1,5 @@
-// Copyright © 2023-Present Chocolatey Software, Inc
+// Copyright © 2017 - 2025 Chocolatey Software, Inc
+// Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/chocolatey.tests.integration/scenarios/PackScenarios.cs
+++ b/src/chocolatey.tests.integration/scenarios/PackScenarios.cs
@@ -1,4 +1,4 @@
-// Copyright © 2017 - 2021 Chocolatey Software, Inc
+// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey.tests.integration/scenarios/PinScenarios.cs
+++ b/src/chocolatey.tests.integration/scenarios/PinScenarios.cs
@@ -1,4 +1,4 @@
-// Copyright © 2017 - 2021 Chocolatey Software, Inc
+// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey.tests.integration/scenarios/SearchScenarios.cs
+++ b/src/chocolatey.tests.integration/scenarios/SearchScenarios.cs
@@ -1,4 +1,4 @@
-// Copyright © 2017 - Present Chocolatey Software, Inc
+// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey.tests.integration/scenarios/UninstallScenarios.cs
+++ b/src/chocolatey.tests.integration/scenarios/UninstallScenarios.cs
@@ -1,4 +1,4 @@
-// Copyright © 2017 - 2021 Chocolatey Software, Inc
+// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey.tests.integration/scenarios/UpgradeScenarios.cs
+++ b/src/chocolatey.tests.integration/scenarios/UpgradeScenarios.cs
@@ -1,4 +1,4 @@
-// Copyright © 2017 - 2021 Chocolatey Software, Inc
+// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -4245,7 +4245,7 @@ namespace chocolatey.tests.integration.scenarios
                     .WhoseValue.Should().NotContain(m => m.Contains("pre-beforemodify-all.ps1 hook ran for upgradepackage 1.1.0"));
             }
         }
-        
+
         public class When_upgrading_an_existing_package_with_uppercase_id : ScenariosBase
         {
             private PackageResult _packageResult;

--- a/src/chocolatey.tests/MockLogger.cs
+++ b/src/chocolatey.tests/MockLogger.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey.tests/Properties/AssemblyInfo.cs
+++ b/src/chocolatey.tests/Properties/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey.tests/TinySpec.cs
+++ b/src/chocolatey.tests/TinySpec.cs
@@ -1,20 +1,18 @@
-// ==============================================================================
+// Copyright © 2017 - 2025 Chocolatey Software, Inc
+// Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
-// Fervent Coder Copyright © 2011 - Released under the Apache 2.0 License
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
 //
-// Copyright 2007-2008 The Apache Software Foundation.
+// You may obtain a copy of the License at
 //
-// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
-// this file except in compliance with the License. You may obtain a copy of the
-// License at
+// 	http://www.apache.org/licenses/LICENSE-2.0
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software distributed
-// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
-// CONDITIONS OF ANY KIND, either express or implied. See the License for the
-// specific language governing permissions and limitations under the License.
-// ==============================================================================
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 using System;
 using NUnit.Framework;

--- a/src/chocolatey.tests/UNCHelper.cs
+++ b/src/chocolatey.tests/UNCHelper.cs
@@ -1,4 +1,20 @@
-﻿using System;
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
+// Copyright © 2011 - 2017 RealDimensions Software, LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
 using System.IO;
 using System.Net;
 

--- a/src/chocolatey.tests/infrastructure.app/attributes/CommandForAttributeSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/attributes/CommandForAttributeSpecs.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey.tests/infrastructure.app/commands/ChocolateyApiKeyCommandSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/commands/ChocolateyApiKeyCommandSpecs.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey.tests/infrastructure.app/commands/ChocolateyCacheCommandSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/commands/ChocolateyCacheCommandSpecs.cs
@@ -1,4 +1,20 @@
-﻿using chocolatey.infrastructure.app.attributes;
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
+// Copyright © 2011 - 2017 RealDimensions Software, LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using chocolatey.infrastructure.app.attributes;
 using System.Collections.Generic;
 using chocolatey.infrastructure.app.commands;
 using chocolatey.infrastructure.app.configuration;

--- a/src/chocolatey.tests/infrastructure.app/commands/ChocolateyConfigCommandSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/commands/ChocolateyConfigCommandSpecs.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey.tests/infrastructure.app/commands/ChocolateyExportCommandSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/commands/ChocolateyExportCommandSpecs.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey.tests/infrastructure.app/commands/ChocolateyFeatureCommandSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/commands/ChocolateyFeatureCommandSpecs.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey.tests/infrastructure.app/commands/ChocolateyHelpCommandSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/commands/ChocolateyHelpCommandSpecs.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey.tests/infrastructure.app/commands/ChocolateyInfoCommandSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/commands/ChocolateyInfoCommandSpecs.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey.tests/infrastructure.app/commands/ChocolateyInstallCommandSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/commands/ChocolateyInstallCommandSpecs.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey.tests/infrastructure.app/commands/ChocolateyListCommandSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/commands/ChocolateyListCommandSpecs.cs
@@ -1,4 +1,5 @@
-﻿// Copyright © 2023-Present Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
+// Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/chocolatey.tests/infrastructure.app/commands/ChocolateyNewCommandSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/commands/ChocolateyNewCommandSpecs.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey.tests/infrastructure.app/commands/ChocolateyOutdatedCommandSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/commands/ChocolateyOutdatedCommandSpecs.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey.tests/infrastructure.app/commands/ChocolateyPackCommandSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/commands/ChocolateyPackCommandSpecs.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey.tests/infrastructure.app/commands/ChocolateyPinCommandSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/commands/ChocolateyPinCommandSpecs.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey.tests/infrastructure.app/commands/ChocolateyPushCommandSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/commands/ChocolateyPushCommandSpecs.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey.tests/infrastructure.app/commands/ChocolateyRuleCommandSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/commands/ChocolateyRuleCommandSpecs.cs
@@ -1,4 +1,20 @@
-﻿using System;
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
+// Copyright © 2011 - 2017 RealDimensions Software, LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;

--- a/src/chocolatey.tests/infrastructure.app/commands/ChocolateySearchCommandSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/commands/ChocolateySearchCommandSpecs.cs
@@ -1,4 +1,4 @@
-// Copyright © 2017 - 2021 Chocolatey Software, Inc
+// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey.tests/infrastructure.app/commands/ChocolateySourceCommandSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/commands/ChocolateySourceCommandSpecs.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey.tests/infrastructure.app/commands/ChocolateyTemplateCommandSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/commands/ChocolateyTemplateCommandSpecs.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey.tests/infrastructure.app/commands/ChocolateyUninstallCommandSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/commands/ChocolateyUninstallCommandSpecs.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey.tests/infrastructure.app/commands/ChocolateyUnpackSelfCommandSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/commands/ChocolateyUnpackSelfCommandSpecs.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey.tests/infrastructure.app/commands/ChocolateyUpgradeCommandSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/commands/ChocolateyUpgradeCommandSpecs.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey.tests/infrastructure.app/configuration/ConfigurationOptionsSpec.cs
+++ b/src/chocolatey.tests/infrastructure.app/configuration/ConfigurationOptionsSpec.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey.tests/infrastructure.app/nuget/ChocolateyNuGetProjectContextSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/nuget/ChocolateyNuGetProjectContextSpecs.cs
@@ -1,4 +1,5 @@
-﻿// Copyright © 2022-Present Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
+// Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/chocolatey.tests/infrastructure.app/nuget/ChocolateyNugetCredentialProviderSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/nuget/ChocolateyNugetCredentialProviderSpecs.cs
@@ -1,3 +1,19 @@
+// Copyright © 2017 - 2025 Chocolatey Software, Inc
+// Copyright © 2011 - 2017 RealDimensions Software, LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/chocolatey.tests/infrastructure.app/nuget/ChocolateyNugetLoggerSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/nuget/ChocolateyNugetLoggerSpecs.cs
@@ -1,4 +1,5 @@
-﻿// Copyright © 2022-Present Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
+// Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/chocolatey.tests/infrastructure.app/nuget/NugetCommonSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/nuget/NugetCommonSpecs.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey.tests/infrastructure.app/services/AutomaticUninstallerServiceSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/services/AutomaticUninstallerServiceSpecs.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey.tests/infrastructure.app/services/ChocolateyConfigSettingsServiceSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/services/ChocolateyConfigSettingsServiceSpecs.cs
@@ -1,4 +1,20 @@
-﻿using System;
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
+// Copyright © 2011 - 2017 RealDimensions Software, LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using chocolatey.infrastructure.app;
@@ -1063,7 +1079,7 @@ namespace chocolatey.tests.integration.infrastructure.app.services
             }
         }
 
-        public class When_ChocolateyConfigSettingsService_EnableFeature_When_Feature_Already_Enabled: ChocolateyConfigSettingsServiceSpecsBase
+        public class When_ChocolateyConfigSettingsService_EnableFeature_When_Feature_Already_Enabled : ChocolateyConfigSettingsServiceSpecsBase
         {
             public override void Because()
             {

--- a/src/chocolatey.tests/infrastructure.app/services/ChocolateyPackageServiceSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/services/ChocolateyPackageServiceSpecs.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2023 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -396,7 +396,7 @@ namespace chocolatey.tests.infrastructure.app.services
                 Action = () => Service.Upgrade(Configuration);
                 Configuration.CommandName = "upgrade";
             }
-        }   
+        }
 
         public class When_ChocolateyPackageService_tries_to_upgrade_noop_nupkg_file : When_ChocolateyPackageService_tries_to_install_nupkg_file
         {
@@ -438,7 +438,7 @@ namespace chocolatey.tests.infrastructure.app.services
             [Fact]
             public void Should_Return_0_Exit_Code()
             {
-                using(new AssertionScope())
+                using (new AssertionScope())
                 {
                     MockLogger.Messages.Should().ContainKey("Warn").WhoseValue.Should().Contain(m => m.Contains("Chocolatey upgraded 0/1 packages."));
                     Environment.ExitCode.Should().Be(0);

--- a/src/chocolatey.tests/infrastructure.app/services/FilesServiceSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/services/FilesServiceSpecs.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey.tests/infrastructure.app/services/NugetServiceSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/services/NugetServiceSpecs.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey.tests/infrastructure.app/services/RegistryServiceSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/services/RegistryServiceSpecs.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey.tests/infrastructure.app/services/RulesServiceSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/services/RulesServiceSpecs.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey.tests/infrastructure.app/services/TemplateServiceSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/services/TemplateServiceSpecs.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey.tests/infrastructure.app/utility/ArgumentsUtilitySpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/utility/ArgumentsUtilitySpecs.cs
@@ -1,4 +1,20 @@
-﻿using chocolatey.infrastructure.app.utility;
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
+// Copyright © 2011 - 2017 RealDimensions Software, LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using chocolatey.infrastructure.app.utility;
 using NUnit.Framework;
 using FluentAssertions;
 

--- a/src/chocolatey.tests/infrastructure.app/utility/PackageUtilitySpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/utility/PackageUtilitySpecs.cs
@@ -1,4 +1,5 @@
-﻿// Copyright © 2021 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
+// Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/chocolatey.tests/infrastructure/commandline/InteractivePromptSpecs.cs
+++ b/src/chocolatey.tests/infrastructure/commandline/InteractivePromptSpecs.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey.tests/infrastructure/commands/CommandExecutorSpecs.cs
+++ b/src/chocolatey.tests/infrastructure/commands/CommandExecutorSpecs.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey.tests/infrastructure/commands/ExternalCommandArgsBuilderSpecs.cs
+++ b/src/chocolatey.tests/infrastructure/commands/ExternalCommandArgsBuilderSpecs.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey.tests/infrastructure/commands/PowershellExecutorSpecs.cs
+++ b/src/chocolatey.tests/infrastructure/commands/PowershellExecutorSpecs.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey.tests/infrastructure/configuration/ConfigSpecs.cs
+++ b/src/chocolatey.tests/infrastructure/configuration/ConfigSpecs.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey.tests/infrastructure/cryptography/CryptoHashProviderSpecs.cs
+++ b/src/chocolatey.tests/infrastructure/cryptography/CryptoHashProviderSpecs.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey.tests/infrastructure/events/EventSubscriptionManagerSpecs.cs
+++ b/src/chocolatey.tests/infrastructure/events/EventSubscriptionManagerSpecs.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey.tests/infrastructure/events/context/FakeEvent.cs
+++ b/src/chocolatey.tests/infrastructure/events/context/FakeEvent.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey.tests/infrastructure/events/context/FakeSubscriber.cs
+++ b/src/chocolatey.tests/infrastructure/events/context/FakeSubscriber.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey.tests/infrastructure/filesystem/DotNetFileSystemSpecs.cs
+++ b/src/chocolatey.tests/infrastructure/filesystem/DotNetFileSystemSpecs.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey.tests/infrastructure/guards/EnsureSpecs.cs
+++ b/src/chocolatey.tests/infrastructure/guards/EnsureSpecs.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey.tests/infrastructure/information/VersionInformationSpecs.cs
+++ b/src/chocolatey.tests/infrastructure/information/VersionInformationSpecs.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey.tests/infrastructure/platforms/PlatformSpecs.cs
+++ b/src/chocolatey.tests/infrastructure/platforms/PlatformSpecs.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey.tests/infrastructure/tokens/TokenReplacerSpecs.cs
+++ b/src/chocolatey.tests/infrastructure/tokens/TokenReplacerSpecs.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey.tests/infrastructure/tolerance/FaultToleranceSpecs.cs
+++ b/src/chocolatey.tests/infrastructure/tolerance/FaultToleranceSpecs.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/AssemblyExtensions.cs
+++ b/src/chocolatey/AssemblyExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2022 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/EnumExtensions.cs
+++ b/src/chocolatey/EnumExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/EnumerableExtensions.cs
+++ b/src/chocolatey/EnumerableExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/ExceptionExtensions.cs
+++ b/src/chocolatey/ExceptionExtensions.cs
@@ -1,4 +1,20 @@
-﻿using System;
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
+// Copyright © 2011 - 2017 RealDimensions Software, LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/chocolatey/FileSystemExtensions.cs
+++ b/src/chocolatey/FileSystemExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2022 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/GetChocolatey.cs
+++ b/src/chocolatey/GetChocolatey.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2022 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/ILogExtensions.cs
+++ b/src/chocolatey/ILogExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/LogExtensions.cs
+++ b/src/chocolatey/LogExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/NuGetVersionExtensions.cs
+++ b/src/chocolatey/NuGetVersionExtensions.cs
@@ -1,4 +1,5 @@
-﻿// Copyright © 2022-Present Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
+// Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/chocolatey/ObjectExtensions.cs
+++ b/src/chocolatey/ObjectExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/Properties/AssemblyInfo.cs
+++ b/src/chocolatey/Properties/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/RuleResultExtensions.cs
+++ b/src/chocolatey/RuleResultExtensions.cs
@@ -1,4 +1,5 @@
-﻿// Copyright © 2023-Present Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
+// Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/chocolatey/StringExtensions.cs
+++ b/src/chocolatey/StringExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/StringResources.cs
+++ b/src/chocolatey/StringResources.cs
@@ -1,4 +1,5 @@
-﻿// Copyright © 2023-Present Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
+// Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/chocolatey/TypeExtensions.cs
+++ b/src/chocolatey/TypeExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/ApplicationParameters.cs
+++ b/src/chocolatey/infrastructure.app/ApplicationParameters.cs
@@ -1,4 +1,4 @@
-// Copyright © 2017 - 2021 Chocolatey Software, Inc
+// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/attributes/CommandForAttribute.cs
+++ b/src/chocolatey/infrastructure.app/attributes/CommandForAttribute.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/attributes/MultiServiceAttribute.cs
+++ b/src/chocolatey/infrastructure.app/attributes/MultiServiceAttribute.cs
@@ -1,13 +1,13 @@
-﻿// Copyright © 2017 - 2022 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
-// 
+//
 // You may obtain a copy of the License at
-// 
+//
 // 	http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/chocolatey/infrastructure.app/builders/ConfigurationBuilder.cs
+++ b/src/chocolatey/infrastructure.app/builders/ConfigurationBuilder.cs
@@ -1,4 +1,4 @@
-// Copyright © 2017 - 2022 Chocolatey Software, Inc
+// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/commands/ChocolateyApiKeyCommand.cs
+++ b/src/chocolatey/infrastructure.app/commands/ChocolateyApiKeyCommand.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/commands/ChocolateyCacheCommand.cs
+++ b/src/chocolatey/infrastructure.app/commands/ChocolateyCacheCommand.cs
@@ -1,4 +1,5 @@
-﻿// Copyright © 2023 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
+// Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/chocolatey/infrastructure.app/commands/ChocolateyCommandBase.cs
+++ b/src/chocolatey/infrastructure.app/commands/ChocolateyCommandBase.cs
@@ -1,4 +1,5 @@
-﻿// Copyright © 2023 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
+// Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/chocolatey/infrastructure.app/commands/ChocolateyConfigCommand.cs
+++ b/src/chocolatey/infrastructure.app/commands/ChocolateyConfigCommand.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/commands/ChocolateyExportCommand.cs
+++ b/src/chocolatey/infrastructure.app/commands/ChocolateyExportCommand.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/commands/ChocolateyFeatureCommand.cs
+++ b/src/chocolatey/infrastructure.app/commands/ChocolateyFeatureCommand.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/commands/ChocolateyHelpCommand.cs
+++ b/src/chocolatey/infrastructure.app/commands/ChocolateyHelpCommand.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2022 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -6,7 +6,7 @@
 //
 // You may obtain a copy of the License at
 //
-//  http://www.apache.org/licenses/LICENSE-2.0
+// 	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/chocolatey/infrastructure.app/commands/ChocolateyInfoCommand.cs
+++ b/src/chocolatey/infrastructure.app/commands/ChocolateyInfoCommand.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/commands/ChocolateyInstallCommand.cs
+++ b/src/chocolatey/infrastructure.app/commands/ChocolateyInstallCommand.cs
@@ -1,4 +1,4 @@
-// Copyright © 2017 - 2021 Chocolatey Software, Inc
+// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/commands/ChocolateyListCommand.cs
+++ b/src/chocolatey/infrastructure.app/commands/ChocolateyListCommand.cs
@@ -1,4 +1,5 @@
-﻿// Copyright © 2023-Present Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
+// Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/chocolatey/infrastructure.app/commands/ChocolateyNewCommand.cs
+++ b/src/chocolatey/infrastructure.app/commands/ChocolateyNewCommand.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/commands/ChocolateyOutdatedCommand.cs
+++ b/src/chocolatey/infrastructure.app/commands/ChocolateyOutdatedCommand.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/commands/ChocolateyPackCommand.cs
+++ b/src/chocolatey/infrastructure.app/commands/ChocolateyPackCommand.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/commands/ChocolateyPinCommand.cs
+++ b/src/chocolatey/infrastructure.app/commands/ChocolateyPinCommand.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/commands/ChocolateyPushCommand.cs
+++ b/src/chocolatey/infrastructure.app/commands/ChocolateyPushCommand.cs
@@ -1,4 +1,4 @@
-// Copyright © 2017 - 2021 Chocolatey Software, Inc
+// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/commands/ChocolateyRuleCommand.cs
+++ b/src/chocolatey/infrastructure.app/commands/ChocolateyRuleCommand.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2024 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/commands/ChocolateySearchCommand.cs
+++ b/src/chocolatey/infrastructure.app/commands/ChocolateySearchCommand.cs
@@ -1,4 +1,4 @@
-// Copyright © 2017 - 2021 Chocolatey Software, Inc
+// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/commands/ChocolateySourceCommand.cs
+++ b/src/chocolatey/infrastructure.app/commands/ChocolateySourceCommand.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/commands/ChocolateyTemplateCommand.cs
+++ b/src/chocolatey/infrastructure.app/commands/ChocolateyTemplateCommand.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/commands/ChocolateyUninstallCommand.cs
+++ b/src/chocolatey/infrastructure.app/commands/ChocolateyUninstallCommand.cs
@@ -1,4 +1,4 @@
-// Copyright © 2017 - 2021 Chocolatey Software, Inc
+// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/commands/ChocolateyUnpackSelfCommand.cs
+++ b/src/chocolatey/infrastructure.app/commands/ChocolateyUnpackSelfCommand.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/commands/ChocolateyUpgradeCommand.cs
+++ b/src/chocolatey/infrastructure.app/commands/ChocolateyUpgradeCommand.cs
@@ -1,4 +1,4 @@
-// Copyright © 2017 - 2021 Chocolatey Software, Inc
+// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/configuration/ChocolateyConfiguration.cs
+++ b/src/chocolatey/infrastructure.app/configuration/ChocolateyConfiguration.cs
@@ -1,4 +1,4 @@
-// Copyright © 2017 - 2023 Chocolatey Software, Inc
+// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/configuration/ChocolateySource.cs
+++ b/src/chocolatey/infrastructure.app/configuration/ChocolateySource.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/configuration/ConfigFileApiKeySetting.cs
+++ b/src/chocolatey/infrastructure.app/configuration/ConfigFileApiKeySetting.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/configuration/ConfigFileConfigSetting.cs
+++ b/src/chocolatey/infrastructure.app/configuration/ConfigFileConfigSetting.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/configuration/ConfigFileFeatureSetting.cs
+++ b/src/chocolatey/infrastructure.app/configuration/ConfigFileFeatureSetting.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/configuration/ConfigFileSettings.cs
+++ b/src/chocolatey/infrastructure.app/configuration/ConfigFileSettings.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/configuration/ConfigFileSourceSetting.cs
+++ b/src/chocolatey/infrastructure.app/configuration/ConfigFileSourceSetting.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/configuration/ConfigurationOptions.cs
+++ b/src/chocolatey/infrastructure.app/configuration/ConfigurationOptions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/configuration/EnvironmentSettings.cs
+++ b/src/chocolatey/infrastructure.app/configuration/EnvironmentSettings.cs
@@ -1,4 +1,4 @@
-// Copyright © 2017 - 2021 Chocolatey Software, Inc
+// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/configuration/PackagesConfigFilePackageSetting.cs
+++ b/src/chocolatey/infrastructure.app/configuration/PackagesConfigFilePackageSetting.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/configuration/PackagesConfigFileSettings.cs
+++ b/src/chocolatey/infrastructure.app/configuration/PackagesConfigFileSettings.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/domain/ApiKeyCommandType.cs
+++ b/src/chocolatey/infrastructure.app/domain/ApiKeyCommandType.cs
@@ -1,4 +1,5 @@
-﻿// Copyright © 2023 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
+// Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/chocolatey/infrastructure.app/domain/CacheCommandType.cs
+++ b/src/chocolatey/infrastructure.app/domain/CacheCommandType.cs
@@ -1,4 +1,5 @@
-﻿// Copyright © 2023 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
+// Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/chocolatey/infrastructure.app/domain/ChocolateyPackageInformation.cs
+++ b/src/chocolatey/infrastructure.app/domain/ChocolateyPackageInformation.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/domain/ChocolateyPackageMetadata.cs
+++ b/src/chocolatey/infrastructure.app/domain/ChocolateyPackageMetadata.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2022 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/domain/CommandNameType.cs
+++ b/src/chocolatey/infrastructure.app/domain/CommandNameType.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/domain/ConfigCommandType.cs
+++ b/src/chocolatey/infrastructure.app/domain/ConfigCommandType.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/domain/FeatureCommandType.cs
+++ b/src/chocolatey/infrastructure.app/domain/FeatureCommandType.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/domain/GenericRegistryKey.cs
+++ b/src/chocolatey/infrastructure.app/domain/GenericRegistryKey.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/domain/GenericRegistryValue.cs
+++ b/src/chocolatey/infrastructure.app/domain/GenericRegistryValue.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/domain/InstallTokens.cs
+++ b/src/chocolatey/infrastructure.app/domain/InstallTokens.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/domain/InstallerType.cs
+++ b/src/chocolatey/infrastructure.app/domain/InstallerType.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/domain/PackageFile.cs
+++ b/src/chocolatey/infrastructure.app/domain/PackageFile.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/domain/PackageFiles.cs
+++ b/src/chocolatey/infrastructure.app/domain/PackageFiles.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/domain/PinCommandType.cs
+++ b/src/chocolatey/infrastructure.app/domain/PinCommandType.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/domain/Registry.cs
+++ b/src/chocolatey/infrastructure.app/domain/Registry.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/domain/RegistryApplicationKey.cs
+++ b/src/chocolatey/infrastructure.app/domain/RegistryApplicationKey.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/domain/RegistryHiveType.cs
+++ b/src/chocolatey/infrastructure.app/domain/RegistryHiveType.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/domain/RegistryValueExtensions.cs
+++ b/src/chocolatey/infrastructure.app/domain/RegistryValueExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/domain/RegistryValueKindType.cs
+++ b/src/chocolatey/infrastructure.app/domain/RegistryValueKindType.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/domain/SourceCommandType.cs
+++ b/src/chocolatey/infrastructure.app/domain/SourceCommandType.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/domain/SourceType.cs
+++ b/src/chocolatey/infrastructure.app/domain/SourceType.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2022 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/domain/SourceTypes.cs
+++ b/src/chocolatey/infrastructure.app/domain/SourceTypes.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2022 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/domain/TemplateCommandType.cs
+++ b/src/chocolatey/infrastructure.app/domain/TemplateCommandType.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/domain/installers/BitRockInstaller.cs
+++ b/src/chocolatey/infrastructure.app/domain/installers/BitRockInstaller.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/domain/installers/CustomInstaller.cs
+++ b/src/chocolatey/infrastructure.app/domain/installers/CustomInstaller.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/domain/installers/GhostInstaller.cs
+++ b/src/chocolatey/infrastructure.app/domain/installers/GhostInstaller.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/domain/installers/IInstaller.cs
+++ b/src/chocolatey/infrastructure.app/domain/installers/IInstaller.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/domain/installers/InnoSetupInstaller.cs
+++ b/src/chocolatey/infrastructure.app/domain/installers/InnoSetupInstaller.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/domain/installers/InstallForJInstaller.cs
+++ b/src/chocolatey/infrastructure.app/domain/installers/InstallForJInstaller.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/domain/installers/InstallShieldInstaller.cs
+++ b/src/chocolatey/infrastructure.app/domain/installers/InstallShieldInstaller.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/domain/installers/InstallerBase.cs
+++ b/src/chocolatey/infrastructure.app/domain/installers/InstallerBase.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/domain/installers/IzPackInstaller.cs
+++ b/src/chocolatey/infrastructure.app/domain/installers/IzPackInstaller.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/domain/installers/MsiInstaller.cs
+++ b/src/chocolatey/infrastructure.app/domain/installers/MsiInstaller.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/domain/installers/MsiPatchInstaller.cs
+++ b/src/chocolatey/infrastructure.app/domain/installers/MsiPatchInstaller.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/domain/installers/NsisInstaller.cs
+++ b/src/chocolatey/infrastructure.app/domain/installers/NsisInstaller.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/domain/installers/PackageForTheWebInstaller.cs
+++ b/src/chocolatey/infrastructure.app/domain/installers/PackageForTheWebInstaller.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/domain/installers/QtInstaller.cs
+++ b/src/chocolatey/infrastructure.app/domain/installers/QtInstaller.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/domain/installers/SetupFactoryInstaller.cs
+++ b/src/chocolatey/infrastructure.app/domain/installers/SetupFactoryInstaller.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/domain/installers/SquirrelInstaller.cs
+++ b/src/chocolatey/infrastructure.app/domain/installers/SquirrelInstaller.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/domain/installers/WindowsUpdateInstaller.cs
+++ b/src/chocolatey/infrastructure.app/domain/installers/WindowsUpdateInstaller.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/domain/installers/WiseInstaller.cs
+++ b/src/chocolatey/infrastructure.app/domain/installers/WiseInstaller.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/events/HandlePackageResultCompletedMessage.cs
+++ b/src/chocolatey/infrastructure.app/events/HandlePackageResultCompletedMessage.cs
@@ -1,5 +1,5 @@
-﻿// Copyright Â© 2017 - 2021 Chocolatey Software, Inc
-// Copyright Â© 2011 - 2017 RealDimensions Software, LLC
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
+// Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/chocolatey/infrastructure.app/events/PostRunMessage.cs
+++ b/src/chocolatey/infrastructure.app/events/PostRunMessage.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/events/PreRunMessage.cs
+++ b/src/chocolatey/infrastructure.app/events/PreRunMessage.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/nuget/ChocolateyLocalPackageRepository.cs
+++ b/src/chocolatey/infrastructure.app/nuget/ChocolateyLocalPackageRepository.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/nuget/ChocolateyNuGetProjectContext.cs
+++ b/src/chocolatey/infrastructure.app/nuget/ChocolateyNuGetProjectContext.cs
@@ -1,4 +1,20 @@
-﻿using System;
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
+// Copyright © 2011 - 2017 RealDimensions Software, LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/chocolatey/infrastructure.app/nuget/ChocolateyNuGetSettings.cs
+++ b/src/chocolatey/infrastructure.app/nuget/ChocolateyNuGetSettings.cs
@@ -1,4 +1,20 @@
-﻿using System;
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
+// Copyright © 2011 - 2017 RealDimensions Software, LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/chocolatey/infrastructure.app/nuget/ChocolateyNugetCredentialProvider.cs
+++ b/src/chocolatey/infrastructure.app/nuget/ChocolateyNugetCredentialProvider.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/nuget/ChocolateyNugetLogger.cs
+++ b/src/chocolatey/infrastructure.app/nuget/ChocolateyNugetLogger.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2022 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/nuget/ChocolateyPackagePathResolver.cs
+++ b/src/chocolatey/infrastructure.app/nuget/ChocolateyPackagePathResolver.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/nuget/ChocolateyPhysicalFileSystem.cs
+++ b/src/chocolatey/infrastructure.app/nuget/ChocolateyPhysicalFileSystem.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/nuget/ChocolateySourceCacheContext.cs
+++ b/src/chocolatey/infrastructure.app/nuget/ChocolateySourceCacheContext.cs
@@ -1,4 +1,20 @@
-﻿using System;
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
+// Copyright © 2011 - 2017 RealDimensions Software, LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
 using System.Threading;
 using Alphaleonis.Win32.Filesystem;
 using chocolatey.infrastructure.app.configuration;

--- a/src/chocolatey/infrastructure.app/nuget/DictionaryPropertyProvider.cs
+++ b/src/chocolatey/infrastructure.app/nuget/DictionaryPropertyProvider.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/nuget/NuGetEndpointResources.cs
+++ b/src/chocolatey/infrastructure.app/nuget/NuGetEndpointResources.cs
@@ -1,4 +1,5 @@
-﻿// Copyright © 2023-Present Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
+// Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/chocolatey/infrastructure.app/nuget/NuGetEndpointResourcesExtensions.cs
+++ b/src/chocolatey/infrastructure.app/nuget/NuGetEndpointResourcesExtensions.cs
@@ -1,4 +1,5 @@
-﻿// Copyright © 2023-Present Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
+// Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/chocolatey/infrastructure.app/nuget/NuGetFileSystemExtensions.cs
+++ b/src/chocolatey/infrastructure.app/nuget/NuGetFileSystemExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/nuget/NugetCommon.cs
+++ b/src/chocolatey/infrastructure.app/nuget/NugetCommon.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/nuget/NugetEncryptionUtility.cs
+++ b/src/chocolatey/infrastructure.app/nuget/NugetEncryptionUtility.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/nuget/NugetList.cs
+++ b/src/chocolatey/infrastructure.app/nuget/NugetList.cs
@@ -1,4 +1,4 @@
-// Copyright © 2017 - 2021 Chocolatey Software, Inc
+// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/nuget/NugetPack.cs
+++ b/src/chocolatey/infrastructure.app/nuget/NugetPack.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/nuget/NugetPush.cs
+++ b/src/chocolatey/infrastructure.app/nuget/NugetPush.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/registration/ChocolateyRegistrationModule.cs
+++ b/src/chocolatey/infrastructure.app/registration/ChocolateyRegistrationModule.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2023 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/registration/ContainerBinding.cs
+++ b/src/chocolatey/infrastructure.app/registration/ContainerBinding.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2022 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/registration/IContainerRegistrator.cs
+++ b/src/chocolatey/infrastructure.app/registration/IContainerRegistrator.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2022 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,6 +13,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 using System;
 
 namespace chocolatey.infrastructure.app.registration

--- a/src/chocolatey/infrastructure.app/registration/IContainerResolver.cs
+++ b/src/chocolatey/infrastructure.app/registration/IContainerResolver.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2022 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -6,7 +6,7 @@
 //
 // You may obtain a copy of the License at
 //
-//  http://www.apache.org/licenses/LICENSE-2.0
+// 	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/chocolatey/infrastructure.app/registration/IExtensionConfiguration.cs
+++ b/src/chocolatey/infrastructure.app/registration/IExtensionConfiguration.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2022 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/registration/IExtensionEnvironment.cs
+++ b/src/chocolatey/infrastructure.app/registration/IExtensionEnvironment.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2022 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/registration/IExtensionModule.cs
+++ b/src/chocolatey/infrastructure.app/registration/IExtensionModule.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2022 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -6,7 +6,7 @@
 //
 // You may obtain a copy of the License at
 //
-//  http://www.apache.org/licenses/LICENSE-2.0
+// 	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/chocolatey/infrastructure.app/registration/SimpleInjectorContainerRegistrator.cs
+++ b/src/chocolatey/infrastructure.app/registration/SimpleInjectorContainerRegistrator.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2022 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/registration/SimpleInjectorContainerResolver.cs
+++ b/src/chocolatey/infrastructure.app/registration/SimpleInjectorContainerResolver.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2022 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -6,7 +6,7 @@
 //
 // You may obtain a copy of the License at
 //
-//  http://www.apache.org/licenses/LICENSE-2.0
+// 	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/chocolatey/infrastructure.app/rules/EmptyOrInvalidUrlMetadataRule.cs
+++ b/src/chocolatey/infrastructure.app/rules/EmptyOrInvalidUrlMetadataRule.cs
@@ -1,4 +1,5 @@
-﻿// Copyright © 2023-Present Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
+// Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/chocolatey/infrastructure.app/rules/FrameWorkReferencesMetadataRule.cs
+++ b/src/chocolatey/infrastructure.app/rules/FrameWorkReferencesMetadataRule.cs
@@ -1,4 +1,5 @@
-﻿// Copyright © 2023-Present Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
+// Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/chocolatey/infrastructure.app/rules/IconMetadataRule.cs
+++ b/src/chocolatey/infrastructure.app/rules/IconMetadataRule.cs
@@ -1,4 +1,5 @@
-﻿// Copyright © 2023-Present Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
+// Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/chocolatey/infrastructure.app/rules/LicenseMetadataRule.cs
+++ b/src/chocolatey/infrastructure.app/rules/LicenseMetadataRule.cs
@@ -1,4 +1,5 @@
-﻿// Copyright © 2023-Present Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
+// Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/chocolatey/infrastructure.app/rules/MetadataRuleBase.cs
+++ b/src/chocolatey/infrastructure.app/rules/MetadataRuleBase.cs
@@ -1,4 +1,5 @@
-﻿// Copyright © 2023-Present Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
+// Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/chocolatey/infrastructure.app/rules/PackageTypesMetadataRule.cs
+++ b/src/chocolatey/infrastructure.app/rules/PackageTypesMetadataRule.cs
@@ -1,4 +1,5 @@
-﻿// Copyright © 2023-Present Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
+// Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/chocolatey/infrastructure.app/rules/ReadmeMetadataRule.cs
+++ b/src/chocolatey/infrastructure.app/rules/ReadmeMetadataRule.cs
@@ -1,4 +1,5 @@
-﻿// Copyright © 2023-Present Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
+// Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/chocolatey/infrastructure.app/rules/RepositoryMetadataRule.cs
+++ b/src/chocolatey/infrastructure.app/rules/RepositoryMetadataRule.cs
@@ -1,4 +1,5 @@
-﻿// Copyright © 2023-Present Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
+// Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/chocolatey/infrastructure.app/rules/RequireLicenseAcceptanceMetadataRule.cs
+++ b/src/chocolatey/infrastructure.app/rules/RequireLicenseAcceptanceMetadataRule.cs
@@ -1,4 +1,5 @@
-﻿// Copyright © 2023-Present Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
+// Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/chocolatey/infrastructure.app/rules/RequiredMetadataRule.cs
+++ b/src/chocolatey/infrastructure.app/rules/RequiredMetadataRule.cs
@@ -1,4 +1,5 @@
-﻿// Copyright © 2023-Present Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
+// Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/chocolatey/infrastructure.app/rules/RuleIdentifiers.cs
+++ b/src/chocolatey/infrastructure.app/rules/RuleIdentifiers.cs
@@ -1,4 +1,5 @@
-﻿// Copyright © 2023-Present Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
+// Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/chocolatey/infrastructure.app/rules/ServicableMetadataRule.cs
+++ b/src/chocolatey/infrastructure.app/rules/ServicableMetadataRule.cs
@@ -1,4 +1,5 @@
-﻿// Copyright © 2023-Present Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
+// Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/chocolatey/infrastructure.app/rules/VersionMetadataRule.cs
+++ b/src/chocolatey/infrastructure.app/rules/VersionMetadataRule.cs
@@ -1,4 +1,5 @@
-﻿// Copyright © 2023-Present Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
+// Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/chocolatey/infrastructure.app/runners/ConsoleApplication.cs
+++ b/src/chocolatey/infrastructure.app/runners/ConsoleApplication.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/runners/GenericRunner.cs
+++ b/src/chocolatey/infrastructure.app/runners/GenericRunner.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2022 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/services/AutomaticUninstallerService.cs
+++ b/src/chocolatey/infrastructure.app/services/AutomaticUninstallerService.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/services/ChocolateyConfigSettingsService.cs
+++ b/src/chocolatey/infrastructure.app/services/ChocolateyConfigSettingsService.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -160,7 +160,7 @@ namespace chocolatey.infrastructure.app.services
                     {
                         this.Log().Warn(NoChangeMessage);
                     }
-                    
+
                     if (configuration.Features.UseEnhancedExitCodes && Environment.ExitCode == 0)
                     {
                         Environment.ExitCode = 2;
@@ -522,7 +522,7 @@ namespace chocolatey.infrastructure.app.services
                 if (configuration.ConfigCommand.ConfigValue.IsEqualTo(currentValue.ToStringSafe()))
                 {
                     this.Log().Warn(NoChangeMessage);
-                    
+
                     if (configuration.Features.UseEnhancedExitCodes && Environment.ExitCode == 0)
                     {
                         Environment.ExitCode = 2;

--- a/src/chocolatey/infrastructure.app/services/ChocolateyPackageInformationService.cs
+++ b/src/chocolatey/infrastructure.app/services/ChocolateyPackageInformationService.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -303,7 +303,7 @@ A corrupt .registry file exists at {0}.
                 {
                     _fileSystem.DeleteFile(locationFile);
                 }
-                
+
                 _fileSystem.WriteFile(locationFile, packageInformation.DeploymentLocation);
             }
             else

--- a/src/chocolatey/infrastructure.app/services/ChocolateyPackageService.cs
+++ b/src/chocolatey/infrastructure.app/services/ChocolateyPackageService.cs
@@ -1,4 +1,4 @@
-// Copyright © 2017 - 2023 Chocolatey Software, Inc
+// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/services/ConfigTransformService.cs
+++ b/src/chocolatey/infrastructure.app/services/ConfigTransformService.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/services/CygwinService.cs
+++ b/src/chocolatey/infrastructure.app/services/CygwinService.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2022 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/services/FilesService.cs
+++ b/src/chocolatey/infrastructure.app/services/FilesService.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/services/IAutomaticUninstallerService.cs
+++ b/src/chocolatey/infrastructure.app/services/IAutomaticUninstallerService.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/services/IChocolateyConfigSettingsService.cs
+++ b/src/chocolatey/infrastructure.app/services/IChocolateyConfigSettingsService.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/services/IChocolateyPackageInformationService.cs
+++ b/src/chocolatey/infrastructure.app/services/IChocolateyPackageInformationService.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/services/IChocolateyPackageService.cs
+++ b/src/chocolatey/infrastructure.app/services/IChocolateyPackageService.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/services/IConfigTransformService.cs
+++ b/src/chocolatey/infrastructure.app/services/IConfigTransformService.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/services/IFilesService.cs
+++ b/src/chocolatey/infrastructure.app/services/IFilesService.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/services/INugetService.cs
+++ b/src/chocolatey/infrastructure.app/services/INugetService.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/services/IPendingRebootService.cs
+++ b/src/chocolatey/infrastructure.app/services/IPendingRebootService.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/services/IPowershellService.cs
+++ b/src/chocolatey/infrastructure.app/services/IPowershellService.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2022 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/services/IProcessCollectorService.cs
+++ b/src/chocolatey/infrastructure.app/services/IProcessCollectorService.cs
@@ -1,4 +1,20 @@
-﻿using chocolatey.infrastructure.information;
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
+// Copyright © 2011 - 2017 RealDimensions Software, LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using chocolatey.infrastructure.information;
 
 namespace chocolatey.infrastructure.app.services
 {

--- a/src/chocolatey/infrastructure.app/services/IRegistryService.cs
+++ b/src/chocolatey/infrastructure.app/services/IRegistryService.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/services/IShimGenerationService.cs
+++ b/src/chocolatey/infrastructure.app/services/IShimGenerationService.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/services/ISourceRunner.cs
+++ b/src/chocolatey/infrastructure.app/services/ISourceRunner.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2022 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/services/ITemplateService.cs
+++ b/src/chocolatey/infrastructure.app/services/ITemplateService.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/services/NugetService.cs
+++ b/src/chocolatey/infrastructure.app/services/NugetService.cs
@@ -1,4 +1,4 @@
-// Copyright © 2017 - 2023 Chocolatey Software, Inc
+// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -618,7 +618,7 @@ folder.");
                     // We have already processed this package (likely during dependency resolution of another package).
                     continue;
                 }
-                
+
                 // We need to ensure we are using a clean configuration file
                 // before we start reading it.
                 config.RevertChanges();
@@ -820,7 +820,7 @@ Please see https://docs.chocolatey.org/en-us/troubleshooting for more
                         this.Log().Error(ChocolateyLoggers.Important, logMessage);
 
                         foreach (var pkgMetadata in packagesToInstall)
-                        
+
                         {
                             var errorResult = packageResultsToReturn.GetOrAdd(pkgMetadata.Identity.Id, new PackageResult(pkgMetadata, pathResolver.GetInstallPath(pkgMetadata.Identity)));
                             errorResult.Messages.Add(new ResultMessage(ResultType.Error, logMessage));
@@ -878,7 +878,7 @@ Please see https://docs.chocolatey.org/en-us/troubleshooting for more
                             packageResultsToReturn.GetOrAdd(packageToUninstall.Name, packageToUninstall)
                                 .Messages.Add(new ResultMessage(ResultType.Error, logMessage));
                             this.Log().Error(ChocolateyLoggers.Important, logMessage);
-                            
+
                             if (config.Features.StopOnFirstPackageFailure)
                             {
                                 throw new ApplicationException("Stopping further execution as {0} has failed install.".FormatWith(packageToUninstall.Identity.Id));
@@ -1354,12 +1354,12 @@ Please see https://docs.chocolatey.org/en-us/troubleshooting for more
                             var logMessage = "{0} is pinned. Skipping pinned package.".FormatWith(packageName);
                             packageResult.Messages.Add(new ResultMessage(ResultType.Warn, logMessage));
                             packageResult.Messages.Add(new ResultMessage(ResultType.Inconclusive, logMessage));
-                            
+
                             if (config.RegularOutput)
                             {
                                 this.Log().Warn(ChocolateyLoggers.Important, logMessage);
                             }
-                            
+
                             continue;
                         }
                         else
@@ -1371,7 +1371,7 @@ Please see https://docs.chocolatey.org/en-us/troubleshooting for more
                             {
                                 this.Log().Warn(ChocolateyLoggers.Important, logMessage);
                             }
-                            
+
                             config.PinPackage = true;
                         }
                     }
@@ -1453,7 +1453,7 @@ Please see https://docs.chocolatey.org/en-us/troubleshooting for more
                         }
 
                         var removedSources = new HashSet<SourcePackageDependencyInfo>();
-                        
+
                         if (!config.UpgradeCommand.IgnorePinned)
                         {
                             removedSources.AddRange(RemovePinnedSourceDependencies(sourcePackageDependencyInfos, allLocalPackages));
@@ -1648,7 +1648,7 @@ Please see https://docs.chocolatey.org/en-us/troubleshooting for more
                             {
                                 var logMessage = StringResources.ErrorMessages.DependencyFailedToInstall.FormatWith(packageDependencyInfo.Id, packageDependencyInfo.Version);
                                 packageResultsToReturn.GetOrAdd(
-                                        packageDependencyInfo.Id, 
+                                        packageDependencyInfo.Id,
                                         new PackageResult(packageDependencyInfo.Id, packageDependencyInfo.Version.ToFullStringChecked(), string.Empty)
                                     )
                                     .Messages.Add(new ResultMessage(ResultType.Error, logMessage));
@@ -1686,7 +1686,7 @@ Please see https://docs.chocolatey.org/en-us/troubleshooting for more
                                         packageResultsToReturn.GetOrAdd(packageToUninstall.Name, packageToUninstall)
                                             .Messages.Add(new ResultMessage(ResultType.Error, logMessage));
                                         this.Log().Error(ChocolateyLoggers.Important, logMessage);
-                                        
+
                                         if (config.Features.StopOnFirstPackageFailure)
                                         {
                                             throw new ApplicationException("Stopping further execution as {0} has failed.".FormatWith(packageDependencyInfo.Id));
@@ -1951,7 +1951,7 @@ Please see https://docs.chocolatey.org/en-us/troubleshooting for more
             }
 
             var packageArguments = ArgumentsUtility.DecryptPackageArgumentsFile(
-                _fileSystem, 
+                _fileSystem,
                 packageInfo.Package.Id,
                 packageInfo.Package.Version.ToNormalizedStringChecked(),
                 redactSensitiveArguments: false,
@@ -3128,7 +3128,7 @@ Please see https://docs.chocolatey.org/en-us/troubleshooting for more
                 {
                     using (var metadataFileStream = downloadResult.PackageReader.GetStream(PackagingCoreConstants.NupkgMetadataFileExtension))
                     {
-                        var metadataFileContents = NupkgMetadataFileFormat.Read(metadataFileStream, 
+                        var metadataFileContents = NupkgMetadataFileFormat.Read(metadataFileStream,
                                                                                 _nugetLogger,
                                                                                 PackagingCoreConstants.NupkgMetadataFileExtension);
 

--- a/src/chocolatey/infrastructure.app/services/PendingRebootService.cs
+++ b/src/chocolatey/infrastructure.app/services/PendingRebootService.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/services/PowershellService.cs
+++ b/src/chocolatey/infrastructure.app/services/PowershellService.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2022 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/services/ProcessCollectorService.cs
+++ b/src/chocolatey/infrastructure.app/services/ProcessCollectorService.cs
@@ -1,4 +1,20 @@
-﻿using System;
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
+// Copyright © 2011 - 2017 RealDimensions Software, LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
 using chocolatey.infrastructure.information;
 
 namespace chocolatey.infrastructure.app.services

--- a/src/chocolatey/infrastructure.app/services/PythonService.cs
+++ b/src/chocolatey/infrastructure.app/services/PythonService.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2022 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/services/RegistryService.cs
+++ b/src/chocolatey/infrastructure.app/services/RegistryService.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/services/RubyGemsService.cs
+++ b/src/chocolatey/infrastructure.app/services/RubyGemsService.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2022 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/services/RuleService.cs
+++ b/src/chocolatey/infrastructure.app/services/RuleService.cs
@@ -1,4 +1,5 @@
-﻿// Copyright © 2023-Present Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
+// Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/chocolatey/infrastructure.app/services/ShimGenerationService.cs
+++ b/src/chocolatey/infrastructure.app/services/ShimGenerationService.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/services/TemplateService.cs
+++ b/src/chocolatey/infrastructure.app/services/TemplateService.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/services/WindowsFeatureService.cs
+++ b/src/chocolatey/infrastructure.app/services/WindowsFeatureService.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2022 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/tasks/RemovePendingPackagesTask.cs
+++ b/src/chocolatey/infrastructure.app/tasks/RemovePendingPackagesTask.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/templates/ChocolateyBeforeModifyTemplate.cs
+++ b/src/chocolatey/infrastructure.app/templates/ChocolateyBeforeModifyTemplate.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/templates/ChocolateyInstallTemplate.cs
+++ b/src/chocolatey/infrastructure.app/templates/ChocolateyInstallTemplate.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/templates/ChocolateyLicenseFileTemplate.cs
+++ b/src/chocolatey/infrastructure.app/templates/ChocolateyLicenseFileTemplate.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/templates/ChocolateyReadMeTemplate.cs
+++ b/src/chocolatey/infrastructure.app/templates/ChocolateyReadMeTemplate.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/templates/ChocolateyTodoTemplate.cs
+++ b/src/chocolatey/infrastructure.app/templates/ChocolateyTodoTemplate.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/templates/ChocolateyUninstallTemplate.cs
+++ b/src/chocolatey/infrastructure.app/templates/ChocolateyUninstallTemplate.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/templates/ChocolateyVerificationFileTemplate.cs
+++ b/src/chocolatey/infrastructure.app/templates/ChocolateyVerificationFileTemplate.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/templates/NuspecTemplate.cs
+++ b/src/chocolatey/infrastructure.app/templates/NuspecTemplate.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/templates/TemplateValues.cs
+++ b/src/chocolatey/infrastructure.app/templates/TemplateValues.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/utility/ArgumentsUtility.cs
+++ b/src/chocolatey/infrastructure.app/utility/ArgumentsUtility.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/utility/PackageUtility.cs
+++ b/src/chocolatey/infrastructure.app/utility/PackageUtility.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,6 +13,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 using System;
 using chocolatey.infrastructure.app.configuration;
 using chocolatey.infrastructure.platforms;

--- a/src/chocolatey/infrastructure.app/validations/CacheFolderValidationLockdown.cs
+++ b/src/chocolatey/infrastructure.app/validations/CacheFolderValidationLockdown.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2023 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/validations/GlobalConfigurationValidation.cs
+++ b/src/chocolatey/infrastructure.app/validations/GlobalConfigurationValidation.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure.app/validations/SystemStateValidation.cs
+++ b/src/chocolatey/infrastructure.app/validations/SystemStateValidation.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure/adapters/Assembly.cs
+++ b/src/chocolatey/infrastructure/adapters/Assembly.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2022 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure/adapters/Console.cs
+++ b/src/chocolatey/infrastructure/adapters/Console.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure/adapters/CustomString.cs
+++ b/src/chocolatey/infrastructure/adapters/CustomString.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure/adapters/DateTime.cs
+++ b/src/chocolatey/infrastructure/adapters/DateTime.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure/adapters/Environment.cs
+++ b/src/chocolatey/infrastructure/adapters/Environment.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure/adapters/HashAlgorithm.cs
+++ b/src/chocolatey/infrastructure/adapters/HashAlgorithm.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure/adapters/IAssembly.cs
+++ b/src/chocolatey/infrastructure/adapters/IAssembly.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2022 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure/adapters/IConsole.cs
+++ b/src/chocolatey/infrastructure/adapters/IConsole.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure/adapters/IDateTime.cs
+++ b/src/chocolatey/infrastructure/adapters/IDateTime.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure/adapters/IEncryptionUtility.cs
+++ b/src/chocolatey/infrastructure/adapters/IEncryptionUtility.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure/adapters/IEnvironment.cs
+++ b/src/chocolatey/infrastructure/adapters/IEnvironment.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure/adapters/IHashAlgorithm.cs
+++ b/src/chocolatey/infrastructure/adapters/IHashAlgorithm.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure/adapters/IProcess.cs
+++ b/src/chocolatey/infrastructure/adapters/IProcess.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure/adapters/Process.cs
+++ b/src/chocolatey/infrastructure/adapters/Process.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure/commandline/ExitScenarioHandler.cs
+++ b/src/chocolatey/infrastructure/commandline/ExitScenarioHandler.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure/commandline/InteractivePrompt.cs
+++ b/src/chocolatey/infrastructure/commandline/InteractivePrompt.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure/commandline/ReadKeyTimeout.cs
+++ b/src/chocolatey/infrastructure/commandline/ReadKeyTimeout.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure/commandline/ReadLineTimeout.cs
+++ b/src/chocolatey/infrastructure/commandline/ReadLineTimeout.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure/commands/CommandExecutor.cs
+++ b/src/chocolatey/infrastructure/commands/CommandExecutor.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure/commands/Execute.cs
+++ b/src/chocolatey/infrastructure/commands/Execute.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure/commands/ExitCodeDescription.cs
+++ b/src/chocolatey/infrastructure/commands/ExitCodeDescription.cs
@@ -1,4 +1,5 @@
-﻿// Copyright © 2023 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
+// Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/chocolatey/infrastructure/commands/ExternalCommandArgsBuilder.cs
+++ b/src/chocolatey/infrastructure/commands/ExternalCommandArgsBuilder.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure/commands/ExternalCommandArgument.cs
+++ b/src/chocolatey/infrastructure/commands/ExternalCommandArgument.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure/commands/ICommand.cs
+++ b/src/chocolatey/infrastructure/commands/ICommand.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure/commands/ICommandExecutor.cs
+++ b/src/chocolatey/infrastructure/commands/ICommandExecutor.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure/commands/IListCommand.cs
+++ b/src/chocolatey/infrastructure/commands/IListCommand.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure/commands/PowershellExecutor.cs
+++ b/src/chocolatey/infrastructure/commands/PowershellExecutor.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure/configuration/Config.cs
+++ b/src/chocolatey/infrastructure/configuration/Config.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure/cryptography/CryptoHashProvider.cs
+++ b/src/chocolatey/infrastructure/cryptography/CryptoHashProvider.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure/cryptography/CryptoHashProviderType.cs
+++ b/src/chocolatey/infrastructure/cryptography/CryptoHashProviderType.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure/cryptography/DefaultEncryptionUtility.cs
+++ b/src/chocolatey/infrastructure/cryptography/DefaultEncryptionUtility.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure/cryptography/HashConverter.cs
+++ b/src/chocolatey/infrastructure/cryptography/HashConverter.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure/cryptography/IHashProvider.cs
+++ b/src/chocolatey/infrastructure/cryptography/IHashProvider.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure/events/EventManager.cs
+++ b/src/chocolatey/infrastructure/events/EventManager.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure/events/IMessage.cs
+++ b/src/chocolatey/infrastructure/events/IMessage.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure/extractors/AssemblyFileExtractor.cs
+++ b/src/chocolatey/infrastructure/extractors/AssemblyFileExtractor.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure/filesystem/DotNetFileSystem.cs
+++ b/src/chocolatey/infrastructure/filesystem/DotNetFileSystem.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure/filesystem/FileSystem.cs
+++ b/src/chocolatey/infrastructure/filesystem/FileSystem.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure/filesystem/IFileSystem.cs
+++ b/src/chocolatey/infrastructure/filesystem/IFileSystem.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure/guards/Ensure.cs
+++ b/src/chocolatey/infrastructure/guards/Ensure.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure/information/ExtensionInformation.cs
+++ b/src/chocolatey/infrastructure/information/ExtensionInformation.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2022 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure/information/ProcessInformation.cs
+++ b/src/chocolatey/infrastructure/information/ProcessInformation.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure/information/ProcessTree.cs
+++ b/src/chocolatey/infrastructure/information/ProcessTree.cs
@@ -1,4 +1,20 @@
-﻿using System;
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
+// Copyright © 2011 - 2017 RealDimensions Software, LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;

--- a/src/chocolatey/infrastructure/information/VersionInformation.cs
+++ b/src/chocolatey/infrastructure/information/VersionInformation.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure/licensing/ChocolateyLicense.cs
+++ b/src/chocolatey/infrastructure/licensing/ChocolateyLicense.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure/licensing/ChocolateyLicenseType.cs
+++ b/src/chocolatey/infrastructure/licensing/ChocolateyLicenseType.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure/licensing/License.cs
+++ b/src/chocolatey/infrastructure/licensing/License.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2022 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure/licensing/LicenseValidation.cs
+++ b/src/chocolatey/infrastructure/licensing/LicenseValidation.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure/logging/AggregateLog.cs
+++ b/src/chocolatey/infrastructure/logging/AggregateLog.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure/logging/ChocolateyLoggers.cs
+++ b/src/chocolatey/infrastructure/logging/ChocolateyLoggers.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure/logging/ILog.cs
+++ b/src/chocolatey/infrastructure/logging/ILog.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure/logging/Log.cs
+++ b/src/chocolatey/infrastructure/logging/Log.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure/logging/Log4NetAppenderConfiguration.cs
+++ b/src/chocolatey/infrastructure/logging/Log4NetAppenderConfiguration.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure/logging/Log4NetLog.cs
+++ b/src/chocolatey/infrastructure/logging/Log4NetLog.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure/logging/LogLevelType.cs
+++ b/src/chocolatey/infrastructure/logging/LogLevelType.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure/logging/LogMessage.cs
+++ b/src/chocolatey/infrastructure/logging/LogMessage.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure/logging/LogSinkLog.cs
+++ b/src/chocolatey/infrastructure/logging/LogSinkLog.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure/logging/NullLog.cs
+++ b/src/chocolatey/infrastructure/logging/NullLog.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure/logging/TraceLog.cs
+++ b/src/chocolatey/infrastructure/logging/TraceLog.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure/platforms/Platform.cs
+++ b/src/chocolatey/infrastructure/platforms/Platform.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure/platforms/PlatformType.cs
+++ b/src/chocolatey/infrastructure/platforms/PlatformType.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure/powershell/PoshHost.cs
+++ b/src/chocolatey/infrastructure/powershell/PoshHost.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure/powershell/PoshHostRawUserInterface.cs
+++ b/src/chocolatey/infrastructure/powershell/PoshHostRawUserInterface.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure/powershell/PoshHostUserInterface.cs
+++ b/src/chocolatey/infrastructure/powershell/PoshHostUserInterface.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure/registration/AssemblyResolution.cs
+++ b/src/chocolatey/infrastructure/registration/AssemblyResolution.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2022 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure/registration/Bootstrap.cs
+++ b/src/chocolatey/infrastructure/registration/Bootstrap.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure/registration/HttpsSecurity.cs
+++ b/src/chocolatey/infrastructure/registration/HttpsSecurity.cs
@@ -1,4 +1,20 @@
-﻿using System;
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
+// Copyright © 2011 - 2017 RealDimensions Software, LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;

--- a/src/chocolatey/infrastructure/registration/SecurityProtocol.cs
+++ b/src/chocolatey/infrastructure/registration/SecurityProtocol.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure/registration/SimpleInjectorContainer.cs
+++ b/src/chocolatey/infrastructure/registration/SimpleInjectorContainer.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2022 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure/registration/SimpleInjectorContainerResolutionBehavior.cs
+++ b/src/chocolatey/infrastructure/registration/SimpleInjectorContainerResolutionBehavior.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure/results/IResult.cs
+++ b/src/chocolatey/infrastructure/results/IResult.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure/results/PackageResult.cs
+++ b/src/chocolatey/infrastructure/results/PackageResult.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure/results/PowerShellExecutionResults.cs
+++ b/src/chocolatey/infrastructure/results/PowerShellExecutionResults.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure/results/Result.cs
+++ b/src/chocolatey/infrastructure/results/Result.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure/results/ResultMessage.cs
+++ b/src/chocolatey/infrastructure/results/ResultMessage.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure/results/ResultType.cs
+++ b/src/chocolatey/infrastructure/results/ResultType.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure/rules/IMetadataRule.cs
+++ b/src/chocolatey/infrastructure/rules/IMetadataRule.cs
@@ -1,4 +1,5 @@
-﻿// Copyright © 2023-Present Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
+// Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/chocolatey/infrastructure/rules/ImmutableRule.cs
+++ b/src/chocolatey/infrastructure/rules/ImmutableRule.cs
@@ -1,4 +1,5 @@
-﻿// Copyright © 2023-Present Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
+// Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/chocolatey/infrastructure/rules/RuleResult.cs
+++ b/src/chocolatey/infrastructure/rules/RuleResult.cs
@@ -1,4 +1,5 @@
-﻿// Copyright © 2023-Present Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
+// Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/chocolatey/infrastructure/rules/RuleType.cs
+++ b/src/chocolatey/infrastructure/rules/RuleType.cs
@@ -1,4 +1,5 @@
-﻿// Copyright © 2023-Present Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
+// Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/chocolatey/infrastructure/services/EventSubscriptionManagerService.cs
+++ b/src/chocolatey/infrastructure/services/EventSubscriptionManagerService.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure/services/IDateTimeService.cs
+++ b/src/chocolatey/infrastructure/services/IDateTimeService.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure/services/IEventSubscriptionManagerService.cs
+++ b/src/chocolatey/infrastructure/services/IEventSubscriptionManagerService.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure/services/IRegularExpressionService.cs
+++ b/src/chocolatey/infrastructure/services/IRegularExpressionService.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure/services/IRuleService.cs
+++ b/src/chocolatey/infrastructure/services/IRuleService.cs
@@ -1,4 +1,5 @@
-﻿// Copyright © 2023-Present Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
+// Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/chocolatey/infrastructure/services/IXmlService.cs
+++ b/src/chocolatey/infrastructure/services/IXmlService.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure/services/RegularExpressionService.cs
+++ b/src/chocolatey/infrastructure/services/RegularExpressionService.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure/services/SystemDateTimeService.cs
+++ b/src/chocolatey/infrastructure/services/SystemDateTimeService.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure/services/SystemDateTimeUtcService.cs
+++ b/src/chocolatey/infrastructure/services/SystemDateTimeUtcService.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure/services/XmlService.cs
+++ b/src/chocolatey/infrastructure/services/XmlService.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure/synchronization/GlobalMutex.cs
+++ b/src/chocolatey/infrastructure/synchronization/GlobalMutex.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure/tasks/ITask.cs
+++ b/src/chocolatey/infrastructure/tasks/ITask.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure/tokens/TokenReplacer.cs
+++ b/src/chocolatey/infrastructure/tokens/TokenReplacer.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure/tolerance/FaultTolerance.cs
+++ b/src/chocolatey/infrastructure/tolerance/FaultTolerance.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure/validations/IValidation.cs
+++ b/src/chocolatey/infrastructure/validations/IValidation.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2022 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure/validations/ValidationResult.cs
+++ b/src/chocolatey/infrastructure/validations/ValidationResult.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure/validations/ValidationStatus.cs
+++ b/src/chocolatey/infrastructure/validations/ValidationStatus.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/chocolatey/infrastructure/xml/XmlCData.cs
+++ b/src/chocolatey/infrastructure/xml/XmlCData.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2017 - 2021 Chocolatey Software, Inc
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
 // Copyright © 2011 - 2017 RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
## Description Of Changes

This updates the license header in each source C# file to ensure that the same license header is used. It also adds this commit to the git blabe ignore file.

The PowerShell scripts has not been updated, as this would require new authenticode signatures.

## Motivation and Context

To keep the license headers up to date.

## Testing

N/A.

### Operating Systems Testing

- Windows 10

## Change Types Made
<!-- Tick the boxes for the type of changes that have been made -->

* [ ] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [x] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [ ] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v3 compatibility checked?

## Related Issue

N/A