### PR TITLE
(maint) Move support exclusion to VCR filter

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -39,7 +39,6 @@ object Chocolatey : BuildType({
 
         branchFilter = """
             +:*
-            -:support/*
         """.trimIndent()
     }
 
@@ -73,7 +72,9 @@ object Chocolatey : BuildType({
 
     triggers {
         vcs {
-            branchFilter = ""
+            branchFilter = """
+                -:support/*
+            """.trimIndent()
         }
     }
 


### PR DESCRIPTION
## Description Of Changes

This updates the settings.kts file by moving the support filter from VCS
to the VCS filter.

## Motivation and Context

This is believed to be the correct place to be able to filter out the
support branch, while still being able to manually initiate a build on
the branch.


## Testing

N/A

### Operating Systems Testing

N/A

## Change Types Made
<!-- Tick the boxes for the type of changes that have been made -->

* [ ] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.
* [x] Build

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [ ] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v3 compatibility checked?

## Related Issue

N/A
