### PR TITLE
(#3591) Remove no7zip build tasks

### DIFF
--- a/recipe.cake
+++ b/recipe.cake
@@ -59,31 +59,6 @@ Func<List<ILMergeConfig>> getILMergeConfigs = () =>
         PrimaryAssemblyName = BuildParameters.Paths.Directories.PublishedLibraries + "/chocolatey/chocolatey.dll",
         AssemblyPaths = assembliesToILMerge });
 
-    if (DirectoryExists(BuildParameters.Paths.Directories.PublishedApplications + "/choco-no7zip/"))
-    {
-        var no7zAssembliesToILMerge = GetFiles(BuildParameters.Paths.Directories.PublishedApplications + "/choco-no7zip/*.{exe|dll}")
-                                - GetFiles(BuildParameters.Paths.Directories.PublishedApplications + "/choco-no7zip/choco.exe")
-                                - GetFiles(BuildParameters.Paths.Directories.PublishedApplications + "/choco-no7zip/System.Management.Automation.dll")
-                                - GetFiles(BuildParameters.Paths.Directories.PublishedApplications + "/choco-no7zip/chocolatey.tests*.dll")
-                                - GetFiles(BuildParameters.Paths.Directories.PublishedApplications + "/choco-no7zip/{Moq|nunit.framework|Should}.dll");
-
-        Information("The following assemblies have been selected to be ILMerged for choco.exe No7zip Version...");
-        foreach (var assemblyToILMerge in no7zAssembliesToILMerge)
-        {
-            Information(assemblyToILMerge.FullPath);
-        }
-
-        mergeConfigs.Add(new ILMergeConfig() {
-            KeyFile = BuildParameters.StrongNameKeyPath,
-            LogFile = BuildParameters.Paths.Directories.Build + "/ilmerge-chocono7zipexe.log",
-            TargetPlatform = targetPlatform,
-            Target = "exe",
-            Internalize = BuildParameters.RootDirectoryPath + "/src/chocolatey.console/ilmerge.internalize.ignore.txt",
-            Output = BuildParameters.Paths.Directories.PublishedApplications + "/choco-no7zip_merged/choco.exe",
-            PrimaryAssemblyName = BuildParameters.Paths.Directories.PublishedApplications + "/choco-no7zip/choco.exe",
-            AssemblyPaths = no7zAssembliesToILMerge });
-    }
-
     return mergeConfigs;
 };
 
@@ -92,11 +67,6 @@ Func<FilePathCollection> getScriptsToVerify = () =>
     var scriptsToVerify = GetFiles("./src/chocolatey.resources/**/*.{ps1|psm1|psd1}") +
                         GetFiles(BuildParameters.Paths.Directories.NuGetNuspecDirectory + "/**/*.{ps1|psm1|psd1}") +
                         GetFiles(BuildParameters.Paths.Directories.ChocolateyNuspecDirectory + "/**/*.{ps1|psm1|psd1}");
-
-    if (DirectoryExists(BuildParameters.Paths.Directories.ChocolateyNuspecDirectory + "-no7zip"))
-    {
-        scriptsToVerify += GetFiles(BuildParameters.Paths.Directories.ChocolateyNuspecDirectory + "-no7zip/**/*.{ps1|psm1|psd1}");
-    }
 
     Information("The following PowerShell scripts have been selected to be verified...");
     foreach (var scriptToVerify in scriptsToVerify)
@@ -127,13 +97,6 @@ Func<FilePathCollection> getFilesToSign = () =>
                     + GetFiles(BuildParameters.Paths.Directories.ChocolateyNuspecDirectory + "/tools/chocolateyInstall/choco.exe")
                     + GetFiles(BuildParameters.Paths.Directories.ChocolateyNuspecDirectory + "/tools/chocolateyInstall/tools/{checksum|shimgen}.exe")
                     + GetFiles(BuildParameters.Paths.Directories.ChocolateyNuspecDirectory + "/tools/chocolateyInstall/redirects/*.exe");
-
-    if (DirectoryExists(BuildParameters.Paths.Directories.ChocolateyNuspecDirectory + "-no7zip"))
-    {
-        filesToSign += GetFiles(BuildParameters.Paths.Directories.ChocolateyNuspecDirectory + "-no7zip/tools/chocolateyInstall/choco.exe")
-                    + GetFiles(BuildParameters.Paths.Directories.ChocolateyNuspecDirectory + "-no7zip/tools/chocolateyInstall/tools/{checksum|shimgen}.exe")
-                    + GetFiles(BuildParameters.Paths.Directories.ChocolateyNuspecDirectory + "-no7zip/tools/chocolateyInstall/redirects/*.exe");
-    }
 
     Information("The following assemblies have been selected to be signed...");
     foreach (var fileToSign in filesToSign)
@@ -185,122 +148,6 @@ Task("Prepare-Chocolatey-Packages")
     }
 });
 
-Task("Build-ChocolateyNo7zip")
-    .WithCriteria(() => BuildParameters.Configuration == "ReleaseOfficial", "Skipping No7zip because this isn't an official release")
-    .IsDependentOn("Build")
-    .IsDependentOn("Test")
-    .IsDependeeOf("Run-ILMerge")
-    .Does<BuildData>(data => RequireTool(ToolSettings.MSBuildExtensionPackTool, () =>
-{
-    Information("Building {0} with No7zip", BuildParameters.SolutionFilePath);
-
-    CleanDirectory(BuildParameters.Paths.Directories.PublishedApplications + "/choco-no7zip/");
-
-    var no7zLogPath = BuildParameters.Paths.Files.BuildLogFilePath.ToString().Replace("\\.(\\S+)$", "-no7zip.${1}");
-
-    if (BuildParameters.BuildAgentOperatingSystem == PlatformFamily.Windows)
-    {
-        var msbuildSettings = new MSBuildSettings
-        {
-            ToolPath = ToolSettings.MSBuildToolPath
-        }
-            .SetPlatformTarget(ToolSettings.BuildPlatformTarget)
-            .UseToolVersion(ToolSettings.BuildMSBuildToolVersion)
-            .WithProperty("OutputPath", MakeAbsolute(new DirectoryPath(BuildParameters.Paths.Directories.PublishedApplications + "/choco-no7zip/")).FullPath)
-            .WithProperty("TreatWarningsAsErrors", BuildParameters.TreatWarningsAsErrors.ToString())
-            .WithTarget("Build")
-            .SetMaxCpuCount(ToolSettings.MaxCpuCount)
-            .SetConfiguration("ReleaseOfficialNo7zip")
-            .WithLogger(
-                Context.Tools.Resolve("MSBuild.ExtensionPack.Loggers.dll").FullPath,
-                "XmlFileLogger",
-                string.Format(
-                    "logfile=\"{0}\";invalidCharReplacement=_;verbosity=Detailed;encoding=UTF-8",
-                    no7zLogPath
-                )
-            );
-
-        MSBuild(BuildParameters.SolutionFilePath, msbuildSettings);
-    }
-
-    if (FileExists(no7zLogPath))
-    {
-        BuildParameters.BuildProvider.UploadArtifact(no7zLogPath);
-    }
-}));
-
-Task("Prepare-ChocolateyNo7zip-Package")
-    .WithCriteria(() => BuildParameters.Configuration == "ReleaseOfficial", "Skipping No7zip because this isn't an official release")
-    .WithCriteria(() => BuildParameters.BuildAgentOperatingSystem == PlatformFamily.Windows, "Skipping because not running on Windows")
-    .WithCriteria(() => BuildParameters.ShouldRunChocolatey, "Skipping because execution of Chocolatey has been disabled")
-    .IsDependentOn("Build-ChocolateyNo7zip")
-    .IsDependeeOf("Sign-Assemblies")
-    .IsDependeeOf("Verify-PowerShellScripts")
-    .IsDependeeOf("Create-ChocolateyNo7zip-Package")
-    .Does(() =>
-{
-    var nuspecDirectory = BuildParameters.Paths.Directories.ChocolateyNuspecDirectory + "-no7zip";
-    // Copy the Nuget/Chocolatey directory from Root Folder to temp/nuspec/chocolatey-no7zip
-    EnsureDirectoryExists(nuspecDirectory);
-    CopyFiles(GetFiles("./nuspec/chocolatey/**/*"), nuspecDirectory, true);
-
-    // Copy legal documents
-    CopyFile(BuildParameters.RootDirectoryPath + "/docs/legal/CREDITS.md", nuspecDirectory + "/tools/chocolateyInstall/CREDITS.txt");
-
-    // Run Chocolatey Unpackself
-    CopyFile(BuildParameters.Paths.Directories.PublishedApplications + "/choco-no7zip_merged/choco.exe", nuspecDirectory + "/tools/chocolateyInstall/choco.exe");
-
-    StartProcess(nuspecDirectory + "/tools/chocolateyInstall/choco.exe", new ProcessSettings{ Arguments = "unpackself -f -y --allow-unofficial-build" });
-
-    // Tidy up logs and config folder which are not required
-    var logsDirectory = nuspecDirectory + "/tools/chocolateyInstall/logs";
-    var configDirectory = nuspecDirectory + "/tools/chocolateyInstall/config";
-
-    if (DirectoryExists(logsDirectory))
-    {
-        DeleteDirectory(logsDirectory, new DeleteDirectorySettings {
-            Recursive = true,
-            Force = true
-        });
-    }
-
-    if (DirectoryExists(configDirectory))
-    {
-        DeleteDirectory(configDirectory, new DeleteDirectorySettings {
-            Recursive = true,
-            Force = true
-        });
-    }
-});
-
-Task("Create-ChocolateyNo7zip-Package")
-    .WithCriteria(() => BuildParameters.Configuration == "ReleaseOfficial", "Skipping No7zip because this isn't an official release")
-    .WithCriteria(() => BuildParameters.ShouldRunChocolatey, "Skipping because execution of Chocolatey has been disabled")
-    .WithCriteria(() => BuildParameters.BuildAgentOperatingSystem == PlatformFamily.Windows, "Skipping because not running on Windows")
-    .IsDependentOn("Prepare-ChocolateyNo7zip-Package")
-    .IsDependeeOf("Package")
-    .Does(() =>
-{
-    var nuspecDirectory = BuildParameters.Paths.Directories.ChocolateyNuspecDirectory + "-no7zip/";
-    var nuspecFile = nuspecDirectory + "chocolatey.nuspec";
-
-    ChocolateyPack(nuspecFile, new ChocolateyPackSettings {
-        AllowUnofficial = true,
-        Version = BuildParameters.Version.PackageVersion,
-        OutputDirectory = nuspecDirectory,
-        WorkingDirectory = BuildParameters.Paths.Directories.PublishedApplications
-    });
-
-    MoveFile(
-        nuspecDirectory + "chocolatey." + BuildParameters.Version.PackageVersion + ".nupkg",
-        BuildParameters.Paths.Directories.ChocolateyPackages + "/chocolatey-no7zip." + BuildParameters.Version.PackageVersion + ".nupkg"
-    );
-
-    // Due to the fact that we have chosen to ignore the no7zip package via the chocolateyNupkgGlobbingPattern, it will
-    // no longer be automatically uploaded via Chocolatey.Cake.Recipe, so we need to handle that work here.
-    BuildParameters.BuildProvider.UploadArtifact(BuildParameters.Paths.Directories.ChocolateyPackages + "/chocolatey-no7zip." + BuildParameters.Version.PackageVersion + ".nupkg");
-});
-
 Task("Prepare-NuGet-Packages")
     .WithCriteria(() => BuildParameters.ShouldRunNuGet, "Skipping because execution of NuGet has been disabled")
     .IsDependeeOf("Create-NuGet-Packages")
@@ -348,7 +195,7 @@ BuildParameters.SetParameters(context: Context,
                             shouldRunNuGet: IsRunningOnWindows(),
                             shouldAuthenticodeSignPowerShellScripts: IsRunningOnWindows(),
                             shouldPublishAwsLambdas: false,
-                            chocolateyNupkgGlobbingPattern: "/**/chocolatey[!-no7zip]*.nupkg");
+                            chocolateyNupkgGlobbingPattern: "/**/chocolatey*.nupkg");
 
 ToolSettings.SetToolSettings(context: Context,
                             buildMSBuildToolVersion: MSBuildToolVersion.NET40);

--- a/src/chocolatey.console/chocolatey.console.csproj
+++ b/src/chocolatey.console/chocolatey.console.csproj
@@ -118,26 +118,6 @@
     <CodeAnalysisIgnoreBuiltInRuleSets>false</CodeAnalysisIgnoreBuiltInRuleSets>
     <CodeAnalysisIgnoreBuiltInRules>false</CodeAnalysisIgnoreBuiltInRules>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'ReleaseOfficialNo7zip|x86'">
-    <OutputPath>bin\x86\ReleaseOfficialNo7zip\</OutputPath>
-    <DefineConstants>TRACE;FORCE_CHOCOLATEY_OFFICIAL_KEY</DefineConstants>
-    <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
-    <Optimize>true</Optimize>
-    <PlatformTarget>x86</PlatformTarget>
-    <ErrorReport>prompt</ErrorReport>
-    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'ReleaseOfficialNo7zip|AnyCPU'">
-    <OutputPath>bin\ReleaseOfficialNo7zip\</OutputPath>
-    <DefineConstants>TRACE;FORCE_CHOCOLATEY_OFFICIAL_KEY</DefineConstants>
-    <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
-    <Optimize>true</Optimize>
-    <PlatformTarget>AnyCPU</PlatformTarget>
-    <ErrorReport>prompt</ErrorReport>
-    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
-    <CodeAnalysisIgnoreBuiltInRuleSets>false</CodeAnalysisIgnoreBuiltInRuleSets>
-    <CodeAnalysisIgnoreBuiltInRules>false</CodeAnalysisIgnoreBuiltInRules>
-  </PropertyGroup>
   <ItemGroup>
     <Reference Include="AlphaFS, Version=2.1.0.0, Culture=neutral, PublicKeyToken=4d31a58f7d7ad5c9, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>

--- a/src/chocolatey.resources/chocolatey.resources.csproj
+++ b/src/chocolatey.resources/chocolatey.resources.csproj
@@ -38,7 +38,7 @@
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'ReleaseOfficial|AnyCPU' or '$(Configuration)|$(Platform)' == 'ReleaseOfficialNo7zip|AnyCPU'">
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'ReleaseOfficial|AnyCPU'">
     <OutputPath>bin\ReleaseOfficial\</OutputPath>
     <DefineConstants>TRACE;FORCE_CHOCOLATEY_OFFICIAL_KEY</DefineConstants>
     <Optimize>true</Optimize>
@@ -104,7 +104,7 @@
     <EmbeddedResource Include="redirects\cpush.exe" />
     <EmbeddedResource Include="redirects\cuninst.exe" />
     <EmbeddedResource Include="redirects\cup.exe" />
-    <EmbeddedResource Include="tools\7zip.license.txt" Condition="'$(Configuration)' != 'ReleaseOfficialNo7zip'" />
+    <EmbeddedResource Include="tools\7zip.license.txt" />
     <EmbeddedResource Include="tools\checksum.exe" />
     <EmbeddedResource Include="tools\checksum.license.txt" />
     <EmbeddedResource Include="tools\shimgen.exe" />
@@ -155,15 +155,15 @@
   <ItemGroup>
     <EmbeddedResource Include="helpers\functions\Get-UninstallRegistryKey.ps1" />
   </ItemGroup>
-  <ItemGroup Condition="'$(Configuration)' != 'ReleaseOfficialNo7zip'">
+  <ItemGroup>
     <EmbeddedResource Include="tools\7z.dll" />
     <EmbeddedResource Include="tools\7z.exe" />
   </ItemGroup>
-  <ItemGroup Condition="'$(Configuration)' != 'ReleaseOfficialNo7zip'">
+  <ItemGroup>
     <EmbeddedResource Include="tools\7z.exe.ignore" />
     <EmbeddedResource Include="tools\7z.exe.manifest" />
   </ItemGroup>
-  <ItemGroup Condition="'$(Configuration)' != 'ReleaseOfficialNo7zip'">
+  <ItemGroup>
     <EmbeddedResource Include="tools\7z.dll.manifest" />
   </ItemGroup>
   <ItemGroup>

--- a/src/chocolatey.sln
+++ b/src/chocolatey.sln
@@ -60,9 +60,6 @@ Global
 		ReleaseOfficial|Any CPU = ReleaseOfficial|Any CPU
 		ReleaseOfficial|Mixed Platforms = ReleaseOfficial|Mixed Platforms
 		ReleaseOfficial|x86 = ReleaseOfficial|x86
-		ReleaseOfficialNo7zip|Any CPU = ReleaseOfficialNo7zip|Any CPU
-		ReleaseOfficialNo7zip|Mixed Platforms = ReleaseOfficialNo7zip|Mixed Platforms
-		ReleaseOfficialNo7zip|x86 = ReleaseOfficialNo7zip|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{E24E3386-244F-4404-9E6E-5B53818EA903}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -86,12 +83,6 @@ Global
 		{E24E3386-244F-4404-9E6E-5B53818EA903}.ReleaseOfficial|Mixed Platforms.Build.0 = ReleaseOfficial|x86
 		{E24E3386-244F-4404-9E6E-5B53818EA903}.ReleaseOfficial|x86.ActiveCfg = ReleaseOfficial|x86
 		{E24E3386-244F-4404-9E6E-5B53818EA903}.ReleaseOfficial|x86.Build.0 = ReleaseOfficial|x86
-		{E24E3386-244F-4404-9E6E-5B53818EA903}.ReleaseOfficialNo7zip|Any CPU.ActiveCfg = ReleaseOfficialNo7zip|Any CPU
-		{E24E3386-244F-4404-9E6E-5B53818EA903}.ReleaseOfficialNo7zip|Any CPU.Build.0 = ReleaseOfficialNo7zip|Any CPU
-		{E24E3386-244F-4404-9E6E-5B53818EA903}.ReleaseOfficialNo7zip|Mixed Platforms.ActiveCfg = ReleaseOfficialNo7zip|x86
-		{E24E3386-244F-4404-9E6E-5B53818EA903}.ReleaseOfficialNo7zip|Mixed Platforms.Build.0 = ReleaseOfficialNo7zip|x86
-		{E24E3386-244F-4404-9E6E-5B53818EA903}.ReleaseOfficialNo7zip|x86.ActiveCfg = ReleaseOfficialNo7zip|x86
-		{E24E3386-244F-4404-9E6E-5B53818EA903}.ReleaseOfficialNo7zip|x86.Build.0 = ReleaseOfficialNo7zip|x86
 		{5C4C60F0-47B1-498E-ABF7-D315E1A94BC9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{5C4C60F0-47B1-498E-ABF7-D315E1A94BC9}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{5C4C60F0-47B1-498E-ABF7-D315E1A94BC9}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
@@ -111,11 +102,6 @@ Global
 		{5C4C60F0-47B1-498E-ABF7-D315E1A94BC9}.ReleaseOfficial|Mixed Platforms.Build.0 = ReleaseOfficial|Any CPU
 		{5C4C60F0-47B1-498E-ABF7-D315E1A94BC9}.ReleaseOfficial|x86.ActiveCfg = ReleaseOfficial|Any CPU
 		{5C4C60F0-47B1-498E-ABF7-D315E1A94BC9}.ReleaseOfficial|x86.Build.0 = ReleaseOfficial|Any CPU
-		{5C4C60F0-47B1-498E-ABF7-D315E1A94BC9}.ReleaseOfficialNo7zip|Any CPU.ActiveCfg = ReleaseOfficialNo7zip|Any CPU
-		{5C4C60F0-47B1-498E-ABF7-D315E1A94BC9}.ReleaseOfficialNo7zip|Any CPU.Build.0 = ReleaseOfficialNo7zip|Any CPU
-		{5C4C60F0-47B1-498E-ABF7-D315E1A94BC9}.ReleaseOfficialNo7zip|Mixed Platforms.ActiveCfg = ReleaseOfficialNo7zip|Any CPU
-		{5C4C60F0-47B1-498E-ABF7-D315E1A94BC9}.ReleaseOfficialNo7zip|x86.ActiveCfg = ReleaseOfficialNo7zip|Any CPU
-		{5C4C60F0-47B1-498E-ABF7-D315E1A94BC9}.ReleaseOfficialNo7zip|x86.Build.0 = ReleaseOfficialNo7zip|Any CPU
 		{5563DC61-35FD-4FAB-B331-9AE1FDB23F80}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{5563DC61-35FD-4FAB-B331-9AE1FDB23F80}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{5563DC61-35FD-4FAB-B331-9AE1FDB23F80}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
@@ -138,12 +124,6 @@ Global
 		{5563DC61-35FD-4FAB-B331-9AE1FDB23F80}.ReleaseOfficial|Mixed Platforms.Build.0 = ReleaseOfficial|Any CPU
 		{5563DC61-35FD-4FAB-B331-9AE1FDB23F80}.ReleaseOfficial|x86.ActiveCfg = ReleaseOfficial|Any CPU
 		{5563DC61-35FD-4FAB-B331-9AE1FDB23F80}.ReleaseOfficial|x86.Build.0 = ReleaseOfficial|Any CPU
-		{5563DC61-35FD-4FAB-B331-9AE1FDB23F80}.ReleaseOfficialNo7zip|Any CPU.ActiveCfg = ReleaseOfficialNo7zip|Any CPU
-		{5563DC61-35FD-4FAB-B331-9AE1FDB23F80}.ReleaseOfficialNo7zip|Any CPU.Build.0 = ReleaseOfficialNo7zip|Any CPU
-		{5563DC61-35FD-4FAB-B331-9AE1FDB23F80}.ReleaseOfficialNo7zip|Mixed Platforms.ActiveCfg = ReleaseOfficialNo7zip|Any CPU
-		{5563DC61-35FD-4FAB-B331-9AE1FDB23F80}.ReleaseOfficialNo7zip|Mixed Platforms.Build.0 = ReleaseOfficialNo7zip|Any CPU
-		{5563DC61-35FD-4FAB-B331-9AE1FDB23F80}.ReleaseOfficialNo7zip|x86.ActiveCfg = ReleaseOfficialNo7zip|Any CPU
-		{5563DC61-35FD-4FAB-B331-9AE1FDB23F80}.ReleaseOfficialNo7zip|x86.Build.0 = ReleaseOfficialNo7zip|Any CPU
 		{AF584111-FE32-448D-A1D0-63217AF8B43C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{AF584111-FE32-448D-A1D0-63217AF8B43C}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{AF584111-FE32-448D-A1D0-63217AF8B43C}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
@@ -163,12 +143,6 @@ Global
 		{AF584111-FE32-448D-A1D0-63217AF8B43C}.ReleaseOfficial|Mixed Platforms.Build.0 = ReleaseOfficial|Any CPU
 		{AF584111-FE32-448D-A1D0-63217AF8B43C}.ReleaseOfficial|x86.ActiveCfg = ReleaseOfficial|Any CPU
 		{AF584111-FE32-448D-A1D0-63217AF8B43C}.ReleaseOfficial|x86.Build.0 = ReleaseOfficial|Any CPU
-		{AF584111-FE32-448D-A1D0-63217AF8B43C}.ReleaseOfficialNo7zip|Any CPU.ActiveCfg = ReleaseOfficialNo7zip|Any CPU
-		{AF584111-FE32-448D-A1D0-63217AF8B43C}.ReleaseOfficialNo7zip|Any CPU.Build.0 = ReleaseOfficialNo7zip|Any CPU
-		{AF584111-FE32-448D-A1D0-63217AF8B43C}.ReleaseOfficialNo7zip|Mixed Platforms.ActiveCfg = ReleaseOfficialNo7zip|Any CPU
-		{AF584111-FE32-448D-A1D0-63217AF8B43C}.ReleaseOfficialNo7zip|Mixed Platforms.Build.0 = ReleaseOfficialNo7zip|Any CPU
-		{AF584111-FE32-448D-A1D0-63217AF8B43C}.ReleaseOfficialNo7zip|x86.ActiveCfg = ReleaseOfficialNo7zip|Any CPU
-		{AF584111-FE32-448D-A1D0-63217AF8B43C}.ReleaseOfficialNo7zip|x86.Build.0 = ReleaseOfficialNo7zip|Any CPU
 		{12ECAD4F-D463-4D72-A792-A4FCCFE9C456}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{12ECAD4F-D463-4D72-A792-A4FCCFE9C456}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{12ECAD4F-D463-4D72-A792-A4FCCFE9C456}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
@@ -188,11 +162,6 @@ Global
 		{12ECAD4F-D463-4D72-A792-A4FCCFE9C456}.ReleaseOfficial|Mixed Platforms.Build.0 = ReleaseOfficial|Any CPU
 		{12ECAD4F-D463-4D72-A792-A4FCCFE9C456}.ReleaseOfficial|x86.ActiveCfg = ReleaseOfficial|Any CPU
 		{12ECAD4F-D463-4D72-A792-A4FCCFE9C456}.ReleaseOfficial|x86.Build.0 = ReleaseOfficial|Any CPU
-		{12ECAD4F-D463-4D72-A792-A4FCCFE9C456}.ReleaseOfficialNo7zip|Any CPU.ActiveCfg = ReleaseOfficialNo7zip|Any CPU
-		{12ECAD4F-D463-4D72-A792-A4FCCFE9C456}.ReleaseOfficialNo7zip|Any CPU.Build.0 = ReleaseOfficialNo7zip|Any CPU
-		{12ECAD4F-D463-4D72-A792-A4FCCFE9C456}.ReleaseOfficialNo7zip|Mixed Platforms.ActiveCfg = ReleaseOfficialNo7zip|Any CPU
-		{12ECAD4F-D463-4D72-A792-A4FCCFE9C456}.ReleaseOfficialNo7zip|x86.ActiveCfg = ReleaseOfficialNo7zip|Any CPU
-		{12ECAD4F-D463-4D72-A792-A4FCCFE9C456}.ReleaseOfficialNo7zip|x86.Build.0 = ReleaseOfficialNo7zip|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/chocolatey.tests.integration/chocolatey.tests.integration.csproj
+++ b/src/chocolatey.tests.integration/chocolatey.tests.integration.csproj
@@ -50,15 +50,6 @@
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'ReleaseOfficialNo7zip|AnyCPU'">
-    <OutputPath>bin\ReleaseOfficialNo7zip\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <Optimize>true</Optimize>
-    <DebugType>pdbonly</DebugType>
-    <PlatformTarget>AnyCPU</PlatformTarget>
-    <ErrorReport>prompt</ErrorReport>
-    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
-  </PropertyGroup>
   <ItemGroup>
     <Reference Include="log4net, Version=2.0.12.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
       <HintPath>..\packages\log4net.2.0.12\lib\net40\log4net.dll</HintPath>

--- a/src/chocolatey.tests/chocolatey.tests.csproj
+++ b/src/chocolatey.tests/chocolatey.tests.csproj
@@ -49,15 +49,6 @@
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'ReleaseOfficialNo7zip|AnyCPU'">
-    <OutputPath>bin\ReleaseOfficialNo7zip\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <Optimize>true</Optimize>
-    <DebugType>pdbonly</DebugType>
-    <PlatformTarget>AnyCPU</PlatformTarget>
-    <ErrorReport>prompt</ErrorReport>
-    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
-  </PropertyGroup>
   <ItemGroup>
     <Reference Include="log4net, Version=2.0.12.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
       <HintPath>..\packages\log4net.2.0.12\lib\net40\log4net.dll</HintPath>

--- a/src/chocolatey/chocolatey.csproj
+++ b/src/chocolatey/chocolatey.csproj
@@ -63,18 +63,6 @@
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'ReleaseOfficialNo7zip|AnyCPU'">
-    <DebugSymbols>true</DebugSymbols>
-    <OutputPath>bin\ReleaseOfficialNo7zip\</OutputPath>
-    <DefineConstants>TRACE;FORCE_CHOCOLATEY_OFFICIAL_KEY</DefineConstants>
-    <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
-    <DocumentationFile>bin\Release\chocolatey.xml</DocumentationFile>
-    <Optimize>true</Optimize>
-    <DebugType>pdbonly</DebugType>
-    <PlatformTarget>AnyCPU</PlatformTarget>
-    <ErrorReport>prompt</ErrorReport>
-    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
-  </PropertyGroup>
   <ItemGroup>
     <Reference Include="AlphaFS, Version=2.1.0.0, Culture=neutral, PublicKeyToken=4d31a58f7d7ad5c9, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>


### PR DESCRIPTION
## Description Of Changes

This commit removes the no longer required no7zip build tasks, and also the associated sln and csproj entries, from the support branch.

This work has already been completed on the develop branch via this [PR](https://github.com/chocolatey/choco/pull/3609).

## Motivation and Context

Previously, it was necessary to build a version of choco.exe that didn't include the 7zip binaries, however, this version of Chocolatey CLI is no longer required.

To simplify the overall build process, and also the release steps required, the decision was taken to completely remove the no7zip build.

## Testing

* Full local build completed using `.\build.bat`.
* Verify no no7zip artifacts are created
* Verify that normal artifacts from build are created, i.e. chocolatey, chocolatey.lib, chocolatey.powershell nupkg's
* CI builds will be completed as a result of this PR.

### Operating Systems Testing

N/A

## Change Types Made

* [ ] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.
* [x] Build changes

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [x] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v3 compatibility checked?

## Related Issue

Fixes #3591 