### PR TITLE
(#1836) Update Chocolatey NuGet references

### DIFF
--- a/docs/legal/CREDITS.md
+++ b/docs/legal/CREDITS.md
@@ -13,7 +13,7 @@
   - [Microsoft.Bcl.HashCode @ 1.1.1](#microsoftbclhashcode--111)
   - [Microsoft.Web.Xdt @ 3.1.0](#microsoftwebxdt--310)
   - [Newtonsoft.Json @ 13.0.1](#newtonsoftjson--1301)
-  - [Chocolatey.NuGet.Client @ 3.4.2](#chocolateynugetclient--342)
+  - [Chocolatey.NuGet.Client @ 3.4.3](#chocolateynugetclient--343)
   - [Rhino.Licensing @ 1.4.1 (modified)](#rhinolicensing--141-modified)
   - [Shim Generator (shimgen) @ 2.0.0](#shim-generator-shimgen--200)
   - [SimpleInjector @ 2.8.3](#simpleinjector--283)
@@ -799,7 +799,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 ```
 
-### Chocolatey.NuGet.Client @ 3.4.2
+### Chocolatey.NuGet.Client @ 3.4.3
 
 Chocolatey uses [NuGet.Client](https://github.com/NuGet/NuGet.Client) [(modified)](https://github.com/chocolatey/NuGet.Client) to work with packaging.
 [License terms](https://github.com/NuGet/NuGet.Client/blob/72f9f2b2eab28c9d91a22065c55aa7702abf7e01/LICENSE.txt):

--- a/src/chocolatey.tests.integration/chocolatey.tests.integration.csproj
+++ b/src/chocolatey.tests.integration/chocolatey.tests.integration.csproj
@@ -66,22 +66,22 @@
       <HintPath>..\packages\AnyOf.0.3.0\lib\net45\AnyOf.dll</HintPath>
     </Reference>
     <Reference Include="Chocolatey.NuGet.Common">
-      <HintPath>..\packages\Chocolatey.NuGet.Common.3.4.2\lib\net472\Chocolatey.NuGet.Common.dll</HintPath>
+      <HintPath>..\packages\Chocolatey.NuGet.Common.3.4.3\lib\net472\Chocolatey.NuGet.Common.dll</HintPath>
     </Reference>
     <Reference Include="Chocolatey.NuGet.Configuration">
-      <HintPath>..\packages\Chocolatey.NuGet.Configuration.3.4.2\lib\net472\Chocolatey.NuGet.Configuration.dll</HintPath>
+      <HintPath>..\packages\Chocolatey.NuGet.Configuration.3.4.3\lib\net472\Chocolatey.NuGet.Configuration.dll</HintPath>
     </Reference>
     <Reference Include="Chocolatey.NuGet.Frameworks">
-      <HintPath>..\packages\Chocolatey.NuGet.Frameworks.3.4.2\lib\net472\Chocolatey.NuGet.Frameworks.dll</HintPath>
+      <HintPath>..\packages\Chocolatey.NuGet.Frameworks.3.4.3\lib\net472\Chocolatey.NuGet.Frameworks.dll</HintPath>
     </Reference>
     <Reference Include="Chocolatey.NuGet.Packaging">
-      <HintPath>..\packages\Chocolatey.NuGet.Packaging.3.4.2\lib\net472\Chocolatey.NuGet.Packaging.dll</HintPath>
+      <HintPath>..\packages\Chocolatey.NuGet.Packaging.3.4.3\lib\net472\Chocolatey.NuGet.Packaging.dll</HintPath>
     </Reference>
     <Reference Include="Chocolatey.NuGet.Protocol">
-      <HintPath>..\packages\Chocolatey.NuGet.Protocol.3.4.2\lib\net472\Chocolatey.NuGet.Protocol.dll</HintPath>
+      <HintPath>..\packages\Chocolatey.NuGet.Protocol.3.4.3\lib\net472\Chocolatey.NuGet.Protocol.dll</HintPath>
     </Reference>
     <Reference Include="Chocolatey.NuGet.Versioning">
-      <HintPath>..\packages\Chocolatey.NuGet.Versioning.3.4.2\lib\net472\Chocolatey.NuGet.Versioning.dll</HintPath>
+      <HintPath>..\packages\Chocolatey.NuGet.Versioning.3.4.3\lib\net472\Chocolatey.NuGet.Versioning.dll</HintPath>
     </Reference>
     <Reference Include="Fare, Version=2.2.0.0, Culture=neutral, PublicKeyToken=ea68d375bf33a7c8, processorArchitecture=MSIL">
       <HintPath>..\packages\Fare.2.2.1\lib\net35\Fare.dll</HintPath>

--- a/src/chocolatey.tests.integration/packages.config
+++ b/src/chocolatey.tests.integration/packages.config
@@ -1,12 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="AnyOf" version="0.3.0" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.Common" version="3.4.2" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.Configuration" version="3.4.2" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.Frameworks" version="3.4.2" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.Packaging" version="3.4.2" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.Protocol" version="3.4.2" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.Versioning" version="3.4.2" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.Common" version="3.4.3" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.Configuration" version="3.4.3" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.Frameworks" version="3.4.3" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.Packaging" version="3.4.3" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.Protocol" version="3.4.3" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.Versioning" version="3.4.3" targetFramework="net48" />
   <package id="Fare" version="2.2.1" targetFramework="net48" />
   <package id="FluentAssertions" version="6.11.0" targetFramework="net48" />
   <package id="FluentAssertions.Analyzers" version="0.19.1" targetFramework="net48" developmentDependency="true" />

--- a/src/chocolatey.tests/chocolatey.tests.csproj
+++ b/src/chocolatey.tests/chocolatey.tests.csproj
@@ -61,43 +61,43 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Chocolatey.NuGet.Commands">
-      <HintPath>..\packages\Chocolatey.NuGet.Commands.3.4.2\lib\net472\Chocolatey.NuGet.Commands.dll</HintPath>
+      <HintPath>..\packages\Chocolatey.NuGet.Commands.3.4.3\lib\net472\Chocolatey.NuGet.Commands.dll</HintPath>
     </Reference>
     <Reference Include="Chocolatey.NuGet.Common">
-      <HintPath>..\packages\Chocolatey.NuGet.Common.3.4.2\lib\net472\Chocolatey.NuGet.Common.dll</HintPath>
+      <HintPath>..\packages\Chocolatey.NuGet.Common.3.4.3\lib\net472\Chocolatey.NuGet.Common.dll</HintPath>
     </Reference>
     <Reference Include="Chocolatey.NuGet.Configuration">
-      <HintPath>..\packages\Chocolatey.NuGet.Configuration.3.4.2\lib\net472\Chocolatey.NuGet.Configuration.dll</HintPath>
+      <HintPath>..\packages\Chocolatey.NuGet.Configuration.3.4.3\lib\net472\Chocolatey.NuGet.Configuration.dll</HintPath>
     </Reference>
     <Reference Include="Chocolatey.NuGet.Credentials">
-      <HintPath>..\packages\Chocolatey.NuGet.Credentials.3.4.2\lib\net472\Chocolatey.NuGet.Credentials.dll</HintPath>
+      <HintPath>..\packages\Chocolatey.NuGet.Credentials.3.4.3\lib\net472\Chocolatey.NuGet.Credentials.dll</HintPath>
     </Reference>
     <Reference Include="Chocolatey.NuGet.DependencyResolver.Core">
-      <HintPath>..\packages\Chocolatey.NuGet.DependencyResolver.Core.3.4.2\lib\net472\Chocolatey.NuGet.DependencyResolver.Core.dll</HintPath>
+      <HintPath>..\packages\Chocolatey.NuGet.DependencyResolver.Core.3.4.3\lib\net472\Chocolatey.NuGet.DependencyResolver.Core.dll</HintPath>
     </Reference>
     <Reference Include="Chocolatey.NuGet.Frameworks">
-      <HintPath>..\packages\Chocolatey.NuGet.Frameworks.3.4.2\lib\net472\Chocolatey.NuGet.Frameworks.dll</HintPath>
+      <HintPath>..\packages\Chocolatey.NuGet.Frameworks.3.4.3\lib\net472\Chocolatey.NuGet.Frameworks.dll</HintPath>
     </Reference>
     <Reference Include="Chocolatey.NuGet.LibraryModel">
-      <HintPath>..\packages\Chocolatey.NuGet.LibraryModel.3.4.2\lib\net472\Chocolatey.NuGet.LibraryModel.dll</HintPath>
+      <HintPath>..\packages\Chocolatey.NuGet.LibraryModel.3.4.3\lib\net472\Chocolatey.NuGet.LibraryModel.dll</HintPath>
     </Reference>
     <Reference Include="Chocolatey.NuGet.PackageManagement">
-      <HintPath>..\packages\Chocolatey.NuGet.PackageManagement.3.4.2\lib\net472\Chocolatey.NuGet.PackageManagement.dll</HintPath>
+      <HintPath>..\packages\Chocolatey.NuGet.PackageManagement.3.4.3\lib\net472\Chocolatey.NuGet.PackageManagement.dll</HintPath>
     </Reference>
     <Reference Include="Chocolatey.NuGet.Packaging">
-      <HintPath>..\packages\Chocolatey.NuGet.Packaging.3.4.2\lib\net472\Chocolatey.NuGet.Packaging.dll</HintPath>
+      <HintPath>..\packages\Chocolatey.NuGet.Packaging.3.4.3\lib\net472\Chocolatey.NuGet.Packaging.dll</HintPath>
     </Reference>
     <Reference Include="Chocolatey.NuGet.ProjectModel">
-      <HintPath>..\packages\Chocolatey.NuGet.ProjectModel.3.4.2\lib\net472\Chocolatey.NuGet.ProjectModel.dll</HintPath>
+      <HintPath>..\packages\Chocolatey.NuGet.ProjectModel.3.4.3\lib\net472\Chocolatey.NuGet.ProjectModel.dll</HintPath>
     </Reference>
     <Reference Include="Chocolatey.NuGet.Protocol">
-      <HintPath>..\packages\Chocolatey.NuGet.Protocol.3.4.2\lib\net472\Chocolatey.NuGet.Protocol.dll</HintPath>
+      <HintPath>..\packages\Chocolatey.NuGet.Protocol.3.4.3\lib\net472\Chocolatey.NuGet.Protocol.dll</HintPath>
     </Reference>
     <Reference Include="Chocolatey.NuGet.Resolver">
-      <HintPath>..\packages\Chocolatey.NuGet.Resolver.3.4.2\lib\net472\Chocolatey.NuGet.Resolver.dll</HintPath>
+      <HintPath>..\packages\Chocolatey.NuGet.Resolver.3.4.3\lib\net472\Chocolatey.NuGet.Resolver.dll</HintPath>
     </Reference>
     <Reference Include="Chocolatey.NuGet.Versioning">
-      <HintPath>..\packages\Chocolatey.NuGet.Versioning.3.4.2\lib\net472\Chocolatey.NuGet.Versioning.dll</HintPath>
+      <HintPath>..\packages\Chocolatey.NuGet.Versioning.3.4.3\lib\net472\Chocolatey.NuGet.Versioning.dll</HintPath>
     </Reference>
     <Reference Include="FluentAssertions, Version=6.11.0.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
       <HintPath>..\packages\FluentAssertions.6.11.0\lib\net47\FluentAssertions.dll</HintPath>

--- a/src/chocolatey.tests/packages.config
+++ b/src/chocolatey.tests/packages.config
@@ -1,18 +1,18 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Chocolatey.NuGet.Commands" version="3.4.2" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.Common" version="3.4.2" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.Configuration" version="3.4.2" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.Credentials" version="3.4.2" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.DependencyResolver.Core" version="3.4.2" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.Frameworks" version="3.4.2" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.LibraryModel" version="3.4.2" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.PackageManagement" version="3.4.2" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.Packaging" version="3.4.2" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.ProjectModel" version="3.4.2" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.Protocol" version="3.4.2" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.Resolver" version="3.4.2" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.Versioning" version="3.4.2" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.Commands" version="3.4.3" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.Common" version="3.4.3" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.Configuration" version="3.4.3" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.Credentials" version="3.4.3" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.DependencyResolver.Core" version="3.4.3" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.Frameworks" version="3.4.3" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.LibraryModel" version="3.4.3" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.PackageManagement" version="3.4.3" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.Packaging" version="3.4.3" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.ProjectModel" version="3.4.3" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.Protocol" version="3.4.3" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.Resolver" version="3.4.3" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.Versioning" version="3.4.3" targetFramework="net48" />
   <package id="FluentAssertions" version="6.11.0" targetFramework="net48" />
   <package id="FluentAssertions.Analyzers" version="0.19.1" targetFramework="net48" developmentDependency="true" />
   <package id="log4net" version="2.0.12" targetFramework="net48" />

--- a/src/chocolatey/chocolatey.csproj
+++ b/src/chocolatey/chocolatey.csproj
@@ -79,43 +79,43 @@
       <HintPath>..\packages\AlphaFS.2.1.3\lib\net40\AlphaFS.dll</HintPath>
     </Reference>
     <Reference Include="Chocolatey.NuGet.Commands">
-      <HintPath>..\packages\Chocolatey.NuGet.Commands.3.4.2\lib\net472\Chocolatey.NuGet.Commands.dll</HintPath>
+      <HintPath>..\packages\Chocolatey.NuGet.Commands.3.4.3\lib\net472\Chocolatey.NuGet.Commands.dll</HintPath>
     </Reference>
     <Reference Include="Chocolatey.NuGet.Common">
-      <HintPath>..\packages\Chocolatey.NuGet.Common.3.4.2\lib\net472\Chocolatey.NuGet.Common.dll</HintPath>
+      <HintPath>..\packages\Chocolatey.NuGet.Common.3.4.3\lib\net472\Chocolatey.NuGet.Common.dll</HintPath>
     </Reference>
     <Reference Include="Chocolatey.NuGet.Configuration">
-      <HintPath>..\packages\Chocolatey.NuGet.Configuration.3.4.2\lib\net472\Chocolatey.NuGet.Configuration.dll</HintPath>
+      <HintPath>..\packages\Chocolatey.NuGet.Configuration.3.4.3\lib\net472\Chocolatey.NuGet.Configuration.dll</HintPath>
     </Reference>
     <Reference Include="Chocolatey.NuGet.Credentials">
-      <HintPath>..\packages\Chocolatey.NuGet.Credentials.3.4.2\lib\net472\Chocolatey.NuGet.Credentials.dll</HintPath>
+      <HintPath>..\packages\Chocolatey.NuGet.Credentials.3.4.3\lib\net472\Chocolatey.NuGet.Credentials.dll</HintPath>
     </Reference>
     <Reference Include="Chocolatey.NuGet.DependencyResolver.Core">
-      <HintPath>..\packages\Chocolatey.NuGet.DependencyResolver.Core.3.4.2\lib\net472\Chocolatey.NuGet.DependencyResolver.Core.dll</HintPath>
+      <HintPath>..\packages\Chocolatey.NuGet.DependencyResolver.Core.3.4.3\lib\net472\Chocolatey.NuGet.DependencyResolver.Core.dll</HintPath>
     </Reference>
     <Reference Include="Chocolatey.NuGet.Frameworks">
-      <HintPath>..\packages\Chocolatey.NuGet.Frameworks.3.4.2\lib\net472\Chocolatey.NuGet.Frameworks.dll</HintPath>
+      <HintPath>..\packages\Chocolatey.NuGet.Frameworks.3.4.3\lib\net472\Chocolatey.NuGet.Frameworks.dll</HintPath>
     </Reference>
     <Reference Include="Chocolatey.NuGet.LibraryModel">
-      <HintPath>..\packages\Chocolatey.NuGet.LibraryModel.3.4.2\lib\net472\Chocolatey.NuGet.LibraryModel.dll</HintPath>
+      <HintPath>..\packages\Chocolatey.NuGet.LibraryModel.3.4.3\lib\net472\Chocolatey.NuGet.LibraryModel.dll</HintPath>
     </Reference>
     <Reference Include="Chocolatey.NuGet.PackageManagement">
-      <HintPath>..\packages\Chocolatey.NuGet.PackageManagement.3.4.2\lib\net472\Chocolatey.NuGet.PackageManagement.dll</HintPath>
+      <HintPath>..\packages\Chocolatey.NuGet.PackageManagement.3.4.3\lib\net472\Chocolatey.NuGet.PackageManagement.dll</HintPath>
     </Reference>
     <Reference Include="Chocolatey.NuGet.Packaging">
-      <HintPath>..\packages\Chocolatey.NuGet.Packaging.3.4.2\lib\net472\Chocolatey.NuGet.Packaging.dll</HintPath>
+      <HintPath>..\packages\Chocolatey.NuGet.Packaging.3.4.3\lib\net472\Chocolatey.NuGet.Packaging.dll</HintPath>
     </Reference>
     <Reference Include="Chocolatey.NuGet.ProjectModel">
-      <HintPath>..\packages\Chocolatey.NuGet.ProjectModel.3.4.2\lib\net472\Chocolatey.NuGet.ProjectModel.dll</HintPath>
+      <HintPath>..\packages\Chocolatey.NuGet.ProjectModel.3.4.3\lib\net472\Chocolatey.NuGet.ProjectModel.dll</HintPath>
     </Reference>
     <Reference Include="Chocolatey.NuGet.Protocol">
-      <HintPath>..\packages\Chocolatey.NuGet.Protocol.3.4.2\lib\net472\Chocolatey.NuGet.Protocol.dll</HintPath>
+      <HintPath>..\packages\Chocolatey.NuGet.Protocol.3.4.3\lib\net472\Chocolatey.NuGet.Protocol.dll</HintPath>
     </Reference>
     <Reference Include="Chocolatey.NuGet.Resolver">
-      <HintPath>..\packages\Chocolatey.NuGet.Resolver.3.4.2\lib\net472\Chocolatey.NuGet.Resolver.dll</HintPath>
+      <HintPath>..\packages\Chocolatey.NuGet.Resolver.3.4.3\lib\net472\Chocolatey.NuGet.Resolver.dll</HintPath>
     </Reference>
     <Reference Include="Chocolatey.NuGet.Versioning">
-      <HintPath>..\packages\Chocolatey.NuGet.Versioning.3.4.2\lib\net472\Chocolatey.NuGet.Versioning.dll</HintPath>
+      <HintPath>..\packages\Chocolatey.NuGet.Versioning.3.4.3\lib\net472\Chocolatey.NuGet.Versioning.dll</HintPath>
     </Reference>
     <Reference Include="log4net, Version=2.0.12.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
       <HintPath>..\packages\log4net.2.0.12\lib\net45\log4net.dll</HintPath>

--- a/src/chocolatey/packages.config
+++ b/src/chocolatey/packages.config
@@ -1,19 +1,19 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="AlphaFS" version="2.1.3" targetFramework="net40-Client" />
-  <package id="Chocolatey.NuGet.Commands" version="3.4.2" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.Common" version="3.4.2" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.Configuration" version="3.4.2" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.Credentials" version="3.4.2" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.DependencyResolver.Core" version="3.4.2" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.Frameworks" version="3.4.2" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.LibraryModel" version="3.4.2" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.PackageManagement" version="3.4.2" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.Packaging" version="3.4.2" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.ProjectModel" version="3.4.2" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.Protocol" version="3.4.2" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.Resolver" version="3.4.2" targetFramework="net48" />
-  <package id="Chocolatey.NuGet.Versioning" version="3.4.2" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.Commands" version="3.4.3" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.Common" version="3.4.3" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.Configuration" version="3.4.3" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.Credentials" version="3.4.3" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.DependencyResolver.Core" version="3.4.3" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.Frameworks" version="3.4.3" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.LibraryModel" version="3.4.3" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.PackageManagement" version="3.4.3" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.Packaging" version="3.4.3" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.ProjectModel" version="3.4.3" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.Protocol" version="3.4.3" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.Resolver" version="3.4.3" targetFramework="net48" />
+  <package id="Chocolatey.NuGet.Versioning" version="3.4.3" targetFramework="net48" />
   <package id="log4net" version="2.0.12" targetFramework="net48" />
   <package id="Microsoft.Bcl.HashCode" version="1.1.1" targetFramework="net48" />
   <package id="Microsoft.CodeAnalysis.BannedApiAnalyzers" version="3.3.3" targetFramework="net48" developmentDependency="true" />


### PR DESCRIPTION
## Description Of Changes

This updates the Chocolatey NuGet package references to the latest
version available that was just recently created.

This new version fixes a problem in Chocolatey CLI where we are unable
to search for packages that starts with a prefix in an identifier.

## Motivation and Context

We want to fix the bug in Chocolatey CLI where you are unable to search for anything other than the prefix `chocolatey` when using `--id-starts-with`.

## Testing

1. Run `choco search sysinternals --id-starts-with`.
2. Verify that the sysinternals package is listed.

### Operating Systems Testing

- Windows 10

## Change Types Made
<!-- Tick the boxes for the type of changes that have been made -->

* [x] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [x] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v3 compatibility checked?

## Related Issue
<!-- Make sure you have raised an issue for this pull request before
continuing. -->

Fixes #1836