### PR TITLE
(#3650) Update GitHub Action to use cache@v4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
       with:
         fetch-depth: 0
     - name: Cache Tools
-      uses: actions/cache@v3.0.11
+      uses: actions/cache@v4
       with:
         path: tools
         key: ${{ runner.os }}-tools-${{ hashFiles('recipe.cake') }}
@@ -44,7 +44,7 @@ jobs:
       with:
         fetch-depth: 0
     - name: Cache Tools
-      uses: actions/cache@v3.0.11
+      uses: actions/cache@v4
       with:
         path: tools
         key: ${{ runner.os }}-tools-${{ hashFiles('recipe.cake') }}
@@ -83,7 +83,7 @@ jobs:
       with:
         fetch-depth: 0
     - name: Cache Tools
-      uses: actions/cache@v3.0.11
+      uses: actions/cache@v4
       with:
         path: tools
         key: ${{ runner.os }}-tools-${{ hashFiles('recipe.cake') }}
@@ -111,7 +111,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Cache Tools
-        uses: actions/cache@v3.0.11
+        uses: actions/cache@v4
         with:
           path: tools
           key: ${{ runner.os }}-tools-${{ hashFiles('recipe.cake') }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
       with:
         fetch-depth: 0
     - name: Cache Tools
-      uses: actions/cache@v3.0.11
+      uses: actions/cache@v4
       with:
         path: tools
         key: ${{ runner.os }}-tools-${{ hashFiles('recipe.cake') }}
@@ -43,7 +43,7 @@ jobs:
       with:
         fetch-depth: 0
     - name: Cache Tools
-      uses: actions/cache@v3.0.11
+      uses: actions/cache@v4
       with:
         path: tools
         key: ${{ runner.os }}-tools-${{ hashFiles('recipe.cake') }}
@@ -69,7 +69,7 @@ jobs:
       with:
         fetch-depth: 0
     - name: Cache Tools
-      uses: actions/cache@v3.0.11
+      uses: actions/cache@v4
       with:
         path: tools
         key: ${{ runner.os }}-tools-${{ hashFiles('recipe.cake') }}


### PR DESCRIPTION
## Description Of Changes

Update to action/cache v4.

## Motivation and Context

https://github.blog/changelog/2024-12-05-notice-of-upcoming-releases-and-breaking-changes-for-github-actions/#actions-cache-v1-v2-and-actions-toolkit-cache-package-closing-down

## Testing

The GHAs attached to this PR should complete successfully.

### Operating Systems Testing

N/A

## Change Types Made

* [ ] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [ ] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v3 compatibility checked?

## Related Issue

* Fixes #3650  
