### PR TITLE
(#3668) Add choco support command

### DIFF
--- a/src/chocolatey.tests/chocolatey.tests.csproj
+++ b/src/chocolatey.tests/chocolatey.tests.csproj
@@ -151,6 +151,7 @@
     <Compile Include="infrastructure.app\commands\ChocolateyApiKeyCommandSpecs.cs" />
     <Compile Include="infrastructure.app\commands\ChocolateyConfigCommandSpecs.cs" />
     <Compile Include="infrastructure.app\commands\ChocolateyRuleCommandSpecs.cs" />
+    <Compile Include="infrastructure.app\commands\ChocolateySupportCommandSpecs.cs" />
     <Compile Include="infrastructure.app\commands\ChocolateyTemplateCommandSpecs.cs" />
     <Compile Include="infrastructure.app\commands\ChocolateyExportCommandSpecs.cs" />
     <Compile Include="infrastructure.app\commands\ChocolateyFeatureCommandSpecs.cs" />

--- a/src/chocolatey.tests/infrastructure.app/commands/ChocolateySupportCommandSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/commands/ChocolateySupportCommandSpecs.cs
@@ -1,0 +1,137 @@
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
+// Copyright © 2011 - 2017 RealDimensions Software, LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using chocolatey.infrastructure.app.attributes;
+using chocolatey.infrastructure.app.commands;
+using chocolatey.infrastructure.app.configuration;
+using FluentAssertions;
+using Moq;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+namespace chocolatey.tests.infrastructure.app.commands
+{
+    public class ChocolateySupportCommandSpecs
+    {
+        [ConcernFor("support")]
+        public abstract class ChocolateySupportCommandSpecsBase : TinySpec
+        {
+            protected ChocolateySupportCommand Command;
+            protected ChocolateyConfiguration Configuration = new ChocolateyConfiguration();
+
+            public override void Context()
+            {
+                Command = new ChocolateySupportCommand();
+            }
+        }
+
+        public class When_Implementing_Command_For : ChocolateySupportCommandSpecsBase
+        {
+            private List<CommandForAttribute> _results;
+
+            public override void Because()
+            {
+                _results = Command.GetType().GetCustomAttributes<CommandForAttribute>().ToList();
+            }
+
+            [Fact]
+            public void Should_Have_Expected_Number_Of_Commands()
+            {
+                _results.Should().HaveCount(1);
+            }
+
+            [InlineData("support")]
+            public void Should_Implement_Expected_Command(string name)
+            {
+                _results.Should().ContainSingle(r => r.CommandName == name);
+            }
+
+            [Fact]
+            public void Should_Specify_Expected_Version_For_All_Commands()
+            {
+                _results.Should().AllSatisfy(r => r.Version.Should().Be("2.5.0"));
+            }
+        }
+
+        public class When_Noop_Is_Called : ChocolateySupportCommandSpecsBase
+        {
+            public override void Because()
+            {
+                Command.DryRun(Configuration);
+            }
+
+            [Fact]
+            public void Should_log_a_message()
+            {
+                MockLogger.Verify(l => l.Info(It.IsAny<string>()), Times.AtLeastOnce);
+            }
+
+            [Fact]
+            public void Should_log_the_message_we_expect()
+            {
+                var messages = MockLogger.MessagesFor(LogLevel.Info);
+                messages.Should().ContainSingle();
+                messages[0].Should().Contain("Unfortunately, we are unable to provide private support");
+            }
+        }
+
+        public class When_Run_Is_Called : ChocolateySupportCommandSpecsBase
+        {
+            public override void Because()
+            {
+                Command.Run(Configuration);
+            }
+
+            [Fact]
+            public void Should_log_a_message()
+            {
+                MockLogger.Verify(l => l.Info(It.IsAny<string>()), Times.AtLeastOnce);
+            }
+
+            [Fact]
+            public void Should_log_the_message_we_expect()
+            {
+                var messages = MockLogger.MessagesFor(LogLevel.Info);
+                messages.Should().ContainSingle();
+                messages[0].Should().Contain("Unfortunately, we are unable to provide private support");
+            }
+        }
+
+        public class When_Help_Is_Called : ChocolateySupportCommandSpecsBase
+        {
+            public override void Because()
+            {
+                Command.HelpMessage(Configuration);
+            }
+
+            [Fact]
+            public void Should_log_a_message()
+            {
+                MockLogger.Verify(l => l.Info(It.IsAny<string>()), Times.AtLeastOnce);
+            }
+
+            [Fact]
+            public void Should_log_the_message_we_expect()
+            {
+                var messages = MockLogger.MessagesFor(LogLevel.Info);
+                messages.Should().HaveCount(2);
+                messages[0].Should().Contain("Support Command");
+                messages[1].Should().Contain("As an open-source user of Chocolatey CLI, we are not able to");
+            }
+        }
+    }
+}

--- a/src/chocolatey/chocolatey.csproj
+++ b/src/chocolatey/chocolatey.csproj
@@ -181,6 +181,7 @@
     <Compile Include="infrastructure.app\commands\ChocolateyCacheCommand.cs" />
     <Compile Include="infrastructure.app\commands\ChocolateyListCommand.cs" />
     <Compile Include="infrastructure.app\commands\ChocolateyRuleCommand.cs" />
+    <Compile Include="infrastructure.app\commands\ChocolateySupportCommand.cs" />
     <Compile Include="infrastructure.app\commands\ChocolateyTemplateCommand.cs" />
     <Compile Include="infrastructure.app\commands\ChocolateyCommandBase.cs" />
     <Compile Include="infrastructure.app\domain\ApiKeyCommandType.cs" />

--- a/src/chocolatey/infrastructure.app/commands/ChocolateySupportCommand.cs
+++ b/src/chocolatey/infrastructure.app/commands/ChocolateySupportCommand.cs
@@ -1,0 +1,138 @@
+﻿// Copyright © 2017 - 2025 Chocolatey Software, Inc
+// Copyright © 2011 - 2017 RealDimensions Software, LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using chocolatey.infrastructure.app.attributes;
+using chocolatey.infrastructure.app.configuration;
+using chocolatey.infrastructure.commandline;
+using chocolatey.infrastructure.commands;
+using chocolatey.infrastructure.logging;
+
+namespace chocolatey.infrastructure.app.commands
+{
+    [CommandFor("support", "provides support information", Version = "2.5.0")]
+    public class ChocolateySupportCommand : ICommand
+    {
+        public void ConfigureArgumentParser(OptionSet optionSet, ChocolateyConfiguration configuration)
+        {
+            // Intentionally left blank
+        }
+
+        public void ParseAdditionalArguments(IList<string> unparsedArguments, ChocolateyConfiguration configuration)
+        {
+            // Intentionally left blank
+        }
+
+        public void Validate(ChocolateyConfiguration configuration)
+        {
+            // Intentionally left blank
+        }
+
+        public void HelpMessage(ChocolateyConfiguration configuration)
+        {
+            this.Log().Info(ChocolateyLoggers.Important, "Support Command");
+            this.Log().Info(@"
+As an open-source user of Chocolatey CLI, we are not able to
+ provide private support. See https://chocolatey.org/support
+ for details.
+");
+
+        }
+
+        public void DryRun(ChocolateyConfiguration configuration)
+        {
+            Run(configuration);
+        }
+
+        public void Run(ChocolateyConfiguration config)
+        {
+            var isLicensed = config.Information.IsLicensedVersion;
+
+            if (config.Information.IsLicensedVersion)
+            {
+                this.Log().Warn(@"
+As a licensed customer, you can access our Support Team, however,
+ it looks like the Chocolatey Licensed Extension package is not
+ currently installed. Ensure that you run:
+ `choco install chocolatey.extension`
+ and run `choco support` again.
+");
+            }
+            else
+            {
+                this.Log().Info(@"
+Unfortunately, we are unable to provide private support for
+ open-source users. However, there are a lot of avenues for open
+ source users within the community to get the help they need.
+
+If you are an open-source user, please visit
+ https://chocolatey.org/support for the full list of options, or
+ https://docs.chocolatey.org for our open source documentation.
+");
+            }
+        }
+
+        public bool MayRequireAdminAccess()
+        {
+            return false;
+        }
+
+#pragma warning disable IDE1006
+        [Obsolete("This overload is deprecated and will be removed in v3.")]
+        public virtual void configure_argument_parser(OptionSet optionSet, ChocolateyConfiguration configuration)
+        {
+            ConfigureArgumentParser(optionSet, configuration);
+        }
+
+        [Obsolete("This overload is deprecated and will be removed in v3.")]
+        public virtual void handle_additional_argument_parsing(IList<string> unparsedArguments, ChocolateyConfiguration configuration)
+        {
+            ParseAdditionalArguments(unparsedArguments, configuration);
+        }
+
+        [Obsolete("This overload is deprecated and will be removed in v3.")]
+        public virtual void handle_validation(ChocolateyConfiguration configuration)
+        {
+            Validate(configuration);
+        }
+
+        [Obsolete("This overload is deprecated and will be removed in v3.")]
+        public virtual void help_message(ChocolateyConfiguration configuration)
+        {
+            HelpMessage(configuration);
+        }
+
+        [Obsolete("This overload is deprecated and will be removed in v3.")]
+        public virtual void noop(ChocolateyConfiguration configuration)
+        {
+            DryRun(configuration);
+        }
+
+        [Obsolete("This overload is deprecated and will be removed in v3.")]
+        public virtual void run(ChocolateyConfiguration configuration)
+        {
+            Run(configuration);
+        }
+
+        [Obsolete("This overload is deprecated and will be removed in v3.")]
+        public virtual bool may_require_admin_access()
+        {
+            return MayRequireAdminAccess();
+        }
+#pragma warning restore IDE1006
+    }
+}

--- a/tests/pester-tests/commands/choco-support.Tests.ps1
+++ b/tests/pester-tests/commands/choco-support.Tests.ps1
@@ -1,0 +1,62 @@
+﻿Import-Module helpers/common-helpers
+
+Describe "choco support" -Tag Chocolatey, SupportCommand {
+    BeforeDiscovery {
+        $HasLicensedExtension = Test-PackageIsEqualOrHigher -PackageName 'chocolatey.extension' -Version '6.0.0'
+    }
+
+    BeforeAll {
+        Remove-NuGetPaths
+        Initialize-ChocolateyTestInstall
+        New-ChocolateyInstallSnapshot
+    }
+
+    AfterAll {
+        Remove-ChocolateyTestInstall
+    }
+
+    Context "Support" {
+        BeforeAll {
+            $Output = Invoke-Choco support
+        }
+
+        It "Exits successfully (0)" {
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
+        }
+
+        It "Reports support options" {
+            $ExpectedOutput = if($HasLicensedExtension) {
+                "Howdy, you have access to private support channels."
+            } else {
+                "Unfortunately, we are unable to provide private support for"
+            }
+            $Output.Lines | Should -Contain $ExpectedOutput -Because $Output.String
+        }
+    }
+
+    Context "Help Documentation (<_>)" -ForEach @("--help", "-?", "-help") {
+        BeforeAll {
+            $Output = Invoke-Choco support $_
+        }
+
+        It "Exits successfully (0)" {
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
+        }
+
+        It "Outputs Help for Support" {
+            $Output.String | Should -Match "Support Command" -Because $Output.String
+        }
+
+        It "Outputs Help for Support" {
+            $ExpectedOutput = if($HasLicensedExtension) {
+                "As a licensed customer, you can reach out to"
+            } else {
+                "As an open-source user of Chocolatey CLI, we are not able to"
+            }
+            $Output.Lines | Should -Contain $ExpectedOutput -Because $Output.String
+        }
+    }
+
+    # This needs to be the last test in this block, to ensure NuGet configurations aren't being created.
+    Test-NuGetPaths
+}


### PR DESCRIPTION
## Description Of Changes

This commit introduces a new choco support command for Chocolatey CLI. This command already exists for Chocolatey Licensed Extension, but the decision was made to also introduce it into open-source, for consistency reasons.  The output from this version of the command is different to what is shown when you have a license in play, as it points the user to the open-source resources, rather than to reach out to the support team.

Also included is some unit tests and some pester tests, to ensure that the command is working as expected.

## Motivation and Context

After discussion with the support team, having the `choco support` command in both CLI and CLE makes a lot of sense, and will help people find the help that they need.

## Testing

1. Check out and build PR
2. Run `choco support` and verify the output
3. Run `choco support -h` and verify the output
4. Run `choco -h` and see the support command listed
5. Run the unit tests and verify that they complete
6. Verify that Test-Kitchen tests complete succesfully

### Operating Systems Testing

- Windows 11

## Change Types Made

* [ ] Bug fix (non-breaking change).
* [x] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [x] Requires a change to the documentation.
* [ ] Documentation has been updated - this will be completed at the end of the release process
* [x] Tests to cover my changes, have been added.
* [x] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v3 compatibility checked?

## Related Issue

Fixes #3668