### PR TITLE
(#1176) Extend Install-ChocolateyFileAssociation

### DIFF
--- a/src/chocolatey.resources/helpers/functions/Install-ChocolateyFileAssociation.ps1
+++ b/src/chocolatey.resources/helpers/functions/Install-ChocolateyFileAssociation.ps1
@@ -42,6 +42,13 @@ The file extension to be associated.
 .PARAMETER Executable
 The path to the application's executable to be associated.
 
+.PARAMETER Arguments
+Specifies how the file name and CLI arguments are passed to the executable.
+Default value is `"%1" "%*"`; another example: `-o "%1"`, if executable
+requires it. Use `%1`, `%2`, `%3`, etc. to refer to first, second, third,
+etc. arguments. `%*` refers to all arguments, `$~n` refers to all arguments
+starting with argument n (2 <= n <= 9).
+
 .PARAMETER IgnoredArguments
 Allows splatting with arguments that do not apply. Do not use directly.
 
@@ -57,6 +64,7 @@ Install-ChocolateyFileAssociation ".txt" $sublimeExe
     param(
         [parameter(Mandatory = $true, Position = 0)][string] $extension,
         [parameter(Mandatory = $true, Position = 1)][string] $executable,
+        [parameter(Mandatory=$false, Position=2)][string] $arguments = '"%1" "%*"',
         [parameter(ValueFromRemainingArguments = $true)][Object[]] $ignoredArguments
     )
 
@@ -75,7 +83,7 @@ Install-ChocolateyFileAssociation ".txt" $sublimeExe
     $fileType = $fileType.Replace(" ", "_")
     $elevated = @"
     cmd /c "assoc $extension=$fileType"
-    cmd /c 'ftype $fileType="$executable" "%1" "%*"'
+    cmd /c 'ftype $fileType="$executable" $arguments'
     New-PSDrive -Name HKCR -PSProvider Registry -Root HKEY_CLASSES_ROOT
     Set-ItemProperty -Path "HKCR:\$fileType" -Name "(Default)" -Value "$fileType file" -ErrorAction Stop
 "@


### PR DESCRIPTION
## Description Of Changes

This commit adds additional parameter to the function, with the default value that maintains full backwards compatibility.

## Motivation and Context

This allows for greater control over the arguments that are passed through when setting up the file association.  This allows for scenarios where you might need to do something like `-o "%1"` when the default is to do something like `"%1" "%*"`.

## Testing

This change allows for full backwards compatability, so no additional testing has been completed.

### Operating Systems Testing

N/A

## Change Types Made

* [ ] Bug fix (non-breaking change).
* [x] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [x] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [x] All new and existing tests passed?
* [x] PowerShell code changes: PowerShell v3 compatibility checked?

## Related Issue

Fixes #1176