### PR TITLE
(#3294, #1664) Handle "|" and "&" in environment variable value

### DIFF
--- a/src/chocolatey.resources/redirects/RefreshEnv.cmd
+++ b/src/chocolatey.resources/redirects/RefreshEnv.cmd
@@ -1,20 +1,20 @@
-:: Code generously provided by @beatcracker: https://github.com/beatcracker/detect-batch-subshell
 @echo off
+REM Code generously provided by @beatcracker: https://github.com/beatcracker/detect-batch-subshell
 
 setlocal EnableDelayedExpansion
 
-:: Dequote path to command processor and this script path
+REM Dequote path to command processor and this script path
 set ScriptPath=%~0
 set CmdPath=%COMSPEC:"=%
 
-:: Get command processor filename and filename with extension
+REM Get command processor filename and filename with extension
 for %%c in (!CmdPath!) do (
     set CmdExeName=%%~nxc
     set CmdName=%%~nc
 )
 
-:: Get this process' PID
-:: Adapted from: http://www.dostips.com/forum/viewtopic.php?p=22675#p22675
+REM Get this process' PID
+REM Adapted from: http://www.dostips.com/forum/viewtopic.php?p=22675#p22675
 set "uid="
 for /l %%i in (1 1 128) do (
     set /a "bit=!random!&1"
@@ -59,23 +59,23 @@ if !IsExternal!==1 (
     exit 1
 )
 
-:: End code from @beatcracker
+REM End code from @beatcracker
 @echo off
-::
-:: RefreshEnv.cmd
-::
-:: Batch file to read environment variables from registry and
-:: set session variables to these values.
-::
-:: With this batch file, there should be no need to reload command
-:: environment every time you want environment changes to propagate
+REM
+REM RefreshEnv.cmd
+REM
+REM Batch file to read environment variables from registry and
+REM set session variables to these values.
+REM
+REM With this batch file, there should be no need to reload command
+REM environment every time you want environment changes to propagate
 
-::echo "RefreshEnv.cmd only works from cmd.exe, please install the Chocolatey Profile to take advantage of refreshenv from PowerShell"
+REM echo "RefreshEnv.cmd only works from cmd.exe, please install the Chocolatey Profile to take advantage of refreshenv from PowerShell"
 echo | set /p dummy="Refreshing environment variables from registry for cmd.exe. Please wait..."
 
 goto main
 
-:: Set one environment variable from registry key
+REM Set one environment variable from registry key
 :SetFromReg
     "%WinDir%\System32\Reg" QUERY "%~1" /v "%~2" > "%TEMP%\_envset.tmp" 2>NUL
     for /f "usebackq skip=2 tokens=2,*" %%A IN ("%TEMP%\_envset.tmp") do (
@@ -100,7 +100,7 @@ goto main
     )
     goto :EOF
 
-:: Get a list of environment variables from registry
+REM Get a list of environment variables from registry
 :GetRegEnv
     "%WinDir%\System32\Reg" QUERY "%~1" > "%TEMP%\_envget.tmp"
     for /f "usebackq skip=2" %%A IN ("%TEMP%\_envget.tmp") do (
@@ -113,34 +113,34 @@ goto main
 :main
     echo/@echo off >"%TEMP%\_env.cmd"
 
-    :: Slowly generating final file
+    REM Slowly generating final file
     call :GetRegEnv "HKLM\System\CurrentControlSet\Control\Session Manager\Environment" >> "%TEMP%\_env.cmd"
     call :GetRegEnv "HKCU\Environment">>"%TEMP%\_env.cmd" >> "%TEMP%\_env.cmd"
 
-    :: Special handling for PATH - mix both User and System
+    REM Special handling for PATH - mix both User and System
     call :SetFromReg "HKLM\System\CurrentControlSet\Control\Session Manager\Environment" Path Path_HKLM >> "%TEMP%\_env.cmd"
     call :SetFromReg "HKCU\Environment" Path Path_HKCU >> "%TEMP%\_env.cmd"
 
     endlocal
 
-    :: Caution: do not insert space-chars before >> redirection sign
+    REM Caution: do not insert space-chars before >> redirection sign
     echo/set "Path=%%Path_HKLM%%;%%Path_HKCU%%" >> "%TEMP%\_env.cmd"
 
-    :: Cleanup
+    REM Cleanup
     del /f /q "%TEMP%\_envset.tmp" 2>nul
     del /f /q "%TEMP%\_envget.tmp" 2>nul
 
-    :: capture user / architecture
+    REM capture user / architecture
     SET "OriginalUserName=%USERNAME%"
     SET "OriginalArchitecture=%PROCESSOR_ARCHITECTURE%"
 
-    :: Set these variables
+    REM Set these variables
     call "%TEMP%\_env.cmd"
 
-    :: Cleanup
+    REM Cleanup
     del /f /q "%TEMP%\_env.cmd" 2>nul
 
-    :: reset user / architecture
+    REM reset user / architecture
     SET "USERNAME=%OriginalUserName%"
     SET "PROCESSOR_ARCHITECTURE=%OriginalArchitecture%"
 

--- a/src/chocolatey.resources/redirects/RefreshEnv.cmd
+++ b/src/chocolatey.resources/redirects/RefreshEnv.cmd
@@ -83,6 +83,12 @@ goto main
         REM Remove double quotes from temporary value
         set "__tempvar=!tempvar:"=!"
 
+        REM Only escape percentage signs when the value type
+        REM is not defined as an expandable string.
+        if /I NOT "%%~A"=="REG_EXPAND_SZ" (
+            set "tempvar=!tempvar:%%=%%%%!"
+        )
+
         REM If the dequoted string differs from the original string, the variable contains double quotes.
         REM Escape the | and & in the variable to avoid errors.
         if NOT "!__tempvar!" == "!tempvar!" (

--- a/tests/pester-tests/features/RefreshEnvCmd.Tests.ps1
+++ b/tests/pester-tests/features/RefreshEnvCmd.Tests.ps1
@@ -1,0 +1,71 @@
+﻿Describe "Ensuring RefreshEnv.cmd updates environment variables" -Tag EnvironmentVariables, RefreshEnv, Chocolatey {
+    BeforeDiscovery {
+        $testVariables = @(
+            @{
+                Name = "test"
+                Value = "test%20value"
+            }
+            @{
+                Name = "zsdblamp"
+                Value = '"&1'
+            }
+            @{
+                Name = "zsdblpercent"
+                Value = '"%1'
+            }
+            @{
+                Name = "zsdblpipe"
+                Value = '"|1'
+            }
+            @{
+                Name = "zsnoneamp"
+                Value = "&1"
+            }
+            @{
+                Name = "zspercent"
+                Value = "%1"
+            }
+            @{
+                Name = "zsnonepipe"
+                Value = "|1"
+            }
+            @{
+                Name = "zssingleamp"
+                Value = "'&1"
+            }
+            @{
+                Name = "zssinglepercent"
+                Value = "'%1"
+            }
+            @{
+                Name = "zssinglepipe"
+                Value = "'|1"
+            }
+        )
+    }
+
+    BeforeAll {
+        Initialize-ChocolateyTestInstall
+        New-ChocolateyInstallSnapshot
+    }
+
+    AfterAll {
+        Remove-ChocolateyTestInstall
+    }
+
+    Context "When refreshing environment variables with special characters (<Name>=<Value>)" -ForEach $testVariables {
+        BeforeAll {
+            [System.Environment]::SetEnvironmentVariable($Name, $Value, 'User')
+
+            $Output = & "cmd.exe" "/c" "`"$env:ChocolateyInstall\bin\RefreshEnv.cmd`" & set"
+        }
+
+        AfterAll {
+            [System.Environment]::SetEnvironmentVariable($Name, $null, 'User')
+        }
+
+        It "Should have expected value in refreshed variable" {
+            $Output | Should -Contain "$Name=$Value" -Because ($Output -join "`n")
+        }
+    }
+}


### PR DESCRIPTION
## Description Of Changes

This commit adds this replacement, in addition to moving the endlocal further down the file, so that the EnableDelayedExpansion is in place when the operation is done.

## Motivation and Context

When an environment variable contains a "|" character, during the process of hydrating the values, the "|" causes an error, as it is attempting to do "something" when executing the "set" command, from the _env.cmd file.  We suspect that the underlying problem is the combination of the " which is added to the environment variable by Windows itself, and usage of the | as a logical OR operation.  To get around this problem, we needed to escape the pipe character using a ^ character.  This is done using a replacement of a single "|" with "^|".

## Testing

1. Apply the changes in this PR to your local `refreshenv.cmd` file
2. Create an environment variable with the value of `|1`
3. Open a Windows Command Prompt
4. Run `set` to verify you can see the created environment variable with the value of `|1`
5. Run `refreshenv`
6. Verify that there is not an error
7. Run `set` to verify you can see the created environment variable with the same value as before
8. Repeat for `&` and `%` instead of `|`

## Change Types Made

* [x] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [ ] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v3 compatibility checked?

## Related Issue

- Fixes #3294
- Fixes #1664 