### PR TITLE
(#1713) Previous package version as env variable

### DIFF
--- a/src/chocolatey/StringResources.cs
+++ b/src/chocolatey/StringResources.cs
@@ -175,6 +175,11 @@ namespace chocolatey
                 public const string OsVersion = "OS_VERSION";
 
                 /// <summary>
+                /// The normalized version of the currently installed package version - set during package upgrade.
+                /// </summary>
+                public const string ChocolateyPreviousPackageVersion = nameof(ChocolateyPreviousPackageVersion);
+
+                /// <summary>
                 /// The location where temporary files should be stored during PowerShell execution.
                 /// </summary>
                 /// <remarks>

--- a/src/chocolatey/infrastructure.app/configuration/ChocolateyConfiguration.cs
+++ b/src/chocolatey/infrastructure.app/configuration/ChocolateyConfiguration.cs
@@ -530,6 +530,11 @@ NOTE: Hiding sensitive configuration data! Please double and triple
     [Serializable]
     public sealed class InformationCommandConfiguration
     {
+        public InformationCommandConfiguration()
+        {
+            EnvironmentVariables = new Dictionary<string, string>();
+        }
+
         // application set variables
         public PlatformType PlatformType { get; set; }
 
@@ -552,6 +557,15 @@ NOTE: Hiding sensitive configuration data! Please double and triple
         public bool IsLicensedAssemblyLoaded { get; set; }
         public string LicenseType { get; set; }
         public string CurrentDirectory { get; set; }
+
+        /// <summary>
+        /// A collection of values that should be written out as environment variables
+        /// within the PowerShell execution that Chocolatey CLI creates. This allows
+        /// for passing information, such as the previous Chocolatey package version
+        /// during `choco upgrade` through to the method that writes the environment
+        /// variables into the PowerShell session.
+        /// </summary>
+        public Dictionary<string, string> EnvironmentVariables { get; set; }
     }
 
     [Serializable]

--- a/src/chocolatey/infrastructure.app/configuration/EnvironmentSettings.cs
+++ b/src/chocolatey/infrastructure.app/configuration/EnvironmentSettings.cs
@@ -70,6 +70,16 @@ namespace chocolatey.infrastructure.app.configuration
         {
             ResetEnvironmentVariables(config);
 
+            // During the Chocolatey execution, it is possible that the EnvironmentVariables property of
+            // the ChocolateyConfiguration object has been updated to include values that should be written
+            // out as environment variables into the current PowerShell session.  As example of this would
+            // be the previous package version during the exection of a `choco upgrade` command.  We need
+            // to loop through this collection, and write them out as environment variables.
+            foreach (var environmentVariable in config.Information.EnvironmentVariables)
+            {
+                Environment.SetEnvironmentVariable(environmentVariable.Key, environmentVariable.Value);
+            }
+
             Environment.SetEnvironmentVariable(EnvironmentVariables.System.ChocolateyInstall, ApplicationParameters.InstallLocation);
             Environment.SetEnvironmentVariable(EnvironmentVariables.Package.ChocolateyVersion, config.Information.ChocolateyVersion);
             Environment.SetEnvironmentVariable(EnvironmentVariables.Package.ChocolateyProductVersion, config.Information.ChocolateyProductVersion);

--- a/src/chocolatey/infrastructure.app/services/NugetService.cs
+++ b/src/chocolatey/infrastructure.app/services/NugetService.cs
@@ -1769,12 +1769,6 @@ Please see https://docs.chocolatey.org/en-us/troubleshooting for more
                                         downloadResult,
                                         projectContext,
                                         CancellationToken.None).GetAwaiter().GetResult();
-
-                                    // To make sure that there is no "pollution" of a previous package version into another package
-                                    // operation, such as during a `choco upgrade all` or when upgrading a package that has one or
-                                    // more dependencies, we need to make sure to clear the entry in the EnvironmentVariables collection,
-                                    // and rely on this being set again when the current and previous package versions are "known" again.
-                                    config.Information.EnvironmentVariables[EnvironmentVariables.Package.ChocolateyPreviousPackageVersion] = null;
                                 }
 
                                 var installedPath = nugetProject.GetInstalledPath(packageDependencyInfo);
@@ -1855,6 +1849,14 @@ Please see https://docs.chocolatey.org/en-us/troubleshooting for more
                                 {
                                     continueAction.Invoke(errorResult, config);
                                 }
+                            }
+                            finally
+                            {
+                                // To make sure that there is no "pollution" of a previous package version into another package
+                                // operation, such as during a `choco upgrade all` or when upgrading a package that has one or
+                                // more dependencies, we need to make sure to clear the entry in the EnvironmentVariables collection,
+                                // and rely on this being set again when the current and previous package versions are "known" again.
+                                config.Information.EnvironmentVariables[EnvironmentVariables.Package.ChocolateyPreviousPackageVersion] = null;
                             }
                         }
                     }

--- a/tests/pester-tests/features/EnvironmentVariables.Tests.ps1
+++ b/tests/pester-tests/features/EnvironmentVariables.Tests.ps1
@@ -1,3 +1,11 @@
+# This test is covering a number of different things
+# 1. Verify that the TEMP/TMP variables are set with the cachelocation value when
+# it is set, either in the chocolatey.config file or via command line
+# 2. Verify that some of the expected environment variables are present during a
+# package operation, i.e. ChocolateyPackageName
+# 3. Verify that the ChocolateyPreviousPackageVersion environment variable is set
+# during an upgrade operation. We are testing here for the normalized package
+# version, even though the installed package version is not normalized.
 Describe "Ensuring Chocolatey Environment variables are correct (<_>)" -ForEach @(
     "config"
     "cli"
@@ -10,6 +18,7 @@ Describe "Ensuring Chocolatey Environment variables are correct (<_>)" -ForEach 
             @{ Name = 'ChocolateyPackageName' ; Value = 'test-environment' }
             @{ Name = 'ChocolateyPackageTitle' ; Value = 'test-environment (Install)' }
             @{ Name = 'ChocolateyPackageVersion' ; Value = '1.0.0' }
+            @{ Name = 'ChocolateyPreviousPackageVersion' ; Value = '0.9.0' }
         )
     }
 
@@ -25,7 +34,8 @@ Describe "Ensuring Chocolatey Environment variables are correct (<_>)" -ForEach 
                 $cacheArg = "--cache-location='$cacheDir'"
             }
         }
-        $Output = Invoke-Choco install test-environment --version 1.0.0 $cacheArg
+        $null = Invoke-Choco install test-environment --version 0.9 $cacheArg
+        $Output = Invoke-Choco upgrade test-environment --version 1.0.0 $cacheArg
     }
 
     AfterAll {


### PR DESCRIPTION
## Description Of Changes

This commit adds the ability to output the previous package version, during say a `choco upgrade` command, as an environment variable. Prior to this commit, it was only the package version that was currently being installed/upgraded that was presented as an environment variable.

The method that is responsible for writing the environment variables is the PreparePowerShellEnvironment method, which is defined by the IPowershellService interface.  Rather than make a change to the interface to pass in this information, it was decided to add a property to the ChocolateyConfiguration class, which is currently being passed through to this method.  This means that there is some maintainability in place, where additional information can be passed through as environment variables in the future, should the need arise.  This would be done by simply adding another item into the Dictionary.

Pester tests have been updated to allow the testing for this new environment variable during the process of upgrading a package version.

## Motivation and Context

This is needed since there are times that during an upgrade you want to do something based on which version is being upgraded from. For example, you might have to do "something" when upgrading from version 1.0.0 and "something else" when upgrading from version 2.0.0.  Being able to inspect the previous package version as an environment variable, in the same way as you can the package version being currently installed is _very_ useful, and also consistent with how package maintainers get other information.

## Testing

1. Clone this repository, and check out PR branch
2. Open project in Visual Studio, and set a breakpoint on line 1719 of the `NugetService.cs` class
3. Run `install vscode --version 1.100.2 -n`
4. The above breakpoint should not be hit, as the install is a different code path
5. Run `upgrade vscode -n`
6. The above breakpoint should be hit for first the `vscode.install` package, with the previous version of 1.100.2 and the current version 1.100.3
7. Continue code execution
8. The above breakpoint should be hit for first the `vscode` package, with the previous version of 1.100.2 and the current version 1.100.3
9. Each time, the `config.Information.EnvironmentVariables` should either have a Count of 0, or have a null value for the `ChocolateyPreviousPackageVersion` entry.

### Operating Systems Testing

- Windows 11

## Change Types Made

* [ ] Bug fix (non-breaking change).
* [x] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [x] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [x] Tests to cover my changes, have been added.
* [x] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v3 compatibility checked?

## Related Issue

Fixes #1713 