### PR TITLE
(maint) Update VCS trigger to include all branches

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -73,6 +73,8 @@ object Chocolatey : BuildType({
     triggers {
         vcs {
             branchFilter = """
+                +:*
+                -:master
                 -:support/*
             """.trimIndent()
         }


### PR DESCRIPTION
## Description Of Changes

Modify the VCS trigger branch filter to include all branches except the master and support/* branches. This change prevents builds from running on the master branch, reducing unnecessary CI runs and focusing resources on feature and development branches.

## Motivation and Context

We want to be able to run builds from any branch in the repository, with the exception of the master and support branches. This change was indicated to be the solution to the problem we have with builds on the develop branch and pull requests not being initiated.

## Testing

A similar change was added to our development testing instance, which indicates that is working as expected.

### Operating Systems Testing

N/A

## Change Types Made

* [ ] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.
* [x] Build Related

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [ ] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v3 compatibility checked?

## Related Issue

N/A