### PR TITLE
(#3666) Add ChocolateyNotSilent env variable

### DIFF
--- a/src/chocolatey/StringResources.cs
+++ b/src/chocolatey/StringResources.cs
@@ -83,6 +83,12 @@ namespace chocolatey
                 public const string ChocolateyLicenseType = nameof(ChocolateyLicenseType);
 
                 /// <summary>
+                /// Whether the user has requested to explicitly make the package installation not silent.
+                /// </summary>
+                /// <remarks>Available in v2.5.0+</remarks>
+                public const string ChocolateyNotSilent = nameof(ChocolateyNotSilent);
+
+                /// <summary>
                 /// The location that the package was found to be installed to. When found will be
                 /// outputted by Chocolatey CLI at the end of its execution.
                 /// </summary>

--- a/src/chocolatey/infrastructure.app/services/PowershellService.cs
+++ b/src/chocolatey/infrastructure.app/services/PowershellService.cs
@@ -489,6 +489,7 @@ namespace chocolatey.infrastructure.app.services
             Environment.SetEnvironmentVariable(EnvironmentVariables.Package.ChocolateyChecksumType64, null);
             Environment.SetEnvironmentVariable(EnvironmentVariables.Package.ChocolateyForceX86, null);
             Environment.SetEnvironmentVariable(EnvironmentVariables.Package.DownloadCacheAvailable, null);
+            Environment.SetEnvironmentVariable(EnvironmentVariables.Package.ChocolateyNotSilent, null);
 
             // we only want to pass the following args to packages that would apply.
             // like choco install git --params '' should pass those params to git.install,
@@ -535,6 +536,11 @@ namespace chocolatey.infrastructure.app.services
             if (!string.IsNullOrWhiteSpace(configuration.DownloadChecksumType64))
             {
                 Environment.SetEnvironmentVariable(EnvironmentVariables.Package.ChocolateyChecksumType64, configuration.DownloadChecksumType64);
+            }
+
+            if (configuration.NotSilent)
+            {
+                Environment.SetEnvironmentVariable(EnvironmentVariables.Package.ChocolateyNotSilent, "true");
             }
 
             if (configuration.ForceX86)

--- a/tests/pester-tests/features/EnvironmentVariables.Tests.ps1
+++ b/tests/pester-tests/features/EnvironmentVariables.Tests.ps1
@@ -6,6 +6,8 @@
 # 3. Verify that the ChocolateyPreviousPackageVersion environment variable is set
 # during an upgrade operation. We are testing here for the normalized package
 # version, even though the installed package version is not normalized.
+# 4. Verifies the usage of the ChocolateyNotSilent environment variable by using
+# the --not-silent command line argument
 Describe "Ensuring Chocolatey Environment variables are correct (<_>)" -ForEach @(
     "config"
     "cli"
@@ -19,6 +21,7 @@ Describe "Ensuring Chocolatey Environment variables are correct (<_>)" -ForEach 
             @{ Name = 'ChocolateyPackageTitle' ; Value = 'test-environment (Install)' }
             @{ Name = 'ChocolateyPackageVersion' ; Value = '1.0.0' }
             @{ Name = 'ChocolateyPreviousPackageVersion' ; Value = '0.9.0' }
+            @{ Name = 'ChocolateyNotSilent' ; Value = 'true' }
         )
     }
 
@@ -34,8 +37,8 @@ Describe "Ensuring Chocolatey Environment variables are correct (<_>)" -ForEach 
                 $cacheArg = "--cache-location='$cacheDir'"
             }
         }
-        $null = Invoke-Choco install test-environment --version 0.9 $cacheArg
-        $Output = Invoke-Choco upgrade test-environment --version 1.0.0 $cacheArg
+        $null = Invoke-Choco install test-environment --version 0.9 $cacheArg --not-silent
+        $Output = Invoke-Choco upgrade test-environment --version 1.0.0 $cacheArg --not-silent
     }
 
     AfterAll {
@@ -49,5 +52,37 @@ Describe "Ensuring Chocolatey Environment variables are correct (<_>)" -ForEach 
     It 'Should Output the expected value for <Name> environment variable' -ForEach $TestedVariables {
         $ExpectedLine = "$Name=$Value" -f $env:ChocolateyInstall
         $Output.Lines | Should -Contain $ExpectedLine -Because $Output.String
+    }
+}
+
+# Some environment variables should _only_ be present when the corresponding
+# configuration has been set. An example of that would be the
+# $env:ChocolateyNotSilent variable, which should only be present when the
+# --not-silent command line argument is passed in.  When this doesn't happen,
+# the environment variable should not be included in the output.
+Describe "Ensuring Chocolatey Environment variables are not present (<_>)" -Tag EnvironmentVariables, Chocolatey {
+    BeforeDiscovery {
+        $TestedVariables = @(
+            @{ Name = 'ChocolateyNotSilent' ; Value = 'true' }
+        )
+    }
+
+    BeforeAll {
+        Initialize-ChocolateyTestInstall
+        New-ChocolateyInstallSnapshot
+        $Output = Invoke-Choco install test-environment
+    }
+
+    AfterAll {
+        Remove-ChocolateyTestInstall
+    }
+
+    It "Should exit with success (0)" {
+        $Output.ExitCode | Should -Be 0 -Because $Output.String
+    }
+
+    It 'Should Output the expected value for <Name> environment variable' -ForEach $TestedVariables {
+        $ExpectedLine = "$Name=$Value"
+        $Output.Lines | Should -Not -Contain $ExpectedLine -Because $Output.String
     }
 }


### PR DESCRIPTION
## Description Of Changes

This commit introduces a new ChocolateyNotSilent environment variable, which will be set when the user makes use of the --not-silent command line argument.

In addition, a new Pester test assertion has been added to check for the presence of the environment variable.

## Motivation and Context

This is useful, as it will allow package maintainers to take additional actions in their scripts, when required.  An example of this would be when a package uses an autohotkey script to perform the installation. Passing the --not-silent argument here does nothing, and the autohotkey script is still ran.  The presence of this environment variable can now be used as a trigger for "if" the autohotkey should be run.


## Testing

1. A new pester test assertion has been added to ensure that this new environment variable is output

### Operating Systems Testing

N/A

## Change Types Made

* [ ] Bug fix (non-breaking change).
* [x] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [x] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [x] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v3 compatibility checked?

## Related Issue

Fixes #3666