### PR TITLE
(maint) Improve credential provider and support command tests

### DIFF
--- a/tests/pester-tests/commands/choco-support.Tests.ps1
+++ b/tests/pester-tests/commands/choco-support.Tests.ps1
@@ -1,14 +1,12 @@
 ﻿Import-Module helpers/common-helpers
 
 Describe "choco support" -Tag Chocolatey, SupportCommand {
-    BeforeDiscovery {
-        $HasLicensedExtension = Test-PackageIsEqualOrHigher -PackageName 'chocolatey.extension' -Version '6.0.0'
-    }
-
     BeforeAll {
         Remove-NuGetPaths
         Initialize-ChocolateyTestInstall
         New-ChocolateyInstallSnapshot
+
+        $HasLicensedExtension = Test-PackageIsEqualOrHigher -PackageName 'chocolatey.extension' -Version '6.0.0'
     }
 
     AfterAll {
@@ -43,7 +41,7 @@ Describe "choco support" -Tag Chocolatey, SupportCommand {
             $Output.ExitCode | Should -Be 0 -Because $Output.String
         }
 
-        It "Outputs Help for Support" {
+        It "Outputs Support Command Title in Help Documentation" {
             $Output.String | Should -Match "Support Command" -Because $Output.String
         }
 

--- a/tests/pester-tests/features/CredentialProvider.Tests.ps1
+++ b/tests/pester-tests/features/CredentialProvider.Tests.ps1
@@ -51,7 +51,9 @@ Describe 'Ensuring credentials do not bleed from configured sources' -Tag Creden
             $PackageUnderTest = 'chocolatey-compatibility.extension'
             Restore-ChocolateyInstallSnapshot
             # Chocolatey will prompt for credentials, we need to force something in there, and this will do that.
-            $Output = 'n' | Invoke-Choco $Command $PackageUnderTest --confirm --source="'$($SetupSource.Url)'"
+            # We also ignore the HTTP Cache as if the package has previously been found under different credentials,
+            # the result will sometimes be re-used when it is found.
+            $Output = 'n' | Invoke-Choco $Command $PackageUnderTest --confirm --source="'$($SetupSource.Url)'" --ignore-http-cache
         }
 
         AfterAll {


### PR DESCRIPTION
## Description Of Changes

Add --ignore-http-cache to credential provider test to prevent cached results from interfering when credentials differ. This ensures more reliable test outcomes for package source authentication.

Refactor support command tests by moving license check to BeforeAll for better setup consistency. Also, update test description to clarify it verifies the presence of the support command title in help output.

## Motivation and Context

To update tests that have transitive failures or is make use of incorrect logic as well as making our internal test kitchen build succeed.

## Testing

Some manual testing was done, but will be properly tested on internal test kitchen

### Operating Systems Testing

- Windows 11

## Change Types Made

* [ ] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.
* [x] Test changes

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [x] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v3 compatibility checked?

## Related Issue

- PROJ-1366