### PR TITLE
(#3633) Update GHA build runners and install mono on Ubuntu runner

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,7 +38,7 @@ jobs:
           code_drop/MsBuild.log
   # Build on Windows
   windows-build:
-    runs-on: windows-2019
+    runs-on: windows-latest
     steps:
     - uses: actions/checkout@v3
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   # Build using mono on Ubuntu
   ubuntu-build:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
       with:
@@ -21,6 +21,14 @@ jobs:
       with:
         path: tools
         key: ${{ runner.os }}-tools-${{ hashFiles('recipe.cake') }}
+    - name: Install Mono
+      run: |
+        sudo apt install ca-certificates gnupg
+        sudo gpg --homedir /tmp --no-default-keyring --keyring /usr/share/keyrings/mono-official-archive-keyring.gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
+        echo "deb [signed-by=/usr/share/keyrings/mono-official-archive-keyring.gpg] https://download.mono-project.com/repo/ubuntu stable-focal main" | sudo tee /etc/apt/sources.list.d/mono-official-stable.list
+        sudo apt update
+        sudo apt install -y mono-complete
+        mono --version
     - name: Build with Mono
       run: |
         chmod +x build.sh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,7 +37,7 @@ jobs:
           code_drop/MsBuild.log
   # Build and test on Windows
   windows-build:
-    runs-on: windows-2019
+    runs-on: windows-latest
     steps:
     - uses: actions/checkout@v3
       with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,6 +21,14 @@ jobs:
       with:
         path: tools
         key: ${{ runner.os }}-tools-${{ hashFiles('recipe.cake') }}
+    - name: Install Mono
+      run: |
+        sudo apt install ca-certificates gnupg
+        sudo gpg --homedir /tmp --no-default-keyring --keyring /usr/share/keyrings/mono-official-archive-keyring.gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
+        echo "deb [signed-by=/usr/share/keyrings/mono-official-archive-keyring.gpg] https://download.mono-project.com/repo/ubuntu stable-focal main" | sudo tee /etc/apt/sources.list.d/mono-official-stable.list
+        sudo apt update
+        sudo apt install -y mono-complete
+        mono --version
     - name: Test with NUnit on Mono
       run: |
         chmod +x build.sh


### PR DESCRIPTION
## Description Of Changes
- Updated Windows runner in CI workflow from windows-2019 to windows-latest.
- Added Mono installation steps to GitHub workflow jobs for both test and build.
- Changed runner environment to ubuntu-latest for improved compatibility.
- Included Mono repository setup and installation commands in workflows.

## Motivation and Context
- To keep the build environment current with the latest Windows updates and tools.
- To ensure the required Mono runtime is available during CI runs.
- To improve compatibility and reduce maintenance overhead in CI workflows.
- To avoid build environment failing when windows-2019 is removed later in June.

## Testing
- Verified CI workflows run successfully with updated runners and Mono installation. (https://github.com/AdmiringWorm/choco/actions/runs/15609863589)

### Operating Systems Testing
- Windows (windows-latest) (_GHA_)
- Ubuntu (ubuntu-latest) (_GHA_)

## Change Types Made
* [ ] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.
* [x] Build Related

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [x] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v3 compatibility checked?

## Related Issue

- Fixes #3633
- PROJ-1484