### PR TITLE
(#2410) Update arguments utility to handle package parameters starting with dashes

### DIFF
--- a/src/chocolatey.tests/infrastructure.app/utility/ArgumentsUtilitySpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/utility/ArgumentsUtilitySpecs.cs
@@ -14,9 +14,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System.IO;
+using System.Linq;
+using chocolatey.infrastructure.app;
+using chocolatey.infrastructure.app.nuget;
 using chocolatey.infrastructure.app.utility;
-using NUnit.Framework;
+using chocolatey.infrastructure.filesystem;
 using FluentAssertions;
+using Moq;
+using NUnit.Framework;
 
 namespace chocolatey.tests.infrastructure.app.utility
 {
@@ -26,6 +32,285 @@ namespace chocolatey.tests.infrastructure.app.utility
         {
             public override void Context()
             {
+            }
+        }
+
+        public abstract class ArgumentsUtilityDecryptSpecsBase : TinySpec
+        {
+            protected string[] Result;
+            protected Mock<IFileSystem> FileSystem = new Mock<IFileSystem>();
+
+            public override void Context()
+            {
+                FileSystem.Setup(f => f.CombinePaths(It.IsAny<string>(), It.IsAny<string[]>()))
+                    .Returns<string, string[]>((arg1, args) => Path.Combine(arg1, Path.Combine(args)));
+            }
+
+            public override void Because()
+            {
+                Result = ArgumentsUtility.DecryptPackageArgumentsFile(FileSystem.Object, "test-package", "0.1.0").ToArray();
+            }
+
+            protected void AddArgumentsMock(string arguments)
+            {
+                AddArgumentsMock(arguments, "test-package", "0.1.0");
+            }
+
+            protected void AddArgumentsMock(string arguments, string id, string version)
+            {
+                var expectedPathEnds = Path.Combine(
+                    ApplicationParameters.InstallLocation,
+                    ".chocolatey",
+                    id + "." + version,
+                    ".arguments");
+
+                var exists = true;
+
+                if (arguments is null)
+                {
+                    exists = false;
+                    FileSystem.Setup(f => f.ReadFile(expectedPathEnds)).Throws(new FileNotFoundException());
+                }
+                else
+                {
+                    FileSystem.Setup(f => f.ReadFile(expectedPathEnds)).Returns(NugetEncryptionUtility.EncryptString(arguments));
+                }
+
+                FileSystem.Setup(f => f.FileExists(expectedPathEnds)).Returns(exists);
+            }
+        }
+
+        public class When_ArgumentsUtility_is_parsing_remembered_arguments_and_file_does_not_exist : ArgumentsUtilityDecryptSpecsBase
+        {
+            public override void Context()
+            {
+                base.Context();
+
+                AddArgumentsMock(null);
+            }
+
+            [Fact]
+            public void Should_Have_Returned_An_Empty_Set()
+            {
+                Result.Should().BeEmpty();
+            }
+        }
+
+        public class When_ArgumentsUtility_is_parsing_remembered_arguments_with_single_quote_in_variable : ArgumentsUtilityDecryptSpecsBase
+        {
+            public override void Context()
+            {
+                base.Context();
+
+                AddArgumentsMock(" --prerelease  --ignore-dependencies --package-parameters=\"'--quiet --install-path=\"C:\\User\\My' User\\Install\"'\"");
+            }
+
+            [Fact]
+            public void Should_Only_Contain_Three_Arguments()
+            {
+                Result.Should().HaveCount(3);
+            }
+
+            [InlineData("--prerelease")]
+            [InlineData("--ignore-dependencies")]
+            [InlineData("--package-parameters='--quiet --install-path=\"C:\\User\\My' User\\Install\"'")]
+            public void Should_Contain_Expected_Arguments(string argument)
+            {
+                Result.Should().Contain(argument);
+            }
+        }
+
+        public class When_ArgumentsUtility_is_parsing_remembered_arguments_with_quotes : ArgumentsUtilityDecryptSpecsBase
+        {
+            public override void Context()
+            {
+                base.Context();
+
+                AddArgumentsMock(" --override-arguments --package-parameters=\"'--quiet --norestart --wait --includeRecommended --includeOptional'\" --cache-location=\"'C:\\Users\\Test\\AppData\\Local\\Temp\\chocolatey'\"");
+            }
+
+            [Fact]
+            public void Should_Only_Contain_Three_Arguments()
+            {
+                Result.Should().HaveCount(3);
+            }
+
+            [InlineData("--override-arguments")]
+            [InlineData("--package-parameters='--quiet --norestart --wait --includeRecommended --includeOptional'")]
+            [InlineData("--cache-location='C:\\Users\\Test\\AppData\\Local\\Temp\\chocolatey'")]
+            public void Should_Contain_Expected_Arguments(string argument)
+            {
+                Result.Should().Contain(argument);
+            }
+        }
+
+        public class When_ArgumentsUtility_is_parsing_arguments_with_large_junk_string : ArgumentsUtilityDecryptSpecsBase
+        {
+            public override void Context()
+            {
+                base.Context();
+
+                // Create a large, unmatched string that never contains the expected quote sequence
+                var junk = new string('x', 10_000);
+
+                AddArgumentsMock($"--package-parameters=\"'{junk}'\"");
+            }
+
+            [Fact]
+            public void Should_Contain_A_Single_Argument()
+            {
+                Result.Should().ContainSingle();
+            }
+
+            [Fact]
+            public void Should_Not_Throw_Or_Overflow()
+            {
+                // If we reach this point, no exception or stack overflow occurred
+                Result.First().Should().StartWith("--package-parameters=");
+            }
+        }
+
+        public class When_ArgumentsUtility_encounters_many_partial_quote_matches : ArgumentsUtilityDecryptSpecsBase
+        {
+            public override void Context()
+            {
+                base.Context();
+
+                // This will trigger hundreds of failed partial matches, forcing recursion
+                var misleading = string.Concat(Enumerable.Repeat("'junk ", 200));
+                var args = $"--package-parameters=\"{misleading}\"";
+
+                AddArgumentsMock(args);
+            }
+
+            [Fact]
+            public void Should_Not_Throw_Or_Overflow()
+            {
+                // If this completes, we didn't blow the stack
+                Result.Should().NotBeEmpty();
+            }
+        }
+
+        public class When_ArgumentsUtility_is_parsing_remembered_arguments_with_quotes_and_pkg_parameters_in_quotes : ArgumentsUtilityDecryptSpecsBase
+        {
+            public override void Context()
+            {
+                base.Context();
+
+                AddArgumentsMock("--package-parameters='\"/User:\\\"kim\\\" /Env:\\\"dev\\\"\"'");
+            }
+
+            [Fact]
+            public void Should_Only_Contain_A_Single_Argument_Arguments()
+            {
+                Result.Should().ContainSingle();
+            }
+
+            [InlineData("--package-parameters=\"/User:\\\"kim\\\" /Env:\\\"dev\\\"\"")]
+            public void Should_Contain_Expected_Arguments(string argument)
+            {
+                Result.Should().Contain(argument);
+            }
+        }
+
+        public class When_ArgumentsUtility_is_parsing_remembered_arguments_with_quotes_and_pkg_parameters_in_quotes_and_spaces : ArgumentsUtilityDecryptSpecsBase
+        {
+            public override void Context()
+            {
+                base.Context();
+
+                AddArgumentsMock("--package-parameters=\"'/Path:\"\"C:\\Program Files\\Dummy\"\" /LicenseKey:ABC-123-XYZ'\"");
+            }
+
+            [Fact]
+            public void Should_Only_Contain_A_Single_Argument()
+            {
+                Result.Should().ContainSingle();
+            }
+
+            [InlineData("--package-parameters='/Path:\"\"C:\\Program Files\\Dummy\"\" /LicenseKey:ABC-123-XYZ'")]
+            public void Should_Contain_Expected_Arguments(string argument)
+            {
+                Result.Should().Contain(argument);
+            }
+        }
+
+        public class When_ArgumentsUtility_is_parsing_remembered_arguments_with_parameter_using_single_quote : ArgumentsUtilityDecryptSpecsBase
+        {
+            public override void Context()
+            {
+                base.Context();
+
+                AddArgumentsMock("--package-parameters=\"/Author:O'Reilly /Title:Beginner's Guide\"");
+            }
+
+            [Fact]
+            public void Should_Contain_A_Single_Argument()
+            {
+                Result.Should().ContainSingle();
+            }
+
+            [InlineData("--package-parameters=/Author:O'Reilly /Title:Beginner's Guide")]
+            public void Should_Contain_Expected_Arguments(string argument)
+            {
+                Result.Should().Contain(argument);
+            }
+        }
+        public class When_ArgumentsUtility_encounters_unterminated_quotes : ArgumentsUtilityDecryptSpecsBase
+        {
+            public override void Context()
+            {
+                base.Context();
+
+                AddArgumentsMock("--package-parameters='--opt1 --opt2");
+            }
+
+            [Fact]
+            public void Should_Preserve_Unterminated_Argument()
+            {
+                // We don't ensure that the argument is closing the quote,
+                // as such the same argument that was passed in is returned.
+                Result.Should().Equal(new[]
+                {
+                    "--package-parameters='--opt1 --opt2"
+                });
+            }
+        }
+        public class When_ArgumentsUtility_encounters_empty_quoted_argument : ArgumentsUtilityDecryptSpecsBase
+        {
+            public override void Context()
+            {
+                base.Context();
+
+                AddArgumentsMock("--option=\"\"");
+            }
+
+            [Fact]
+            public void Should_Treat_Empty_Quoted_Value_As_Empty_String()
+            {
+                Result.Should().Equal(new[]
+                {
+                    "--option"
+                });
+            }
+        }
+        public class When_ArgumentsUtility_encounters_mixed_quote_styles : ArgumentsUtilityDecryptSpecsBase
+        {
+            public override void Context()
+            {
+                base.Context();
+
+                AddArgumentsMock("--first='value one' --second=\"value two\"");
+            }
+
+            [Fact]
+            public void Should_Parse_Mixed_Quoted_Arguments_Correctly()
+            {
+                Result.Should().Equal(new[]
+                {
+                    "--first=value one",
+                    "--second=value two"
+                });
             }
         }
 

--- a/src/chocolatey/infrastructure.app/services/PowershellService.cs
+++ b/src/chocolatey/infrastructure.app/services/PowershellService.cs
@@ -216,7 +216,7 @@ namespace chocolatey.infrastructure.app.services
 
         private string EscapePowerShellArguments(string argument)
         {
-            return argument.ToStringSafe().Replace("\"", "\\\"");
+            return argument.ToStringSafe().Replace("\"", "\\\"").Replace("'", "''");
         }
 
         public bool RunAction(ChocolateyConfiguration configuration, PackageResult packageResult, CommandNameType command)

--- a/tests/pester-tests/commands/choco-info.Tests.ps1
+++ b/tests/pester-tests/commands/choco-info.Tests.ps1
@@ -259,6 +259,24 @@
         }
     }
 
+    Context 'Listing package information with single quote in parameter shows expected parameters' -Tag Arguments {
+        BeforeAll {
+            Restore-ChocolateyInstallSnapshot
+            
+            $null = Invoke-Choco install test-params --package-parameters="/Comment:It's great! /SubmittedBy:Kim"
+
+            $Output = Invoke-Choco info test-params --local-only
+        }
+        
+        It "Exits successfully (0)" {
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
+        }
+
+        It "Should output package parameter" {
+            $Output.Lines | Should -Contain "--package-parameters='/Comment:It's great! /SubmittedBy:Kim'"
+        }
+    }
+
     # This needs to be the last test in this block, to ensure NuGet configurations aren't being created.
     Test-NuGetPaths
 }

--- a/tests/pester-tests/commands/choco-install.Tests.ps1
+++ b/tests/pester-tests/commands/choco-install.Tests.ps1
@@ -2270,6 +2270,31 @@ To install a local, or remote file, you may use:
         }
     }
 
+    Context 'Installing a package using a single quote in the parameters' -Tag Arguments {
+        BeforeAll {
+            Restore-ChocolateyInstallSnapshot
+            
+            $Output = Invoke-Choco install test-params --package-parameters="/Comment:It's great! /SubmittedBy:Kim"
+        }
+        
+        It "Exits successfully (0)" {
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
+        }
+
+        It "Should output expected package parameters (<Name>=<Value>)" -ForEach @(
+            @{
+                Name = 'Comment'
+                Value = 'It''s great!'
+            }
+            @{
+                Name = 'SubmittedBy'
+                Value = 'Kim'
+            }
+        ) {
+            $Output.Lines | Should -Contain "WARNING:  - $Name = $Value"
+        }
+    }
+
     # This needs to be the last test in this block, to ensure NuGet configurations aren't being created.
     # Any tests after this block are expected to generate the configuration as they're explicitly using the NuGet CLI
     Test-NuGetPaths

--- a/tests/pester-tests/commands/choco-upgrade.Tests.ps1
+++ b/tests/pester-tests/commands/choco-upgrade.Tests.ps1
@@ -834,6 +834,30 @@ To upgrade a local, or remote file, you may use:
         }
     }
 
+    Context 'Upgrading a package using double-dash arguments in package arguments' -Tag Arguments {
+        BeforeAll {
+            Restore-ChocolateyInstallSnapshot
+
+            Enable-ChocolateyFeature -Name "useRememberedArgumentsForUpgrades"
+
+            $null = Invoke-Choco install test-environment --package-parameters="'--quiet --norestart --wait --includeRecommended --includeOptional'" --verbose --version 0.9
+
+            $Output = Invoke-Choco upgrade test-environment --verbose
+        }
+
+        It "Exits successfully (0)" {
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
+        }
+
+        It "Should have set the expected package parameter to environment variable" {
+            $Output.Lines | Should -Contain "chocolateyPackageParameters=--quiet --norestart --wait --includeRecommended --includeOptional" -Because $Output.String
+        }
+
+        It "Should report 1 out of 1 packages upgraded" {
+            $Output.Lines | Should -Contain "Chocolatey upgraded 1/1 packages." -Because $Output.String
+        }
+    }
+
     # This needs to be (almost) the last test in this block, to ensure NuGet configurations aren't being created.
     # Any tests after this block are expected to generate the configuration as they're explicitly using the NuGet CLI
     Test-NuGetPaths

--- a/tests/pester-tests/commands/choco-upgrade.Tests.ps1
+++ b/tests/pester-tests/commands/choco-upgrade.Tests.ps1
@@ -834,6 +834,29 @@ To upgrade a local, or remote file, you may use:
         }
     }
 
+    Context 'Upgrading a package using a single quote in the parameters and remembering arguments' -Tag Arguments {
+        BeforeAll {
+            Restore-ChocolateyInstallSnapshot
+
+            Enable-ChocolateyFeature -Name "useRememberedArgumentsForUpgrades"
+
+            $null = Invoke-Choco install test-environment --package-parameters="/Comment:It's Great! /SubmittedBy:Kim" --version 0.9
+            $Output = Invoke-Choco upgrade test-environment
+        }
+
+        It "Exits successfully (0)" {
+            $Output.ExitCode | Should -Be 0 -Because $Output.String
+        }
+
+        It "Should warn about possible upgrade failure" {
+            $Output.Lines | Should -Contain "Upgrade failures may be related to this issue." -Because $Output.String
+        }
+
+        It "Should give diagnostic information" {
+            $Output.Lines | Should -Contain "To troubleshoot, run: ``choco info test-environment --local-only`` and review the package" -Because $Output.String
+        }
+    }
+
     Context 'Upgrading a package using double-dash arguments in package arguments' -Tag Arguments {
         BeforeAll {
             Restore-ChocolateyInstallSnapshot


### PR DESCRIPTION
## Description Of Changes

- Escape single quotes in PowerShell arguments by doubling them to handle parameters containing single quotes correctly; added Pester tests for validation.
- Refactor argument parsing to properly handle package arguments with double-dash syntax (--), including quoted strings and nested quotes; added tests for upgrade scenarios.
- Add warnings for unbalanced single or double quotes in package arguments during install, upgrade, and uninstall commands, with troubleshooting advice for upgrades and uninstalls; included tests for warning behavior with remembered arguments.

## Motivation and Context

Packages should be possible to install and upgrade even with single quotes being used, and not having an exception about "unterminated single quotes" being thrown.

## Testing

1. Enable the feature `useRememberedArgumentsForUpgrades` using `choco feature enable -n useRememberedArgumentsForUpgrades`.
2. Install the test-params package using `choco install test-params --package-parameters="/Comment:It's great! /SubmittedBy:Someone"`.
3. Verify package installed correctly, and it outputted a warning for the environment variable: `"WARNING:  - Comment = It's great!`.
4. Verify parameters show up when calling info using `choco info test-params --local-only`.
5. Verify the full package-parameters line is not cut off.
6. Install the test-environment package using `choco install test-environment --package-parameters="'--quiet --norestart --wait --includeRecommended --includeOptional'" --verbose --version 0.9`.
7. Ensure it was installed successfully.
8. Verify teh package parameters are outputted correctly using `choco info test-environment --local-only` (to partial package-parameter lines)
9. Attempt to ugrade the package using `choco upgrade test-environment`.
10. Verify the package was updated successfully.
11. Verify the package outputted `chocolateyPackageParameters=--quiet --norestart --wait --includeRecommended --includeOptional`

### Operating Systems Testing

- Windows 11

## Change Types Made

* [x] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [x] Tests to cover my changes, have been added.
* [x] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v3 compatibility checked?

## Related Issue

- Fixes #2410 
- PROJ-1287