### PR TITLE
(#3713) Add short -n variant of option

### DIFF
--- a/src/chocolatey.tests/infrastructure.app/commands/ChocolateyConfigCommandSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/commands/ChocolateyConfigCommandSpecs.cs
@@ -81,6 +81,12 @@ namespace chocolatey.tests.infrastructure.app.commands
             }
 
             [Fact]
+            public void Should_add_short_version_name_to_the_option_set()
+            {
+                _optionSet.Contains("n").Should().BeTrue();
+            }
+
+            [Fact]
             public void Should_add_value_to_the_option_set()
             {
                 _optionSet.Contains("value").Should().BeTrue();

--- a/src/chocolatey.tests/infrastructure.app/commands/ChocolateyNewCommandSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/commands/ChocolateyNewCommandSpecs.cs
@@ -93,6 +93,12 @@ namespace chocolatey.tests.infrastructure.app.commands
             }
 
             [Fact]
+            public void Should_add_short_version_name_to_the_option_set()
+            {
+                _optionSet.Contains("n").Should().BeTrue();
+            }
+
+            [Fact]
             public void Should_add_version_to_the_option_set()
             {
                 _optionSet.Contains("version").Should().BeTrue();

--- a/src/chocolatey/infrastructure.app/commands/ChocolateyConfigCommand.cs
+++ b/src/chocolatey/infrastructure.app/commands/ChocolateyConfigCommand.cs
@@ -44,7 +44,7 @@ namespace chocolatey.infrastructure.app.commands
 
             optionSet
                 .Add(
-                    "name=",
+                    "n=|name=",
                     "Name - the name of the config setting. Required with some actions. Defaults to empty.",
                     option => configuration.ConfigCommand.Name = option.UnquoteSafe())
                 .Add(

--- a/src/chocolatey/infrastructure.app/commands/ChocolateyNewCommand.cs
+++ b/src/chocolatey/infrastructure.app/commands/ChocolateyNewCommand.cs
@@ -46,7 +46,7 @@ namespace chocolatey.infrastructure.app.commands
                 .Add("t=|template=|template-name=",
                      "TemplateName - Use a named template in {0}\\templates\\templatename instead of built-in template.".FormatWith(ApplicationParameters.InstallLocation),
                      option => configuration.NewCommand.TemplateName = option.UnquoteSafe())
-                .Add("name=",
+                .Add("n=|name=",
                      "Name [Required]- the name of the package. Can be passed as first parameter without \"--name=\".",
                      option =>
                          {


### PR DESCRIPTION
## Description Of Changes

This commit addresses this inconsistency, and also adds tests to cover the change.

## Motivation and Context

The short -n variant for the name option was missing on the choco new and choco config command.  This is inconsistent with the name option on for example the choco feature and choco pin commands.

## Testing

Ran unit tests.

### Operating Systems Testing

- Windows 11

## Change Types Made

* [x] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [x] Tests to cover my changes, have been added.
* [x] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v3 compatibility checked?

## Related Issue

Fixes #3713