### PR TITLE
(#669) Improve PowerShell Tab Completion

### DIFF
--- a/src/chocolatey.resources/helpers/ChocolateyTabExpansion.ps1
+++ b/src/chocolatey.resources/helpers/ChocolateyTabExpansion.ps1
@@ -126,7 +126,7 @@ function script:chocoCommands($filter) {
         $cmdList += $script:chocoCommands -like "$filter*"
     }
     else {
-        $cmdList += (& $script:choco -h) |
+        $cmdList += (& $script:choco --help) |
             Where-Object { $_ -match '^  \S.*' } |
             ForEach-Object { $_.Split(' ', [StringSplitOptions]::RemoveEmptyEntries) } |
             Where-Object { $_ -like "$filter*" }
@@ -136,46 +136,62 @@ function script:chocoCommands($filter) {
 }
 
 function script:chocoApiKeysList() {
-    @(& $script:choco apikey list --limit-output) | ForEach-Object { $_.Split('|')[0] }
+    @(& $script:choco apikey list --limit-output --include-headers) |
+        ConvertFrom-Csv -Delimiter '|' |
+        Select-Object -ExpandProperty Source
 }
 
 function script:chocoConfigsList() {
-    @(& $script:choco config list --limit-output) | ForEach-Object { $_.Split('|')[0] }
+    @(& $script:choco config list --limit-output --include-headers) |
+        ConvertFrom-Csv -Delimiter '|' |
+        Select-Object -ExpandProperty Name
 }
 
 function script:chocoFeaturesList() {
-    @(& $script:choco feature list --limit-output) | ForEach-Object { $_.Split('|')[0] }
+    @(& $script:choco feature list --limit-output --include-headers) |
+        ConvertFrom-Csv -Delimiter '|' |
+        Select-Object -ExpandProperty Name
 }
 
 function script:chocoLocalNonPinnedPackages() {
-    @(& $script:choco list --limit-output --ignore-pinned) | ForEach-Object { $_.Split('|')[0] }
+    @(& $script:choco list --limit-output --ignore-pinned --include-headers) |
+        ConvertFrom-Csv -Delimiter '|' |
+        Select-Object -ExpandProperty Id
 }
 
 function script:chocoLocalPackages($filter) {
     if ($filter -and $filter.StartsWith(".")) {
         return;
     } #file search
-    @(& $script:choco list $filter -r --id-starts-with) | ForEach-Object { $_.Split('|')[0] }
+    @(& $script:choco list $filter --limit-output --id-starts-with --include-headers) |
+        ConvertFrom-Csv -Delimiter '|' |
+        Select-Object -ExpandProperty Id
 }
 
 function script:chocoLocalPackagesUpgrade($filter) {
     if ($filter -and $filter.StartsWith(".")) {
         return;
     } #file search
-    @('all|') + @(& $script:choco list $filter -r --id-starts-with) |
+    @('all|') + @(& $script:choco list $filter --limit-output --id-starts-with --include-headers) |
+        ConvertFrom-Csv -Delimiter '|' |
+        Select-Object -ExpandProperty Id
         Where-Object { $_ -like "$filter*" } |
         ForEach-Object { $_.Split('|')[0] }
 }
 
 function script:chocoLocalPinnedPackages() {
-    @(& $script:choco pin list --limit-output) | ForEach-Object { $_.Split('|')[0] }
+    @(& $script:choco pin list --limit-output --include-headers) |
+        ConvertFrom-Csv -Delimiter '|' |
+        Select-Object -ExpandProperty Id
 }
 
 function script:chocoRemotePackages($filter) {
     if ($filter -and $filter.StartsWith(".")) {
         return;
     } #file search
-    @('packages.config|') + @(& $script:choco search $filter --page='0' --page-size='30' -r --id-starts-with --order-by='popularity') |
+    @('packages.config|') + @(& $script:choco search $filter --page='0' --page-size='30' --limit-output --id-starts-with --include-headers --order-by='popularity') |
+        ConvertFrom-Csv -Delimiter '|' |
+        Select-Object -ExpandProperty Id
         Where-Object { $_ -like "$filter*" } |
         ForEach-Object { $_.Split('|')[0] }
 }
@@ -192,15 +208,21 @@ function script:chocoRemotePackageVersions($Name, $Version) {
 }
 
 function script:chocoRulesList() {
-    @(& $script:choco rule list --limit-output) | ForEach-Object { $_.Split('|')[1] }
+    @(& $script:choco rule list --limit-output --include-headers) |
+        ConvertFrom-Csv -Delimiter '|' |
+        Select-Object -ExpandProperty Id
 }
 
 function script:chocoSourcesList() {
-    @(& $script:choco source list --limit-output) | ForEach-Object { $_.Split('|')[0] }
+    @(& $script:choco source list --limit-output --include-headers) |
+        ConvertFrom-Csv -Delimiter '|' |
+        Select-Object -ExpandProperty Name
 }
 
 function script:chocoTemplatesList() {
-    @(& $script:choco template list --limit-output) | ForEach-Object { $_.Split('|')[0] }
+    @(& $script:choco template list --limit-output --include-headers) |
+        ConvertFrom-Csv -Delimiter '|' |
+        Select-Object -ExpandProperty Name
 }
 
 function Get-AliasPattern($exe) {

--- a/tests/pester-tests/chocolateyProfile.Tests.ps1
+++ b/tests/pester-tests/chocolateyProfile.Tests.ps1
@@ -4,6 +4,8 @@ Import-Module "$env:ChocolateyInstall\helpers\chocolateyProfile.psm1"
 Describe "Chocolatey Profile" -Tag Chocolatey, Profile, Environment {
     # Because we're not modifying the install in any way, there is no need to Initialize-ChocolateyTestInstall
     BeforeDiscovery {
+        $isLicensed = Test-PackageIsEqualOrHigher "chocolatey.extension" "0.0.0"
+
         $ExportNotPresent = $true
         if (Test-ChocolateyVersionEqualOrHigherThan -Version "0.10.16-beta") {
             $ExportNotPresent = $false
@@ -11,6 +13,19 @@ Describe "Chocolatey Profile" -Tag Chocolatey, Profile, Environment {
     }
 
     Context "Tab Completion" {
+        BeforeAll {
+            Initialize-ChocolateyTestInstall
+
+            # These are needed in order to test the tab completions for some
+            # Chocolatey operations
+            $null = Invoke-Choco pin add --name="chocolatey"
+
+            $null = Invoke-Choco apikey add --source "https://test.com/api/add/" --api-key "test-api-key"
+
+            $null = Invoke-Choco install upgradepackage --version 1.0.0 --confirm
+
+            New-ChocolateyInstallSnapshot
+        }
         It "Should list completions for all Top Level Commands, sorted alphabetically, but not aliases or unpackself" {
             $Command = "choco "
             $Completions = (TabExpansion2 -inputScript $Command -cursorColumn $Command.Length).CompletionMatches.CompletionText
@@ -432,6 +447,153 @@ Describe "Chocolatey Profile" -Tag Chocolatey, Profile, Environment {
             $Completions | Should -Contain "--use-remembered-arguments" -Because $becauseCompletions
             $Completions | Should -Contain "--user=''" -Because $becauseCompletions
             $Completions | Should -Contain "--version=''" -Because $becauseCompletions
+        }
+
+        It "Should list completions for apikey remove" {
+            $Command = "choco apikey remove --source='"
+            $Completions = (TabExpansion2 -inputScript $Command -cursorColumn $Command.Length).CompletionMatches.CompletionText
+
+            $becauseCompletions = ($Completions -Join ", ")
+
+            $Completions | Should -Contain "--source='https://test.com/api/add/'" -Because $becauseCompletions
+        }
+
+        It "Should list completions for feature enable" {
+            $Command = "choco feature enable --name='"
+            $Completions = (TabExpansion2 -inputScript $Command -cursorColumn $Command.Length).CompletionMatches.CompletionText
+
+            $becauseCompletions = ($Completions -Join ", ")
+
+            $Completions | Should -Contain "--name='allowEmptyChecksums'" -Because $becauseCompletions
+            $Completions | Should -Contain "--name='useRememberedArgumentsForUpgrades'" -Because $becauseCompletions
+
+            if ($isLicensed) {
+                $Completions | Should -Contain "--name='adminOnlyExecutionForAllChocolateyCommands'" -Because $becauseCompletions
+            }
+        }
+
+        It "Should list completions for feature disable" {
+            $Command = "choco feature disable --name='"
+            $Completions = (TabExpansion2 -inputScript $Command -cursorColumn $Command.Length).CompletionMatches.CompletionText
+
+            $becauseCompletions = ($Completions -Join ", ")
+
+            $Completions | Should -Contain "--name='allowEmptyChecksums'" -Because $becauseCompletions
+            $Completions | Should -Contain "--name='useRememberedArgumentsForUpgrades'" -Because $becauseCompletions
+
+            if ($isLicensed) {
+                $Completions | Should -Contain "--name='adminOnlyExecutionForAllChocolateyCommands'" -Because $becauseCompletions
+            }
+        }
+
+        It "Should list completions for feature get" {
+            $Command = "choco feature get --name='"
+            $Completions = (TabExpansion2 -inputScript $Command -cursorColumn $Command.Length).CompletionMatches.CompletionText
+
+            $becauseCompletions = ($Completions -Join ", ")
+
+            $Completions | Should -Contain "--name='allowEmptyChecksums'" -Because $becauseCompletions
+            $Completions | Should -Contain "--name='useRememberedArgumentsForUpgrades'" -Because $becauseCompletions
+
+            if ($isLicensed) {
+                $Completions | Should -Contain "--name='adminOnlyExecutionForAllChocolateyCommands'" -Because $becauseCompletions
+            }
+        }
+
+        It "Should list completions for config get" {
+            $Command = "choco config get --name='"
+            $Completions = (TabExpansion2 -inputScript $Command -cursorColumn $Command.Length).CompletionMatches.CompletionText
+
+            $becauseCompletions = ($Completions -Join ", ")
+
+            $Completions | Should -Contain "--name='cacheLocation'" -Because $becauseCompletions
+            $Completions | Should -Contain "--name='webRequestTimeoutSeconds'" -Because $becauseCompletions
+
+            if ($isLicensed) {
+                $Completions | Should -Contain "--name='virusScannerType'" -Because $becauseCompletions
+            }
+        }
+
+        It "Should list completions for config set" {
+            $Command = "choco config set --name='"
+            $Completions = (TabExpansion2 -inputScript $Command -cursorColumn $Command.Length).CompletionMatches.CompletionText
+
+            $becauseCompletions = ($Completions -Join ", ")
+
+            $Completions | Should -Contain "--name='cacheLocation'" -Because $becauseCompletions
+            $Completions | Should -Contain "--name='webRequestTimeoutSeconds'" -Because $becauseCompletions
+
+            if ($isLicensed) {
+                $Completions | Should -Contain "--name='virusScannerType'" -Because $becauseCompletions
+            }
+        }
+
+        It "Should list completions for config unset" {
+            $Command = "choco config unset --name='"
+            $Completions = (TabExpansion2 -inputScript $Command -cursorColumn $Command.Length).CompletionMatches.CompletionText
+
+            $becauseCompletions = ($Completions -Join ", ")
+
+            $Completions | Should -Contain "--name='cacheLocation'" -Because $becauseCompletions
+            $Completions | Should -Contain "--name='webRequestTimeoutSeconds'" -Because $becauseCompletions
+
+            if ($isLicensed) {
+                $Completions | Should -Contain "--name='virusScannerType'" -Because $becauseCompletions
+            }
+        }
+
+        It "Should list completions for pin add" {
+            $Command = "choco pin add --name='"
+            $Completions = (TabExpansion2 -inputScript $Command -cursorColumn $Command.Length).CompletionMatches.CompletionText
+
+            $becauseCompletions = ($Completions -Join ", ")
+
+            $Completions | Should -Contain "--name='upgradepackage'" -Because $becauseCompletions
+        }
+
+        It "Should list completions for pin remove" {
+            $Command = "choco pin remove --name='"
+            $Completions = (TabExpansion2 -inputScript $Command -cursorColumn $Command.Length).CompletionMatches.CompletionText
+
+            $becauseCompletions = ($Completions -Join ", ")
+
+            $Completions | Should -Contain "--name='chocolatey'" -Because $becauseCompletions
+        }
+
+        It "Should list completions for rule get" {
+            $Command = "choco rule get --name='"
+            $Completions = (TabExpansion2 -inputScript $Command -cursorColumn $Command.Length).CompletionMatches.CompletionText
+
+            $becauseCompletions = ($Completions -Join ", ")
+
+            $Completions | Should -Contain "--name='CHCU0001'" -Because $becauseCompletions
+        }
+
+        It "Should list completions for source disable" {
+            $Command = "choco source disable --name='"
+            $Completions = (TabExpansion2 -inputScript $Command -cursorColumn $Command.Length).CompletionMatches.CompletionText
+
+            $becauseCompletions = ($Completions -Join ", ")
+
+            $Completions | Should -Contain "--name='chocolatey'" -Because $becauseCompletions
+        }
+
+        It "Should list completions for source enable" {
+            $Command = "choco source enable --name='"
+            $Completions = (TabExpansion2 -inputScript $Command -cursorColumn $Command.Length).CompletionMatches.CompletionText
+
+            $becauseCompletions = ($Completions -Join ", ")
+
+            $Completions | Should -Contain "--name='chocolatey'" -Because $becauseCompletions
+        }
+
+        It "Should list completions for source remove" {
+            $Command = "choco source remove --name='"
+            $Completions = (TabExpansion2 -inputScript $Command -cursorColumn $Command.Length).CompletionMatches.CompletionText
+
+            $becauseCompletions = ($Completions -Join ", ")
+
+            $Completions | Should -Contain "--name='chocolatey'" -Because $becauseCompletions
         }
 
         It "Should list versions for <_> isdependency --version=" -ForEach @('install', 'upgrade') {


### PR DESCRIPTION
## Description Of Changes

This commit improves the PowerShell Tab Completion for Chocolatey CLI, by including completions for the following commands:

* apikey
* config
* feature
* pin
* rule
* source
* template

Each of these completions rely on directly calling the equivalent "list£ sub-command for each command (with the exception of one of the pin completions, which also relies on running choco list), which unfortunately can take a second to complete.

As a future enhancement to this functionality, we should look to serializing these completions to disk, so that they can be loaded and shown from there. These files would be updated each time an associated command is executed. For example, when someone runs "choco source add" update the completions file for when doing "choco source remove".

A group of Pester tests have been added to ensure that these completions work as expected.

## Motivation and Context

We want to have as good an experience at the command line as possible.  By bringing more things into the completions file, we make it easier to do the work that is being done.

## Testing

The new Pester tests exercise all the tab completions.  If the Test-Kitchen tests complete, we shoud be good.

### Operating Systems Testing

- Windows 11

## Change Types Made

* [ ] Bug fix (non-breaking change).
* [x] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [x] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [x] Tests to cover my changes, have been added.
* [x] All new and existing tests passed?
* [x] PowerShell code changes: PowerShell v3 compatibility checked?

## Related Issue

Relates to #669 

Some additional work is required in order to complete this issue.