### PR TITLE
(#123) Add validation to prevent value with short verbose option

### DIFF
--- a/src/chocolatey.tests/infrastructure.app/configuration/ConfigurationOptionsSpec.cs
+++ b/src/chocolatey.tests/infrastructure.app/configuration/ConfigurationOptionsSpec.cs
@@ -24,6 +24,7 @@ using chocolatey.infrastructure.app.configuration;
 using chocolatey.infrastructure.commandline;
 using Moq;
 using FluentAssertions;
+using NUnit.Framework;
 
 namespace chocolatey.tests.infrastructure.app.configuration
 {
@@ -337,6 +338,29 @@ namespace chocolatey.tests.infrastructure.app.configuration
                 BecauseAction();
 
                 Config.UnsuccessfulParsing.Should().BeTrue();
+            }
+
+            // This test uses the [Combinatorial] attribute to run multiple times,
+            // trying out every possible combination of the input values we've defined.
+            // It helps us make sure the code works across many different scenarios.
+            // Even though this is how NUnit works by default, we include the attribute
+            // to make it clear what's happening and to prevent surprises in the future.
+            [Fact, Combinatorial]
+            public void Should_Throw_Exception_When_Short_Name_Verbose_Is_Used_With_Value(
+                [Values(null, "install ")] string command,
+                [Values('/', '-')] char @switch,
+                [Values('=', ':', ' ')] char seperator,
+                [Values(null, '\'', '"')] char? quote)
+            {
+                Args.Add(command + @switch + "v" + seperator + quote + "5.2.1" + quote);
+
+                BecauseAction.Should().Throw<ApplicationException>()
+                    .WithMessage(@"
+A value was passed to the `-v` option, but this option does not support an
+ explicit value.
+
+Did you mean to use `--version='5.2.1'` instead?
+");
             }
         }
     }

--- a/src/chocolatey/infrastructure.app/configuration/ConfigurationOptions.cs
+++ b/src/chocolatey/infrastructure.app/configuration/ConfigurationOptions.cs
@@ -66,9 +66,31 @@ namespace chocolatey.infrastructure.app.configuration
         {
             IList<string> unparsedArguments = new List<string>();
 
-            // add help only once
+            // add help only once.
+            // OptionSet.Count only happens the first time
+            // we set the options, not when we add additional options.
             if (OptionSet.Count == 0)
             {
+                // Before we do any parsing, let us check if the
+                // user has passed -v=value, -v:value, -v value or /v value.
+                // If the user has passed this information, we will assume
+                // that they intended to pass a version to the command, but
+                // -v is a short name for --verbose, and as such we need to
+                // throw an exception to prevent further processing.
+                var joinedArguments = string.Join(" ", args);
+
+                var match = Regex.Match(joinedArguments, @"(^|\s)[-/]v([=:]['""]?(?<value>[^\s'""]+)| ['""]?(?<value>[^\s-'""]+))", RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+                if (match.Success)
+                {
+                    throw new ApplicationException($@"
+A value was passed to the `-v` option, but this option does not support an
+ explicit value.
+
+Did you mean to use `--version='{match.Groups["value"].Value}'` instead?
+");
+                }
+
                 OptionSet
                     .Add("?|help|h",
                         "Prints out the help menu.",


### PR DESCRIPTION
## Description Of Changes

Adds validation to detect and reject attempts to pass a value to the `-v` (verbose) short option, which does not support values. If such usage is detected (e.g., `-v:5.2.1` or `/v='5.2.1'`), the parser throws a helpful exception suggesting the user may have meant `--version` instead.

Also adds a corresponding test using `[Fact, Combinatorial]` to ensure the exception is thrown correctly across combinations of separators, quotes, and prefixes.

## Motivation and Context

Users commonly mistake the `-v` (verbose) option for `--version`, leading to confusing or incorrect behavior when supplying a value. This change preempts the error by detecting the misuse early in argument parsing and providing a targeted suggestion to improve the user experience and prevent unintentional silent failures.

## Testing

1. Added a new `Fact, Combinatorial` test that validates the parser throws an `ApplicationException` for common invalid usages of `-v` with a value.
2. Validated message formatting and suggestion output to guide users toward the correct `--version` usage.

Manual Tests:

1. Run `choco -v 5.2.1` and verify the expected excetpion message is outputted.
2. Run `choco search /v 2.1.6` and verify the expected exception message is outputted.
3. Feel free to combine different seperators (`=`, `:` and ` `, as well as with double and single quotes).

### Operating Systems Testing

- Windows 11

## Change Types Made

* [x] Bug fix (non-breaking change) (Kinda breaking, but as it was never intended to work, we consider it non-breaking).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [x] Tests to cover my changes, have been added.
* [x] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v3 compatibility checked?

## Related Issue

- Fixes #123
- PROJ-1502
