### PR TITLE
Prefer Hyper-V for the vagrant local testing

### DIFF
--- a/tests/Vagrantfile
+++ b/tests/Vagrantfile
@@ -1,7 +1,14 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
+$memory = ENV['VM_MEMORY'] ? ENV['VM_MEMORY'].to_i : 16384
+$cpus = ENV['VM_CPU'] ? ENV['VM_CPU'].to_i : 4
+
 Vagrant.configure("2") do |config|
+  # Set preferred order of providers
+  config.vm.provider :hyperv
+  config.vm.provider :virtualbox
+
   config.vm.box = "chocolatey/test-environment"
   # Set Hostname to prevent error messages. https://github.com/hashicorp/vagrant/issues/12644
   config.vm.hostname = 'chocolatey-tests'
@@ -23,21 +30,32 @@ Vagrant.configure("2") do |config|
   config.vm.network :forwarded_port, guest: 5985, host: 14985, id: 'winrm', auto_correct: true
   config.vm.network :forwarded_port, guest: 3389, host: 14389, id: 'rdp', auto_correct: true
 
-  config.vm.provider "virtualbox" do |vb|
+  config.vm.provider :virtualbox do |vb|
     vb.gui = ENV['VM_GUI'] ? ENV['VM_GUI'].to_s.downcase == 'true' : true
-    vb.memory = ENV['VM_MEMORY'] ? ENV['VM_MEMORY'].to_i : 4096
-    vb.cpus = ENV['VM_CPU'] ? ENV['VM_CPU'].to_i : 2
+    vb.memory = $memory
+    vb.cpus = $cpus
     vb.linked_clone = true
     vb.customize ['modifyvm', :id, '--vram', '128']
   end
-  config.vm.provider "hyperv" do |h|
-    h.memory = 4096
-    h.cpus = 2
+
+  config.vm.provider :hyperv do |h, o|
+    # Use dynamic memory. In testing this has not presented any issues. If there are issues believed to be related to dynamic memory, uncomment the h.memory line to disable it.
+    h.maxmemory = $memory
+    # h.memory = $memory
+    h.cpus = $cpus
     h.linked_clone = true
     h.enable_checkpoints = false
+
+    # Set the Virtual Switch to prevent Vagrant prompting.
+    o.vm.network :private_network, bridge: ENV['VM_VSWITCH'].nil? ? "Default Switch" : ENV['VM_VSWITCH'].to_s
   end
 
-  config.vm.synced_folder '../', '/chocoRoot'
+  # Allow passing in the username/password through environment variables.
+  if ENV['VM_SMB_USERNAME'].nil? || ENV['VM_SMB_PASSWORD'].nil?
+    config.vm.synced_folder '../', '/chocoRoot'
+  else
+    config.vm.synced_folder '../', '/chocoRoot', type: "smb", smb_username: ENV['VM_SMB_USERNAME'], smb_password: ENV['VM_SMB_PASSWORD']
+  end
 
   config.vm.provision "shell", name: "prep", inline: <<-SHELL
     cscript c:/windows/system32/slmgr.vbs /rearm | Out-Null
@@ -50,10 +68,10 @@ Vagrant.configure("2") do |config|
     Update-SessionEnvironment
     Write-Host "($(Get-Date -Format "dddd MM/dd/yyyy HH:mm:ss K")) Done installing software, now copying files"
     # If you try to build on macOS, then run this, there are attributes on some files that cause the build to fail inside of the vagrant environment.
-    $null = robocopy c:/chocoRoot c:/code/choco /e /copy:dt
+    $null = robocopy c:/chocoRoot c:/code/choco /e /copy:dt /dcopy:t /xd .vagrant /mt:12 /log:robocopy.txt
   SHELL
   config.vm.provision "shell", name: "build", inline: <<-SHELL
-    $null = robocopy c:/chocoRoot c:/code/choco /e /copy:dt /purge
+    $null = robocopy c:/chocoRoot c:/code/choco /e /copy:dt /dcopy:t /xd .vagrant /mt:12 /log:robocopy.txt /purge
     Push-Location c:/code/choco
     Write-Host "($(Get-Date -Format "dddd MM/dd/yyyy HH:mm:ss K")) Files have been copied, beginning build process."
     $CakeOutput = ./build.bat --verbosity=diagnostic --target=CI --testExecutionType=none --shouldRunalyze=false --shouldRunNuGet=false 2>&1
@@ -73,9 +91,9 @@ Vagrant.configure("2") do |config|
   SHELL
   config.vm.provision "shell", name: "test", inline: <<-SHELL
     # Copy changed files.
-    $null = robocopy c:/chocoRoot c:/code/choco /e /copy:dt
+    $null = robocopy c:/chocoRoot c:/code/choco /e /copy:dt /dcopy:t /xd .vagrant /mt:12 /log:robocopy.txt
     # Purge any tests files that have been removed.
-    $null = robocopy c:/chocoRoot/tests c:/code/choco/tests /e /copy:dt /purge
+    $null = robocopy c:/chocoRoot/tests c:/code/choco/tests /e /copy:dt /dcopy:t /xd .vagrant /mt:12 /log:robocopy.txt /purge
     Write-Host "($(Get-Date -Format "dddd MM/dd/yyyy HH:mm:ss K")) Starting Test Execution"
     Push-Location c:/code/choco
     # $env:TEST_KITCHEN = 1

--- a/tests/pester-tests/chocolateyProfile.Tests.ps1
+++ b/tests/pester-tests/chocolateyProfile.Tests.ps1
@@ -1,4 +1,4 @@
-﻿Import-Module helpers/common-helpers
+Import-Module helpers/common-helpers
 Import-Module "$env:ChocolateyInstall\helpers\chocolateyProfile.psm1"
 
 Describe "Chocolatey Profile" -Tag Chocolatey, Profile, Environment {
@@ -12,7 +12,7 @@ Describe "Chocolatey Profile" -Tag Chocolatey, Profile, Environment {
         }
     }
 
-    Context "Tab Completion" {
+    Context "Tab Completion" -Tag TabCompletions {
         BeforeAll {
             Initialize-ChocolateyTestInstall
 
@@ -449,216 +449,219 @@ Describe "Chocolatey Profile" -Tag Chocolatey, Profile, Environment {
             $Completions | Should -Contain "--version=''" -Because $becauseCompletions
         }
 
-        It "Should list completions for apikey remove" {
-            $Command = "choco apikey remove --source='"
-            $Completions = (TabExpansion2 -inputScript $Command -cursorColumn $Command.Length).CompletionMatches.CompletionText
+        # This is marked Internal as all the tests run `choco.exe` to determine the tab expansion and unofficial builds will not provide the tab completion.
+        Context "Requires Official Build" -Tag Internal {
+            It "Should list completions for apikey remove" {
+                $Command = "choco apikey remove --source='"
+                $Completions = (TabExpansion2 -inputScript $Command -cursorColumn $Command.Length).CompletionMatches.CompletionText
 
-            $becauseCompletions = ($Completions -Join ", ")
+                $becauseCompletions = ($Completions -Join ", ")
 
-            $Completions | Should -Contain "--source='https://test.com/api/add/'" -Because $becauseCompletions
-        }
-
-        It "Should list completions for feature enable" {
-            $Command = "choco feature enable --name='"
-            $Completions = (TabExpansion2 -inputScript $Command -cursorColumn $Command.Length).CompletionMatches.CompletionText
-
-            $becauseCompletions = ($Completions -Join ", ")
-
-            $Completions | Should -Contain "--name='allowEmptyChecksums'" -Because $becauseCompletions
-            $Completions | Should -Contain "--name='useRememberedArgumentsForUpgrades'" -Because $becauseCompletions
-
-            if ($isLicensed) {
-                $Completions | Should -Contain "--name='adminOnlyExecutionForAllChocolateyCommands'" -Because $becauseCompletions
+                $Completions | Should -Contain "--source='https://test.com/api/add/'" -Because $becauseCompletions
             }
-        }
 
-        It "Should list completions for feature disable" {
-            $Command = "choco feature disable --name='"
-            $Completions = (TabExpansion2 -inputScript $Command -cursorColumn $Command.Length).CompletionMatches.CompletionText
+            It "Should list completions for feature enable" {
+                $Command = "choco feature enable --name='"
+                $Completions = (TabExpansion2 -inputScript $Command -cursorColumn $Command.Length).CompletionMatches.CompletionText
 
-            $becauseCompletions = ($Completions -Join ", ")
+                $becauseCompletions = ($Completions -Join ", ")
 
-            $Completions | Should -Contain "--name='allowEmptyChecksums'" -Because $becauseCompletions
-            $Completions | Should -Contain "--name='useRememberedArgumentsForUpgrades'" -Because $becauseCompletions
+                $Completions | Should -Contain "--name='allowEmptyChecksums'" -Because $becauseCompletions
+                $Completions | Should -Contain "--name='useRememberedArgumentsForUpgrades'" -Because $becauseCompletions
 
-            if ($isLicensed) {
-                $Completions | Should -Contain "--name='adminOnlyExecutionForAllChocolateyCommands'" -Because $becauseCompletions
+                if ($isLicensed) {
+                    $Completions | Should -Contain "--name='adminOnlyExecutionForAllChocolateyCommands'" -Because $becauseCompletions
+                }
             }
-        }
 
-        It "Should list completions for feature get" {
-            $Command = "choco feature get --name='"
-            $Completions = (TabExpansion2 -inputScript $Command -cursorColumn $Command.Length).CompletionMatches.CompletionText
+            It "Should list completions for feature disable" {
+                $Command = "choco feature disable --name='"
+                $Completions = (TabExpansion2 -inputScript $Command -cursorColumn $Command.Length).CompletionMatches.CompletionText
 
-            $becauseCompletions = ($Completions -Join ", ")
+                $becauseCompletions = ($Completions -Join ", ")
 
-            $Completions | Should -Contain "--name='allowEmptyChecksums'" -Because $becauseCompletions
-            $Completions | Should -Contain "--name='useRememberedArgumentsForUpgrades'" -Because $becauseCompletions
+                $Completions | Should -Contain "--name='allowEmptyChecksums'" -Because $becauseCompletions
+                $Completions | Should -Contain "--name='useRememberedArgumentsForUpgrades'" -Because $becauseCompletions
 
-            if ($isLicensed) {
-                $Completions | Should -Contain "--name='adminOnlyExecutionForAllChocolateyCommands'" -Because $becauseCompletions
+                if ($isLicensed) {
+                    $Completions | Should -Contain "--name='adminOnlyExecutionForAllChocolateyCommands'" -Because $becauseCompletions
+                }
             }
-        }
 
-        It "Should list completions for config get" {
-            $Command = "choco config get --name='"
-            $Completions = (TabExpansion2 -inputScript $Command -cursorColumn $Command.Length).CompletionMatches.CompletionText
+            It "Should list completions for feature get" {
+                $Command = "choco feature get --name='"
+                $Completions = (TabExpansion2 -inputScript $Command -cursorColumn $Command.Length).CompletionMatches.CompletionText
 
-            $becauseCompletions = ($Completions -Join ", ")
+                $becauseCompletions = ($Completions -Join ", ")
 
-            $Completions | Should -Contain "--name='cacheLocation'" -Because $becauseCompletions
-            $Completions | Should -Contain "--name='webRequestTimeoutSeconds'" -Because $becauseCompletions
+                $Completions | Should -Contain "--name='allowEmptyChecksums'" -Because $becauseCompletions
+                $Completions | Should -Contain "--name='useRememberedArgumentsForUpgrades'" -Because $becauseCompletions
 
-            if ($isLicensed) {
-                $Completions | Should -Contain "--name='virusScannerType'" -Because $becauseCompletions
+                if ($isLicensed) {
+                    $Completions | Should -Contain "--name='adminOnlyExecutionForAllChocolateyCommands'" -Because $becauseCompletions
+                }
             }
-        }
 
-        It "Should list completions for config set" {
-            $Command = "choco config set --name='"
-            $Completions = (TabExpansion2 -inputScript $Command -cursorColumn $Command.Length).CompletionMatches.CompletionText
+            It "Should list completions for config get" {
+                $Command = "choco config get --name='"
+                $Completions = (TabExpansion2 -inputScript $Command -cursorColumn $Command.Length).CompletionMatches.CompletionText
 
-            $becauseCompletions = ($Completions -Join ", ")
+                $becauseCompletions = ($Completions -Join ", ")
 
-            $Completions | Should -Contain "--name='cacheLocation'" -Because $becauseCompletions
-            $Completions | Should -Contain "--name='webRequestTimeoutSeconds'" -Because $becauseCompletions
+                $Completions | Should -Contain "--name='cacheLocation'" -Because $becauseCompletions
+                $Completions | Should -Contain "--name='webRequestTimeoutSeconds'" -Because $becauseCompletions
 
-            if ($isLicensed) {
-                $Completions | Should -Contain "--name='virusScannerType'" -Because $becauseCompletions
+                if ($isLicensed) {
+                    $Completions | Should -Contain "--name='virusScannerType'" -Because $becauseCompletions
+                }
             }
-        }
 
-        It "Should list completions for config unset" {
-            $Command = "choco config unset --name='"
-            $Completions = (TabExpansion2 -inputScript $Command -cursorColumn $Command.Length).CompletionMatches.CompletionText
+            It "Should list completions for config set" {
+                $Command = "choco config set --name='"
+                $Completions = (TabExpansion2 -inputScript $Command -cursorColumn $Command.Length).CompletionMatches.CompletionText
 
-            $becauseCompletions = ($Completions -Join ", ")
+                $becauseCompletions = ($Completions -Join ", ")
 
-            $Completions | Should -Contain "--name='cacheLocation'" -Because $becauseCompletions
-            $Completions | Should -Contain "--name='webRequestTimeoutSeconds'" -Because $becauseCompletions
+                $Completions | Should -Contain "--name='cacheLocation'" -Because $becauseCompletions
+                $Completions | Should -Contain "--name='webRequestTimeoutSeconds'" -Because $becauseCompletions
 
-            if ($isLicensed) {
-                $Completions | Should -Contain "--name='virusScannerType'" -Because $becauseCompletions
+                if ($isLicensed) {
+                    $Completions | Should -Contain "--name='virusScannerType'" -Because $becauseCompletions
+                }
             }
-        }
 
-        It "Should list completions for pin add" {
-            $Command = "choco pin add --name='"
-            $Completions = (TabExpansion2 -inputScript $Command -cursorColumn $Command.Length).CompletionMatches.CompletionText
+            It "Should list completions for config unset" {
+                $Command = "choco config unset --name='"
+                $Completions = (TabExpansion2 -inputScript $Command -cursorColumn $Command.Length).CompletionMatches.CompletionText
 
-            $becauseCompletions = ($Completions -Join ", ")
+                $becauseCompletions = ($Completions -Join ", ")
 
-            $Completions | Should -Contain "--name='upgradepackage'" -Because $becauseCompletions
-        }
+                $Completions | Should -Contain "--name='cacheLocation'" -Because $becauseCompletions
+                $Completions | Should -Contain "--name='webRequestTimeoutSeconds'" -Because $becauseCompletions
 
-        It "Should list completions for pin remove" {
-            $Command = "choco pin remove --name='"
-            $Completions = (TabExpansion2 -inputScript $Command -cursorColumn $Command.Length).CompletionMatches.CompletionText
+                if ($isLicensed) {
+                    $Completions | Should -Contain "--name='virusScannerType'" -Because $becauseCompletions
+                }
+            }
 
-            $becauseCompletions = ($Completions -Join ", ")
+            It "Should list completions for pin add" {
+                $Command = "choco pin add --name='"
+                $Completions = (TabExpansion2 -inputScript $Command -cursorColumn $Command.Length).CompletionMatches.CompletionText
 
-            $Completions | Should -Contain "--name='chocolatey'" -Because $becauseCompletions
-        }
+                $becauseCompletions = ($Completions -Join ", ")
 
-        It "Should list completions for rule get" {
-            $Command = "choco rule get --name='"
-            $Completions = (TabExpansion2 -inputScript $Command -cursorColumn $Command.Length).CompletionMatches.CompletionText
+                $Completions | Should -Contain "--name='upgradepackage'" -Because $becauseCompletions
+            }
 
-            $becauseCompletions = ($Completions -Join ", ")
+            It "Should list completions for pin remove" {
+                $Command = "choco pin remove --name='"
+                $Completions = (TabExpansion2 -inputScript $Command -cursorColumn $Command.Length).CompletionMatches.CompletionText
 
-            $Completions | Should -Contain "--name='CHCU0001'" -Because $becauseCompletions
-        }
+                $becauseCompletions = ($Completions -Join ", ")
 
-        It "Should list completions for source disable" {
-            $Command = "choco source disable --name='"
-            $Completions = (TabExpansion2 -inputScript $Command -cursorColumn $Command.Length).CompletionMatches.CompletionText
+                $Completions | Should -Contain "--name='chocolatey'" -Because $becauseCompletions
+            }
 
-            $becauseCompletions = ($Completions -Join ", ")
+            It "Should list completions for rule get" {
+                $Command = "choco rule get --name='"
+                $Completions = (TabExpansion2 -inputScript $Command -cursorColumn $Command.Length).CompletionMatches.CompletionText
 
-            $Completions | Should -Contain "--name='chocolatey'" -Because $becauseCompletions
-        }
+                $becauseCompletions = ($Completions -Join ", ")
 
-        It "Should list completions for source enable" {
-            $Command = "choco source enable --name='"
-            $Completions = (TabExpansion2 -inputScript $Command -cursorColumn $Command.Length).CompletionMatches.CompletionText
+                $Completions | Should -Contain "--name='CHCU0001'" -Because $becauseCompletions
+            }
 
-            $becauseCompletions = ($Completions -Join ", ")
+            It "Should list completions for source disable" {
+                $Command = "choco source disable --name='"
+                $Completions = (TabExpansion2 -inputScript $Command -cursorColumn $Command.Length).CompletionMatches.CompletionText
 
-            $Completions | Should -Contain "--name='chocolatey'" -Because $becauseCompletions
-        }
+                $becauseCompletions = ($Completions -Join ", ")
 
-        It "Should list completions for source remove" {
-            $Command = "choco source remove --name='"
-            $Completions = (TabExpansion2 -inputScript $Command -cursorColumn $Command.Length).CompletionMatches.CompletionText
+                $Completions | Should -Contain "--name='chocolatey'" -Because $becauseCompletions
+            }
 
-            $becauseCompletions = ($Completions -Join ", ")
+            It "Should list completions for source enable" {
+                $Command = "choco source enable --name='"
+                $Completions = (TabExpansion2 -inputScript $Command -cursorColumn $Command.Length).CompletionMatches.CompletionText
 
-            $Completions | Should -Contain "--name='chocolatey'" -Because $becauseCompletions
-        }
+                $becauseCompletions = ($Completions -Join ", ")
 
-        It "Should list versions for <_> isdependency --version=" -ForEach @('install', 'upgrade') {
-            $Command = "choco $_ isdependency --version="
-            $Completions = (TabExpansion2 -inputScript $Command -cursorColumn $Command.Length).CompletionMatches.CompletionText
+                $Completions | Should -Contain "--name='chocolatey'" -Because $becauseCompletions
+            }
 
-            $becauseCompletions = ($Completions -Join ", ")
+            It "Should list completions for source remove" {
+                $Command = "choco source remove --name='"
+                $Completions = (TabExpansion2 -inputScript $Command -cursorColumn $Command.Length).CompletionMatches.CompletionText
 
-            $Completions | Should -Contain "--version='2.1.0'" -Because $becauseCompletions
-            $Completions | Should -Contain "--version='2.0.0'" -Because $becauseCompletions
-            $Completions | Should -Contain "--version='1.1.0'" -Because $becauseCompletions
-            $Completions | Should -Contain "--version='1.0.1'" -Because $becauseCompletions
-            $Completions | Should -Contain "--version='1.0.0'" -Because $becauseCompletions
-        }
+                $becauseCompletions = ($Completions -Join ", ")
 
-        It "Should list versions for <_> isdependency --version='" -ForEach @('install', 'upgrade') {
-            $Command = "choco $_ isdependency --version='"
-            $Completions = (TabExpansion2 -inputScript $Command -cursorColumn $Command.Length).CompletionMatches.CompletionText
+                $Completions | Should -Contain "--name='chocolatey'" -Because $becauseCompletions
+            }
 
-            $becauseCompletions = ($Completions -Join ", ")
+            It "Should list versions for <_> isdependency --version=" -ForEach @('install', 'upgrade') {
+                $Command = "choco $_ isdependency --version="
+                $Completions = (TabExpansion2 -inputScript $Command -cursorColumn $Command.Length).CompletionMatches.CompletionText
 
-            $Completions | Should -Contain "--version='2.1.0'" -Because $becauseCompletions
-            $Completions | Should -Contain "--version='2.0.0'" -Because $becauseCompletions
-            $Completions | Should -Contain "--version='1.1.0'" -Because $becauseCompletions
-            $Completions | Should -Contain "--version='1.0.1'" -Because $becauseCompletions
-            $Completions | Should -Contain "--version='1.0.0'" -Because $becauseCompletions
-        }
+                $becauseCompletions = ($Completions -Join ", ")
 
-        It "Should list versions for <_> isdependency --version=''" -ForEach @('install', 'upgrade') {
-            $Command = "choco $_ isdependency --version=''"
-            $Completions = (TabExpansion2 -inputScript $Command -cursorColumn ($Command.Length - 1)).CompletionMatches.CompletionText
+                $Completions | Should -Contain "--version='2.1.0'" -Because $becauseCompletions
+                $Completions | Should -Contain "--version='2.0.0'" -Because $becauseCompletions
+                $Completions | Should -Contain "--version='1.1.0'" -Because $becauseCompletions
+                $Completions | Should -Contain "--version='1.0.1'" -Because $becauseCompletions
+                $Completions | Should -Contain "--version='1.0.0'" -Because $becauseCompletions
+            }
 
-            $becauseCompletions = ($Completions -Join ", ")
+            It "Should list versions for <_> isdependency --version='" -ForEach @('install', 'upgrade') {
+                $Command = "choco $_ isdependency --version='"
+                $Completions = (TabExpansion2 -inputScript $Command -cursorColumn $Command.Length).CompletionMatches.CompletionText
 
-            $Completions | Should -Contain "--version='2.1.0'" -Because $becauseCompletions
-            $Completions | Should -Contain "--version='2.0.0'" -Because $becauseCompletions
-            $Completions | Should -Contain "--version='1.1.0'" -Because $becauseCompletions
-            $Completions | Should -Contain "--version='1.0.1'" -Because $becauseCompletions
-            $Completions | Should -Contain "--version='1.0.0'" -Because $becauseCompletions
-        }
+                $becauseCompletions = ($Completions -Join ", ")
 
-        It "Should list versions for <_> isdependency --version='' without moving cursor" -ForEach @('install', 'upgrade') {
-            $Command = "choco $_ isdependency --version=''"
-            $Completions = (TabExpansion2 -inputScript $Command -cursorColumn ($Command.Length)).CompletionMatches.CompletionText
+                $Completions | Should -Contain "--version='2.1.0'" -Because $becauseCompletions
+                $Completions | Should -Contain "--version='2.0.0'" -Because $becauseCompletions
+                $Completions | Should -Contain "--version='1.1.0'" -Because $becauseCompletions
+                $Completions | Should -Contain "--version='1.0.1'" -Because $becauseCompletions
+                $Completions | Should -Contain "--version='1.0.0'" -Because $becauseCompletions
+            }
 
-            $becauseCompletions = ($Completions -Join ", ")
+            It "Should list versions for <_> isdependency --version=''" -ForEach @('install', 'upgrade') {
+                $Command = "choco $_ isdependency --version=''"
+                $Completions = (TabExpansion2 -inputScript $Command -cursorColumn ($Command.Length - 1)).CompletionMatches.CompletionText
 
-            $Completions | Should -Contain "--version='2.1.0'" -Because $becauseCompletions
-            $Completions | Should -Contain "--version='2.0.0'" -Because $becauseCompletions
-            $Completions | Should -Contain "--version='1.1.0'" -Because $becauseCompletions
-            $Completions | Should -Contain "--version='1.0.1'" -Because $becauseCompletions
-            $Completions | Should -Contain "--version='1.0.0'" -Because $becauseCompletions
-        }
+                $becauseCompletions = ($Completions -Join ", ")
 
-        It "Should list 2.x versions for <_> isdependency --version='2" -ForEach @('install', 'upgrade') {
-            $Command = "choco $_ isdependency --version='2"
-            $Completions = (TabExpansion2 -inputScript $Command -cursorColumn ($Command.Length)).CompletionMatches.CompletionText
+                $Completions | Should -Contain "--version='2.1.0'" -Because $becauseCompletions
+                $Completions | Should -Contain "--version='2.0.0'" -Because $becauseCompletions
+                $Completions | Should -Contain "--version='1.1.0'" -Because $becauseCompletions
+                $Completions | Should -Contain "--version='1.0.1'" -Because $becauseCompletions
+                $Completions | Should -Contain "--version='1.0.0'" -Because $becauseCompletions
+            }
 
-            $becauseCompletions = ($Completions -Join ", ")
+            It "Should list versions for <_> isdependency --version='' without moving cursor" -ForEach @('install', 'upgrade') {
+                $Command = "choco $_ isdependency --version=''"
+                $Completions = (TabExpansion2 -inputScript $Command -cursorColumn ($Command.Length)).CompletionMatches.CompletionText
 
-            $Completions | Should -Contain "--version='2.1.0'" -Because $becauseCompletions
-            $Completions | Should -Contain "--version='2.0.0'" -Because $becauseCompletions
-            $Completions | Should -Not -Contain "--version='1.1.0'" -Because $becauseCompletions
-            $Completions | Should -Not -Contain "--version='1.0.1'" -Because $becauseCompletions
-            $Completions | Should -Not -Contain "--version='1.0.0'" -Because $becauseCompletions
+                $becauseCompletions = ($Completions -Join ", ")
+
+                $Completions | Should -Contain "--version='2.1.0'" -Because $becauseCompletions
+                $Completions | Should -Contain "--version='2.0.0'" -Because $becauseCompletions
+                $Completions | Should -Contain "--version='1.1.0'" -Because $becauseCompletions
+                $Completions | Should -Contain "--version='1.0.1'" -Because $becauseCompletions
+                $Completions | Should -Contain "--version='1.0.0'" -Because $becauseCompletions
+            }
+
+            It "Should list 2.x versions for <_> isdependency --version='2" -ForEach @('install', 'upgrade') {
+                $Command = "choco $_ isdependency --version='2"
+                $Completions = (TabExpansion2 -inputScript $Command -cursorColumn ($Command.Length)).CompletionMatches.CompletionText
+
+                $becauseCompletions = ($Completions -Join ", ")
+
+                $Completions | Should -Contain "--version='2.1.0'" -Because $becauseCompletions
+                $Completions | Should -Contain "--version='2.0.0'" -Because $becauseCompletions
+                $Completions | Should -Not -Contain "--version='1.1.0'" -Because $becauseCompletions
+                $Completions | Should -Not -Contain "--version='1.0.1'" -Because $becauseCompletions
+                $Completions | Should -Not -Contain "--version='1.0.0'" -Because $becauseCompletions
+            }
         }
     }
 }


### PR DESCRIPTION
## Description Of Changes

Update the `Vagrantfile` used in the repository to prefer and work with Hyper-V.

This also adds a Context block to the Tab Expansion tests to skip over the tests that require an official Chocolatey CLI.

## Motivation and Context

The Chocolatey Software team is standardizing on Hyper-V with Vagrant, and so this repository should work with it.

## Testing

1. In the tests directory, run `vagrant up`.
2. Ensure that the hyperv is used as the provider.
3. Ensure that the bulk of the tests pass. (There are a number of tests that fail for various reasons in the Vagrantfile. It is beyond the scope of this PR to address them. The main concern of this PR is that the environment builds Chocolatey, and executes tests.)

### Operating Systems Testing

- Windows 11 host.

## Change Types Made

* [ ] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.
* [x] Testing infrastructure changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [x] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v3 compatibility checked?

## Related Issue
<!-- Make sure you have raised an issue for this pull request before
continuing. -->

- Fixes #3749 
- ENGTASKS-4461