### PR TITLE
(#3672) Add "info" to default license links

### DIFF
--- a/docs/legal/CREDITS.json
+++ b/docs/legal/CREDITS.json
@@ -156,7 +156,8 @@
             "licenses": [
                 {
                     "type": "MIT",
-                    "link": "https://github.com/dotnet/corefx/blob/master/LICENSE.TXT",
+                    "link": "https://github.com/dotnet/corefx/blob/b8b81a66738bb10ef0790023598396861d92b2c4/LICENSE.TXT",
+                    "info": "No tag present for this specific release point; falling back to the current permalink of the latest license file from the default branch.",
                     "name": "LICENSE.TXT"
                 }
             ]
@@ -168,7 +169,8 @@
             "licenses": [
                 {
                     "type": "MIT",
-                    "link": "https://github.com/dotnet/corefx/blob/master/LICENSE.TXT",
+                    "link": "https://github.com/dotnet/corefx/blob/b8b81a66738bb10ef0790023598396861d92b2c4/LICENSE.TXT",
+                    "info": "No tag present for this specific release point; falling back to the current permalink of the latest license file from the default branch.",
                     "name": "LICENSE.TXT"
                 }
             ]


### PR DESCRIPTION
## Description Of Changes
For some dependencies, they do not contain a tag or a version in the repository. Instead of linking to the license of master or main, we now link to the permalink to better track history over time. We do not want this going to master or main incase a license type changes in the future and the dependency becomes inaccurate. An "info" entry has been added as well, to explain this change further.


## Motivation and Context
We want the links to be as accurate as possible, and we also want to provide information on how/why we got the link.

### Operating Systems Testing
n/a

## Change Types Made
* [ ] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [x] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [x] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [ ] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v3 compatibility checked?

## Related Issue
#3672 
