### PR TITLE
(#3600) Handle non-ASCII passwords with legacy encoding fallback

### DIFF
--- a/src/chocolatey.tests/infrastructure.app/nuget/ChocolateyNugetCredentialProviderSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/nuget/ChocolateyNugetCredentialProviderSpecs.cs
@@ -182,6 +182,69 @@ namespace chocolatey.tests.infrastructure.app.nuget
             }
         }
 
+        public class When_A_Password_Using_Non_ASCII_Characters_With_Explicit_Username_and_Password : ChocolateyNugetCredentialProviderSpecsBase
+        {
+            public override void Context()
+            {
+                base.Context();
+                Configuration.Sources = Configuration.ExplicitSources = TargetSourceUrl;
+                Configuration.SourceCommand.Username = "user";
+                Configuration.SourceCommand.Password = "tøtally_sæcure_påssword!!!";
+            }
+
+            [Fact]
+            public void Should_Find_The_Saved_Source_And_Return_The_Credential()
+            {
+                Result.Should().NotBeNull();
+            }
+
+            [Fact]
+            public void Should_Provide_The_Correct_Username()
+            {
+                Result.UserName.Should().Be(Username);
+            }
+
+            [Fact]
+            public void Should_Provide_Password_Using_1252_Codepage()
+            {
+                // The following looks odd, but this is a workaround to
+                // allow passwords using non-ascii characters to be used
+                // against sources.
+                Result.Password.Should().Be("tÃ¸tally_sÃ¦cure_pÃ¥ssword!!!");
+            }
+        }
+
+        public class When_A_Password_Using_Non_ASCII_Characters_With_Implicit_Username_And_Password : ChocolateyNugetCredentialProviderSpecsBase
+        {
+            public override void Context()
+            {
+                base.Context();
+                Configuration.Sources = Configuration.ExplicitSources = TargetSourceName;
+                Configuration.MachineSources[1].EncryptedPassword = NugetEncryptionUtility.EncryptString("tøtally_sæcure_påssword!!!");
+            }
+
+            [Fact]
+            public void Should_Find_The_Saved_Source_And_Return_The_Credential()
+            {
+                Result.Should().NotBeNull();
+            }
+
+            [Fact]
+            public void Should_Provide_The_Correct_Username()
+            {
+                Result.UserName.Should().Be(Username);
+            }
+
+            [Fact]
+            public void Should_Provide_Password_Using_1252_Codepage()
+            {
+                // The following looks odd, but this is a workaround to
+                // allow passwords using non-ascii characters to be used
+                // against sources.
+                Result.Password.Should().Be("tÃ¸tally_sÃ¦cure_pÃ¥ssword!!!");
+            }
+        }
+
         public class Looks_Up_Source_Url_When_Name_And_Credentials_Is_Provided : ChocolateyNugetCredentialProviderSpecsBase
         {
             public override void Context()


### PR DESCRIPTION
## Description Of Changes

Add a method to convert passwords to NetworkCredential using codepage 1252 encoding to support non-ASCII characters in credentials. This addresses issues with encoding mismatches in .NET 4.8.1 that cause incorrect password handling.

Update credential retrieval to use this conversion method, falling back to the original password on retry attempts to maintain compatibility.

Add tests verifying correct username and legacy-encoded password handling for non-ASCII characters in explicit and implicit credential scenarios.

## Motivation and Context

Even when a user is using a password with non-ascii characters, we would still want the user to be able to connect to a remote source, even when 

## Testing

1. Update the credentials used for one of your sources to include non-ascii characters  (ie, `øæåéèàù`)
2. Attempt to search for a package using the updated source with the new credentials.
3. Verify the expected results are shown.

### Operating Systems Testing

- Windows 11

## Change Types Made

* [x] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [x] Tests to cover my changes, have been added.
* [x] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v3 compatibility checked?

## Related Issue

Fixes #3600
