### PR TITLE
(tests) Update CCR Only tests

### DIFF
--- a/tests/pester-tests/commands/choco-search.Tests.ps1
+++ b/tests/pester-tests/commands/choco-search.Tests.ps1
@@ -505,10 +505,17 @@ Describe "choco <_>" -ForEach $Command -Tag Chocolatey, SearchCommand, FindComma
     }
 
     Context "CCR Only Tests" -Tag CCR, CCROnly {
+        BeforeDiscovery {
+            $TotalSeededPackages = 74
+        }
+
+        BeforeAll {
+            $TotalSeededPackages = 74
+        }
+
         Context "Searching of all package versions of Package13" {
             BeforeAll {
                 $Output = Invoke-Choco $_ Package13 --exact --all-versions
-                $TotalExpectedPackages = 74
             }
 
             It "Exits with Success (0)" {
@@ -757,8 +764,8 @@ Describe "choco <_>" -ForEach $Command -Tag Chocolatey, SearchCommand, FindComma
                 $Output.Lines[0] | Should -Contain "add-path|1.0.0" -Because $Output.String
             }
 
-            It "Should contain $TotalExpectedPackages package versions" {
-                $Output.Lines | Should -HaveCount $TotalExpectedPackages -Because $Output.String
+            It "Should contain $TotalSeededPackages package versions" {
+                $Output.Lines | Should -HaveCount $TotalSeededPackages -Because $Output.String
             }
         }
 
@@ -782,8 +789,8 @@ Describe "choco <_>" -ForEach $Command -Tag Chocolatey, SearchCommand, FindComma
             }
 
             # This is two more lines due to the warning tested above.
-            It "Should contain $TotalExpectedPackages package versions ($($TotalExpectedPackages + 2) lines)" {
-                $Output.Lines | Should -HaveCount $($TotalExpectedPackages + 2) -Because $Output.String
+            It "Should contain $TotalSeededPackages package versions ($($TotalSeededPackages + 2) lines)" {
+                $Output.Lines | Should -HaveCount $($TotalSeededPackages + 2) -Because $Output.String
             }
         }
 
@@ -800,8 +807,8 @@ Describe "choco <_>" -ForEach $Command -Tag Chocolatey, SearchCommand, FindComma
                 $Output.Lines[0] | Should -Contain "package13|10.10.10" -Because $Output.String
             }
 
-            It "Should contain $TotalExpectedPackages package versions" {
-                $Output.Lines | Should -HaveCount $TotalExpectedPackages -Because $Output.String
+            It "Should contain $TotalSeededPackages package versions" {
+                $Output.Lines | Should -HaveCount $TotalSeededPackages -Because $Output.String
             }
         }
 
@@ -818,8 +825,8 @@ Describe "choco <_>" -ForEach $Command -Tag Chocolatey, SearchCommand, FindComma
                 $Output.Lines[0] | Should -Contain "business-only-license|19.0.0" -Because $Output.String
             }
 
-            It "Should contain $TotalExpectedPackages package versions" {
-                $Output.Lines | Should -HaveCount $TotalExpectedPackages -Because $Output.String
+            It "Should contain $TotalSeededPackages package versions" {
+                $Output.Lines | Should -HaveCount $TotalSeededPackages -Because $Output.String
             }
         }
 
@@ -836,8 +843,8 @@ Describe "choco <_>" -ForEach $Command -Tag Chocolatey, SearchCommand, FindComma
                 $Output.Lines[0] | Should -Contain "add-path|1.0.0" -Because $Output.String
             }
 
-            It "Should contain $TotalExpectedPackages package versions" {
-                $Output.Lines | Should -HaveCount $TotalExpectedPackages -Because $Output.String
+            It "Should contain $TotalSeededPackages package versions" {
+                $Output.Lines | Should -HaveCount $TotalSeededPackages -Because $Output.String
             }
         }
 
@@ -854,8 +861,8 @@ Describe "choco <_>" -ForEach $Command -Tag Chocolatey, SearchCommand, FindComma
                 $Output.Lines[0] | Should -Contain "package12|10.10.10" -Because $Output.String
             }
 
-            It "Should contain $TotalExpectedPackages package versions" {
-                $Output.Lines | Should -HaveCount $TotalExpectedPackages -Because $Output.String
+            It "Should contain $TotalSeededPackages package versions" {
+                $Output.Lines | Should -HaveCount $TotalSeededPackages -Because $Output.String
             }
         }
 
@@ -874,8 +881,8 @@ Describe "choco <_>" -ForEach $Command -Tag Chocolatey, SearchCommand, FindComma
                 $Output.Lines[0] | Should -Contain "package13|10.10.10" -Because $Output.String
             }
 
-            It "Should contain $TotalExpectedPackages package versions" {
-                $Output.Lines | Should -HaveCount $TotalExpectedPackages -Because $Output.String
+            It "Should contain $TotalSeededPackages package versions" {
+                $Output.Lines | Should -HaveCount $TotalSeededPackages -Because $Output.String
             }
         }
     }


### PR DESCRIPTION
## Description Of Changes

This commit updates the CCR Only tests to change the variable name to more closely match the intention of the variable, and it moves the assignment to a location where it will be available where it's needed.

## Motivation and Context

Keep the tests working and reduce the work needed if we change the packages seeded.

## Testing

I have run the `CCROnly` tag in a Local Test Kitchen. All of the tests pass.

### Operating Systems Testing

Windows Server 2019

## Change Types Made

* [ ] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.
* [x] Tests

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [x] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v3 compatibility checked?

## Related Issue

- PROJ-1816