### PR TITLE
(tests) Update push tests to set API key if CCR

### DIFF
--- a/tests/pester-tests/commands/choco-push.Tests.ps1
+++ b/tests/pester-tests/commands/choco-push.Tests.ps1
@@ -11,7 +11,7 @@ Describe "choco push" -Tag Chocolatey, PushCommand, ProxySkip, CCR -Skip:($null 
         # Check if we're in a CCR Test Kitchen. If we are, utilize the local details.
         if (Test-Path $CcrApiKey) {
             $ApiKey = (Get-Content $CcrApiKey -Raw).Trim()
-            $RepositoryToUse = 'http://localhost/api/v2/'
+            $RepositoryToUse = 'http://localhost/'
         }
 
         Initialize-ChocolateyTestInstall
@@ -48,8 +48,9 @@ Describe "choco push" -Tag Chocolatey, PushCommand, ProxySkip, CCR -Skip:($null 
 
         It "Should Report the actual cause of the error" {
             $Output.Lines | Should -Contain "Attempting to push $PackageUnderTest.$VersionUnderTest.nupkg to $RepositoryToUse" -Because $Output.String
-            $Output.Lines | Should -Contain "An error has occurred. This package version already exists on the repository and cannot be modified." -Because $Output.String
-            $Output.Lines | Should -Contain "Package versions that are approved, rejected, or exempted cannot be modified." -Because $Output.String
+            # The output of this differs depending on where you're running from. The following phrases appear on 1 or more line in every permutation that I've seen.
+            ($Output.Lines -match 'already exists on the repository').Count | Should -BeGreaterOrEqual 1 -Because $Output.String
+            ($Output.Lines -match 'cannot be modified').Count | Should -BeGreaterOrEqual 1 -Because $Output.String
         }
     }
 

--- a/tests/pester-tests/commands/choco-push.Tests.ps1
+++ b/tests/pester-tests/commands/choco-push.Tests.ps1
@@ -158,12 +158,12 @@ Describe 'choco push nuget <_> repository' -Tag Chocolatey, PushCommand -Skip:($
                 AddedVersion = $AddedVersion
             }
             $PackagePath = New-ChocolateyTestPackage @NewChocolateyTestPackage
+            # Add the Nuget source so that the push doesn't prompt for credentials.
+            # See https://github.com/chocolatey/choco/issues/2026#issuecomment-2423828013
+            $null = Invoke-Choco source add --name temporary-nuget --source $RepositoryToUse$RepositoryEndpoint --user $env:NUGET_SOURCE_USERNAME --password $env:NUGET_SOURCE_PASSWORD
 
             if ($UseConfig) {
                 $null = Invoke-Choco apikey add --source $RepositoryToUse$RepositoryEndpoint --api-key $ApiKey
-                # Add the Nuget source so that the push doesn't prompt for credentials.
-                # See https://github.com/chocolatey/choco/issues/2026#issuecomment-2423828013
-                $null = Invoke-Choco source add --name temporary-nuget --source $RepositoryToUse$RepositoryEndpoint --user $env:NUGET_SOURCE_USERNAME --password $env:NUGET_SOURCE_PASSWORD
                 # Ensure the key is null (should always be, but scoping can be wonky)
                 $KeyParameter = $null
             } else {


### PR DESCRIPTION
## Description Of Changes

Update the Push tests to use the proper local CCR URL, and to explicitly add the push source.

## Motivation and Context

- The push tests in CCR were getting the wrong response because they were pushing to the wrong endpoint.
- Pushing to Nexus requires that the nexus repository also be added as a source so that a username and password can be provided.

## Testing

Running in Test Kitchen.

### Operating Systems Testing

Windows Server 2019

## Change Types Made

* [ ] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.
* [x] Tests

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [ ] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v3 compatibility checked?

## Related Issue

N/A
