### PR TITLE
(#3765) Don't try to decrypt cert password

### DIFF
--- a/src/chocolatey/infrastructure/cryptography/DefaultEncryptionUtility.cs
+++ b/src/chocolatey/infrastructure/cryptography/DefaultEncryptionUtility.cs
@@ -61,6 +61,11 @@ Anything encrypted as CurrentUser can only be decrypted by your current user.");
 
         public string DecryptString(string encryptedString)
         {
+            if (string.IsNullOrEmpty(encryptedString))
+            {
+                return null;
+            }
+
             var encryptedByteArray = Convert.FromBase64String(encryptedString);
             byte[] decryptedByteArray;
 


### PR DESCRIPTION
## Description Of Changes

When attempting to decrypt a string that is null or empty, instead of attempting to decrypt, return null.

## Motivation and Context

It is not possible to decrypt a string that doesn't exist. This also brings the decrypt logic in line with the encrypt logic that already included this check.

## Testing

1. Setup a Repository that accepts a certificate (https://docs.chocolatey.org/en-us/guides/organizations/set-up-certificate-authentication/#using-sonatype-nexus for using Nexus through nginx).
2. Add the new source with a passwordless certificate
3. Attempt to use the source

Internal Chocolatey Software testing:

1. Follow the testing found [here](https://gitlab.com/chocolatey/build-automation/chocolatey-test-kitchen/-/merge_requests/175). Add to the testing using `userNoPassword.pfx` as well as `userWithPassword.pfx` in your testing.

### Operating Systems Testing

Windows 11

## Change Types Made

* [x] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [ ] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v3 compatibility checked?

## Related Issue

- Fixes #3765