### PR TITLE
(#3681) Check for correct computer name when refreshing environment variables

### DIFF
--- a/src/Chocolatey.PowerShell/Chocolatey.PowerShell.csproj
+++ b/src/Chocolatey.PowerShell/Chocolatey.PowerShell.csproj
@@ -87,5 +87,8 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>
+  <ItemGroup>
+    <None Include="ReadMe.md" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/src/Chocolatey.PowerShell/Helpers/EnvironmentHelper.cs
+++ b/src/Chocolatey.PowerShell/Helpers/EnvironmentHelper.cs
@@ -226,7 +226,7 @@ namespace Chocolatey.PowerShell.Helpers
             var computerName = GetVariable(cmdlet, EnvironmentVariables.System.ComputerName, EnvironmentVariableTarget.Process);
 
             // User scope should override (be checked after) machine scope, but only if we're not running as SYSTEM
-            if (userName != computerName && userName != Shared.EnvironmentNames.System)
+            if (userName != $"{computerName}$" && userName != Shared.EnvironmentNames.System)
             {
                 scopeList.Add(EnvironmentVariableTarget.User);
             }

--- a/src/Chocolatey.PowerShell/ReadMe.md
+++ b/src/Chocolatey.PowerShell/ReadMe.md
@@ -1,0 +1,29 @@
+## About this project
+
+The Chocolatey.PowerShell project within the Chocolatey CLI solution is the compiled PowerShell cmdlets.
+
+## Debugging the Chocolatey.PowerShell cmdlets
+
+Because the Chocolatey.PowerShell module is a compiled module, debugging it is a little more involved than a script based module.
+If you need to debug cmdlets within a Chocolatey CLI execution, you can merely create a package that calls the Chocolatey.PowerShell function you are debugging, and it will work.
+However, if you need to test the functions outside of a Chocolatey CLI invocation, that is a little bit more involved.
+Fortunately, Marc-Andr� Moreau provides and [excellent guide](https://awakecoding.com/posts/debugging-powershell-binary-modules-in-visual-studio/) on debugging a binary PowerShell module from Visual Studio.
+The below steps are greatly simplified and targetted specifically at the Chocolatey.PowerShell project.
+
+1. Edit or create a `Chocolatey.PowerShell.csproj.user` file beside the `Chocolatey.PowerShell.csproj` file (located at `$ChocoSourceRepository/src/Chocolatey.PowerShell`).
+1. Set it's contents to the XML following this list.
+1. (Re)Launch Visual Studio to have it pick up the addition of the `Chocolatey.PowerShell.csproj.user` file.
+1. Set the `Chocolatey.PowerShell` project as the startup project.
+1. Start the debugger.
+1. In the Windows PowerShell that launched, import the module with `Import-Module ./Chocolatey.PowerShell.dll`.
+1. Now when you call any of the compiled PowerShell files, you will be able to stop at set breakpoints and debug as normal.
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="Current" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
+    <StartAction>Program</StartAction>
+    <StartProgram>c:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe</StartProgram>
+  </PropertyGroup>
+</Project>
+```

--- a/tests/helpers/common/ConvertTo-Base64String.ps1
+++ b/tests/helpers/common/ConvertTo-Base64String.ps1
@@ -1,0 +1,14 @@
+﻿function ConvertTo-Base64String {
+    <#
+        .Synopsis
+            Helper function to Convert a string to a Base64 encoded string.
+    #>
+    [CmdletBinding()]
+    param(
+        # The string to be converted to base64.
+        [Parameter(ValueFromPipeline)]
+        [string]$InputObject
+    )
+    $bytes = [system.text.encoding]::Unicode.GetBytes($InputObject)
+    [Convert]::ToBase64String($bytes)
+}


### PR DESCRIPTION
## Description Of Changes

Update the `EnvironmentHelper` to check for the computername with `$`.

## Motivation and Context

When running as system, the username is actually reported as `COMPUTERNAME$` instead of `COMPUTERNAME`. This is the also the way the check was done when it was written in PowerShell.

## Testing

A new Pester test has been added. The full suite has been run against the current `develop` branch [here](https://sra-soteria-web.ch0.co/buildConfiguration/TestKitchen_AdHoc/36703), which is expected to fail with 2 failed tests. Also ran the full suite of tests against this PR branch [here](https://sra-soteria-web.ch0.co/buildConfiguration/TestKitchen_Chocolatey/36705)

### Operating Systems Testing

- Windows 11 (Manual Tests)
- Windows Server 2016 (Test Kitchen Pester tests)
- Windows Server 2019 (Test Kitchen Pester tests)

## Change Types Made

* [x] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [x] **Developer** Documentation has been updated.
* [x] Tests to cover my changes, have been added.
* [x] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v3 compatibility checked?

## Related Issue

Fixes #3681 