### PR TITLE
(tests) Exclude test from CCR testing

### DIFF
--- a/tests/pester-tests/commands/choco-install.Tests.ps1
+++ b/tests/pester-tests/commands/choco-install.Tests.ps1
@@ -2068,7 +2068,8 @@ To install a local, or remote file, you may use:
         }
     }
 
-    Context 'Installing package with large number of dependency versions' {
+    # Excluded from CCR testing as this is not testing remote repositories in any way.
+    Context 'Installing package with large number of dependency versions' -Tag CCRExcluded {
         BeforeAll {
             Restore-ChocolateyInstallSnapshot -SetWorkDir
 


### PR DESCRIPTION
## Description Of Changes

Exclude a test from CCR testing.

## Motivation and Context

This test doesn't exercise anything outside of the local system, so is not needed for CCR testing.

## Testing

N/A - This is merely excluding an existing test from one of the Test Kitchen suites. The only testing we could possibly do is target the CCR tests to this branch and ensure they don't run this one test.

### Operating Systems Testing

N/A

## Change Types Made

* [ ] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [x] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v3 compatibility checked?

## Related Issue

N/A