### PR TITLE
(#3802) Fix up test setup for license tests

### DIFF
--- a/tests/pester-tests/chocolatey.Tests.ps1
+++ b/tests/pester-tests/chocolatey.Tests.ps1
@@ -262,7 +262,7 @@ exit $error.count
         BeforeAll {
             Restore-ChocolateyInstallSnapshot
 
-            Enable-ChocolateySource -Name hermes
+            Enable-ChocolateySource -Name hermes-setup
 
             Invoke-Choco install chocolatey-license-business
         }
@@ -285,7 +285,7 @@ exit $error.count
         BeforeAll {
             Restore-ChocolateyInstallSnapshot
 
-            Enable-ChocolateySource -Name hermes
+            Enable-ChocolateySource -Name hermes-setup
 
             $result = Invoke-Choco install chocolatey-license-business
             $LicenseFolder = "$env:ChocolateyInstall\lib\chocolatey-license-business\tools"


### PR DESCRIPTION
## Description Of Changes

- Fix license tests setup for #3802

## Motivation and Context

This test passed in CLE but not in CLI, due to the setup having incorrect expectations as to which source should be enabled here.

This should allow the test to pass for both runs.

## Testing

Testing both runs in Test Kitchen.

### Operating Systems Testing
Win11

## Change Types Made
<!-- Tick the boxes for the type of changes that have been made -->

* [ ] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [x] Tests to cover my changes, have been added.
* [ ] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v3 compatibility checked?

## Related Issue
<!-- Make sure you have raised an issue for this pull request before
continuing. -->

#3802

<!-- PLEASE REMOVE ALL COMMENTS BEFORE SUBMITTING -->
