### PR TITLE
(#3804) Update test use package with full details

### DIFF
--- a/tests/pester-tests/commands/choco-info.Tests.ps1
+++ b/tests/pester-tests/commands/choco-info.Tests.ps1
@@ -36,13 +36,18 @@
 
     Context "Should display source and deployment locations when using --local-only" {
         BeforeAll {
-            Initialize-ChocolateyTestInstall -Source $PSScriptRoot\testpackages
+            New-ChocolateyInstallSnapshot
+            $PackageUnderTest = 'pureportable'
+            Enable-ChocolateySource -Name hermes-setup
 
-            $Setup = Invoke-Choco install installpackage
-
+            $Setup = Invoke-Choco install $PackageUnderTest
             $Setup.ExitCode | Should -Be 0 -Because $Setup.String
 
-            $Output = Invoke-Choco info installpackage --local-only
+            $Output = Invoke-Choco info $PackageUnderTest --local-only
+        }
+
+        AfterAll {
+            Remove-ChocolateyInstallSnapshot
         }
 
         It "Exits with Success (0)" {
@@ -50,8 +55,9 @@
         }
 
         It "Should contain source and deployment location summary" {
-            $Output.Lines | Should -Contain "Source package was installed from: $PSScriptRoot\testpackages" -Because $Output.String
-            $Output.String | Should -Match "Deployed to:"
+            # We do not necessarily know what source will be used, so we match on the leading string.
+            $Output.String | Should -Match "Source package was installed from: '"
+            $Output.String | Should -Match "Deployed to: '"
         }
     }
 


### PR DESCRIPTION
## Description Of Changes

This updates the tests used for choco info --local-only to use a package that will include all of the details being tested. It also adjusts the comparison for scenarios where the source won't necessarily be known until the test is fully run.

## Motivation and Context

The test wasn't quite working as the source location wasn't always the same. This updates to use `hermes-source` for the source, and ensured the deployment location is listed.

## Testing

Ran tests on Team City: https://sra-soteria-web.ch0.co/buildConfiguration/TestKitchen_Chocolatey/39464

### Operating Systems Testing

Windows Server 2016/2019

## Change Types Made

* [ ] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [x] Tests to cover my changes, have been added.
* [x] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v3 compatibility checked?

## Related Issue

Fixes #3804 