### PR TITLE
(#3817) Append download tab completion options

### DIFF
--- a/src/chocolatey.resources/helpers/ChocolateyTabExpansion.ps1
+++ b/src/chocolatey.resources/helpers/ChocolateyTabExpansion.ps1
@@ -74,7 +74,7 @@ if (Test-Path $licenseFile) {
         'optimize'
     )
 
-    $commandOptions.download = "--append-use-original-location --cert='' --certpassword='' --disable-repository-optimizations --download-location='' --ignore-dependencies --ignore-unfound --installed-packages --internalize --internalize-all-urls --output-directory='' --password='' --prerelease --resources-location='' --skip-download-cache --skip-virus-check --source='' --use-download-cache --user='' --version='' --virus-check --virus-positives-minimum=''"
+    $commandOptions.download = "--allow-empty-checksums --allow-empty-checksums-secure --append-use-original-location --cert='' --certpassword='' --disable-repository-optimizations --download-location='' --ignore-checksum --ignore-dependencies --ignore-dependencies-from-source='' --ignore-unfound --installed-packages --internalize --internalize-all-urls --output-directory='' --password='' --prerelease --require-checksums --resources-location='' --skip-download-cache --skip-virus-check --source='' --use-download-cache --user='' --version='' --virus-check --virus-positives-minimum=''"
     $commandOptions.optimize = "--id='' --reduce-nupkg-only"
 
     # Add pro switches to commands that have additional switches on Pro

--- a/tests/pester-tests/chocolateyProfile.Tests.ps1
+++ b/tests/pester-tests/chocolateyProfile.Tests.ps1
@@ -100,6 +100,41 @@ Describe "Chocolatey Profile" -Tag Chocolatey, Profile, Environment {
             $Completions | Should -Contain "--value=''" -Because $becauseCompletions
         }
 
+        It "Should list completions for download (Licensed)" -Skip:(!$isLicensed) {
+            $Command = "choco download "
+            $Completions = (TabExpansion2 -inputScript $Command -cursorColumn $Command.Length).CompletionMatches.CompletionText
+
+            $becauseCompletions = ($Completions -Join ", ")
+
+            $Completions | Should -Contain "--allow-empty-checksums" -Because $becauseCompletions
+            $Completions | Should -Contain "--allow-empty-checksums-secure" -Because $becauseCompletions
+            $Completions | Should -Contain "--append-use-original-location" -Because $becauseCompletions
+            $Completions | Should -Contain "--cert=''" -Because $becauseCompletions
+            $Completions | Should -Contain "--certpassword=''" -Because $becauseCompletions
+            $Completions | Should -Contain "--disable-repository-optimizations" -Because $becauseCompletions
+            $Completions | Should -Contain "--download-location=''" -Because $becauseCompletions
+            $Completions | Should -Contain "--ignore-checksum" -Because $becauseCompletions
+            $Completions | Should -Contain "--ignore-dependencies" -Because $becauseCompletions
+            $Completions | Should -Contain "--ignore-dependencies-from-source=''" -Because $becauseCompletions
+            $Completions | Should -Contain "--ignore-unfound" -Because $becauseCompletions
+            $Completions | Should -Contain "--installed-packages" -Because $becauseCompletions
+            $Completions | Should -Contain "--internalize" -Because $becauseCompletions
+            $Completions | Should -Contain "--internalize-all-urls" -Because $becauseCompletions
+            $Completions | Should -Contain "--output-directory=''" -Because $becauseCompletions
+            $Completions | Should -Contain "--password=''" -Because $becauseCompletions
+            $Completions | Should -Contain "--prerelease" -Because $becauseCompletions
+            $Completions | Should -Contain "--require-checksums" -Because $becauseCompletions
+            $Completions | Should -Contain "--resources-location=''" -Because $becauseCompletions
+            $Completions | Should -Contain "--skip-download-cache" -Because $becauseCompletions
+            $Completions | Should -Contain "--skip-virus-check" -Because $becauseCompletions
+            $Completions | Should -Contain "--source=''" -Because $becauseCompletions
+            $Completions | Should -Contain "--use-download-cache" -Because $becauseCompletions
+            $Completions | Should -Contain "--user=''" -Because $becauseCompletions
+            $Completions | Should -Contain "--version=''" -Because $becauseCompletions
+            $Completions | Should -Contain "--virus-check" -Because $becauseCompletions
+            $Completions | Should -Contain "--virus-positives-minimum=''" -Because $becauseCompletions
+        }
+
         It "Should list completions for export" -Skip:$ExportNotPresent {
             $Command = "choco export "
             $Completions = (TabExpansion2 -inputScript $Command -cursorColumn $Command.Length).CompletionMatches.CompletionText


### PR DESCRIPTION
## Description Of Changes
- Added comprehensive tab completion entries for `choco download` options: allow-empty-checksums, allow-empty-checksums-secure, ignore-checksum, ignore-dependencies-from-source, require-checksums, and other existing download switches.
- Updated TabExpansion to expose all download-related options so shell completion shows these flags.
- Added a Pester test (Should list completions for downolad (Licensed)) to verify the new completions when licensed features are available.

## Motivation and Context
- Fix missing completions for `choco download` to improve shell UX for licensed/pro users and ensure completion parity with available command flags.

## Testing

- Added Pester test that asserts the completion list includes the newly added download switches.

1. Source the changed tab completion files using `. .\src\chocolatey.resources\helpers\ChocolateyTabExpansion.ps1`.
2. Type `choco download` the continue hitting the `tab` character to verify the following options are showing up:
  - `--allow-empty-checksums`
  - `--allow-empty-checksums-secure`
  - `--ignore-checksum`
  - `--ignore-dependencies-from-source=''`
  - `--require-checksums`

### Operating Systems Testing
- Windows 11

## Change Types Made
* [ ] Bug fix (non-breaking change).
* [x] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [x] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [x] Tests to cover my changes, have been added.
* [x] All new and existing tests passed?
* [x] PowerShell code changes: PowerShell v3 compatibility checked?

## Related Issue
Fixes #3817