### PR TITLE
(tests) Add all Chocolatey products to signature checks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -90,6 +90,7 @@ jobs:
         key: ${{ runner.os }}-tools-${{ hashFiles('recipe.cake') }}
     - name: Build with Mono
       run: |
+        export DOTNET_ROOT=$HOME/.dotnet
         chmod +x build.sh
         $GITHUB_WORKSPACE//build.sh --verbosity=diagnostic --target=CI --testExecutionType=unit
     - name: Upload MacOS build results

--- a/tests/pester-tests/chocolatey.Tests.ps1
+++ b/tests/pester-tests/chocolatey.Tests.ps1
@@ -7,6 +7,12 @@ Describe "Ensuring Chocolatey is correctly installed" -Tag Environment, Chocolat
             "$env:ChocolateyInstall\extensions\chocolatey"
             "$env:ChocolateyInstall\bin"
         )
+        $ChocolateyPackageDirectoriesToCheck = @(
+            "$env:ChocolateyInstall\lib\chocolatey"
+            "$env:ChocolateyInstall\lib\chocolatey.extension"
+            "$env:ChocolateyInstall\lib\chocolatey-agent"
+            "$env:ChocolateyInstall\lib\chocolatey-management-*"
+        )
         $StrongNamingKeyFilesToCheck = @(
             "$env:ChocolateyInstall\choco.exe"
             "$env:ChocolateyInstall\extensions\chocolatey\chocolatey.licensed.dll"
@@ -21,7 +27,7 @@ Describe "Ensuring Chocolatey is correctly installed" -Tag Environment, Chocolat
             "\bin\cuninst.exe"
             "\bin\cup.exe"
         )
-        $PowerShellFiles = Get-ChildItem -Path $ChocolateyDirectoriesToCheck -Include "*.ps1", "*.psm1" -Recurse -ErrorAction Ignore
+        $PowerShellFiles = Get-ChildItem -Path @($ChocolateyDirectoriesToCheck; $ChocolateyPackageDirectoriesToCheck) -Include "*.ps1", "*.psm1" -Recurse -ErrorAction Ignore
         # For certain test scenarios we run, there are additional files available in the bin directory.
         # These files should not be tested as part of the signing check.
         $ExecutableFiles = Get-ChildItem -Path $ChocolateyDirectoriesToCheck -Include "*.exe", "*.dll" -Recurse -ErrorAction Ignore | Where-Object Name -NotMatch 'driver\.exe$'
@@ -114,8 +120,9 @@ Describe "Ensuring Chocolatey is correctly installed" -Tag Environment, Chocolat
         $path | Should -Not -Exist
     }
 
+    # This is tagged CCM as we require it to also run on the CCM suite that only runs the CCM tags.
     # This is skipped when not run in CI because it requires signed executables.
-    Context "File signing (<_.FullName>)" -ForEach @($PowerShellFiles; $ExecutableFiles; $StrongNamingKeyFiles) -Skip:((-not $env:TEST_KITCHEN) -or (-not (Test-ChocolateyVersionEqualOrHigherThan "1.0.0"))) {
+    Context "File signing (<_.FullName>)" -ForEach @($PowerShellFiles; $ExecutableFiles; $StrongNamingKeyFiles) -Tag CCM -Skip:((-not $env:TEST_KITCHEN) -or (-not (Test-ChocolateyVersionEqualOrHigherThan "1.0.0"))) {
         BeforeAll {
             # Due to changes in the signing setup, the certificate used to sign PS1 files and the Chocolatey CLI executable MIGHT be different. This ensures that the both certificates are trusted.
             $FileUnderTest = $_


### PR DESCRIPTION
## Description Of Changes

Update the signature check tests to test signatures of other Chocolatey Products.

This also updates the GHA runner to set the dotnet root as per https://github.com/actions/runner-images/issues/13470

## Motivation and Context

Automating some of our manual tests.

## Testing

Run through TeamCity Test Kitchen. See all the tests run: https://gitlab.com/chocolatey/build-automation/chocolatey-test-kitchen/-/merge_requests/225

### Operating Systems Testing

- Windows Server 2016
- Windows Server 2019

## Change Types Made

* [ ] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.
* [x] Pester Test changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [x] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v3 compatibility checked?

## Related Issue

- PROJ-2511 - CCMWEB0033
- PROJ-2601 - CCMDB0001
- PROJ-2608 - CCMSVC0008