### PR TITLE
(builld) Adjust TeamCity "pullRequests" build feature

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -3,6 +3,7 @@ import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.script
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildSteps.powerShell
 import jetbrains.buildServer.configs.kotlin.v2019_2.Dependencies
 import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.pullRequests
+import jetbrains.buildServer.configs.kotlin.v2019_2.buildFeatures.PullRequests
 import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.vcs
 import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.finishBuildTrigger
 import jetbrains.buildServer.configs.kotlin.v2019_2.triggers.ScheduleTrigger
@@ -86,6 +87,8 @@ object Chocolatey : BuildType({
                 authType = token {
                     token = "%system.GitHubPAT%"
                 }
+                filterAuthorRole = PullRequests.GitHubRoleFilter.MEMBER
+                ignoreDrafts = true
             }
         }
     }


### PR DESCRIPTION
## Description Of Changes

This PR makes two changes to this project's TeamCity build configuration:

- Sets TeamCity to ignore draft PRs. _This saves on CI time for builds that are not yet ready to be worked on._
- Sets TeamCity to only build PRs that have been authored by organization members. _This ensures that untrusted code will not be run in CI automatically._

## Motivation and Context

The _purpose_ of this PR is to discuss these changes which may be rolled out to other GitHub based projects.

- https://teamcity.jetbrains.com/app/dsl-documentation/buildFeatures/pull-requests/index.html

## Testing

N/A

This change has been synced onto a test TeamCity instance to validate syntax and that the intended settings have applied.

### Operating Systems Testing

N/A

## Change Types Made

* [ ] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [ ] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v3 compatibility checked?

## Related Issue

N/A
