### PR TITLE
(maint) Guard against null Data in process output callbacks

### DIFF
--- a/src/chocolatey.tests.integration/scenarios/InstallScenarios.cs
+++ b/src/chocolatey.tests.integration/scenarios/InstallScenarios.cs
@@ -262,8 +262,8 @@ namespace chocolatey.tests.integration.scenarios
                     shimfile,
                     "--shimgen-noop",
                     10,
-                    stdOutAction: (s, e) => messages.Add(e.Data),
-                    stdErrAction: (s, e) => messages.Add(e.Data)
+                    stdOutAction: (s, e) => messages.Add(e.Data ?? string.Empty),
+                    stdErrAction: (s, e) => messages.Add(e.Data ?? string.Empty)
                 );
 
                 messages.Should()
@@ -283,8 +283,8 @@ namespace chocolatey.tests.integration.scenarios
                     shimfile,
                     "--shimgen-noop",
                     10,
-                    stdOutAction: (s, e) => messages.Add(e.Data),
-                    stdErrAction: (s, e) => messages.Add(e.Data)
+                    stdOutAction: (s, e) => messages.Add(e.Data ?? string.Empty),
+                    stdErrAction: (s, e) => messages.Add(e.Data ?? string.Empty)
                 );
 
                 messages.Should()
@@ -3208,8 +3208,8 @@ namespace chocolatey.tests.integration.scenarios
                     shimfile,
                     "--shimgen-noop",
                     10,
-                    stdOutAction: (s, e) => messages.Add(e.Data),
-                    stdErrAction: (s, e) => messages.Add(e.Data)
+                    stdOutAction: (s, e) => messages.Add(e.Data ?? string.Empty),
+                    stdErrAction: (s, e) => messages.Add(e.Data ?? string.Empty)
                 );
 
                 messages.Should()
@@ -3229,8 +3229,8 @@ namespace chocolatey.tests.integration.scenarios
                     shimfile,
                     "--shimgen-noop",
                     10,
-                    stdOutAction: (s, e) => messages.Add(e.Data),
-                    stdErrAction: (s, e) => messages.Add(e.Data)
+                    stdOutAction: (s, e) => messages.Add(e.Data ?? string.Empty),
+                    stdErrAction: (s, e) => messages.Add(e.Data ?? string.Empty)
                 );
 
                 messages.Should()
@@ -3455,8 +3455,8 @@ namespace chocolatey.tests.integration.scenarios
                     shimfile,
                     "--shimgen-noop",
                     10,
-                    stdOutAction: (s, e) => messages.Add(e.Data),
-                    stdErrAction: (s, e) => messages.Add(e.Data)
+                    stdOutAction: (s, e) => messages.Add(e.Data ?? string.Empty),
+                    stdErrAction: (s, e) => messages.Add(e.Data ?? string.Empty)
                 );
 
                 messages.Should()
@@ -3476,8 +3476,8 @@ namespace chocolatey.tests.integration.scenarios
                     shimfile,
                     "--shimgen-noop",
                     10,
-                    stdOutAction: (s, e) => messages.Add(e.Data),
-                    stdErrAction: (s, e) => messages.Add(e.Data)
+                    stdOutAction: (s, e) => messages.Add(e.Data ?? string.Empty),
+                    stdErrAction: (s, e) => messages.Add(e.Data ?? string.Empty)
                 );
 
                 messages.Should()
@@ -4377,8 +4377,8 @@ namespace chocolatey.tests.integration.scenarios
                     shimfile,
                     "--shimgen-noop",
                     10,
-                    stdOutAction: (s, e) => messages.Add(e.Data),
-                    stdErrAction: (s, e) => messages.Add(e.Data)
+                    stdOutAction: (s, e) => messages.Add(e.Data ?? string.Empty),
+                    stdErrAction: (s, e) => messages.Add(e.Data ?? string.Empty)
                 );
 
                 messages.Should()
@@ -4398,8 +4398,8 @@ namespace chocolatey.tests.integration.scenarios
                     shimfile,
                     "--shimgen-noop",
                     10,
-                    stdOutAction: (s, e) => messages.Add(e.Data),
-                    stdErrAction: (s, e) => messages.Add(e.Data)
+                    stdOutAction: (s, e) => messages.Add(e.Data ?? string.Empty),
+                    stdErrAction: (s, e) => messages.Add(e.Data ?? string.Empty)
                 );
 
                 messages.Should()


### PR DESCRIPTION
## Description Of Changes
- Guard against null Data in process output/error event handlers in integration tests.
- Replace messages.Add(e.Data) with messages.Add(e.Data ?? string.Empty) across affected tests.
- Apply null-coalescing fix to both stdOutAction and stdErrAction delegates where used.

## Motivation and Context
- Prevent null entries or null-reference issues from Process output events that can raise null Data values during integration test assertions.

## Testing
- Run integration tests.

### Operating Systems Testing
- N/A

## Change Types Made
* [x] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist
* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [x] All new and existing tests passed? (fix intends to prevent test failures)
* [ ] PowerShell code changes: PowerShell v3 compatibility checked?
* [x] All items are complete on the [Definition of Done](https://github.com/chocolatey/home/blob/main/definition-of-done.md). (_Not everything, but those that are relevant_)

## Related Issue
N/A