### PR TITLE
(#3849) Use new AvailableVersionSource property

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <config>
+    <add key="globalPackagesFolder" value=".\src\packages" />
+  </config>
+</configuration>

--- a/src/chocolatey/chocolatey.csproj
+++ b/src/chocolatey/chocolatey.csproj
@@ -93,7 +93,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="AlphaFS" Version="2.2.6" />
-    <PackageReference Include="Chocolatey.NuGet.PackageManagement" Version="3.4.3" />
+    <PackageReference Include="Chocolatey.NuGet.PackageManagement" Version="3.5.0-alpha-20260227-1505" />
     <PackageReference Include="log4net" Version="3.2.0" />
     <PackageReference Include="Microsoft.Bcl.HashCode" Version="6.0.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.BannedApiAnalyzers">

--- a/src/chocolatey/infrastructure.app/nuget/NugetList.cs
+++ b/src/chocolatey/infrastructure.app/nuget/NugetList.cs
@@ -421,6 +421,7 @@ namespace chocolatey.infrastructure.app.nuget
 
                         if (!(package is null))
                         {
+                            package.AvailableVersionSource = resource.Source.PackageSource.Source;
                             packagesList.Add(package);
                         }
                     }
@@ -431,6 +432,11 @@ namespace chocolatey.infrastructure.app.nuget
                             errorMessage: "Unable to connect to source '{0}'".FormatWith(resource.Source.PackageSource.Source),
                             throwError: false,
                             logWarningInsteadOfError: true).OrEmpty();
+
+                        foreach (var package in packages)
+                        {
+                            package.AvailableVersionSource = resource.Source.PackageSource.Source;
+                        }
 
                         packagesList.AddRange(packages);
                     }
@@ -445,6 +451,7 @@ namespace chocolatey.infrastructure.app.nuget
 
                     if (!(package is null))
                     {
+                        package.AvailableVersionSource = resource.Source.PackageSource.Source;
                         packagesList.Add(package);
                     }
                 }

--- a/update-nuget-client.ps1
+++ b/update-nuget-client.ps1
@@ -32,9 +32,12 @@ if ($build -or !(Test-Path "$sourceLocation\artifacts")) {
 }
 
 Get-ChildItem "$thisLocation\src\packages\Chocolatey.NuGet.*" | ForEach-Object {
-    $name = $_.Name -replace "^Chocolatey\.NuGet([^\d]+)(\.\d.*)$", "NuGet`$1"
+    $name = $_.Name -replace "^Chocolatey\.NuGet([^\d]+)$", "NuGet`$1"
 
-    $destination = "$($_.FullName)\lib"
+    $packageDirectory = $_.FullName
+    $versionDirectory = Get-ChildItem -Path $packageDirectory -Directory | Sort-Object Name -Descending | Select-Object -First 1
+    $destination = Join-Path $versionDirectory.FullName 'lib'
+
     Remove-Item "$destination\*\*"
 
     Get-ChildItem "$sourceLocation\artifacts\$name\bin\Debug" -Directory | ForEach-Object {


### PR DESCRIPTION
## Description Of Changes

With the latest Chocolatey.NuGet.Client assemblies, there is a new
AvailableVersionSource property on the IChocolateySearchMetadata
instances, which can be used to store the URL to the source that was
being used when querying for a package.  Now, when calling methods like
FindPackage, when enumerating sources, we can store the actual source
that was used when the package was found, and the result can be passed
back to the caller of the method, in order to do _something_ with this
information.

This change will require a bump in the package version, but this will
only be possible once the latest Chocolatey.NuGet.Client packages are
available somewhere.  For now, we will have to rely on pulling through
the latest debug builds of the assemblies.

## Motivation and Context

We need to be able to store the available version source for a package.

## Testing

This will be tested using an upstream application PR, and the testing steps will be included on that PR.

### Operating Systems Testing

- Dev 4 VM

## Change Types Made

* [ ] Bug fix (non-breaking change).
* [x] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [x] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v3 compatibility checked?
* [ ] All items are complete on the [Definition of Done](https://github.com/chocolatey/home/blob/main/definition-of-done.md).

## Related Issue

Fixes #3849 