### PR TITLE
(#3853) Copy NuGet Extraction tests from support branch to develop

### DIFF
--- a/tests/pester-tests/features/Extraction.Tests.ps1
+++ b/tests/pester-tests/features/Extraction.Tests.ps1
@@ -1,0 +1,54 @@
+Import-Module helpers/common-helpers
+
+# These tests are skipped when not in Test Kitchen as the packages for this test are not available in this repository.
+# These tests also modify files outside of the tests.
+Describe "Extraction tests <_> command" -Skip:(-not $env:TEST_KITCHEN) -ForEach @(
+    'install'
+    'upgrade'
+    if (Test-PackageIsEqualOrHigher -PackageName chocolatey.extension -Version 5.0.0) {
+        'download'
+    }
+) -Tag Extraction {
+    BeforeDiscovery {
+        $Type = @(
+            'combined-extracted-path'
+            'absolute-extracted-path'
+            'relative-extracted-path'
+        )
+    }
+
+    BeforeAll {
+        Initialize-ChocolateyTestInstall
+        New-ChocolateyInstallSnapshot
+        $Command = $_
+    }
+
+    AfterAll {
+        Remove-ChocolateyTestInstall
+    }
+
+    Context '<_> extraction' -ForEach $Type {
+        BeforeAll {
+            Restore-ChocolateyInstallSnapshot
+
+            $Output = Invoke-Choco $Command $_ --confirm
+        }
+
+        AfterAll {
+            Remove-Item -Path C:\demonstration -Force -Recurse -ErrorAction SilentlyContinue
+        }
+
+        It 'Exits correctly' {
+            $Output.ExitCode | Should -Be 1 -Because $Output.String
+        }
+
+        It 'Should output correctly' {
+            $Output.String | Should -Match "The package contains an entry '.*' which is unsafe for extraction."
+        }
+
+        It 'Should not create the file.' {
+            'C:\demonstration\demo.txt' | Should -Not -Exist -Because $Output.String
+        }
+
+    }
+}

--- a/tests/pester-tests/features/Extraction.Tests.ps1
+++ b/tests/pester-tests/features/Extraction.Tests.ps1
@@ -43,7 +43,7 @@ Describe "Extraction tests <_> command" -Skip:(-not $env:TEST_KITCHEN) -ForEach 
         }
 
         It 'Should output correctly' {
-            $Output.String | Should -Match "The package contains an entry '.*' which is unsafe for extraction."
+            $Output.String | Should -Match "The package '$_.1.0.0' contains an entry '.*' which is unsafe for extraction."
         }
 
         It 'Should not create the file.' {


### PR DESCRIPTION
## Description Of Changes

Copy the NuGet extraction tests from `support/1.x`, and update them for 2.x output.

## Motivation and Context

Ensuring tests are present.

## Testing

Ran through Test Kitchen: 
- Chocolatey CLI: https://sra-soteria-web.ch0.co/buildConfiguration/TestKitchen_Chocolatey/47960
- Licensed Extension: https://sra-soteria-web.ch0.co/buildConfiguration/TestKitchen_ChocolateyLicensed/47963

### Operating Systems Testing

- Windows Server 2016
- Windows Server 2019
- Windows Server 2022
- Windows Server 2025

## Change Types Made

* [ ] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.
* [x] Test Expansion

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [x] Tests to cover my changes, have been added.
* [x] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v3 compatibility checked?
* [ ] All items are complete on the [Definition of Done](https://github.com/chocolatey/home/blob/main/definition-of-done.md).

## Related Issue

- Fixes #3853 