### PR TITLE
(maint) Fix assembly not signed if environment key doesn't exist

### DIFF
--- a/src/Chocolatey.PowerShell/Chocolatey.PowerShell.csproj
+++ b/src/Chocolatey.PowerShell/Chocolatey.PowerShell.csproj
@@ -29,7 +29,7 @@
     <Optimize>true</Optimize>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(CHOCOLATEY_OFFICIAL_KEY)' == ''">
+	<PropertyGroup Condition="'$(CHOCOLATEY_OFFICIAL_KEY)' == '' OR !Exists('$(CHOCOLATEY_OFFICIAL_KEY')">
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\chocolatey.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>

--- a/src/chocolatey.benchmark/chocolatey.benchmark.csproj
+++ b/src/chocolatey.benchmark/chocolatey.benchmark.csproj
@@ -14,7 +14,7 @@
     <Optimize>true</Optimize>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(CHOCOLATEY_OFFICIAL_KEY)' == ''">
+  <PropertyGroup Condition="'$(CHOCOLATEY_OFFICIAL_KEY)' == '' OR !Exists('$(CHOCOLATEY_OFFICIAL_KEY')">
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\chocolatey.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>

--- a/src/chocolatey.console/chocolatey.console.csproj
+++ b/src/chocolatey.console/chocolatey.console.csproj
@@ -53,7 +53,7 @@
   <PropertyGroup>
     <NoWin32Manifest>true</NoWin32Manifest>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(CHOCOLATEY_OFFICIAL_KEY)' == ''">
+  <PropertyGroup Condition="'$(CHOCOLATEY_OFFICIAL_KEY)' == '' OR !Exists('$(CHOCOLATEY_OFFICIAL_KEY')">
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\chocolatey.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>

--- a/src/chocolatey.resources/chocolatey.resources.csproj
+++ b/src/chocolatey.resources/chocolatey.resources.csproj
@@ -24,7 +24,7 @@
     <DefineConstants>TRACE;FORCE_CHOCOLATEY_OFFICIAL_KEY</DefineConstants>
     <Optimize>true</Optimize>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(CHOCOLATEY_OFFICIAL_KEY)' == ''">
+  <PropertyGroup Condition="'$(CHOCOLATEY_OFFICIAL_KEY)' == '' OR !Exists('$(CHOCOLATEY_OFFICIAL_KEY')">
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\chocolatey.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>

--- a/src/chocolatey/chocolatey.csproj
+++ b/src/chocolatey/chocolatey.csproj
@@ -33,7 +33,7 @@
   <PropertyGroup>
     <ApplicationIcon>$(SolutionDir)\..\docs\logo\chocolatey.ico</ApplicationIcon>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(CHOCOLATEY_OFFICIAL_KEY)' == ''">
+  <PropertyGroup Condition="'$(CHOCOLATEY_OFFICIAL_KEY)' == '' OR !Exists('$(CHOCOLATEY_OFFICIAL_KEY')">
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\chocolatey.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>


### PR DESCRIPTION
## Description Of Changes

- Add file existence check to PropertyGroup conditions in project files to validate that the CHOCOLATEY_OFFICIAL_KEY variable is set AND the key file actually exists on disk
- Prevents test failures when the signing key variable is defined but points to a non-existent file path
- Ensures assemblies are always signed when conditions are properly met

## Motivation and Context

Build reliability improvement. The current implementation only checks if the CHOCOLATEY_OFFICIAL_KEY environment variable is set, but doesn't properly verify that the actual key file exists on disk. This causes test failures when the variable is defined but the file path is invalid in cases where the environment variable is available, but the file doesn't exist.

## Testing

### Before Checking out this PR

1. Set the environment variable in your console `$env:CHOCOLATEY_OFFICIAL_KEY = 'C:\missing.snk'`.
2. Run the build script for the tests `.\build.debug.bat --target=DotNetTest` 
3. Notice that no unit tests could be found.

### After Checking out this PR

1. Set the environment variable in your console `$env:CHOCOLATEY_OFFICIAL_KEY = 'C:\missing.snk'`.
2. Run the build script for the tests `.\build.debug.bat --target=DotNetTest` 
3. Notice that the unit tests are now found, and runs successfully. 

### Operating Systems Testing

- Windows 11

## Change Types Made

* [x] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [x] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v3 compatibility checked?
* [x] All items are complete on the [Definition of Done](https://github.com/chocolatey/home/blob/main/definition-of-done.md).

## Related Issue

N/A