### PR TITLE
(#3867) Fix Docker image build

### DIFF
--- a/docker/Dockerfile.linux
+++ b/docker/Dockerfile.linux
@@ -23,10 +23,10 @@ ARG buildscript="build.sh"
 RUN if [ "$buildscript" = "build.official.sh" ]; then \
     export CHOCOLATEY_OFFICIAL_KEY="/usr/local/src/choco/chocolatey.official.snk"; \
     ./$buildscript; \
-    cp docker/choco_official_wrapper code_drop/temp/_PublishedApps/choco/choco_wrapper; \
+    cp docker/choco_official_wrapper code_drop/temp/_PublishedApps/choco/net48/choco_wrapper; \
   else \
     ./$buildscript --verbosity=diagnostic; \
-    cp docker/choco_wrapper code_drop/temp/_PublishedApps/choco/choco_wrapper; \
+    cp docker/choco_wrapper code_drop/temp/_PublishedApps/choco/net48/choco_wrapper; \
   fi;
 
 FROM debian:bookworm AS install
@@ -51,7 +51,7 @@ LABEL org.opencontainers.image.base.name="index.docker.io/library/debian:bookwor
 
 ENV ChocolateyInstall=/opt/chocolatey
 
-COPY --from=build /usr/local/src/choco/code_drop/temp/_PublishedApps/choco /opt/chocolatey
+COPY --from=build /usr/local/src/choco/code_drop/temp/_PublishedApps/choco/net48 /opt/chocolatey
 
 RUN mkdir /opt/chocolatey/lib; \
   cp /opt/chocolatey/choco_wrapper usr/local/bin/choco; \

--- a/recipe.cake
+++ b/recipe.cake
@@ -234,7 +234,7 @@ Task("Create-TarGz-Packages")
                 "-czvf {0} .",
                 outputFile
             ),
-            WorkingDirectory = BuildParameters.Paths.Directories.PublishedApplications.FullPath + "/choco/"
+            WorkingDirectory = BuildParameters.Paths.Directories.PublishedApplications.FullPath + "/choco/net48/"
         }
     );
 


### PR DESCRIPTION
## Description Of Changes

In order to keep things the "same", both in the Docker image, and in the tar.gz file, changes have been made to incorporate the new net48 folder.  Firstly, the working directory for the tar command has changed to navigate into the net48 folder so that the generated file has the same folder structure. And secondly, the copy commands in the Dockerfile.linux file have been updated to copy the contents of the net48 folder, rather than the net48 folder itself.

## Motivation and Context

With the introduction of dotnet build, rather than msbuild, the new net48 folder is causing an issue with the creation of the Docker image. The choco and choco.exe files, which are copies of the choco_wrapper file, are no longer pointing to the correct location.

## Testing

1. Check out this PR
2. Open WSL and navigate to the cloned folder
3. Run `sudo docker build -t choco:latest-linux -f docker/Dockerfile.linux .`
4. Once complete, run `docker run -ti --rm choco:latest-linux /bin/bash`
5. Once running, run `choco`, and verify that the Chocolatey CLI version is output
6. If you run `docker run -ti --rm chocolatey/choco:v2.7.0-linux /bin/bash` and then type `choco`, you will see that this doesn't work

### Operating Systems Testing

- Dev VM 4

## Change Types Made

* [x] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [ ] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v3 compatibility checked?
* [ ] All items are complete on the [Definition of Done](https://github.com/chocolatey/home/blob/main/definition-of-done.md).

## Related Issue

Fixes #3867 