### PR TITLE
(maint) Add `NUGETDEVRESTORE_SOURCE` env param to kts script

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -381,6 +381,7 @@ object ChocolateyPosix : BuildType({
     params {
         param("env.CAKE_NUGET_SOURCE", "") // The Cake version we use has issues with authing to our private source on Linux
         param("env.PRIMARY_NUGET_SOURCE", "") // As above there are issues with authing to our private source on Linux
+        param("env:NUGETDEVRESTORE_SOURCE", "") // As above there are issues with authing to our private source on Linux
         param("env.CHOCOLATEY_VERSION", "%dep.Chocolatey.build.number%")
         param("env.CHOCOLATEY_OFFICIAL_KEY", "%system.teamcity.build.checkoutDir%/chocolatey.official.snk")
         password("env.GITHUB_PAT", "%system.GitHubPAT%", display = ParameterDisplay.HIDDEN, readOnly = true)


### PR DESCRIPTION
## Description Of Changes

- Add `NUGETDEVRESTORE` environment parameter to TeamCity build configuration
- Include explanatory comment about Linux authentication issues

## Motivation and Context

Resolve NuGet authentication problems when restoring packages from private sources on Linux build agents. Maintains consistency with existing `CAKE_NUGET_SOURCE` and `PRIMARY_NUGET_SOURCE` parameters.

## Testing

N/A: Maintenance change to build configuration

## Change Types Made

* [x] Feature / Enhancement (non-breaking change).

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [x] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v3 compatibility checked?
* [x] All items are complete on the [Definition of Done](https://github.com/chocolatey/home/blob/main/definition-of-done.md).

## Related Issue

N/A