### PR TITLE
(maint) Remove GitHub Release publish step

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -429,25 +429,6 @@ object ChocolateyPosix : BuildType({
             """.trimIndent()
         }
 
-        // Please note that this method will need to be changed to some form of CD after we lock agents down
-        script {
-            name = "Publish TarGz to GitHub Release"
-            conditions {
-                exists("env.GITHUB_PAT")
-                startsWith("teamcity.build.branch", "tags")
-            }
-            scriptContent = """
-                curl \
-                    -X POST \
-                    -H "Accept: application/vnd.github+json" \
-                    -H "Authorization: Bearer %env.GITHUB_PAT%"\
-                    -H "X-GitHub-Api-Version: 2022-11-28" \
-                    -H "Content-Type: application/octet-stream" \
-                    https://uploads.github.com/repos/chocolatey/choco/releases/%env.CHOCOLATEY_VERSION%/assets?name=chocolatey.v%env.CHOCOLATEY_VERSION%.tar.gz \
-                    --data-binary "@code_drop/Packages/Chocolatey/chocolatey.v%env.CHOCOLATEY_VERSION%.tar.gz"
-            """.trimIndent()
-        }
-
         script {
             name = "Build Docker Image"
             scriptContent = "./build.official.sh --verbosity=diagnostic --target=Docker"


### PR DESCRIPTION
## Description Of Changes

* Remove GitHub Release publish step (TarGz asset upload script)
* Remove associated environment variable conditions
* Step was failing unexpectedly and will be replaced with a proper task in Chocolatey.Cake.Recipe

## Motivation and Context

The curl-based GitHub Release asset upload step was failing unexpectedly in the CI/CD pipeline. This manual approach is not maintainable long-term and will be replaced with a proper Cake recipe task in the future.

## Testing

N/A: Maintenance change removing non-functional step.

## Change Types Made

* [x] Build Changes

## Change Checklist

* [x] All items are complete on the [Definition of Done](https://github.com/chocolatey/home/blob/main/definition-of-done.md).

## Related Issue

N/A