### PR TITLE
(maint) Fix typo in TeamCity build configuration

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -381,7 +381,7 @@ object ChocolateyPosix : BuildType({
     params {
         param("env.CAKE_NUGET_SOURCE", "") // The Cake version we use has issues with authing to our private source on Linux
         param("env.PRIMARY_NUGET_SOURCE", "") // As above there are issues with authing to our private source on Linux
-        param("env:NUGETDEVRESTORE_SOURCE", "") // As above there are issues with authing to our private source on Linux
+        param("env.NUGETDEVRESTORE_SOURCE", "") // As above there are issues with authing to our private source on Linux
         param("env.CHOCOLATEY_VERSION", "%dep.Chocolatey.build.number%")
         param("env.CHOCOLATEY_OFFICIAL_KEY", "%system.teamcity.build.checkoutDir%/chocolatey.official.snk")
         password("env.GITHUB_PAT", "%system.GitHubPAT%", display = ParameterDisplay.HIDDEN, readOnly = true)


### PR DESCRIPTION
## Description Of Changes
- Fixed typo in an environment variable name in the build configuration.

## Motivation and Context
The environment variable was defined incorreectly, so this build fell over unexpectedly.

## Testing

N/A, will have to be tested in CI when appropriate.

### Operating Systems Testing

N/A

## Change Types Made
<!-- Tick the boxes for the type of changes that have been made -->

* [ ] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [ ] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v3 compatibility checked?
* [ ] All items are complete on the [Definition of Done](https://github.com/chocolatey/home/blob/main/definition-of-done.md).

## Related Issue

N/A