### PR TITLE
(#3875) Improve handling for corrupt nuspec files

### DIFF
--- a/src/chocolatey.tests.integration/Scenario.cs
+++ b/src/chocolatey.tests.integration/Scenario.cs
@@ -192,16 +192,22 @@ namespace chocolatey.tests.integration
             NUnitSetup.MockLogger.Messages.Clear();
         }
 
-        public static void AddFiles(IEnumerable<Tuple<string, string>> files)
+        public static void AddFiles(IEnumerable<(string name, string content)> files)
         {
             foreach (var file in files)
             {
-                if (_fileSystem.FileExists(file.Item1))
-                {
-                    _fileSystem.DeleteFile(file.Item1);
-                }
-                _fileSystem.WriteFile(file.Item1, file.Item2);
+                AddFile(file.name, file.content);
             }
+        }
+
+        public static void AddFile(string name, string content)
+        {
+            if (_fileSystem.FileExists(name))
+            {
+                _fileSystem.DeleteFile(name);
+            }
+
+            _fileSystem.WriteFile(name, content);
         }
 
         public static void CreateDirectory(string directoryPath)

--- a/src/chocolatey.tests.integration/scenarios/InstallScenarios.cs
+++ b/src/chocolatey.tests.integration/scenarios/InstallScenarios.cs
@@ -4208,6 +4208,79 @@ namespace chocolatey.tests.integration.scenarios
             }
         }
 
+        public class When_installing_a_package_with_corrupt_local_package_already_on_disk : ScenariosBase
+        {
+            private PackageResult _packageResult;
+
+            public override void Context()
+            {
+                base.Context();
+
+                var corruptPackageFolder = Path.Combine(Scenario.GetPackageInstallPath(), Configuration.PackageNames);
+                Scenario.CreateDirectory(corruptPackageFolder);
+
+                // Add a corrupt nuspec (full of null bytes) as an "already installed, but corrupted" package.
+                // The nupkg is intentionally missing here, since NuGet doesn't recognise the package as being "installed"
+                // even if files are present at the target install location, so it will blindly attempt to install a package.
+                var corruptNuspec = Path.Combine(corruptPackageFolder, Configuration.PackageNames + ".nuspec");
+                Scenario.AddFile(corruptNuspec, new string((char)0, 1024));
+            }
+
+            public override void Because()
+            {
+                Results = Service.Install(Configuration);
+                _packageResult = Results.FirstOrDefault().Value;
+            }
+
+            [Fact]
+            public void Should_not_install_where_install_location_reports()
+            {
+                Assert.That(_packageResult.InstallLocation ?? string.Empty, Is.Not.EqualTo(string.Empty));
+                Assert.That(_packageResult.InstallLocation, Does.Not.Exist);
+            }
+
+            [Fact]
+            public void Should_move_the_package_to_lib_bad_directory()
+            {
+                var packageDir = Path.Combine(Scenario.GetTopLevel(), "lib-bad", Configuration.PackageNames);
+
+                Assert.That(packageDir, Does.Exist);
+            }
+
+
+            [Fact]
+            public void Should_contain_a_warning_message_that_it_did_not_install_successfully()
+            {
+                MockLogger.Messages.Should().ContainKey(LogLevel.Warn.ToStringSafe())
+                    .WhoseValue.Should().Contain(m => m.Contains("0/1"));
+            }
+
+
+            [Fact]
+            public void Should_not_have_a_successful_package_result()
+            {
+                _packageResult.Success.Should().BeFalse();
+            }
+
+            [Fact]
+            public void Should_not_have_inconclusive_package_result()
+            {
+                _packageResult.Inconclusive.Should().BeFalse();
+            }
+
+            [Fact]
+            public void Config_should_match_package_result_name()
+            {
+                _packageResult.Name.Should().Be(Configuration.PackageNames);
+            }
+
+            [Fact]
+            public void Should_have_an_empty_version_string()
+            {
+                _packageResult.Version.Should().Be(string.Empty);
+            }
+        }
+
         public class When_installing_a_package_with_non_normalized_version : ScenariosBase
         {
             private PackageResult _packageResult;

--- a/src/chocolatey.tests.integration/scenarios/PackScenarios.cs
+++ b/src/chocolatey.tests.integration/scenarios/PackScenarios.cs
@@ -60,7 +60,7 @@ namespace chocolatey.tests.integration.scenarios
 
             protected void AddFile(string fileName, string fileContent)
             {
-                Scenario.AddFiles(new[] { new Tuple<string, string>(fileName, fileContent) });
+                Scenario.AddFile(fileName, fileContent);
             }
         }
 
@@ -136,7 +136,7 @@ namespace chocolatey.tests.integration.scenarios
             {
                 Configuration = Scenario.Pack();
                 Scenario.Reset(Configuration);
-                Scenario.AddFiles(new[] { new Tuple<string, string>("myPackage.nuspec", GetNuspecContent()) });
+                Scenario.AddFile("myPackage.nuspec", GetNuspecContent());
 
                 if (!string.IsNullOrEmpty(ExpectedSubDirectory))
                 {
@@ -600,7 +600,7 @@ namespace chocolatey.tests.integration.scenarios
                 Scenario.Reset(Configuration);
                 Configuration.Version = "0.1.0";
                 Configuration.PackCommand.Properties.Add("commitId", "1234abcd");
-                Scenario.AddFiles(new[] { new Tuple<string, string>("myPackage.nuspec", NuspecContentWithVariables) });
+                Scenario.AddFile("myPackage.nuspec", NuspecContentWithVariables);
             }
 
             public override void Because()

--- a/src/chocolatey/infrastructure.app/services/ChocolateyPackageService.cs
+++ b/src/chocolatey/infrastructure.app/services/ChocolateyPackageService.cs
@@ -1823,7 +1823,11 @@ ATTENTION: You must take manual action to remove {1} from
 
             if (!string.IsNullOrWhiteSpace(packageResult.InstallLocation) && _fileSystem.DirectoryExists(packageResult.InstallLocation))
             {
-                var normalizedVersion = new NuGetVersion(packageResult.Version).ToNormalizedStringChecked();
+                // If there's no version information (certain edge cases on package install errors), fallback to an unknown version with a timestamp
+                // so this can't fail out unexpectedly.
+                var normalizedVersion = string.IsNullOrEmpty(packageResult.Version)
+                    ? "unknown-{0}".FormatWith(DateTime.UtcNow.ToString("yyyy-MM-dd-HH-mm-ss"))
+                    : new NuGetVersion(packageResult.Version).ToNormalizedStringChecked();
                 var failuresFolder = _fileSystem.CombinePaths(ApplicationParameters.PackageFailuresLocation, packageResult.Name, normalizedVersion);
 
                 if (_filesService.MovePackageUsingBackupStrategy(packageResult.InstallLocation, failuresFolder, restoreSource: false))
@@ -1835,7 +1839,7 @@ ATTENTION: You must take manual action to remove {1} from
 
         private void RestorePreviousPackageVersion(ChocolateyConfiguration config, PackageResult packageResult)
         {
-            if (packageResult.InstallLocation == null)
+            if (string.IsNullOrEmpty(packageResult.InstallLocation) || string.IsNullOrEmpty(packageResult.Version))
             {
                 return;
             }

--- a/src/chocolatey/infrastructure.app/services/NugetService.cs
+++ b/src/chocolatey/infrastructure.app/services/NugetService.cs
@@ -50,6 +50,7 @@ using NuGet.Protocol.Core.Types;
 using NuGet.Resolver;
 using NuGet.Versioning;
 using static chocolatey.StringResources;
+using System.Xml;
 
 namespace chocolatey.infrastructure.app.services
 {
@@ -954,7 +955,6 @@ Please see https://docs.chocolatey.org/en-us/troubleshooting for more
                         }
                     }
 
-
                     try
                     {
                         //TODO, do sanity check here.
@@ -975,13 +975,18 @@ Please see https://docs.chocolatey.org/en-us/troubleshooting for more
                                    _nugetLogger, CancellationToken.None).GetAwaiter().GetResult())
                         {
                             ValidatePackageHash(config, packageDependencyInfo, downloadResult);
-
-                            nugetProject.InstallPackageAsync(
-                                packageDependencyInfo,
-                                downloadResult,
-                                projectContext,
-                                CancellationToken.None).GetAwaiter().GetResult();
-
+                            try
+                            {
+                                nugetProject.InstallPackageAsync(
+                                    packageDependencyInfo,
+                                    downloadResult,
+                                    projectContext,
+                                    CancellationToken.None).GetAwaiter().GetResult();
+                            }
+                            catch (XmlException)
+                            {
+                                throw new ApplicationException("An unexpected error was encountered parsing a malformed nuspec file. This may occur if corrupt files are present in the package's install directory.");
+                            }
                         }
 
                         var installedPath = nugetProject.GetInstalledPath(packageDependencyInfo);
@@ -1042,7 +1047,16 @@ Please see https://docs.chocolatey.org/en-us/troubleshooting for more
 
                         var logMessage = "{0} not installed. An error occurred during installation:{1} {2}".FormatWith(packageDependencyInfo.Id, Environment.NewLine, message);
                         this.Log().Error(ChocolateyLoggers.Important, logMessage);
-                        var errorResult = packageResultsToReturn.GetOrAdd(packageDependencyInfo.Id, new PackageResult(packageDependencyInfo.Id, version.ToFullStringChecked(), null));
+
+                        // Set this install path if the folder does exist, to ensure otherwise unrecoverable scenarios still move corrupt files
+                        // to lib-bad if they happen to be present, when the continueAction is set up to do so.
+                        var packageInstallPath = _fileSystem.CombinePaths(nugetProject.Root, pathResolver.GetPackageDirectoryName(packageDependencyInfo));
+                        if (!_fileSystem.DirectoryExists(packageInstallPath))
+                        {
+                            packageInstallPath = null;
+                        }
+
+                        var errorResult = packageResultsToReturn.GetOrAdd(packageDependencyInfo.Id, new PackageResult(packageDependencyInfo.Id, version.ToFullStringChecked(), packageInstallPath));
                         errorResult.Messages.Add(new ResultMessage(ResultType.Error, logMessage));
                         if (errorResult.ExitCode == 0)
                         {
@@ -1801,11 +1815,18 @@ Please see https://docs.chocolatey.org/en-us/troubleshooting for more
                                 {
                                     ValidatePackageHash(config, packageDependencyInfo, downloadResult);
 
-                                    nugetProject.InstallPackageAsync(
-                                        packageDependencyInfo,
-                                        downloadResult,
-                                        projectContext,
-                                        CancellationToken.None).GetAwaiter().GetResult();
+                                    try
+                                    {
+                                        nugetProject.InstallPackageAsync(
+                                            packageDependencyInfo,
+                                            downloadResult,
+                                            projectContext,
+                                            CancellationToken.None).GetAwaiter().GetResult();
+                                    }
+                                    catch (XmlException)
+                                    {
+                                        throw new ApplicationException("An unexpected error was encountered parsing a malformed nuspec file. This may occur if corrupt files are present in the package's install directory.");
+                                    }
                                 }
 
                                 var installedPath = nugetProject.GetInstalledPath(packageDependencyInfo);


### PR DESCRIPTION
## Description Of Changes
- Small refactors to some helper methods used in a couple of the integration tests
- Added a new integration test to cover this edge case
- Add some additional error handling when calling `nugetProject.InstallPackageAsync()` to cover an unhandled `XmlException` that can be hit if there are nuspec files on disk in the package directory, and throw a more coherent error that is at least legible to users and gives some context.
- Ensure that the post-intall-failure handling covers this edge case and ensures the corrupted files are correctly moved to `lib-bad` so that users can simply re-attempt installation or upgrade on a re-run, rather than the current status quo (currently, *none* of the `choco` commands can handle this error case; `uninstall` and `list` do not find the package at all, and `upgrade` follows the same path as `install`).

## Motivation and Context

Prior to these changes, the only error message the user would get is an unrecognisable "weird bad characters" message with no context.

Instead, we now emit a more sensible and informative error to the user, as well as ensuring that the handling for failed installs and upgrades works correctly to move the corrupt files to lib-bad.

Tests have been added to validate the previously not covered edge case.

## Testing

In preparation for testing, download the test case package from #3875 (https://github.com/user-attachments/files/26459293/notepadplusplus.install.zip) and extract to a local folder.

1. Copy the corrupted package files downloaded above into the `src/chocolatey.console/bin/Debug/net48/lib` directory (so, under a `notepadplusplus.install` directory, as contained in the zip file).
2. Run the project in VS in debug mode with the arguments `install notepadplusplus.install -n`
3. You should get an error about the nuspec failing to parse, and the installation should still fail.
4. If you inspect the `lib` directory, the package folder you copied over should be gone. It should now have been moved to a `lib-bad/notepadplusplus.install/unknown-yyyy-MM-dd-HH-mm-ss` directory instead.
5. Rerunning the project in VS with the same arguments should cause a successful installation instead, with the corrupt files no longer being an obstacle.

This test can be rerun with `upgrade` rather than `install`, but the behaviour will be identical.

Additionally, run the added integration test in Visual Studio to validate the change works and the test is functioning correctly.

Minor addenda: there *is* a change in behaviour if there is a `nupkg` with a valid `nuspec` file contained within it in the directory. In that case, `uninstall` would work to remove the corrupt files without issue, and `upgrade` will *fail* but offer a chance to restore the bad package files; it correctly moves the package files to `lib-bad` if rollback of files is rejected. Both of these cases are no different to the prior behaviour, `install` appears to be the only command really affected here (apart from the friendlier error message also appearing in `upgrade` scenarios as well, after this change).

### Operating Systems Testing

Win11

## Change Types Made
<!-- Tick the boxes for the type of changes that have been made -->

* [x] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [x] Tests to cover my changes, have been added.
* [x] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v3 compatibility checked?
* [ ] All items are complete on the [Definition of Done](https://github.com/chocolatey/home/blob/main/definition-of-done.md).

## Related Issue

Fixes #3875 