### PR TITLE
(maint) Automate the submission of MSIs to winget

### DIFF
--- a/Submit-MsiToWinget.ps1
+++ b/Submit-MsiToWinget.ps1
@@ -1,12 +1,31 @@
+[CmdletBinding()]
 param(
-[Parameter(Mandatory)]
-$GitHubToken
+    [Parameter(Mandatory)]
+    [ValidateNotNullOrEmpty()]
+    [string]$GitHubToken
 )
-gh repo sync choco-bot/winget-pkgs
+$syncOutput = gh repo sync choco-bot/winget-pkgs 2>&1
+if ($LASTEXITCODE -ne 0) {
+    throw "Sync of choco-bot/winget-pkgs failed (exit code $LASTEXITCODE): $syncOutput"
+}
 
+$releaseJson = gh release view --repo chocolatey/choco --json assets,name 2>&1
 if ($LASTEXITCODE -ne 0) {
-	throw "Sync of choco-bot repository failed. Check permissions and try again"
+    throw "Failed to query latest release for chocolatey/choco (exit code $LASTEXITCODE): $releaseJson"
 }
 
-$release = gh release view --json assets,name| convertfrom-json
-wingetcreate update --submit --token $GitHubToken --urls ($release.assets | ? url -match msi | % url) --version "$($release.name).0" chocolatey.chocolatey
+$release = $releaseJson | ConvertFrom-Json
+$msiUrls = @(
+    $release.assets |
+        Where-Object { $_.name -like '*.msi' } |
+        ForEach-Object url
+)
+
+if ($msiUrls.Count -eq 0) {
+    throw "No .msi assets found in latest release '$($release.name)'"
+}
+
+$wingetOutput = wingetcreate update --submit --token $GitHubToken --urls $msiUrls --version "$($release.name).0" chocolatey.chocolatey 2>&1
+if ($LASTEXITCODE -ne 0) {
+    throw "wingetcreate update failed (exit code $LASTEXITCODE): $wingetOutput"
+}

--- a/Submit-MsiToWinget.ps1
+++ b/Submit-MsiToWinget.ps1
@@ -1,31 +1,31 @@
-[CmdletBinding()]
-param(
-    [Parameter(Mandatory)]
-    [ValidateNotNullOrEmpty()]
-    [string]$GitHubToken
-)
-$syncOutput = gh repo sync choco-bot/winget-pkgs 2>&1
-if ($LASTEXITCODE -ne 0) {
-    throw "Sync of choco-bot/winget-pkgs failed (exit code $LASTEXITCODE): $syncOutput"
-}
+[CmdletBinding()]
 
-$releaseJson = gh release view --repo chocolatey/choco --json assets,name 2>&1
+param(
+    [Parameter(Mandatory)]
+    [ValidateNotNullOrEmpty()]
+    [string]$GitHubToken
+)
+$syncOutput = gh repo sync choco-bot/winget-pkgs 2>&1
+
 if ($LASTEXITCODE -ne 0) {
-    throw "Failed to query latest release for chocolatey/choco (exit code $LASTEXITCODE): $releaseJson"
+    throw "Sync of choco-bot/winget-pkgs failed (exit code $LASTEXITCODE): $syncOutput"
 }
 
-$release = $releaseJson | ConvertFrom-Json
-$msiUrls = @(
-    $release.assets |
-        Where-Object { $_.name -like '*.msi' } |
-        ForEach-Object url
-)
-
-if ($msiUrls.Count -eq 0) {
-    throw "No .msi assets found in latest release '$($release.name)'"
-}
-
-$wingetOutput = wingetcreate update --submit --token $GitHubToken --urls $msiUrls --version "$($release.name).0" chocolatey.chocolatey 2>&1
-if ($LASTEXITCODE -ne 0) {
-    throw "wingetcreate update failed (exit code $LASTEXITCODE): $wingetOutput"
-}
+$releaseJson = gh release view --repo chocolatey/choco --json assets, name 2>&1
+
+if ($LASTEXITCODE -ne 0) {
+    throw "Failed to query latest release for chocolatey/choco (exit code $LASTEXITCODE): $releaseJson"
+}
+
+$release = $releaseJson | ConvertFrom-Json
+$msiUrls = ($release.assets | Where-Object { $_.name -like '*.msi' }).url
+
+if ($msiUrls.Count -eq 0) {
+    throw "No .msi assets found in latest release '$($release.name)'"
+}
+
+$wingetOutput = wingetcreate update --submit --token $GitHubToken --urls $msiUrls --version "$($release.name).0" chocolatey.chocolatey 2>&1
+
+if ($LASTEXITCODE -ne 0) {
+    throw "wingetcreate update failed (exit code $LASTEXITCODE): $wingetOutput"
+}

--- a/Submit-MsiToWinget.ps1
+++ b/Submit-MsiToWinget.ps1
@@ -1,0 +1,12 @@
+param(
+[Parameter(Mandatory)]
+$GitHubToken
+)
+gh repo sync choco-bot/winget-pkgs
+
+if ($LASTEXITCODE -ne 0) {
+	throw "Sync of choco-bot repository failed. Check permissions and try again"
+}
+
+$release = gh release view --json assets,name| convertfrom-json
+wingetcreate update --submit --token $GitHubToken --urls ($release.assets | ? url -match msi | % url) --version "$($release.name).0" chocolatey.chocolatey


### PR DESCRIPTION
## Description Of Changes

This commit adds a script that will ensure the choco-bot winget-pkgs repository is in sync, then it will run wingetcreate to submit the latest Chocolatey CLI to winget.

## Motivation and Context

Automate parts of our release process.

## Testing

This script was formulated from the commands I ran as part of the 2.7.3 release. There isn't a huge amount of testing that can be done with it until the next release...

### Operating Systems Testing

Dev VM 4.

## Change Types Made

* [ ] Bug fix (non-breaking change).
* [x] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [ ] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v3 compatibility checked?
* [ ] All items are complete on the [Definition of Done](https://github.com/chocolatey/home/blob/main/definition-of-done.md).

## Related Issue

N/A