### PR TITLE
(#3915) Update log4net in chocolatey.lib

### DIFF
--- a/nuspec/nuget/chocolatey.lib/chocolatey.lib.nuspec
+++ b/nuspec/nuget/chocolatey.lib/chocolatey.lib.nuspec
@@ -34,7 +34,7 @@ This is the Chocolatey Library (API / DLL) package which allows Chocolatey to be
 See all - https://docs.chocolatey.org/en-us/choco/release-notes
     </releaseNotes>
     <dependencies>
-      <dependency id="log4net" version="3.2.0" />
+      <dependency id="log4net" version="3.3.1" />
     </dependencies>
   </metadata>
 </package>


### PR DESCRIPTION
## Description Of Changes
This upgrades log4net to 3.3.1 in chocolatey.lib. This is to ensure all references of log4net are the same across the project. The other references were updated as part of issue #3887.

## Motivation and Context
We should be on the same version of log4net across projects.

## Testing
n/a

### Operating Systems Testing
Dev VM 4.

## Change Types Made
* [x] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [x] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v3 compatibility checked?
* [x] All items are complete on the [Definition of Done](https://github.com/chocolatey/home/blob/main/definition-of-done.md).

## Related Issue
* #3887 
* Fixes #3915
* PROJ-2935
