### PR TITLE
[DO NOT MERGE] Pester 6.0.0 release candidate update

### DIFF
--- a/Invoke-AuthedTests.ps1
+++ b/Invoke-AuthedTests.ps1
@@ -1,4 +1,4 @@
-﻿#Requires -Module @{ ModuleName = 'pester'; ModuleVersion = '5.3.1' }
+﻿#Requires -Module @{ ModuleName = 'pester'; ModuleVersion = '6.0.0' }
 #Requires -RunAsAdministrator
 <#
     .SYNOPSIS

--- a/Invoke-Tests.ps1
+++ b/Invoke-Tests.ps1
@@ -1,4 +1,4 @@
-#Requires -Module @{ ModuleName = 'pester'; ModuleVersion = '5.3.1' }
+#Requires -Module @{ ModuleName = 'pester'; ModuleVersion = '6.0.0' }
 #Requires -RunAsAdministrator
 <#
     .SYNOPSIS

--- a/ScriptFormat.Tests.ps1
+++ b/ScriptFormat.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#Requires -Module @{ ModuleName = 'pester'; ModuleVersion = '5.3.1' }
+﻿#Requires -Module @{ ModuleName = 'pester'; ModuleVersion = '6.0.0' }
 
 Describe "Verifying integrity of module files" {
     BeforeDiscovery {

--- a/tests/Vagrantfile
+++ b/tests/Vagrantfile
@@ -63,7 +63,9 @@ Vagrant.configure("2") do |config|
     iex (irm https://community.chocolatey.org/install.ps1)
 
     Write-Host "($(Get-Date -Format "dddd MM/dd/yyyy HH:mm:ss K")) We are going to install some prerequisites now. This could take some time"
-    $null = choco install git pester visualstudio2022community visualstudio2022-workload-manageddesktop netfx-4.8-devpack -y
+    $null = choco install git visualstudio2022community visualstudio2022-workload-manageddesktop netfx-4.8-devpack -y
+    $null = Install-PackageProvider -Name NuGet -Force
+    Install-Module -Name Pester -RequiredVersion '6.0.0-rc1' -AllowPrerelease -Force -SkipPublisherCheck
     Import-Module $env:ChocolateyInstall/helpers/chocolateyProfile.psm1
     Update-SessionEnvironment
     Write-Host "($(Get-Date -Format "dddd MM/dd/yyyy HH:mm:ss K")) Done installing software, now copying files"


### PR DESCRIPTION
Hi — Pester 6.0.0 is almost ready, and before I release it I'm trying it out
against real-world Pester v5 test suites.

This PR updates Pester to the 6.0.0 release candidate and makes the changes
needed for your tests to run on it. I opened it to learn two things:

- whether migrating from v5 to v6 is straightforward, and
- where v6 breaks or behaves differently, so I can fix those things before the
  final release instead of after.

You don't need to merge this, and I'd suggest you don't — it's only meant to
show what a v6 update would involve and to give me feedback. Please leave it
open, though: if more release candidates come out I'll push those updates here
too, and I'll close it myself afterwards.

This PR was co-authored by GitHub Copilot. If you'd rather not receive
AI-assisted PRs, just close it and I won't open one for the next release.

Thanks for the CI time this run used, and for maintaining a suite I could test
against.

— Jakub & Copilot
