### PR TITLE
(build) Add GitHub Action for creating release

### DIFF
--- a/.github/workflows/create-release-notes.yml
+++ b/.github/workflows/create-release-notes.yml
@@ -1,0 +1,51 @@
+name: Create Release Notes
+
+on:
+  # Only ever run this workflow when manually triggered from the Actions tab.
+  # The branch/ref selected in the "Use workflow from" dropdown determines which
+  # branch is checked out and used by GitVersion to calculate the milestone.
+  workflow_dispatch:
+    inputs:
+      target-branch:
+        description: 'Optional target branch (commitish) for the created release. Leave blank to use the branch the workflow is run from / the configured master branch.'
+        required: false
+        default: ''
+
+jobs:
+  create-release-notes:
+    runs-on: ubuntu-24.04
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+    - name: Cache Tools
+      uses: actions/cache@v4
+      with:
+        path: tools
+        key: ${{ runner.os }}-tools-${{ hashFiles('recipe.cake') }}
+    - name: Install Mono
+      run: |
+        sudo apt install ca-certificates gnupg
+        sudo gpg --homedir /tmp --no-default-keyring --keyring /usr/share/keyrings/mono-official-archive-keyring.gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
+        echo "deb [signed-by=/usr/share/keyrings/mono-official-archive-keyring.gpg] https://download.mono-project.com/repo/ubuntu stable-focal main" | sudo tee /etc/apt/sources.list.d/mono-official-stable.list
+        sudo apt update
+        sudo apt install -y mono-complete
+        mono --version
+    - name: Install dotnet #needed for GitVersion
+      uses: actions/setup-dotnet@baa11fbfe1d6520db94683bd5c7a3818018e4309 # v5
+      with:
+        dotnet-version: |
+          5.0.x
+    - name: Report installed dotnet versions
+      run: |
+          dotnet --info
+    - name: Create Release Notes with Mono
+      env:
+        GITRELEASEMANAGER_PAT: ${{ secrets.GITRELEASEMANAGER_PAT }}
+      run: |
+        chmod +x build.sh
+        ARGS="--verbosity=diagnostic --target=Create-Release-Notes"
+        if [ -n "${{ inputs.target-branch }}" ]; then
+          ARGS="$ARGS --target-branch=${{ inputs.target-branch }}"
+        fi
+        $GITHUB_WORKSPACE//build.sh $ARGS


### PR DESCRIPTION
## Description Of Changes

This commit adds a new GitHub Action to run the "Create-Release-Notes" Cake Task, which is responsible for generating a set of Release Notes notes alongside the actual GitHub Release.

After testing, it was decided to run this on an Ubuntu image, as this was still faster than running on a Windows Agent, even with the additional installation requirement for Mono.

In order for this to run correctly, it will be necessary to create the GITRELEASEMANAGER_PAT secret, with a token that has access rights to create the release on GitHub.

The additional manual input is for those cases when we have to force the target branch for the release, to ensure that the tag is created in the right place.

## Motivation and Context

Streamline the overall build/release process by doing the repeatable steps in the same place

## Testing

1. Make sure that your fork of the chocolatey/choco repository is up to date, including any tags that need to be pushed to your fork
2. Create the following milestones in your fork
  * `1.5.0`
  * `2.8.0`
  * `2.7.4`
3. Create some new issues with the `Bug` label, and assign them to each of the milestones
4. Clone this PR locally onto your Dev VM
5. Merge and push the PR into the develop branch locally, and push to `origin`
6. Open the recipe.cake file locally and change line 260 from:
  * `repositoryOwner: "chocolatey",` to `repositoryOwner: "<your-GitHub-username>" so that we can prevent creating releases on `upstream`
7.  Commit this change to `develop` branch
8. Cherry pick the creation of the action onto `support/1.x` and `master`
9. Repeat the change to the recipe.cake file on `support/1.x` and `master`
10. Push the changes on all the branches to `origin` _only_, and cancel any/all builds that are kicked off on your fork
11. Go to the Actions tab, and run the new Action on the `develop` branch, and input `develop` into the second text box
12. Ensure that the Action succeeds, and that the resulting Release has all the issues that you assigned to the 2.8.0 milestone and that it is targetting the develop branch
13. Discard the Release
14. Locally, create a new `release/2.8.0` branch, and push it to origin
15. Go to the Actions tab, and run the new Action on the `release/2.8.0` branch. DON'T PUT ANYTHING INTO THE SECOND BOX THIS TIME
16. Ensure that the Action succeeds, and that the resulting Release has all the issues that you assigned to the 2.8.0 milestone and that it is targetting the master branch
17. Locally, create a new hotfix/2.7.4 branch form master, and push it up to origin
18. Go to the Actions tab, and run the new Action on the `hotifx/2.7.4` branch. DON'T PUT ANYTHING INTO THE SECOND BOX THIS TIME
19. Ensure that the Action succeeds, and that the resulting Release has all the issues that you assigned to the 2.7.4 milestone and that it is targetting the master branch
20. Go to the Actions tab, and run the new Action on the `support/1.x` branch. and input `support/1.x` into the second text box
21. Ensure that the Action succeeds, and that the resulting Release has all the issues that you assigned to the 1.5.0 milestone and that it is targetting the support/1.x branch
22. Reset all branches back to the upstream versions, and delete all the branches that were created, both locally and on origin. 

### Operating Systems Testing

- Dev VM 4 and GitHub Actions

## Change Types Made

* [ ] Bug fix (non-breaking change).
* [x] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [ ] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v3 compatibility checked?
* [ ] All items are complete on the [Definition of Done](https://github.com/chocolatey/home/blob/main/definition-of-done.md).

## Related Issue

N/A