### PR TITLE
(#3923) Error when version mismatches during upgrade

### DIFF
--- a/src/chocolatey.tests/infrastructure.app/commands/ChocolateyInstallCommandSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/commands/ChocolateyInstallCommandSpecs.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Concurrent;
 using System.Linq;
 using chocolatey.infrastructure.app.attributes;
 using chocolatey.infrastructure.app.commands;
@@ -23,6 +24,7 @@ using chocolatey.infrastructure.app.configuration;
 using chocolatey.infrastructure.app.domain;
 using chocolatey.infrastructure.app.services;
 using chocolatey.infrastructure.commandline;
+using chocolatey.infrastructure.results;
 using Moq;
 using FluentAssertions;
 
@@ -346,6 +348,156 @@ namespace chocolatey.tests.infrastructure.app.commands
             public void Should_call_service_install_run()
             {
                 PackageService.Verify(c => c.Install(Configuration), Times.Once);
+            }
+        }
+
+        public class When_install_is_called_with_specific_version : ChocolateyInstallCommandSpecsBase
+        {
+            public override void Context()
+            {
+                base.Context();
+                Configuration.Version = "1.0.0";
+                Configuration.PackageNames = "testpackage";
+            }
+
+            public override void Because()
+            {
+                Command.Run(Configuration);
+            }
+
+            [Fact]
+            public void Should_pass_version_to_service()
+            {
+                PackageService.Verify(c => c.Install(It.Is<ChocolateyConfiguration>(
+                    config => config.Version == "1.0.0")), Times.Once);
+            }
+
+            [Fact]
+            public void Should_pass_package_name_to_service()
+            {
+                PackageService.Verify(c => c.Install(It.Is<ChocolateyConfiguration>(
+                    config => config.PackageNames == "testpackage")), Times.Once);
+            }
+        }
+
+        public class When_install_detects_version_mismatch : ChocolateyInstallCommandSpecsBase
+        {
+            private ConcurrentDictionary<string, PackageResult> _installResults;
+
+            public override void Context()
+            {
+                base.Context();
+                Configuration.Version = "2.0.0";
+                Configuration.PackageNames = "testpackage";
+
+                // Simulate version mismatch scenario - service returns error result
+                _installResults = new ConcurrentDictionary<string, PackageResult>();
+                var packageResult = new PackageResult("testpackage", "2.0.0", null);
+                packageResult.Messages.Add(new ResultMessage(
+                    ResultType.Error,
+                    "Upgrading package testpackage to version 2.0.0 is not possible, likely due to package dependency version requirements. The latest package version that meets the dependency requirements is 1.5.0."));
+                _installResults.TryAdd("testpackage", packageResult);
+
+                PackageService.Setup(s => s.Install(It.IsAny<ChocolateyConfiguration>()))
+                    .Returns(_installResults);
+            }
+
+            public override void Because()
+            {
+                Command.Run(Configuration);
+            }
+
+            [Fact]
+            public void Should_receive_version_mismatch_error_from_service()
+            {
+                PackageService.Verify(c => c.Install(It.Is<ChocolateyConfiguration>(
+                    config => config.Version == "2.0.0")), Times.Once);
+
+                _installResults["testpackage"].Messages
+                    .Should().Contain(m => m.MessageType == ResultType.Error && 
+                                          m.Message.Contains("is not possible"));
+            }
+        }
+
+        public class When_install_with_StopOnFirstPackageFailure_and_version_mismatch : ChocolateyInstallCommandSpecsBase
+        {
+            private Exception _caughtException;
+
+            public override void Context()
+            {
+                base.Context();
+                Configuration.Version = "2.0.0";
+                Configuration.PackageNames = "testpackage";
+                Configuration.Features.StopOnFirstPackageFailure = true;
+
+                // Simulate service throwing when StopOnFirstPackageFailure is enabled
+                PackageService.Setup(s => s.Install(It.IsAny<ChocolateyConfiguration>()))
+                    .Throws(new ApplicationException("Stopping further execution as testpackage has failed."));
+            }
+
+            public override void Because()
+            {
+                try
+                {
+                    Command.Run(Configuration);
+                }
+                catch (Exception ex)
+                {
+                    _caughtException = ex;
+                }
+            }
+
+            [Fact]
+            public void Should_throw_ApplicationException()
+            {
+                _caughtException.Should().NotBeNull();
+                _caughtException.Should().BeOfType<ApplicationException>();
+            }
+
+            [Fact]
+            public void Should_indicate_package_failure_in_exception_message()
+            {
+                _caughtException.Message.Should().Contain("testpackage");
+                _caughtException.Message.Should().Contain("Stopping further execution");
+            }
+        }
+
+        public class When_install_without_version_specified : ChocolateyInstallCommandSpecsBase
+        {
+            private ConcurrentDictionary<string, PackageResult> _installResults;
+
+            public override void Context()
+            {
+                base.Context();
+                Configuration.PackageNames = "testpackage";
+                // Version is not set - should install latest available
+
+                _installResults = new ConcurrentDictionary<string, PackageResult>();
+                var packageResult = new PackageResult("testpackage", "2.0.0", null);
+                packageResult.Messages.Add(new ResultMessage(ResultType.Note, "Successfully installed"));
+                _installResults.TryAdd("testpackage", packageResult);
+
+                PackageService.Setup(s => s.Install(It.IsAny<ChocolateyConfiguration>()))
+                    .Returns(_installResults);
+            }
+
+            public override void Because()
+            {
+                Command.Run(Configuration);
+            }
+
+            [Fact]
+            public void Should_not_check_version_mismatch()
+            {
+                PackageService.Verify(c => c.Install(It.Is<ChocolateyConfiguration>(
+                    config => string.IsNullOrEmpty(config.Version))), Times.Once);
+            }
+
+            [Fact]
+            public void Should_succeed_without_version_mismatch_errors()
+            {
+                _installResults["testpackage"].Messages
+                    .Should().NotContain(m => m.MessageType == ResultType.Error);
             }
         }
     }

--- a/src/chocolatey.tests/infrastructure.app/commands/ChocolateyUpgradeCommandSpecs.cs
+++ b/src/chocolatey.tests/infrastructure.app/commands/ChocolateyUpgradeCommandSpecs.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Concurrent;
 using System.Linq;
 using chocolatey.infrastructure.app.attributes;
 using chocolatey.infrastructure.app.commands;
@@ -23,6 +24,7 @@ using chocolatey.infrastructure.app.configuration;
 using chocolatey.infrastructure.app.domain;
 using chocolatey.infrastructure.app.services;
 using chocolatey.infrastructure.commandline;
+using chocolatey.infrastructure.results;
 using Moq;
 using FluentAssertions;
 
@@ -334,6 +336,235 @@ namespace chocolatey.tests.infrastructure.app.commands
             public void Should_call_service_upgrade_run()
             {
                 PackageService.Verify(c => c.Upgrade(Configuration), Times.Once);
+            }
+        }
+
+        public class When_upgrade_is_called_with_specific_version : ChocolateyUpgradeCommandSpecsBase
+        {
+            public override void Context()
+            {
+                base.Context();
+                Configuration.Version = "2.0.0";
+                Configuration.PackageNames = "testpackage";
+            }
+
+            public override void Because()
+            {
+                Command.Run(Configuration);
+            }
+
+            [Fact]
+            public void Should_pass_version_to_service()
+            {
+                PackageService.Verify(c => c.Upgrade(It.Is<ChocolateyConfiguration>(
+                    config => config.Version == "2.0.0")), Times.Once);
+            }
+
+            [Fact]
+            public void Should_pass_package_name_to_service()
+            {
+                PackageService.Verify(c => c.Upgrade(It.Is<ChocolateyConfiguration>(
+                    config => config.PackageNames == "testpackage")), Times.Once);
+            }
+        }
+
+        public class When_upgrade_detects_version_mismatch : ChocolateyUpgradeCommandSpecsBase
+        {
+            private ConcurrentDictionary<string, PackageResult> _upgradeResults;
+
+            public override void Context()
+            {
+                base.Context();
+                Configuration.Version = "3.0.0";
+                Configuration.PackageNames = "testpackage";
+
+                // Simulate version mismatch scenario - service returns error result
+                _upgradeResults = new ConcurrentDictionary<string, PackageResult>();
+                var packageResult = new PackageResult("testpackage", "3.0.0", null);
+                packageResult.Messages.Add(new ResultMessage(
+                    ResultType.Error,
+                    "Upgrading package testpackage to version 3.0.0 is not possible, likely due to package dependency version requirements. The latest package version that meets the dependency requirements is 2.5.0."));
+                _upgradeResults.TryAdd("testpackage", packageResult);
+
+                PackageService.Setup(s => s.Upgrade(It.IsAny<ChocolateyConfiguration>()))
+                    .Returns(_upgradeResults);
+            }
+
+            public override void Because()
+            {
+                Command.Run(Configuration);
+            }
+
+            [Fact]
+            public void Should_receive_version_mismatch_error_from_service()
+            {
+                PackageService.Verify(c => c.Upgrade(It.Is<ChocolateyConfiguration>(
+                    config => config.Version == "3.0.0")), Times.Once);
+
+                _upgradeResults["testpackage"].Messages
+                    .Should().Contain(m => m.MessageType == ResultType.Error && 
+                                          m.Message.Contains("is not possible"));
+            }
+
+            [Fact]
+            public void Should_include_requested_version_in_error_message()
+            {
+                var errorMessage = _upgradeResults["testpackage"].Messages
+                    .First(m => m.MessageType == ResultType.Error).Message;
+
+                errorMessage.Should().Contain("3.0.0");
+            }
+
+            [Fact]
+            public void Should_include_available_version_in_error_message()
+            {
+                var errorMessage = _upgradeResults["testpackage"].Messages
+                    .First(m => m.MessageType == ResultType.Error).Message;
+
+                errorMessage.Should().Contain("2.5.0");
+            }
+        }
+
+        public class When_upgrade_with_StopOnFirstPackageFailure_and_version_mismatch : ChocolateyUpgradeCommandSpecsBase
+        {
+            private Exception _caughtException;
+
+            public override void Context()
+            {
+                base.Context();
+                Configuration.Version = "3.0.0";
+                Configuration.PackageNames = "testpackage";
+                Configuration.Features.StopOnFirstPackageFailure = true;
+
+                // Simulate service throwing when StopOnFirstPackageFailure is enabled
+                PackageService.Setup(s => s.Upgrade(It.IsAny<ChocolateyConfiguration>()))
+                    .Throws(new ApplicationException("Stopping further execution as testpackage has failed."));
+            }
+
+            public override void Because()
+            {
+                try
+                {
+                    Command.Run(Configuration);
+                }
+                catch (Exception ex)
+                {
+                    _caughtException = ex;
+                }
+            }
+
+            [Fact]
+            public void Should_throw_ApplicationException()
+            {
+                _caughtException.Should().NotBeNull();
+                _caughtException.Should().BeOfType<ApplicationException>();
+            }
+
+            [Fact]
+            public void Should_indicate_package_failure_in_exception_message()
+            {
+                _caughtException.Message.Should().Contain("testpackage");
+                _caughtException.Message.Should().Contain("Stopping further execution");
+            }
+
+            [Fact]
+            public void Should_respect_StopOnFirstPackageFailure_configuration()
+            {
+                PackageService.Verify(c => c.Upgrade(It.Is<ChocolateyConfiguration>(
+                    config => config.Features.StopOnFirstPackageFailure == true)), Times.Once);
+            }
+        }
+
+        public class When_upgrade_without_version_specified : ChocolateyUpgradeCommandSpecsBase
+        {
+            private ConcurrentDictionary<string, PackageResult> _upgradeResults;
+
+            public override void Context()
+            {
+                base.Context();
+                Configuration.PackageNames = "testpackage";
+                // Version is not set - should upgrade to latest available
+
+                _upgradeResults = new ConcurrentDictionary<string, PackageResult>();
+                var packageResult = new PackageResult("testpackage", "3.0.0", null);
+                packageResult.Messages.Add(new ResultMessage(ResultType.Note, "Successfully upgraded"));
+                _upgradeResults.TryAdd("testpackage", packageResult);
+
+                PackageService.Setup(s => s.Upgrade(It.IsAny<ChocolateyConfiguration>()))
+                    .Returns(_upgradeResults);
+            }
+
+            public override void Because()
+            {
+                Command.Run(Configuration);
+            }
+
+            [Fact]
+            public void Should_not_check_version_mismatch()
+            {
+                PackageService.Verify(c => c.Upgrade(It.Is<ChocolateyConfiguration>(
+                    config => string.IsNullOrEmpty(config.Version))), Times.Once);
+            }
+
+            [Fact]
+            public void Should_succeed_without_version_mismatch_errors()
+            {
+                _upgradeResults["testpackage"].Messages
+                    .Should().NotContain(m => m.MessageType == ResultType.Error);
+            }
+        }
+
+        public class When_upgrade_multiple_packages_with_version_mismatch_in_first : ChocolateyUpgradeCommandSpecsBase
+        {
+            private ConcurrentDictionary<string, PackageResult> _upgradeResults;
+
+            public override void Context()
+            {
+                base.Context();
+                Configuration.Version = "2.0.0";
+                Configuration.PackageNames = "package1 package2";
+                Configuration.Features.StopOnFirstPackageFailure = false; // Continue processing
+
+                // Simulate first package having version mismatch, second succeeding
+                _upgradeResults = new ConcurrentDictionary<string, PackageResult>();
+
+                var package1Result = new PackageResult("package1", "2.0.0", null);
+                package1Result.Messages.Add(new ResultMessage(
+                    ResultType.Error,
+                    "Upgrading package package1 to version 2.0.0 is not possible, likely due to package dependency version requirements. The latest package version that meets the dependency requirements is 1.5.0."));
+                _upgradeResults.TryAdd("package1", package1Result);
+
+                var package2Result = new PackageResult("package2", "2.0.0", null);
+                package2Result.Messages.Add(new ResultMessage(ResultType.Note, "Successfully upgraded"));
+                _upgradeResults.TryAdd("package2", package2Result);
+
+                PackageService.Setup(s => s.Upgrade(It.IsAny<ChocolateyConfiguration>()))
+                    .Returns(_upgradeResults);
+            }
+
+            public override void Because()
+            {
+                Command.Run(Configuration);
+            }
+
+            [Fact]
+            public void Should_process_all_packages_when_StopOnFirstPackageFailure_is_false()
+            {
+                _upgradeResults.Should().HaveCount(2);
+            }
+
+            [Fact]
+            public void Should_have_error_for_first_package()
+            {
+                _upgradeResults["package1"].Messages
+                    .Should().Contain(m => m.MessageType == ResultType.Error);
+            }
+
+            [Fact]
+            public void Should_succeed_for_second_package()
+            {
+                _upgradeResults["package2"].Messages
+                    .Should().NotContain(m => m.MessageType == ResultType.Error);
             }
         }
     }

--- a/src/chocolatey/StringResources.cs
+++ b/src/chocolatey/StringResources.cs
@@ -654,6 +654,8 @@ namespace chocolatey
             [Browsable(false)]
             internal const string UnableToDowngrade = "A newer version of {0} (v{1}) is already installed.{2} Use --allow-downgrade or --force to attempt to install older versions.";
             internal const string DependencyFailedToInstall = "Failed to install {0} because a previous dependency failed.";
+            internal const string VersionMismatch = "Upgrading package {0} to version {1} is not possible, likely due to package dependency version requirements. The latest package version that meets the dependency requirements is {2}. " +
+                "For more information on this issue and guidance in resolving the problem, see https://ch0.co/t/deps";
         }
 
         public static class OptionDescriptions

--- a/src/chocolatey/infrastructure.app/services/NugetService.cs
+++ b/src/chocolatey/infrastructure.app/services/NugetService.cs
@@ -894,6 +894,12 @@ Please see https://docs.chocolatey.org/en-us/troubleshooting for more
                         continue;
                     }
 
+                    // Check if the user requested a specific version for this package and dependency resolution changed it
+                    if (HasVersionMismatchError(version, packageName, packageDependencyInfo, config, packageResultsToReturn))
+                    {
+                        continue;
+                    }
+
                     var packageRemoteMetadata = packagesToInstall.FirstOrDefault(p => p.Identity.Equals(packageDependencyInfo));
 
                     if (packageRemoteMetadata is null)
@@ -1715,6 +1721,12 @@ Please see https://docs.chocolatey.org/en-us/troubleshooting for more
                                 continue;
                             }
 
+                            // Check if the user requested a specific version for this package and dependency resolution changed it
+                            if (HasVersionMismatchError(version, packageName, packageDependencyInfo, config, packageResultsToReturn))
+                            {
+                                continue;
+                            }
+
                             var packageRemoteMetadata = packagesToInstall.FirstOrDefault(p => p.Identity.Equals(packageDependencyInfo));
 
                             if (packageRemoteMetadata is null)
@@ -2153,6 +2165,56 @@ and argument details.
             }
 
             return false;
+        }
+
+        /// <summary>
+        /// Validates that the resolved package version matches the user-requested version.
+        /// Returns true if there is a version mismatch error that should prevent installation.
+        /// </summary>
+        private bool HasVersionMismatchError(
+            NuGetVersion requestedVersion,
+            string packageName,
+            SourcePackageDependencyInfo packageDependencyInfo,
+            ChocolateyConfiguration config,
+            ConcurrentDictionary<string, PackageResult> packageResultsToReturn)
+        {
+            // Only validate if user explicitly requested a specific version
+            if (requestedVersion == null)
+            {
+                return false;
+            }
+
+            // Only check the main package being installed/upgraded, not dependencies
+            if (!packageDependencyInfo.Id.Equals(packageName, StringComparison.OrdinalIgnoreCase))
+            {
+                return false;
+            }
+
+            // Check if resolved version differs from requested version
+            if (packageDependencyInfo.Version.Equals(requestedVersion))
+            {
+                return false;
+            }
+
+            // Version mismatch detected - log error and add to results
+            var logMessage = StringResources.ErrorMessages.VersionMismatch.FormatWith(
+                packageName,
+                requestedVersion.ToFullStringChecked(),
+                packageDependencyInfo.Version.ToFullStringChecked());
+
+            var versionMismatchResult = packageResultsToReturn.GetOrAdd(
+                packageDependencyInfo.Id,
+                new PackageResult(packageDependencyInfo.Id, requestedVersion.ToFullStringChecked(), string.Empty)
+            );
+            versionMismatchResult.Messages.Add(new ResultMessage(ResultType.Error, logMessage));
+            this.Log().Error(ChocolateyLoggers.Important, logMessage);
+
+            if (config.Features.StopOnFirstPackageFailure)
+            {
+                throw new ApplicationException("Stopping further execution as {0} has failed.".FormatWith(packageDependencyInfo.Id));
+            }
+
+            return true;
         }
 
         private static void RemoveInvalidDependenciesAndParents(


### PR DESCRIPTION
## Description Of Changes
This change adds a version mismatch Validation to the NugetService.cs.

Created HasVersionMismatchError private helper method that:
  - Validates only when a version is explicitly requested (not when installing latest)
  - Checks only the main package being installed/upgraded (not dependencies)
  - Compares the user-requested version with the dependency-resolved version
  - Returns early if versions match or if no validation is needed

Integrated validation into both Install and Upgrade workflows:
  - Added check after dependency resolution but before package installation
  - Prevents installation/upgrade from proceeding when version mismatch is detected

Adds user friendly error message with guidance and proper error handling.

## Motivation and Context
When users specify an explicit package version using `--version X.Y.Z` with `choco install` or `choco upgrade`, Chocolatey's dependency resolution may silently install a different version if the requested version conflicts with dependency constraints. This behavior is confusing and unexpected for users who explicitly request a specific version. This changes adds logic to display error message when we cannot reconcile the user's request.

## Testing
Running all Tests in Visual Studio should pass. 

Or

Running `ChocolateyInstallCommandSpecs.cs` and `ChocolateyUpgradeCommandSpecs.cs` had new tests added for this PR and should pass.

### Operating Systems Testing
Dev VM4

## Change Types Made

* [x] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [x] Tests to cover my changes, have been added.
* [x] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v3 compatibility checked?
* [ ] All items are complete on the [Definition of Done](https://github.com/chocolatey/home/blob/main/definition-of-done.md).

## Related Issue
#3923 

Fixes #3923
